### PR TITLE
feat(dsh-notifier): 脱敏规则表扩展 + 审批/提问路径接入 + toast AUMID 自举

### DIFF
--- a/packages/dsh-notifier/README.en.md
+++ b/packages/dsh-notifier/README.en.md
@@ -123,9 +123,9 @@ Pick one of the following access forms (both the panel and the README surface a 
 - **Error notification text is redacted**: masked via an ordered rule table and truncated to 300 chars before entering notifications and history, reducing the exposure surface of embedded command echo, paths, and credential fragments. Covered categories and placeholders:
   - User paths (`/home` `/Users` `/root` `/etc` `C:\Users`) → `<path>`
   - PEM private key blocks (including truncated forms with only the BEGIN header) → `<private-key>`
-  - Database / message-queue connection-string credentials (postgres/mysql/mongodb/redis/amqp etc., scheme preserved) → `scheme://<redacted>@host`
+  - Database / message-queue connection-string credentials (postgres/mysql/mongodb/redis/amqps etc., scheme preserved; not redacted when the password contains URL-reserved chars like `<>`/quotes — known limitation) → `scheme://<redacted>@host`
   - Tokens: JWT, AWS AKIA, GitHub PAT (classic and fine-grained), ≥24-char hex / ≥32-char base64 runs → `<token>`
-  - Secret field assignments (`password=`/`token=`/`api_key=`…) → `key=<redacted>`
+  - Secret field assignments (`password=`/`token=`/`api_key=`…; an explicit `=`/`:` separator is required) → `key=<redacted>`
   - Email addresses → `<email>`
   - **Approval reasons and question texts** are redacted too (truncated to 120 chars) — these most often embed command echo and credential fragments
   - Proven false-positive-prone, deliberately not covered: IPv4 (same shape as UA version numbers), phone numbers (same shape as order IDs), credit cards (13-digit millisecond timestamps match at 100%)

--- a/packages/dsh-notifier/README.en.md
+++ b/packages/dsh-notifier/README.en.md
@@ -120,7 +120,15 @@ Pick one of the following access forms (both the panel and the README surface a 
 ## Security & boundaries
 
 - Notification text only contains metadata such as task title / tool name / request reason — **never tool parameters** (prevents sensitive info leakage)
-- **Error notification text is redacted**: user paths / long tokens / key assignments are masked first (`<path>`/`<token>`/`<redacted>`) and then truncated to 300 chars, reducing the exposure surface of embedded command echo, paths, and credential fragments within error messages
+- **Error notification text is redacted**: masked via an ordered rule table and truncated to 300 chars before entering notifications and history, reducing the exposure surface of embedded command echo, paths, and credential fragments. Covered categories and placeholders:
+  - User paths (`/home` `/Users` `/root` `/etc` `C:\Users`) → `<path>`
+  - PEM private key blocks (including truncated forms with only the BEGIN header) → `<private-key>`
+  - Database / message-queue connection-string credentials (postgres/mysql/mongodb/redis/amqp etc., scheme preserved) → `scheme://<redacted>@host`
+  - Tokens: JWT, AWS AKIA, GitHub PAT (classic and fine-grained), ≥24-char hex / ≥32-char base64 runs → `<token>`
+  - Secret field assignments (`password=`/`token=`/`api_key=`…) → `key=<redacted>`
+  - Email addresses → `<email>`
+  - **Approval reasons and question texts** are redacted too (truncated to 120 chars) — these most often embed command echo and credential fragments
+  - Proven false-positive-prone, deliberately not covered: IPv4 (same shape as UA version numbers), phone numbers (same shape as order IDs), credit cards (13-digit millisecond timestamps match at 100%)
 - System notification failures are silent (logs only), and do not affect the main flow; a missing / non-executable native binary (ENOENT etc.) is caught by the `error` event and **never bubbles up as an unhandled error that crashes the host process** (see issue #1)
 - **The two channels are delivered to different machines (don't confuse them)**:
   - **Browser notifications** are pushed to **the browser client you are actually using** (your Mac / phone both count), and pop a native notification via the browser's Notification API; they require permission and by default only pop when the page is hidden (the panel can enable "also when visible"). No matter which machine dsh web runs on, as long as browser notifications are allowed you receive them on your own Mac.
@@ -128,7 +136,7 @@ Pick one of the following access forms (both the panel and the README surface a 
 - **iOS difference**: Safari's normal tabs have no Web Notifications API (only the "Add to Home Screen" PWA does); on iOS the available channels are "in-page banner + sound when the page is visible" and system notifications after HTTPS + A2HS
 - Browser notifications require a **secure context** (HTTPS or localhost); LAN HTTP access automatically routes through the fallback channel (banner / sound / title reminder)
 - Browser notification permission is requested within a gesture (when clicking the sidebar "Notifications" entry or a panel button)
-- Windows system notifications are implemented via a PowerShell WinRT script, with the command passed as a parameter array (no shell concatenation surface)
+- Windows system notifications are implemented via a PowerShell WinRT script, with the command passed as a parameter array (no shell concatenation surface); the script idempotently registers the AppUserModelId on startup (HKCU, no admin required) — an unregistered AUMID gets toasts silently dropped by Windows 10/11
 
 ## Verification
 

--- a/packages/dsh-notifier/README.md
+++ b/packages/dsh-notifier/README.md
@@ -116,7 +116,15 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-notifier
 ## 安全与边界
 
 - 通知文本只含任务标题/工具名/申请理由等元信息，**不含工具参数**（防敏感信息外泄）
-- **错误通知文本经脱敏**：用户路径/长令牌/密钥赋值会先打码（`<path>`/`<token>`/`<redacted>`）再截断 300 字符，降低错误消息内嵌命令回显、路径与凭据片段的外泄面
+- **错误通知文本经脱敏**：进入通知与历史前按有序规则表打码再截断 300 字符，降低错误消息内嵌命令回显、路径与凭据片段的外泄面。覆盖类别与占位符：
+  - 用户路径（`/home` `/Users` `/root` `/etc` `C:\Users`）→ `<path>`
+  - PEM 私钥块（含只有 BEGIN 头的截断形态）→ `<private-key>`
+  - 数据库/消息队列连接串凭据（postgres/mysql/mongodb/redis/amqp 等，scheme 保留）→ `scheme://<redacted>@host`
+  - 各类令牌：JWT、AWS AKIA、GitHub PAT（classic 与 fine-grained）、≥24 位 hex / ≥32 位 base64 长串 → `<token>`
+  - 密钥字段赋值（`password=`/`token=`/`api_key=`…）→ `键名=<redacted>`
+  - 邮箱 → `<email>`
+  - **审批理由与提问文本**同样经脱敏（120 字符截断）——这两类文本最常内嵌命令回显与凭据片段
+  - 已证伪不收录（高频误伤）：IPv4（UA 版本号同形）、手机号（订单号同形）、信用卡（13 位毫秒时间戳 100% 命中）
 - 系统通知失败静默（仅日志），不影响主流程；原生二进制缺失/不可执行（ENOENT 等）
   会被 `error` 事件接住，**绝不冒泡成 unhandled error 把宿主进程打挂**（见 issue #1）
 - **两个通道到达的机器不同（别混淆）**：
@@ -126,7 +134,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-notifier
   才有）；iOS 上可用通道为「页面可见时横幅 + 提示音」及 HTTPS+A2HS 后的系统通知
 - 浏览器通知需要**安全上下文**（HTTPS 或 localhost）；局域网 HTTP 访问自动走降级通道（横幅/提示音/标题提醒）
 - 浏览器通知权限为手势内请求（点击侧边栏「通知」入口或面板按钮时）
-- Windows 系统通知通过 PowerShell WinRT 脚本实现，命令以参数数组传递（无 shell 拼接面）
+- Windows 系统通知通过 PowerShell WinRT 脚本实现，命令以参数数组传递（无 shell 拼接面）；脚本启动时幂等注册 AppUserModelId（HKCU，无需管理员权限）——未注册的 AUMID 在 Win10/11 上 toast 会被系统静默丢弃
 
 ## 验证
 

--- a/packages/dsh-notifier/README.md
+++ b/packages/dsh-notifier/README.md
@@ -119,9 +119,9 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-notifier
 - **错误通知文本经脱敏**：进入通知与历史前按有序规则表打码再截断 300 字符，降低错误消息内嵌命令回显、路径与凭据片段的外泄面。覆盖类别与占位符：
   - 用户路径（`/home` `/Users` `/root` `/etc` `C:\Users`）→ `<path>`
   - PEM 私钥块（含只有 BEGIN 头的截断形态）→ `<private-key>`
-  - 数据库/消息队列连接串凭据（postgres/mysql/mongodb/redis/amqp 等，scheme 保留）→ `scheme://<redacted>@host`
+  - 数据库/消息队列连接串凭据（postgres/mysql/mongodb/redis/amqps 等，scheme 保留；密码含 `<>`/引号等 URL 应编码字符时不脱敏，属已知局限）→ `scheme://<redacted>@host`
   - 各类令牌：JWT、AWS AKIA、GitHub PAT（classic 与 fine-grained）、≥24 位 hex / ≥32 位 base64 长串 → `<token>`
-  - 密钥字段赋值（`password=`/`token=`/`api_key=`…）→ `键名=<redacted>`
+  - 密钥字段赋值（`password=`/`token=`/`api_key=`…，须带显式 `=`/`:` 分隔符）→ `键名=<redacted>`
   - 邮箱 → `<email>`
   - **审批理由与提问文本**同样经脱敏（120 字符截断）——这两类文本最常内嵌命令回显与凭据片段
   - 已证伪不收录（高频误伤）：IPv4（UA 版本号同形）、手机号（订单号同形）、信用卡（13 位毫秒时间戳 100% 命中）

--- a/packages/dsh-notifier/src/index.ts
+++ b/packages/dsh-notifier/src/index.ts
@@ -255,14 +255,20 @@ const SANITIZE_RULES: ReadonlyArray<readonly [RegExp, string]> = [
   // （排除冒号/分号等后缀分隔符，避免吞掉紧随其后的文本：`/home/x: EACCES` 应保留冒号）
   [/(?:\/home\/[^\s"'`<>:;]+|\/Users\/[^\s"'`<>:;]+|\/root\/[^\s"'`<>:;]+|\/etc\/[^\s"'`<>:;]+|C:\\Users\\[^\s"'`<>:;]+)/giu, "<path>"],
   // PEM 私钥完整块（RSA/EC/OPENSSH/ENCRYPTED…）→ <private-key>
-  [/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g, "<private-key>"],
+  // 窗口上限 {0,4096}：真实私钥块 ≤ 数 KB；无窗口时每个 BEGIN 起点都会惰性扫到
+  // 文本尾找 END，k 个 BEGIN 即 O(k·n)，1MB 高密度输入可阻塞宿主事件循环数秒
+  // （评审实测）。超窗视为无 END，交由下一条孤立 BEGIN 兜底规则接住。
+  [/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]{0,4096}?-----END [A-Z ]*PRIVATE KEY-----/g, "<private-key>"],
   // PEM 孤立 BEGIN 兜底：错误消息常只贴出头几行就被截断，无 END 行；
   // 吃到文本尾即可（尾部反正受 maxLen 截断）
   [/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*/g, "<private-key>"],
   // 数据库/消息队列连接串凭据 → 只留 scheme://<redacted>@host
   // 用户名允许为空（redis://:pass@host 是最常见带密码形态）；i flag 兼容大写 scheme；
-  // jdbc 不收录：JDBC 凭据在 query 参数（?password=），密钥赋值规则已覆盖
-  [/\b(postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?|amqp|mssql):\/\/([^\s:@\/"'`<>]*):([^\s@\/"'`<>]+)@/giu, "$1://<redacted>@"],
+  // amqps?：AMQPS 同端口语义，漏收会产生「密码被邮箱规则侥幸掩掉、用户名明文残留」
+  // 的半脱敏误导形态；jdbc 不收录：JDBC 凭据在 query 参数（?password=），密钥赋值规则已覆盖。
+  // 已知局限（评审记录）：密码含 <>/引号等 URL 应编码字符时整条失配、明文残留——
+  // 错误消息中的未编码形态不罕见，但放宽字符类会引入占位符/引号边界歧义，暂记录不改。
+  [/\b(postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?|amqps?|mssql):\/\/([^\s:@\/"'`<>]*):([^\s@\/"'`<>]+)@/giu, "$1://<redacted>@"],
   // GitHub PAT classic（ghp/gho/ghu/ghs/ghr + 36 位字母数字；业界共识写死长度）
   [/\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36}\b/gu, "<token>"],
   // GitHub fine-grained PAT（github_pat_ 强前缀锚定，长度取区间吸收未来调整）
@@ -276,7 +282,9 @@ const SANITIZE_RULES: ReadonlyArray<readonly [RegExp, string]> = [
   // 长令牌/密钥串（≥24 hex 或 ≥32 base64）→ <token>
   [/\b(?:[0-9a-fA-F]{24,}|[A-Za-z0-9+/]{32,}={0,2})\b/gu, "<token>"],
   // 密钥字段赋值（password=/token=/api_key=…）→ 只留键名+掩码
-  [/\b(password|passwd|token|api[_-]?key|secret|authorization)\b\s*[=:]?\s*["']?[^\s"'`,;<>]{3,}/giu, "$1=<redacted>"],
+  // 分隔符 [=:] 必须显式：可选版会把 "token expired"/"password policy" 等自然语言
+  // 高频误伤成 token=<redacted>（审批理由/提问文本接入后误伤面被放大，评审实测）
+  [/\b(password|passwd|token|api[_-]?key|secret|authorization)\b\s*[=:]\s*["']?[^\s"'`,;<>]{3,}/giu, "$1=<redacted>"],
   // 邮箱（严格版：域名首标签须字母开头，排除 image@2x.png / pkg@1.2.3 误伤）→ <email>
   // 负向后行断言排除词字符与 <：防止从 <redacted>@host 占位符中间起配
   [/(?<![A-Za-z0-9._%+<>-])[A-Za-z0-9._%+-]+@[A-Za-z][A-Za-z0-9.-]*\.[A-Za-z]{2,}/gu, "<email>"],

--- a/packages/dsh-notifier/src/index.ts
+++ b/packages/dsh-notifier/src/index.ts
@@ -240,26 +240,60 @@ export function formatDuration(ms: number): string {
 }
 
 /**
- * 错误文本脱敏：掩蔽常见敏感特征（用户路径、长令牌/密钥串、密钥赋值），再截断。
- * 用于 agent/error 进入通知与历史的文本，把「错误信息可能内嵌命令回显/路径/
- * 凭据片段」的外泄面收敛到可读的摘要。
+ * 脱敏规则有序表：顺序即数据（具体在前、泛化在后），消灭隐式语句序。
+ * 顺序硬约束（对抗评审实测确立）：
+ * - DSN 必须先于 JWT/通用长串/密钥赋值：否则 DSN 密码先被劣化为 <token>，
+ *   DSN 字符类排除 <> 随即失配，用户名残留明文；
+ * - 邮箱必须殿后且带 (?<!<) 界定：避免把 DSN 掩码占位符 <redacted>@host
+ *   中的 "redacted@host" 再误判为邮箱产生 <<email>>。
+ * 已证伪不收录（勿加回）：IPv4（UA 版本号 Chrome/120.0.0.0 形态不可区分，
+ * 误伤高频）、手机号（订单号误伤、错误文本出现概率趋零）、信用卡
+ * （13 位毫秒时间戳 100% 命中，Luhn 校验也救不了）。
+ */
+const SANITIZE_RULES: ReadonlyArray<readonly [RegExp, string]> = [
+  // 用户路径（/home/xx、/Users/xx、/root/xx、/etc/xx、C:\Users\xx）→ <path>
+  // （排除冒号/分号等后缀分隔符，避免吞掉紧随其后的文本：`/home/x: EACCES` 应保留冒号）
+  [/(?:\/home\/[^\s"'`<>:;]+|\/Users\/[^\s"'`<>:;]+|\/root\/[^\s"'`<>:;]+|\/etc\/[^\s"'`<>:;]+|C:\\Users\\[^\s"'`<>:;]+)/giu, "<path>"],
+  // PEM 私钥完整块（RSA/EC/OPENSSH/ENCRYPTED…）→ <private-key>
+  [/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g, "<private-key>"],
+  // PEM 孤立 BEGIN 兜底：错误消息常只贴出头几行就被截断，无 END 行；
+  // 吃到文本尾即可（尾部反正受 maxLen 截断）
+  [/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*/g, "<private-key>"],
+  // 数据库/消息队列连接串凭据 → 只留 scheme://<redacted>@host
+  // 用户名允许为空（redis://:pass@host 是最常见带密码形态）；i flag 兼容大写 scheme；
+  // jdbc 不收录：JDBC 凭据在 query 参数（?password=），密钥赋值规则已覆盖
+  [/\b(postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?|amqp|mssql):\/\/([^\s:@\/"'`<>]*):([^\s@\/"'`<>]+)@/giu, "$1://<redacted>@"],
+  // GitHub PAT classic（ghp/gho/ghu/ghs/ghr + 36 位字母数字；业界共识写死长度）
+  [/\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36}\b/gu, "<token>"],
+  // GitHub fine-grained PAT（github_pat_ 强前缀锚定，长度取区间吸收未来调整）
+  [/\bgithub_pat_[A-Za-z0-9]{20,30}_[A-Za-z0-9]{50,80}\b/gu, "<token>"],
+  // JWT（eyJ JWT：header.payload.signature 三段，base64url 字符集含 - _）→ <token>
+  // 精确匹配三段（每段 ≥1 字符，含 - _），避免误伤普通长串（对抗评审建议：勿盲目放宽
+  // 通用 base64 正则到 base64url，那会误伤 URL/长串）。
+  [/\beyJ[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+){2}\b/gu, "<token>"],
+  // AWS 访问密钥前缀（AKIA 20 字符，不满足通用 ≥24hex/≥32base64 阈值）→ <token>
+  [/\bAKIA[A-Z0-9]{16}\b/gu, "<token>"],
+  // 长令牌/密钥串（≥24 hex 或 ≥32 base64）→ <token>
+  [/\b(?:[0-9a-fA-F]{24,}|[A-Za-z0-9+/]{32,}={0,2})\b/gu, "<token>"],
+  // 密钥字段赋值（password=/token=/api_key=…）→ 只留键名+掩码
+  [/\b(password|passwd|token|api[_-]?key|secret|authorization)\b\s*[=:]?\s*["']?[^\s"'`,;<>]{3,}/giu, "$1=<redacted>"],
+  // 邮箱（严格版：域名首标签须字母开头，排除 image@2x.png / pkg@1.2.3 误伤）→ <email>
+  // 负向后行断言排除词字符与 <：防止从 <redacted>@host 占位符中间起配
+  [/(?<![A-Za-z0-9._%+<>-])[A-Za-z0-9._%+-]+@[A-Za-z][A-Za-z0-9.-]*\.[A-Za-z]{2,}/gu, "<email>"],
+];
+
+/**
+ * 错误文本脱敏：按 SANITIZE_RULES 有序表掩蔽常见敏感特征（用户路径、私钥、
+ * 连接串凭据、各类令牌、密钥赋值、邮箱），再截断。
+ * 用于 agent/error 与审批理由/提问文本进入通知与历史前的处理，把「文本可能
+ * 内嵌命令回显/路径/凭据片段」的外泄面收敛到可读的摘要。
  * @returns 脱敏并截断（默认 300 字符）后的错误文本。
  */
 export function sanitizeErrorText(text: unknown, maxLen = 300): string {
   let s = String(text);
-  // 用户路径（/home/xx、/Users/xx、/root/xx、/etc/xx、C:\Users\xx）→ <path>
-  // （排除冒号/分号等后缀分隔符，避免吞掉紧随其后的文本：`/home/x: EACCES` 应保留冒号）
-  s = s.replace(/(?:\/home\/[^\s"'`<>:;]+|\/Users\/[^\s"'`<>:;]+|\/root\/[^\s"'`<>:;]+|\/etc\/[^\s"'`<>:;]+|C:\\Users\\[^\s"'`<>:;]+)/giu, "<path>");
-  // JWT（eyJ JWT：header.payload.signature 三段，base64url 字符集含 - _）→ <token>
-  // 精确匹配三段（每段 ≥1 字符，含 - _），避免误伤普通长串（对抗评审建议：勿盲目放宽
-  // 通用 base64 正则到 base64url，那会误伤 URL/长串）。
-  s = s.replace(/\beyJ[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+){2}\b/gu, "<token>");
-  // AWS 访问密钥前缀（AKIA 20 字符，不满足通用 ≥24hex/≥32base64 阈值）→ <token>
-  s = s.replace(/\bAKIA[A-Z0-9]{16}\b/gu, "<token>");
-  // 长令牌/密钥串（≥24 hex 或 ≥32 base64）→ <token>
-  s = s.replace(/\b(?:[0-9a-fA-F]{24,}|[A-Za-z0-9+/]{32,}={0,2})\b/gu, "<token>");
-  // 密钥字段赋值（password=/token=/api_key=…）→ 只留键名+掩码
-  s = s.replace(/\b(password|passwd|token|api[_-]?key|secret|authorization)\b\s*[=:]?\s*["']?[^\s"'`,;<>]{3,}/giu, "$1=<redacted>");
+  for (const [pattern, replacement] of SANITIZE_RULES) {
+    s = s.replace(pattern, replacement);
+  }
   return s.slice(0, maxLen);
 }
 
@@ -774,7 +808,8 @@ export async function apply(ctx: PluginContext, config: NotifierApplyConfig = {}
       const askDetail = () => ({
         tool: req?.toolName as string | undefined,
         taskTitle: sessionTitleOf(req?.agent),
-        reason: req?.reason ? String(req.reason).slice(0, 120) : undefined,
+        // 审批理由最常内嵌命令回显与凭据片段，进通知前必须脱敏（120 字符截断）
+        reason: req?.reason ? sanitizeErrorText(req.reason, 120) : undefined,
       });
       try {
         notify("ask", askDetail());
@@ -849,7 +884,8 @@ export async function apply(ctx: PluginContext, config: NotifierApplyConfig = {}
           notify("question", {
             tool: "ask_user_question",
             taskTitle: sessionTitleOf((request as { agent?: AgentLite } | null | undefined)?.agent),
-            question: first && (first as { question?: unknown }).question ? String((first as { question?: unknown }).question).slice(0, 120) : undefined,
+            // 提问文本同样可能内嵌上下文片段，进通知前脱敏（120 字符截断）
+            question: first && (first as { question?: unknown }).question ? sanitizeErrorText((first as { question?: unknown }).question, 120) : undefined,
           });
         }
       } catch (error) {

--- a/packages/dsh-notifier/src/toast.ps1
+++ b/packages/dsh-notifier/src/toast.ps1
@@ -7,6 +7,15 @@ param(
 # 失败静默退出（exit 1），宿主只记录日志；不抛出阻塞调用方。
 # -Silent：在 toast XML 中追加 <audio silent="true"/> 静默弹出（用于 notifySound=false）。
 $ErrorActionPreference = "Stop"
+# AUMID 自举：CreateToastNotifier("DSH") 用的 AppUserModelId 若未在
+# HKCU 注册，Win10/11 会静默丢弃 toast（不报错也不弹出）。幂等写 HKCU 键
+# （含 DisplayName 供操作中心显示可读名），无需管理员权限；失败不阻断弹窗尝试。
+try {
+  $appIdKey = New-Item -Path "HKCU:\SOFTWARE\Classes\AppUserModelId\DSH" -Force
+  $null = $appIdKey.SetValue("DisplayName", "DSH", "String")
+} catch {
+  # 注册表不可写等场景仍尝试弹窗（旧版 Windows 未注册也可能成功）
+}
 try {
   Add-Type -AssemblyName System.Runtime.WindowsRuntime
   $null = [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime]

--- a/packages/dsh-notifier/test/smoke.ts
+++ b/packages/dsh-notifier/test/smoke.ts
@@ -103,6 +103,106 @@ assert.ok(!sanitizeErrorText("open /etc/passwd denied").includes("/etc"), "/etc 
 // 防误伤：普通含下划线/连字符的英文单词不应被 JWT/AKIA 规则误打码
 assert.equal(sanitizeErrorText("the-key_is-here and also_fine"), "the-key_is-here and also_fine", "普通文本不被 JWT 规则误伤");
 
+// ---- issue #6 脱敏扩展：GitHub PAT / PEM 私钥 / 连接串凭据 / 邮箱 ----
+// GitHub PAT classic（ghp/gho/ghu/ghs/ghr + 恰 36 位字母数字）
+const patCore36 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+assert.equal(sanitizeErrorText(`token ghp_${patCore36} end`), "token <token> end", "GitHub PAT classic 打码");
+for (const prefix of ["gho", "ghu", "ghs", "ghr"]) {
+  assert.equal(sanitizeErrorText(`${prefix}_${patCore36}`), "<token>", `GitHub PAT ${prefix}_ 前缀打码`);
+}
+// 长度边界锁定：35/37 位不命中（业界共识写死长度），且不被通用长串规则部分命中
+assert.equal(sanitizeErrorText(`ghp_${patCore36.slice(0, 35)}`), `ghp_${patCore36.slice(0, 35)}`, "PAT 35 位不误伤");
+assert.equal(sanitizeErrorText(`ghp_${patCore36}X`), `ghp_${patCore36}X`, "PAT 37 位不误伤");
+// fine-grained PAT（区间长度）
+const fgPat = `github_pat_${"A".repeat(22)}_${"B".repeat(59)}`;
+assert.equal(sanitizeErrorText(`bad ${fgPat}!`), "bad <token>!", "GitHub fine-grained PAT 打码");
+// 回归：通用长串规则不得对 github_pat_ 部分命中产生残缺掩码
+assert.ok(!sanitizeErrorText(fgPat).includes("_"), "fine-grained PAT 无残缺残留");
+
+// PEM 私钥：完整块（含 \r\n 变体）与孤立 BEGIN 兜底；证书/PUBLIC KEY 不误伤
+const pemBody = "MIIEowIBAAKCAQEA0Z3VS5JJcds3xfn/yGWyifZ6IWVpYFKEzBNGIFfD8hV0v";
+assert.equal(
+  sanitizeErrorText(`-----BEGIN RSA PRIVATE KEY-----\n${pemBody}\n-----END RSA PRIVATE KEY-----\nok`),
+  "<private-key>\nok",
+  "PEM 完整私钥块打码"
+);
+assert.ok(
+  !sanitizeErrorText(`-----BEGIN EC PRIVATE KEY-----\r\n${pemBody}\r\n-----END EC PRIVATE KEY-----`).includes("MIIEow"),
+  "PEM 私钥块（\\r\\n）打码"
+);
+assert.ok(
+  !sanitizeErrorText(`-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA\n尾随`).includes("b3BlbnNzaC"),
+  "PEM 孤立 BEGIN（无 END，错误消息截断常态）兜底打码"
+);
+assert.equal(
+  sanitizeErrorText("-----BEGIN CERTIFICATE-----\nc2hvcnRib2R5\n-----END CERTIFICATE-----"),
+  "-----BEGIN CERTIFICATE-----\nc2hvcnRib2R5\n-----END CERTIFICATE-----",
+  "证书块不误伤"
+);
+assert.ok(!sanitizeErrorText("-----BEGIN PUBLIC KEY-----\nc2hvcnRib2R5\n-----END PUBLIC KEY-----").includes("<private-key>"), "PUBLIC KEY 不误伤");
+
+// 数据库/消息队列连接串凭据：scheme 保留、凭据整体掩蔽
+assert.equal(
+  sanitizeErrorText("postgres://admin:s3cret@db.local:5432/app down"),
+  "postgres://<redacted>@db.local:5432/app down",
+  "postgres 连接串掩蔽且 scheme 正确（防 $1 组号回归）"
+);
+assert.equal(sanitizeErrorText("redis://:MyPass@127.0.0.1:6379"), "redis://<redacted>@127.0.0.1:6379", "redis 空用户名形态掩蔽");
+assert.equal(
+  sanitizeErrorText("mongodb+srv://dev:pw123@cluster0.abc12.mongodb.net/test"),
+  "mongodb+srv://<redacted>@cluster0.abc12.mongodb.net/test",
+  "mongodb+srv 连接串掩蔽"
+);
+assert.equal(sanitizeErrorText("POSTGRES://U:P@H"), "POSTGRES://<redacted>@H", "大写 scheme 掩蔽（i flag）");
+assert.equal(
+  sanitizeErrorText("jdbc:mysql://host/db?user=root&password=topsecret"),
+  "jdbc:mysql://host/db?user=root&password=<redacted>",
+  "JDBC 凭据在 query 参数，由密钥赋值规则覆盖"
+);
+assert.equal(sanitizeErrorText("postgres://u:p@ss@h"), "postgres://<redacted>@ss@h", "畸形双 @ 锁定残缺行为（URL 规范要求编码）");
+
+// 邮箱（严格版）：正常邮箱打码；资源引用/版本号不误伤
+assert.equal(sanitizeErrorText("mail a.b-c@example.co.uk end"), "mail <email> end", "邮箱打码");
+assert.equal(sanitizeErrorText("loaded image@2x.png"), "loaded image@2x.png", "资源引用 @2x 不误伤");
+assert.equal(sanitizeErrorText("need @scope/pkg@1.2.3"), "need @scope/pkg@1.2.3", "包版本 pkg@1.2.3 不误伤");
+// 顺序回归：DSN 掩蔽后占位符不得被邮箱规则二次命中产生 <<email>>
+assert.equal(
+  sanitizeErrorText("mysql://admin:s3cret@db.example.com down"),
+  "mysql://<redacted>@db.example.com down",
+  "DSN 与邮箱规则顺序回归"
+);
+
+// 规则顺序硬约束回归
+assert.equal(
+  sanitizeErrorText("postgres://u:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c@h"),
+  "postgres://<redacted>@h",
+  "DSN 先于 JWT：连接串内嵌 JWT 整体掩蔽，用户名不残留"
+);
+assert.equal(
+  sanitizeErrorText("postgres://u:token@hostname down"),
+  "postgres://<redacted>@hostname down",
+  "DSN 先于密钥赋值：host 保留、凭据不劣化残留"
+);
+
+// 边界与容错：Symbol 入参不抛错；截断窗口腰斩行为锁定
+assert.doesNotThrow(() => sanitizeErrorText(Symbol("x")), "Symbol 入参不抛 TypeError");
+assert.equal(sanitizeErrorText(Symbol("x")), "Symbol(x)", "Symbol 入参转字符串");
+assert.equal(sanitizeErrorText("前".repeat(296) + `ghp_${patCore36}`), "前".repeat(296) + "<tok", "占位符落在截断窗口被腰斩（锁定行为）");
+
+// FP 证伪回归：已删除规则的高频误伤形态必须保持原样（防止将来加回来）
+assert.equal(sanitizeErrorText("Date.now()=1718000000000"), "Date.now()=1718000000000", "13 位毫秒时间戳原样（信用卡规则证伪）");
+assert.equal(sanitizeErrorText("Chrome/120.0.0.0 Safari/537.36"), "Chrome/120.0.0.0 Safari/537.36", "UA 版本号原样（IPv4 规则证伪）");
+assert.equal(sanitizeErrorText("order 1234567890123456 paid"), "order 1234567890123456 paid", "16 位订单号原样");
+
+// 性能护栏：大文本全链无灾难性回溯（宽松上限防 CI 抖动，非基准测试）
+{
+  const big = "postgres://admin:s3cret@db.example.com error jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.SflKxwRJSMeKKF2QT4fwpM\n".repeat(10000);
+  const t0 = Date.now();
+  sanitizeErrorText(big);
+  const cost = Date.now() - t0;
+  assert.ok(cost < 1000, `约 1MB 文本脱敏耗时 ${cost}ms < 1000ms（防回溯退化）`);
+}
+
 // M4 配置归一化：askRemindMin / quietHours.allowKinds
 assert.equal(normalizeConfig({ askRemindMin: 3 }).askRemindMin, 3, "审批提醒分钟可配");
 assert.equal(normalizeConfig({ askRemindMin: 0 }).askRemindMin, 0, "0=关闭审批提醒");

--- a/packages/dsh-notifier/test/smoke.ts
+++ b/packages/dsh-notifier/test/smoke.ts
@@ -203,6 +203,48 @@ assert.equal(sanitizeErrorText("order 1234567890123456 paid"), "order 1234567890
   assert.ok(cost < 1000, `约 1MB 文本脱敏耗时 ${cost}ms < 1000ms（防回溯退化）`);
 }
 
+// 性能护栏（对抗形态）：多 BEGIN 无 END 输入曾因完整块规则 O(k·n) 阻塞宿主数秒
+// （评审实测 1MB 高密度 BEGIN 6-17s），限窗 {0,4096} 后必须保持线性量级
+{
+  const adversarial = "-----BEGIN PRIVATE KEY-----".repeat(20000); // 约 560KB
+  const t0 = Date.now();
+  const out = sanitizeErrorText(adversarial);
+  const cost = Date.now() - t0;
+  assert.ok(cost < 5000, `对抗输入（2 万 BEGIN 无 END）脱敏耗时 ${cost}ms < 5000ms（防 PEM 回溯回归）`);
+  assert.ok(out.startsWith("<private-key>"), "对抗输入由孤立 BEGIN 兜底规则接住");
+}
+
+// ---- 评审修复回归：PEM 限窗 / 赋值分隔符收紧 / amqps ----
+
+// PEM 完整块在窗口内仍整体打码；超窗伪块由孤立 BEGIN 兜底接住
+{
+  const pad = "A".repeat(5000);
+  assert.equal(
+    sanitizeErrorText(`-----BEGIN RSA PRIVATE KEY-----\n${pad}\n-----END RSA PRIVATE KEY-----\nok`),
+    "<private-key>",
+    "PEM 超 4096 窗口的真实长块：完整块失配后由兜底规则整体掩蔽到文本尾"
+  );
+  assert.equal(
+    sanitizeErrorText("前 -----BEGIN PRIVATE KEY-----\nMIIEow\n-----END RSA PRIVATE KEY----- 后续可读"),
+    "前 <private-key> 后续可读",
+    "PEM 窗口内完整块打码且块后内容保留可读"
+  );
+}
+
+// 密钥赋值规则：分隔符 [=:] 必须显式——自然语言不得误伤（评审 P1 回归）
+assert.equal(sanitizeErrorText("auth failed: token expired"), "auth failed: token expired", "自然语言 token expired 不误伤");
+assert.equal(sanitizeErrorText("request rejected: invalid token provided"), "request rejected: invalid token provided", "invalid token provided 不误伤");
+assert.equal(sanitizeErrorText("password policy requires changes"), "password policy requires changes", "password policy 不误伤");
+assert.equal(sanitizeErrorText("Authorization header missing"), "Authorization header missing", "Authorization header 不误伤");
+// 显式赋值形态仍打码（含「键名: 空格 值」与引号形态）
+assert.equal(sanitizeErrorText("token: abc123"), "token=<redacted>", "显式冒号赋值仍打码");
+assert.equal(sanitizeErrorText('password = "s3cr3t"'), 'password=<redacted>"', "等号带空格+引号赋值仍打码（收尾引号残留为已知形态）");
+assert.ok(!sanitizeErrorText("api_key=sk-live-9f8e7d6c5b4a").includes("sk-live"), "api_key= 赋值仍打码");
+
+// amqps 连接串凭据：scheme 保留、凭据整体掩蔽（评审 P2 回归，不再半脱敏）
+assert.equal(sanitizeErrorText("amqps://guest:guest@rabbit.local/vhost"), "amqps://<redacted>@rabbit.local/vhost", "amqps 连接串整体掩蔽");
+assert.equal(sanitizeErrorText("AMQPS://u:p@h/v"), "AMQPS://<redacted>@h/v", "amqps 大写 scheme 掩蔽");
+
 // M4 配置归一化：askRemindMin / quietHours.allowKinds
 assert.equal(normalizeConfig({ askRemindMin: 3 }).askRemindMin, 3, "审批提醒分钟可配");
 assert.equal(normalizeConfig({ askRemindMin: 0 }).askRemindMin, 0, "0=关闭审批提醒");


### PR DESCRIPTION
## 概述

Closes #6。

基于独立子 agent 对抗性评审（正则行为全部实测）落地，两条主线：

### A. 脱敏强化 `sanitizeErrorText`（issue 诉求 1）

- 改为**有序规则表**驱动（顺序即数据），顺序硬约束经实测确立：DSN 先于令牌/密钥赋值规则、邮箱殿后
- 新增：GitHub PAT（classic 五前缀恰 36 位 + fine-grained 区间长度）、PEM 私钥块（含孤立 BEGIN 兜底，覆盖错误消息截断常态）、数据库/消息队列连接串凭据（scheme 保留；支持 redis 空用户名与大写 scheme）、严格版邮箱（排除 `image@2x.png`/`pkg@1.2.3` 误伤）
- **审批理由与提问文本接入脱敏**（120 字符截断）——评审发现这两条路径最常内嵌命令回显与凭据却完全不脱敏，堵住干流
- 已证伪不收录并在 README 记录理由：IPv4（UA 版本号同形）、手机号（订单号同形）、信用卡（13 位毫秒时间戳 100% 命中）
- 维持契约：纯函数、`maxLen` 截断、零依赖

### B. Windows 系统通知（issue 诉求 2 的路线修正）

issue 原提议接入 BurntToast；评审实测发现**真病根是 fallback 的 AppId 未注册**——裸 AUMID 未在 `HKCU\SOFTWARE\Classes\AppUserModelId` 注册时 Win10/11 会静默丢弃 toast，而 BurntToast「开箱能弹」仅因模块加载时自动写该注册表键。引入 BurntToast 反而带来 AppId 不一致（操作中心双来源）、非终止错误逃过 catch、每次 spawn 重付模块扫描开销、隐性注册表写入等问题。故本 PR 采用更轻的修法：

- `toast.ps1` 启动时幂等注册 AUMID（HKCU，无需管理员权限），保留现有零依赖 WinRT 实现

### 测试与文档

- smoke 补齐约 30 个用例：PAT 长度边界、PEM 变体、DSN $1 组号回归、规则顺序交互、FP 证伪回归、截断窗口腰斩、Symbol 入参容错、约 1MB 文本性能护栏
- README 中英双语「安全与边界」同步覆盖类别/占位符/不收录理由/AUMID 行为
- 门禁四连全绿：`pnpm build && pnpm test && pnpm contract && pnpm pack:check`