### PR TITLE
fix(dsh-notifier): 子代理识别改用 header.origin 而非 delegationDepth

### DIFF
--- a/packages/dsh-notifier/src/index.ts
+++ b/packages/dsh-notifier/src/index.ts
@@ -8,7 +8,7 @@
  *   用户审批结束），不短路
  * - 任务完成：agent/status（scoped emit，{agent, status}，idle | running）
  *   running → idle 跃迁，per-agent 状态机，多会话互不误报；子代理
- *   （header.delegationDepth ≥ 1）走独立开关/事件类型 subagent-done；
+ *   （header.origin === 'subagent'）走独立开关/事件类型 subagent-done；
  *   用户暂停/中断（turn/end reason aborted）固定静默
  * - 任务错误：agent/error（{agent, turn, step, error}），60 秒滚动窗口合并
  * - 轮结束：agent/turn-stopping（serial，{agent, turn}，仅宿主通知，不跑模型）
@@ -108,8 +108,15 @@ export interface NotifyDetail {
 export interface AgentLite {
   id?: string;
   session?: {
-    /** 子代理深度标记（dsh-subagent 写入：子代理 ≥1，主 agent 无此字段）。 */
-    header?: { delegationDepth?: unknown };
+    /** 会话头（SessionHeader 最小面；子代理识别只用 origin，见 isSubagentOf）。 */
+    header?: {
+      /** 子代理身份标记：DSH 强制唯一合法值为 'subagent'，主会话/fork 派生会话恒为 undefined。 */
+      origin?: unknown;
+      /** 父会话 id：子代理与 fork/派生会话都会写，故不能单独作为子代理判据。 */
+      parentSession?: unknown;
+      /** 子代理深度计数：resume/运行时 deepen 路径可能缺失或失真，仅作兜底。 */
+      delegationDepth?: unknown;
+    };
     events?: Array<{
       type?: string;
       data?: { title?: unknown; turn?: unknown; reason?: { kind?: unknown } };
@@ -388,13 +395,24 @@ export function lastTurnEndOf(agent: AgentLite | undefined): { turn: number; kin
 }
 
 /**
- * agent 是否为子代理：session.header.delegationDepth ≥ 1
- * （dsh-subagent 创建子代理时写入 childDepth = parent+1；主 agent 无此
- * 字段/为 0）。先规约数字再比较（strict 下 unknown 不能直接参与比较）。
+ * agent 是否为子代理：以 session.header.origin === 'subagent' 为唯一判据。
+ *
+ * 选此信号而非 delegationDepth / parentSession 的原因（均经 DSH 源码核验）：
+ * - origin 由 SessionHeader 校验强制唯一合法值为 'subagent'
+ *   （packages/core/session/src/index.ts:125：origin 非 undefined 就必须是
+ *   'subagent'），主会话/fork 派生会话恒为 undefined → 零误判面。
+ * - DSH 自身在无父 id 场景（packages/subagent/subagent/src/list-children.ts:324、
+ *   :235）也只认 origin === 'subagent' 识别子代理，口径一致。
+ * - parentSession 不能作判据：Session.fork()（session/src/index.ts:1091）与
+ *   apiproxy 的 lineage 场景会写 parentSession 但不带 origin → 若用 parentSession
+ *   会把 fork/派生主流程会话误判为子代理，其「任务完成」被默认
+ *   notifySubagentDone=false 静默（当前 bug 的镜像回归）。
+ * - delegationDepth 在某些路径（resume 信任持久化 header、运行时 deepen）下并非
+ *   可靠的「是否子代理」标记，仅作兜底。
+ * 综上：单用 origin 最权威、最稳；notifier 是单 agent 独立判定，不要求父 id 匹配。
  */
 export function isSubagentOf(agent: AgentLite | undefined): boolean {
-  const depth = Number(agent?.session?.header?.delegationDepth ?? 0);
-  return Number.isFinite(depth) && depth >= 1;
+  return agent?.session?.header?.origin === "subagent";
 }
 
 /** "HH:MM" → 分钟数（校验 0-23 时 / 0-59 分）。 */
@@ -735,7 +753,7 @@ export async function apply(ctx: PluginContext, config: NotifierApplyConfig = {}
   /**
    * 任务完成状态机（per-agent）：见到某会话 running 记 pendingDone，下次该会话
    * idle 时判定是否通知（带耗时）。多会话/子代理各自独立跟踪，互不误报。
-   * 子代理（header.delegationDepth ≥ 1）走独立开关 notifySubagentDone 与
+   * 子代理（header.origin === 'subagent'）走独立开关 notifySubagentDone 与
    * 独立事件类型 subagent-done；用户暂停/中断（turn/end reason aborted）固定静默。
    */
   const agentStates = new Map<string, { runningSeen: boolean; startedAt: number; lastEndedTurn?: number }>(); // agentId -> { runningSeen, startedAt, lastEndedTurn }

--- a/packages/dsh-notifier/test/smoke.ts
+++ b/packages/dsh-notifier/test/smoke.ts
@@ -11,7 +11,7 @@
  *   不暴露会话 id，无标题降级）/
  *   next 抛错原样传播 / notifyAsk=false 不通知
  * - agent/status：per-agent 状态机，多会话互不误报；disposed 清理；
- *   子代理分流（delegationDepth≥1 → subagent-done，独立开关默认关，
+ *   子代理分流（header.origin==='subagent' → subagent-done，独立开关默认关，
  *   notifyTaskDone=false 不拦截）；中断抑制（turn/end aborted 静默、
  *   error/blocked 静默（不误报完成）、S1 无新 turn/end closure 静默、
  *   中断/失败后继续正常通知）
@@ -235,21 +235,27 @@ function makeLoggingCtx() {
   return { ctx, routes, listeners, infos };
 }
 
-// 带会话标题/子代理深度/turn/end 的 agent 辅助（模拟 dsh-session-title 与
+// 带会话标题/子代理身份/turn/end 的 agent 辅助（模拟 dsh-session-title 与
 // dsh-agent-loop 写入的日志；真实宿主跑完一轮必有 turn/end 落盘）。
 // opts.turnEnd：turn 号（有则追加一条 turn/end 事件）；
 // opts.turnEndKind：reason.kind（默认 completed，aborted 模拟用户中断）；
-// opts.depth：header.delegationDepth（≥1 模拟子代理）。
+// opts.subagent：true 模拟子代理（写入 origin:'subagent'，与 DSH childSessionMeta 一致）；
+// opts.parentSession：模拟 fork/派生会话（只写 parentSession、不带 origin）；
+// opts.depth：header.delegationDepth（仅作附加，不作子代理判据）。
 function agentWithTitle(id, title, opts = {}) {
   const events = [];
   if (opts.turnEnd !== undefined) {
     events.push({ type: "turn/end", data: { turn: opts.turnEnd, reason: { kind: opts.turnEndKind ?? "completed" } } });
   }
   if (title) events.push({ type: "session/title", data: { title } });
+  const header = {};
+  if (opts.subagent) header.origin = "subagent";
+  if (opts.parentSession !== undefined) header.parentSession = opts.parentSession;
+  if (opts.depth !== undefined) header.delegationDepth = opts.depth;
   return {
     id,
     session: {
-      header: opts.depth !== undefined ? { delegationDepth: opts.depth } : undefined,
+      header: Object.keys(header).length > 0 ? header : undefined,
       events,
     },
   };
@@ -402,14 +408,38 @@ function agentWithTitle(id, title, opts = {}) {
 {
   const subCfg = join(work, "subagent.json");
 
+  // 判定依据回归（issue #7）：单用 header.origin === 'subagent' 识别子代理。
+  // 反例 1：只带 parentSession（无 origin）的 fork/派生会话必须走 done（不被静默）。
+  // 这是三信号「或」方案的镜像回归防护——Session.fork() 写 parentSession 但不带
+  // origin，若用 parentSession 当判据会误判为子代理、致其完成被默认静默。
+  {
+    const infos = [];
+    const { ctx, listeners } = makeFakeCtx({ logger: { warn: () => {}, info: (t) => infos.push(t) } });
+    await apply(ctx, { enabled: true, configFile: subCfg, toastScript: join(work, "toast.ps1"), historyFile: join(work, "history.jsonl") });
+    const status = listeners.get("agent/status")[0];
+    status({ agent: agentWithTitle("fork-1", "fork 派生会话", { parentSession: "parent-x", turnEnd: 1 }), status: "running" });
+    status({ agent: agentWithTitle("fork-1", "fork 派生会话", { parentSession: "parent-x", turnEnd: 1 }), status: "idle" });
+    assert.equal(infos.length, 1, "仅 parentSession（无 origin）的会话走主任务完成，不被静默");
+    assert.match(infos[0], /done/, "fork/派生会话发 done 而非 subagent-done");
+    // 反例 2：主会话（无 header / 无 origin）必须走 done（原 bug 回归防护）。
+    // 注意：fork-1 与 main-x 同为 done 类型，会被完成风暴聚合窗口（默认 3s）合并，
+    // main-x 的「单条」通知延迟到窗口到点才补发；故此处先等聚合窗口过期，
+    // 让 main-x 落在独立窗口、即时通知。
+    await new Promise((resolve) => setTimeout(resolve, 3200));
+    status({ agent: agentWithTitle("main-x", "主任务", { turnEnd: 1 }), status: "running" });
+    status({ agent: agentWithTitle("main-x", "主任务", { turnEnd: 1 }), status: "idle" });
+    assert.equal(infos.length, 2, "主会话完成走 done");
+    assert.match(infos[1], /done/);
+  }
+
   // 默认关：子代理完成不通知，主任务完成不受影响
   {
     const infos = [];
     const { ctx, listeners } = makeFakeCtx({ logger: { warn: () => {}, info: (t) => infos.push(t) } });
     await apply(ctx, { enabled: true, configFile: subCfg, toastScript: join(work, "toast.ps1"), historyFile: join(work, "history.jsonl") });
     const status = listeners.get("agent/status")[0];
-    status({ agent: agentWithTitle("sub-1", "子任务A", { depth: 1, turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("sub-1", "子任务A", { depth: 1, turnEnd: 1 }), status: "idle" });
+    status({ agent: agentWithTitle("sub-1", "子任务A", { subagent: true, turnEnd: 1 }), status: "running" });
+    status({ agent: agentWithTitle("sub-1", "子任务A", { subagent: true, turnEnd: 1 }), status: "idle" });
     assert.equal(infos.length, 0, "notifySubagentDone 默认关：子代理完成不通知");
     status({ agent: agentWithTitle("main-1", "主任务", { turnEnd: 1 }), status: "running" });
     status({ agent: agentWithTitle("main-1", "主任务", { turnEnd: 1 }), status: "idle" });
@@ -424,8 +454,8 @@ function agentWithTitle(id, title, opts = {}) {
     const { ctx, listeners } = makeFakeCtx({ logger: { warn: () => {}, info: (t) => infos.push(t) } });
     await apply(ctx, { enabled: true, configFile: subCfg, toastScript: join(work, "toast.ps1"), historyFile: join(work, "history.jsonl") });
     const status = listeners.get("agent/status")[0];
-    status({ agent: agentWithTitle("sub-2", "子任务B", { depth: 1, turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("sub-2", "子任务B", { depth: 1, turnEnd: 1 }), status: "idle" });
+    status({ agent: agentWithTitle("sub-2", "子任务B", { subagent: true, turnEnd: 1 }), status: "running" });
+    status({ agent: agentWithTitle("sub-2", "子任务B", { subagent: true, turnEnd: 1 }), status: "idle" });
     assert.equal(infos.length, 1);
     assert.match(infos[0], /subagent-done/, "子代理完成用独立事件类型");
     assert.match(infos[0], /子任务「子任务B」已完成/, "subagent-done 文案带任务标题");
@@ -446,8 +476,8 @@ function agentWithTitle(id, title, opts = {}) {
     const { ctx, listeners } = makeFakeCtx({ logger: { warn: () => {}, info: (t) => infos.push(t) } });
     await apply(ctx, { enabled: true, configFile: subCfg, toastScript: join(work, "toast.ps1"), historyFile: join(work, "history.jsonl") });
     const status = listeners.get("agent/status")[0];
-    status({ agent: agentWithTitle("sub-3", "子任务C", { depth: 1, turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("sub-3", "子任务C", { depth: 1, turnEnd: 1 }), status: "idle" });
+    status({ agent: agentWithTitle("sub-3", "子任务C", { subagent: true, turnEnd: 1 }), status: "running" });
+    status({ agent: agentWithTitle("sub-3", "子任务C", { subagent: true, turnEnd: 1 }), status: "idle" });
     assert.equal(infos.length, 1, "notifyTaskDone=false 不拦截子代理完成（S2）");
     assert.match(infos[0], /subagent-done/);
     status({ agent: agentWithTitle("main-3", "主任务3", { turnEnd: 1 }), status: "running" });


### PR DESCRIPTION
## 摘要

修复 dsh-notifier 子代理完成被误判为主任务、触发「任务完成」(done) 通知的 bug。

关联 issue：#7

## 根因

原 `isSubagentOf` 仅凭 `header.delegationDepth >= 1` 判定子代理。该字段在某些子代理路径（resume 信任持久化 header、运行时 deepen）下可能缺失或失真，导致对子代理返回 false → 子代理落回主任务 `done` 分支。实测 `subagent-done`=0、`done`=39（含大量几秒级密集 done，明显是子代理干的活）。

## 修复

改用 DSH 内部的权威信号 `header.origin === 'subagent'`：
- `packages/core/session/src/index.ts:125` 校验 `origin` 唯一合法值为 `'subagent'`，主会话/fork 派生会话恒为 `undefined` → 零误判面
- `packages/subagent/subagent/src/list-children.ts:324/235` 在无父 id 场景纯用 `origin === 'subagent'` 识别子代理，口径一致

**关键：判定单用 `origin`，不把 `parentSession` 拉进「或」**——`session/src/index.ts:1091` 的 `Session.fork()` 写 `parentSession` 但不带 `origin`，用 `parentSession` 当判据会把 fork/派生主流程会话误判为子代理，其「任务完成」被默认 `notifySubagentDone=false` 静默（镜像回归）。

## 改动

- `src/index.ts`：`isSubagentOf` 改为单用 `header.origin === 'subagent'`；补 `AgentLite.header` 最小面（origin/parentSession/delegationDepth）
- `test/smoke.ts`：子代理用例改用 `subagent: true` 构造（写 `origin`）；新增反例——仅 `parentSession`（无 `origin`）的 fork 会话必须走 `done` 不被静默；主会话（无 header/origin）走 `done` 回归防护

## 验证

- `pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm test`（notifier smoke：OK）✅
- `pnpm contract` ✅
- `pnpm pack:check` ✅

## 影响范围

仅宿主端 `packages/dsh-notifier/src/index.ts`。配置/客户端/路由/状态机均不受影响。修复后子代理完成被正确识别：默认仍静默（notifySubagentDone=false），开启后走独立 subagent-done 类型，不再污染主任务 done 通知。