### PR TITLE
refactor(dsh-web-file-preview): 自写 MIME 表改用 mime 库 (#12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "c8": "^12.0.0",
     "esbuild": "^0.28.2",
     "http-proxy": "1.18.1",
+    "mime": "^4.1.0",
     "selfsigned": "^2.4.1",
     "typescript": "^7.0.2"
   },

--- a/packages/dsh-web-file-preview/src/mime.ts
+++ b/packages/dsh-web-file-preview/src/mime.ts
@@ -1,15 +1,18 @@
 /**
  * dsh-web-file-preview — 文件类型分组判定（纯函数，可单测）。
  *
- * 后缀→预览分组复用 `src/grouping.ts` 单一事实源（与浏览器端共用）；Content-Type
- * 由本地小型映射提供（无需引入 mime-db 大表，避免宿主端第三方依赖被 esbuild 内联
- * 时的 ESM/CJS 兼容问题，保持零运行时依赖）。
+ * 后缀→预览分组复用 `src/grouping.ts` 单一事实源（与浏览器端共用）；图片组
+ * Content-Type 由成熟开源库 `mime` 提供（mime-db 全表，issue #12 / 决策 #47
+ * approved：消除自写映射表的维护漂移；构建期由 esbuild 内联进产物，仍保持
+ * 零运行时依赖）。
  *  - image        → 浏览器可解码的图片（直接 <img>）
  *  - renderedMd   → Markdown（marked 渲染，可切原始）
  *  - renderedCode → 代码类（highlight.js 高亮，可切原始）
  *  - text         → 其它纯文本（等宽 <pre>）
  *  - other        → 其余二进制，提示不可预览
  */
+
+import mime from "mime";
 
 import { groupOfPath } from "./grouping.js";
 
@@ -24,19 +27,6 @@ export interface PreviewKind {
   contentType: string;
 }
 
-/** 图片后缀 → Content-Type（与 grouping IMAGE_EXTS 对应）。 */
-const IMAGE_CONTENT_TYPE: Record<string, string> = {
-  png: "image/png",
-  jpg: "image/jpeg",
-  jpeg: "image/jpeg",
-  gif: "image/gif",
-  webp: "image/webp",
-  svg: "image/svg+xml",
-  avif: "image/avif",
-  bmp: "image/bmp",
-  ico: "image/x-icon",
-};
-
 /**
  * 按文件路径（或其 basename）判定预览分组与 Content-Type。
  * @param path - 请求的文件路径（只看扩展名）。
@@ -44,7 +34,10 @@ const IMAGE_CONTENT_TYPE: Record<string, string> = {
 export function previewKindOf(path: string): PreviewKind {
   const { group, ext } = groupOfPath(path);
   if (group === "image") {
-    return { group: "image", ext, contentType: IMAGE_CONTENT_TYPE[ext] ?? "application/octet-stream" };
+    // mime.getType 自带小写归一；未知后缀回退 octet-stream（与原自写表兜底一致）。
+    // 注：ico 由自写表的 image/x-icon 变为 mime-db 标准值 image/vnd.microsoft.icon，
+    // 浏览器 <img> 与 Content-Type 嗅探均兼容，无行为回归。
+    return { group: "image", ext, contentType: mime.getType(ext) ?? "application/octet-stream" };
   }
   if (group === "md") {
     return { group: "renderedMd", ext, contentType: "text/markdown; charset=utf-8" };

--- a/packages/dsh-web-file-preview/test/smoke.ts
+++ b/packages/dsh-web-file-preview/test/smoke.ts
@@ -92,6 +92,12 @@ assert.equal(previewKindOf("a.js").group, "renderedCode", "代码渲染组");
 assert.equal(previewKindOf("hello.md").contentType, "text/markdown; charset=utf-8");
 assert.equal(previewKindOf("a.txt").group, "text");
 assert.equal(previewKindOf("a.exe").group, "other");
+// issue #12：图片组 Content-Type 改由 mime 库提供——精确值逐项断言（原自写表等价映射）。
+assert.equal(previewKindOf("a.png").contentType, "image/png");
+assert.equal(previewKindOf("a.webp").contentType, "image/webp");
+assert.equal(previewKindOf("a.svg").contentType, "image/svg+xml");
+assert.equal(previewKindOf("a.avif").contentType, "image/avif");
+assert.equal(previewKindOf("dir/a.JPG").contentType, "image/jpeg", "大小写不敏感且走 mime 库");
 
 assert.equal(normalizeConfig(undefined).enabled, true, "默认启用");
 assert.equal(normalizeConfig(undefined).maxTextBytes, DEFAULT_CONFIG.maxTextBytes, "默认文本上限");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       http-proxy:
         specifier: 1.18.1
         version: 1.18.1(debug@2.6.9(supports-color@7.2.0))
+      mime:
+        specifier: ^4.1.0
+        version: 4.1.0
       selfsigned:
         specifier: ^2.4.1
         version: 2.4.1
@@ -832,6 +835,11 @@ packages:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
+  mime@4.1.0:
+    resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
@@ -1471,6 +1479,8 @@ snapshots:
   marked@18.0.9: {}
 
   mime-db@1.54.0: {}
+
+  mime@4.1.0: {}
 
   minimatch@10.2.6:
     dependencies:


### PR DESCRIPTION
## 概要

dsh-web-file-preview 宿主端图片组 Content-Type 判定由自写 `IMAGE_CONTENT_TYPE` 映射表改为成熟开源库 `mime@4.1.0`（mime-db 全表），消除自写表与 mime-db 的维护漂移。

Closes #12

## 决策依据

- 新增第三方依赖属仓库红线，决策 issue **#47 已获 approved** 标签，本 PR 在获批边界内执行。
- 遵循「优先引入成熟开源库」纪律：mime 为业界标准实现（零依赖、活跃维护、ESM 原生）；构建期由 esbuild 内联进产物，运行时 dependencies 保持空。

## 改动

- `packages/dsh-web-file-preview/src/mime.ts`：删除自写图片 Content-Type 表，改用 `mime.getType(ext)`；未知后缀仍回退 `application/octet-stream`。
- 对外导出面不变：`previewKindOf` / `PreviewKind` / `PreviewGroup` 签名一致，调用点（routes.ts / index.ts）无改动。
- 纯宿主端改动，客户端不受影响。
- smoke 补 image 组精确 contentType 断言（png/webp/svg/avif/大小写不敏感），断言强度不降。
- `package.json` 仅 devDependencies 新增 `mime: ^4.1.0` + lockfile 变更。

## 行为差异说明

仅 `ico` 一项：`image/x-icon` → `image/vnd.microsoft.icon`（mime-db 标准值），浏览器 `<img>` 与嗅探均兼容，无测试/调用点依赖旧值。

## 发布物边界验证

- [x] 运行时 dependencies 保持为空（内联路径）
- [x] `lib/index.js` 已内联 mime（产物含 getType 调用链）
- [x] `lib/THIRD-PARTY-LICENSES` 含 `mime@4.1.0 — MIT` 条目，pack:check 断言覆盖通过

## 验收勾选（issue #12）

- [x] `pnpm add -D -w mime`（devDependencies 内联路径）
- [x] src/mime.ts 引用 mime 库，对外函数签名与调用点不变
- [x] 保留现有 mime 相关断言并按 mime 库输出补强，强度不降
- [x] 客户端不受影响；THIRD-PARTY-LICENSES 归集覆盖 mime 库
- [x] 五连门禁全绿：pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck