### PR TITLE
docs(DEVELOPMENT): 新增 smoke 测试防 flake 纪律

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ types/dsh.d.ts        宿主端类型层
 
 ## 常用命令
 
-构建 / 测试 / 契约 / 打包命令见 [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) §0。
+构建 / 测试 / 契约 / 打包命令见 [docs/DEVELOPMENT.md §0](docs/DEVELOPMENT.md#0-构建总览)。
 改动提交前至少跑一遍 `pnpm build && pnpm test && pnpm contract && pnpm pack:check`
 （CI 会全量跑所有门禁）。
 
@@ -33,7 +33,8 @@ types/dsh.d.ts        宿主端类型层
 - **零运行时依赖**：所有插件发布物自包含，运行时零 npm 依赖（宿主注入模型）。
 - **客户端为干净模块**：只 `export function apply(ctx)` + `export const inject`，
   样式独立 `src/client/style.css`，构建走 `scripts/build-client.ts`，路由强制 loopback
-  围栏，patch id 用 `ui-<name>`。细则与禁止项见 DEVELOPMENT.md §1/§2/§3。
+  围栏，patch id 用 `ui-<name>`。细则与禁止项见
+  [DEVELOPMENT.md §1/§2/§3](docs/DEVELOPMENT.md#1-宿主端srcindexts规范)。
 - **安全语义**：涉及密钥/凭据/远程执行/令牌的包修改安全语义时同步更新 README
   与测试；安全模型放包 README 的 `## 安全模型` 一节。
 
@@ -60,9 +61,10 @@ Conventional Commits（`type(scope): subject`；type：`feat` / `fix` / `docs` /
 
 smoke 全部无网络、无真实凭据，本地可直接运行；新功能/修复必须带 smoke 断言
 （含路由 403/405 围栏用例、client 契约断言）。防 flake 纪律（隔离文件路径 / 设 DSH_HOME
-到临时目录 / 轮询替代固定 sleep）见 DEVELOPMENT.md §5。
+到临时目录 / 轮询替代固定 sleep）见
+[DEVELOPMENT.md §5](docs/DEVELOPMENT.md#5-smoke-测试防-flake-纪律)。
 
 ## 参考文档
 
-- 开发规范（宿主/客户端写法、构建契约、测试防 flake 纪律）：[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)
+- 开发规范（宿主/客户端写法、构建契约、多端兼容、测试防 flake 纪律）：[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)
 - 贡献规范（Conventional Commits、功能分支 + PR 流程、提交前检查）：[CONTRIBUTING.md](CONTRIBUTING.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,18 +21,7 @@ types/dsh.d.ts        宿主端类型层
 
 ## 常用命令
 
-```sh
-pnpm install
-pnpm build            # 全仓构建（clean-lib → tsc → bundle-host）
-pnpm test             # 全量 smoke（Node ≥23.6 原生直跑 TS）
-pnpm contract         # 客户端契约（执行产物断言）
-pnpm pack:check       # tarball 完整性（含聚合包专项）
-pnpm verify:npmlayout # npm 布局：解包后可加载
-pnpm aggregate:check  # 聚合 patch 不漂移
-pnpm typecheck        # 全仓类型检查
-node scripts/dsh-plugin-new <name>   # 脚手架（F 阶段提供）
-```
-
+构建 / 测试 / 契约 / 打包命令见 [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) §0。
 改动提交前至少跑一遍 `pnpm build && pnpm test && pnpm contract && pnpm pack:check`
 （CI 会全量跑所有门禁）。
 
@@ -42,43 +31,20 @@ node scripts/dsh-plugin-new <name>   # 脚手架（F 阶段提供）
   `types/dsh.d.ts`；禁止 tsconfig 指向任何 DSH 源码 checkout。
 - **新包一律 `dsh-` 前缀**；npm 包名 `@wingsky-1/dsh-*`；聚合包 `dsh-plugins-all`。
 - **零运行时依赖**：所有插件发布物自包含，运行时零 npm 依赖（宿主注入模型）。
-- **构建预设只用 `scripts/build-client.ts`**（客户端契约外壳生成 + load id 注入 +
-  内建校验），禁止在包内复制参数。
-- **客户端源码是「干净模块」**：只 `export function apply(ctx)` + `export const inject`，
-  源码**禁止**写 `window.__ModuleLoader__.load`、IIFE、手拼 `__DSH_PLUGIN_ID__`、
-  `declare var module`/`interface Window.__ModuleLoader__`——这些契约外壳（load 注册、
-  IIFE 闭包工厂 + factory + `Symbol.toStringTag` 装配 + load id === 包名）由
-  build-client 构建期统一生成。客户端入口统一 `src/client/index.ts`。
-- **客户端样式**：独立 `src/client/style.css`（`.css` text-loader 构建期内联），
-  源码 `import STYLE from "./style.css"`；不把 CSS 写进 ts。颜色用 `--dsw-alias-*` 等
-  实时主题变量 + 浅色回退，明暗自适应；挂载失败只 console.warn。
-- **客户端路径二选一**：默认「bare import = 宿主注入 external（React，需
-  `react-shim.d.ts`）」；纯浏览器第三方库用 `dsh.client.inlineBareImports: true`
-  内联（互斥）。契约：load id === 包名（arrive 校验） + `exports.apply/inject` 装配 +
-  自包含零依赖。
-- **全部路由强制 loopback 围栏**（非回环 403，方法不匹配 405）；health 路由必项。
-- **patch id 规范**：独立包 `ui-<name>`；聚合行由 aggregate.ts 生成（同 id，无
-  config）。**独立包与聚合包禁双装**（同 id 双装 loader 报 duplicate）。改独立包
-  patch 后必须 `node scripts/aggregate.ts` 重新生成聚合 patch。
-- **共享层 js + d.ts 双写**（tsc rootDir 硬约束，shared 不可 TS 化）。
+- **客户端为干净模块**：只 `export function apply(ctx)` + `export const inject`，
+  样式独立 `src/client/style.css`，构建走 `scripts/build-client.ts`，路由强制 loopback
+  围栏，patch id 用 `ui-<name>`。细则与禁止项见 DEVELOPMENT.md §1/§2/§3。
 - **安全语义**：涉及密钥/凭据/远程执行/令牌的包修改安全语义时同步更新 README
   与测试；安全模型放包 README 的 `## 安全模型` 一节。
 
-## 提交规范（Conventional Commits）
+## 提交规范
 
-```
-type(scope): subject
-```
-
-- type：`feat` / `fix` / `docs` / `refactor` / `test` / `chore` / `ci` / `perf`
-- scope：包名或主题（如 `dsh-gzip`、`scripts`、`release`）
-- 禁止 emoji（代码、注释、文档、UI、提交信息全覆盖）
+Conventional Commits（`type(scope): subject`；type：`feat` / `fix` / `docs` / `refactor` /
+`test` / `chore` / `ci` / `perf`；**禁止 emoji**）：见 [CONTRIBUTING.md](CONTRIBUTING.md) 提交信息。
 
 ## 提交前检查
 
-- 敏感信息：不提交本机路径/用户名/IP/凭据（提交前扫描）。
-- 发布物：`pnpm pack` 后 tarball 不含 `src/`、`test/`、内部文档。
-- 只推功能代码与对外文档，不推内部治理/讨论细节。
+见 [CONTRIBUTING.md](CONTRIBUTING.md) 提交前检查（敏感信息扫描 / 发布物边界 / 只推功能代码）。
 
 ## 发布纪律（Release notes）
 
@@ -88,12 +54,13 @@ type(scope): subject
 - GitHub Release 更新说明**每版入库**为 `docs/release-notes/vX.Y.Z.md`，由发版 agent
   从上一 tag 至今的常规提交生成、逐条译为 `EN / 中文`、随 `chore(release):` 提交；
   管线优先引用该文件，缺失则回退 GitHub 自动 notes。**禁止 emoji**（覆盖文档与提交信息）。
+- 合并方式：CI 全绿后 squash merge（见 CONTRIBUTING.md 开发流程）。
 
 ## 测试纪律
 
-- smoke 全部无网络、无真实凭据，本地可直接运行。
-- 新功能/修复必须带 smoke 断言（含路由 403/405 围栏用例、client 契约断言）。
-- 新包自带 README（`README.md` 中文 + `README.en.md` 英文，中英配对）。
+smoke 全部无网络、无真实凭据，本地可直接运行；新功能/修复必须带 smoke 断言
+（含路由 403/405 围栏用例、client 契约断言）。防 flake 纪律（隔离文件路径 / 设 DSH_HOME
+到临时目录 / 轮询替代固定 sleep）见 DEVELOPMENT.md §5。
 
 ## 参考文档
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,3 +94,8 @@ type(scope): subject
 - smoke 全部无网络、无真实凭据，本地可直接运行。
 - 新功能/修复必须带 smoke 断言（含路由 403/405 围栏用例、client 契约断言）。
 - 新包自带 README（`README.md` 中文 + `README.en.md` 英文，中英配对）。
+
+## 参考文档
+
+- 开发规范（宿主/客户端写法、构建契约、测试防 flake 纪律）：[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)
+- 贡献规范（Conventional Commits、功能分支 + PR 流程、提交前检查）：[CONTRIBUTING.md](CONTRIBUTING.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,11 @@ node scripts/contract-check.ts && node scripts/pack-check.ts
 - smoke 全部无网络、无真实凭据，本地可直接运行
 - 新功能/修复必须带 smoke 断言（含路由 403/405 围栏用例）
 
+## 参考文档
+
+- 开发规范（宿主/客户端写法、构建契约、多端兼容、测试防 flake 纪律）：[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)
+- 仓库规则（全局约定、发布纪律）：[AGENTS.md](AGENTS.md)
+
 ## License
 
 MIT

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -144,3 +144,29 @@ export const inject: string[] = [];        // 声明 apply 用到的 ctx 服务�
 
 正例（mcp-manager）：设 `DSH_HOME` 到临时目录、每块显式 `storePath: join(dir, "dsh-mcp.json")`、
 写盘为 `await writeFile`（已等待）。
+
+## 6. 多端兼容（三操作系统 + 三访问形态 + 明暗双主题）
+
+dsh web 部署在 Linux 服务器，经局域网被多种设备 / 系统访问。插件（尤其客户端 UI 与
+涉及文件 / 命令的宿主逻辑）必须同时满足以下三端兼容要求：
+
+1. **三操作系统（mac / linux / windows）**：插件在三种 OS 下都能正确工作。
+   - 路径 / 分隔符一律用 `node:path`（`join` / `sep`），禁止字符串拼接 `/` 或 `\`；
+     行尾、大小写敏感路径按 OS 处理。
+   - 不写死 OS 专属命令 / 二进制；若必须（如 notifier 的 Windows `toast.ps1`），按 OS
+     分支并提供 mac / linux 等价实现或优雅降级，不抛错阻断。
+   - 脚本 / 构建在三种 OS 均可跑（CI 即跨平台验证）。
+
+2. **三访问形态（PC / pad / phone）**：界面响应式、触控友好、窄屏可用。
+   - 布局用响应式（flex / grid + 媒体查询），不写死宽度；触控目标足够大、间距合理。
+   - 窄屏（phone / pad 竖屏）下信息不溢出、可滚动、关键操作可达；pad / phone 经局域网
+     访问是主要场景之一。
+
+3. **明暗双主题（light / dark）**：**禁止硬编码单一配色**。
+   - 颜色统一走 `--dsw-alias-*` / `--dsw-hljs-*` 等实时主题变量 + 浅色回退
+     （见 §2.3 / §3），明暗自适应；不要在 CSS / TS 里写死 `#fff` / `rgb(...)` 固定色。
+   - 挂载失败只 `console.warn`，绝不让 GUI 启动失败。
+
+验证：客户端交互改动须真机 / 浏览器在**双主题 + 窄屏（pad / phone）**下验证（呼应
+`dsh-plugin-hub-dev` skill §7 的浏览器 MCP 真点查 DOM）；宿主端逻辑须在三 OS 下可运行。
+构造的样例数据放工作区（如 `fwp-verify/`），不纳入发布包。

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -110,3 +110,37 @@ export const inject: string[] = [];        // 声明 apply 用到的 ctx 服务�
   `factory: function(`、load 注册。
 - **新增/修改客户端后**：`pnpm build && pnpm test && pnpm contract && pnpm pack:check`
   全绿再提交。
+
+## 5. Smoke 测试防 flake 纪律
+
+背景：notifier 的 history 路由测试曾因「多个 `apply()` 实例共享同一 `history.jsonl` +
+`appendHistory` 为 fire-and-forget 异步写盘 + 固定 `setTimeout(50)` 后断言『最后一条
+为 test』」而 CI 偶发失败（issue #17）。根因是**测试多实例共享全局默认持久化路径、且
+依赖异步写盘时序**，与产品逻辑无关。以下纪律用于前置拦截此类 flake。
+
+核心原则：**smoke 测试不得依赖「全局默认持久化路径 + 异步写盘的时序」**。
+
+1. **显式隔离文件路径**：每个测试块必须显式传入 `historyFile` / `persistFile` /
+   `storePath` 等，指向 `join(work, "<包>-<块名>.jsonl")` 之类的**唯一临时文件**；
+   **禁止多个 `apply()` 实例共享同一文件路径**，尤其禁止依赖 `homedir()` / `DSH_HOME`
+   下的默认文件（默认路径是全局单文件，多实例各起一条写链会互相 read-modify-write 竞态）。
+2. **测试前置设置 `DSH_HOME` 等环境到临时目录**：所有测试开头
+   `process.env.DSH_HOME = mkdtempSync(join(tmpdir(), "<pkg>-"))`，结尾还原（delete 或
+   复位原值）。这同时杜绝两件事：① 向真实 `~/.dsh` 写测试数据（污染 + 跨运行状态泄漏）；
+   ② 多个测试块 / 运行间共享同一默认文件。**mcp-manager 已如此实践，作为强制基准。**
+3. **异步落盘用轮询替代固定 sleep**：断言持久化状态前必须 `poll-until` 满足条件再断言，
+   严禁 `setTimeout(resolve, 50 / 300)` 这类「等够毫秒」的时序假设。参考 notifier 的
+   `waitForHistory(route, predicate)` 辅助（轮询 GET 直到谓词成立，超时兜底返回当前态）。
+4. **fire-and-forget 写入禁止跨块断言顺序**：若写是 `void flush()` / 防抖定时器
+   （如 opencode-usage 的 `schedulePersist`、notifier 的 `appendHistory`），绝不能依赖
+   「最后一条是 X」「条数 === N」等顺序敏感断言；必须**隔离文件 + 轮询**。理想情况：
+   被测插件暴露 `await flushPersist()` 之类的可等待落盘钩子，测试直接 `await` 比轮询更稳。
+5. **CI 稳定性门槛**：新增 / 修改 `test/smoke.ts` 后，本地连续跑 **≥10 次**（如
+   `for i in $(seq 1 10); do node packages/<pkg>/test/smoke.ts; done`）确认无 flake 再提交。
+
+反例（notifier #17，已修）：多个 `apply(...)` 都传 `historyFile: join(work, "history.jsonl")`
+（共享文件）；`await setTimeout(resolve, 50)` 后 `assert.equal(records.at(-1).kind, "test")`。
+正例：路由块改用专属 `history-route.jsonl`；落盘用 `waitForHistory` 轮询。
+
+正例（mcp-manager）：设 `DSH_HOME` 到临时目录、每块显式 `storePath: join(dir, "dsh-mcp.json")`、
+写盘为 `await writeFile`（已等待）。

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,8 +2,8 @@
 
 > 覆盖**宿主端 / 客户端**两类代码的写法与构建契约，以及我们统一后的客户端形态
 > （干净模块 + 独立 CSS + `src/client/` 目录 + 第三方内联）。适用于本公开仓库
-> `packages/dsh-*` 的开发与维护。构建/契约/发布脚本见 `scripts/`，根 `AGENTS.md`
-> 是仓库级硬性规则（副本见下）。
+> `packages/dsh-*` 的开发与维护。构建/契约/发布脚本见 `scripts/`；仓库级硬性规则
+> （全局约定 / 发布纪律）见根 [AGENTS.md](../AGENTS.md)。
 
 ## 0. 构建总览
 
@@ -21,6 +21,7 @@ pnpm typecheck    # 全仓类型检查
 1. esbuild 内联 `shared/*` 进 `lib/index.js`（宿主端自包含单文件）。
 2. 客户端经 `scripts/build-client.ts`（唯一契约外壳/注入点）构建 `lib/client.js`。
 3. d.ts X1：改写 `../../../shared|types` → 包内副本，`shared/*.d.ts`、`types/dsh.d.ts` 随包。
+   shared 层因此保持 **js + d.ts 双写**（tsc `rootDir` 硬约束，shared 不可 TS 化）。
 4. 拷贝资源（非 TS 文件）+ LICENSE。
 
 ## 1. 宿主端（`src/index.ts`）规范
@@ -34,7 +35,9 @@ pnpm typecheck    # 全仓类型检查
 - **安全**：全部路由强制 loopback 围栏（非回环 403、方法错 405），`/health` 必项；
   RPC/端点做参数校验；密钥/凭据不入包。
 - **挂载**：`cordis.patch.yml`，patch **id 用 `ui-<name>`**；声明 `dsh.client` 时必须有
-  `exports["./client"]`（`contract-check` 联动断言，缺则整包拒载）。
+  `exports["./client"]`（`contract-check` 联动断言，缺则整包拒载）。**独立包与聚合包
+  禁双装**（同 id 双装 loader 报 duplicate）；改独立包 patch 后必须
+  `node scripts/aggregate.ts` 重新生成聚合 patch。
 - **测试**：`test/smoke.ts` 直跑，必含 403/405 围栏用例 + 客户端契约断言
   （`assertClientSourceContract` / `assertClientProductContract`）。
 
@@ -155,7 +158,8 @@ dsh web 部署在 Linux 服务器，经局域网被多种设备 / 系统访问�
      行尾、大小写敏感路径按 OS 处理。
    - 不写死 OS 专属命令 / 二进制；若必须（如 notifier 的 Windows `toast.ps1`），按 OS
      分支并提供 mac / linux 等价实现或优雅降级，不抛错阻断。
-   - 脚本 / 构建在三种 OS 均可跑（CI 即跨平台验证）。
+   - 脚本 / 构建不得依赖 POSIX 专属行为（CI 目前仅 ubuntu-latest 单平台，跨 OS
+     兼容由本地验证保障；后续可为 CI 增加三 OS matrix）。
 
 2. **三访问形态（PC / pad / phone）**：界面响应式、触控友好、窄屏可用。
    - 布局用响应式（flex / grid + 媒体查询），不写死宽度；触控目标足够大、间距合理。
@@ -167,6 +171,6 @@ dsh web 部署在 Linux 服务器，经局域网被多种设备 / 系统访问�
      （见 §2.3 / §3），明暗自适应；不要在 CSS / TS 里写死 `#fff` / `rgb(...)` 固定色。
    - 挂载失败只 `console.warn`，绝不让 GUI 启动失败。
 
-验证：客户端交互改动须真机 / 浏览器在**双主题 + 窄屏（pad / phone）**下验证（呼应
-`dsh-plugin-hub-dev` skill §7 的浏览器 MCP 真点查 DOM）；宿主端逻辑须在三 OS 下可运行。
-构造的样例数据放工作区（如 `fwp-verify/`），不纳入发布包。
+验证：客户端交互改动须真机 / 浏览器在**双主题 + 窄屏（pad / phone）**下实测 DOM
+（浏览器 DevTools 或浏览器自动化 MCP 均可）；宿主端逻辑须在三 OS 下可运行。
+构造的样例 fixture 放仓库外工作区，不纳入发布物。


### PR DESCRIPTION
## 背景

排查 notifier #17 的 CI flake 时发现：根因是测试多实例共享全局默认持久化路径 +
依赖异步写盘时序，与产品无关。opencode-usage 存在同构隐患（全局默认 persist 路径 +
fire-and-forget 防抖落盘 + smoke 漏设 `DSH_HOME`），mcp-manager 已是良好示范。

为前置拦截此类 flake，在 `docs/DEVELOPMENT.md` 新增 §5「Smoke 测试防 flake 纪律」。

## 内容

本 PR 除新增 §5 外，还包含一次文档架构收敛与 §6 多端兼容纪律：

1. **§5 Smoke 测试防 flake 纪律**：五条纪律——显式隔离文件路径 / 测试前置设
   `DSH_HOME` 到临时目录 / 异步落盘用轮询替代固定 sleep / fire-and-forget 写入禁止
   跨块断言顺序 / 新增修改 smoke 后本地连续跑 ≥10 次。以 notifier #17 为反例、
   mcp-manager 为正例。
2. **§6 多端兼容**：三操作系统（mac/linux/windows）+ 三访问形态（PC/pad/phone）+
   明暗双主题的兼容要求与验证方式。
3. **文档架构收敛**：AGENTS.md 去除与 DEVELOPMENT.md/CONTRIBUTING.md 重复的细则，
   精简为「一句话内核 + 锚点链接」的索引层；CONTRIBUTING.md 补「参考文档」节；
   三文档互链成网（README → DEVELOPMENT/CONTRIBUTING → AGENTS）。
4. **评审修正**（review 后追加）：rebase 到 main 使 §5 引用的 `waitForHistory` /
   `history-route.jsonl` 与代码自洽；开头失效的「副本见下」改为链接；补回精简时
   丢失的三条硬规则（禁双装 / aggregate 再生成 / shared js+d.ts 双写）；§6 的
   「CI 即跨平台验证」修正为如实表述（CI 目前仅 ubuntu-latest）；去除外部读者
   不可见的私有引用。

注：opencode-usage 的隐患按约定本次仅记规范、暂未改动代码，留待后续单独处理。

此 PR 仅供评审，未合并。
