### PR TITLE
fix(dsh-notifier): PR #24 评审遗留四项（尖括号邮箱/AUMID/taskTitle 脱敏/SHA 已知行为）

### DIFF
--- a/packages/dsh-notifier/README.en.md
+++ b/packages/dsh-notifier/README.en.md
@@ -138,6 +138,7 @@ be able to resolve these official packages (skipping type checking is unaffected
   - Secret field assignments (`password=`/`token=`/`api_key=`…; an explicit `=`/`:` separator is required) → `key=<redacted>`
   - Email addresses → `<email>`
   - **Approval reasons and question texts** are redacted too (truncated to 120 chars) — these most often embed command echo and credential fragments
+  - **Known trade-off (rule intentionally unchanged)**: 40-char git commit SHAs are indistinguishable from "≥24-char hex secrets" and get masked to `<token>` by the generic long-run rule (e.g. `HEAD detached at abc0123…` → `HEAD detached at <token>`), losing the lookup value of error messages. The false positive is accepted in exchange for secret coverage: a SHA-scenario whitelist would be unreliable (40-hex cannot be told apart from real secrets by shape), so this is documented as known behavior only
   - Proven false-positive-prone, deliberately not covered: IPv4 (same shape as UA version numbers), phone numbers (same shape as order IDs), credit cards (13-digit millisecond timestamps match at 100%)
 - System notification failures are silent (logs only), and do not affect the main flow; a missing / non-executable native binary (ENOENT etc.) is caught by the `error` event and **never bubbles up as an unhandled error that crashes the host process** (see issue #1)
 - **The two channels are delivered to different machines (don't confuse them)**:

--- a/packages/dsh-notifier/README.en.md
+++ b/packages/dsh-notifier/README.en.md
@@ -146,7 +146,7 @@ be able to resolve these official packages (skipping type checking is unaffected
 - **iOS difference**: Safari's normal tabs have no Web Notifications API (only the "Add to Home Screen" PWA does); on iOS the available channels are "in-page banner + sound when the page is visible" and system notifications after HTTPS + A2HS
 - Browser notifications require a **secure context** (HTTPS or localhost); LAN HTTP access automatically routes through the fallback channel (banner / sound / title reminder)
 - Browser notification permission is requested within a gesture (when clicking the sidebar "Notifications" entry or a panel button)
-- Windows system notifications are implemented via a PowerShell WinRT script, with the command passed as a parameter array (no shell concatenation surface); the script idempotently registers the AppUserModelId on startup (HKCU, no admin required) — an unregistered AUMID gets toasts silently dropped by Windows 10/11
+- Windows system notifications are implemented via a PowerShell WinRT script, with the command passed as a parameter array (no shell concatenation surface); the script idempotently registers the AppUserModelId `DSH.dsh-notifier` on startup (HKCU, no admin required) — an unregistered AUMID gets toasts silently dropped by Windows 10/11. The AUMID follows the `Company.Product` convention to avoid collisions in the public namespace (`HKCU\SOFTWARE\Classes\AppUserModelId`) where same-named apps overwrite each other's display names; a legacy `DSH` key registered by older versions is harmless leftover (just an empty registry entry, does not affect new toasts) and can be removed manually with `Remove-Item -Path "HKCU:\SOFTWARE\Classes\AppUserModelId\DSH"` if desired
 
 ## Verification
 

--- a/packages/dsh-notifier/README.md
+++ b/packages/dsh-notifier/README.md
@@ -132,6 +132,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-notifier
   - 密钥字段赋值（`password=`/`token=`/`api_key=`…，须带显式 `=`/`:` 分隔符）→ `键名=<redacted>`
   - 邮箱 → `<email>`
   - **审批理由与提问文本**同样经脱敏（120 字符截断）——这两类文本最常内嵌命令回显与凭据片段
+  - **已知取舍（不修正则）**：40 位 git commit SHA 与「≥24 位 hex 密钥」同形不可区分，会被通用长串规则打码为 `<token>`（如 `HEAD detached at abc0123…` → `HEAD detached at <token>`），损失错误消息的可查性。接受误伤换取密钥覆盖面：SHA 场景白名单不可靠（40 hex 与真密钥无法凭形态区分），故仅在此记录为已知行为
   - 已证伪不收录（高频误伤）：IPv4（UA 版本号同形）、手机号（订单号同形）、信用卡（13 位毫秒时间戳 100% 命中）
 - 系统通知失败静默（仅日志），不影响主流程；原生二进制缺失/不可执行（ENOENT 等）
   会被 `error` 事件接住，**绝不冒泡成 unhandled error 把宿主进程打挂**（见 issue #1）

--- a/packages/dsh-notifier/README.md
+++ b/packages/dsh-notifier/README.md
@@ -142,7 +142,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-notifier
   才有）；iOS 上可用通道为「页面可见时横幅 + 提示音」及 HTTPS+A2HS 后的系统通知
 - 浏览器通知需要**安全上下文**（HTTPS 或 localhost）；局域网 HTTP 访问自动走降级通道（横幅/提示音/标题提醒）
 - 浏览器通知权限为手势内请求（点击侧边栏「通知」入口或面板按钮时）
-- Windows 系统通知通过 PowerShell WinRT 脚本实现，命令以参数数组传递（无 shell 拼接面）；脚本启动时幂等注册 AppUserModelId（HKCU，无需管理员权限）——未注册的 AUMID 在 Win10/11 上 toast 会被系统静默丢弃
+- Windows 系统通知通过 PowerShell WinRT 脚本实现，命令以参数数组传递（无 shell 拼接面）；脚本启动时幂等注册 AppUserModelId `DSH.dsh-notifier`（HKCU，无需管理员权限）——未注册的 AUMID 在 Win10/11 上 toast 会被系统静默丢弃。AUMID 采用 `Company.Product` 形态，避免在公共命名空间（`HKCU\SOFTWARE\Classes\AppUserModelId`）与其他同名软件冲突互覆；历史版本注册的旧键 `DSH` 残留无害（仅一个空注册表条目，不影响新 toast），如需清理可手动执行 `Remove-Item -Path "HKCU:\SOFTWARE\Classes\AppUserModelId\DSH"`
 
 ## 验证
 

--- a/packages/dsh-notifier/src/message.ts
+++ b/packages/dsh-notifier/src/message.ts
@@ -196,8 +196,13 @@ export function prettyToolName(name: unknown): string {
  * 提取会话标题（用户可读的任务名，替代内部 session id）。
  * 数据源：agent.session.events 中最后一个 session/title 事件（dsh-session-title
  * 官方插件维护，与 GUI 会话列表同源）。无标题（新会话/未生成）返回 undefined。
+ * 标题源自会话内容、可携带敏感片段（凭据/路径/邮箱等），返回前经
+ * sanitizeErrorText 脱敏再截断 40 字符（先打码后截断：避免长敏感串被腰斩成
+ * 不满足规则阈值的残段漏网）；本函数是全部 taskTitle 的唯一来源，在此单点
+ * 接入即覆盖 NOTIFY_KINDS 全部模板拼接与历史落盘（issue #30）。正常标题
+ * 不含敏感特征、脱敏后原样透传，可读性不受影响。
  * @param agent Agent 对象（事件 payload.agent）。
- * @returns 截断 40 字符的标题。
+ * @returns 脱敏并截断 40 字符的标题。
  */
 export function sessionTitleOf(agent: Agent | undefined): string | undefined {
   try {
@@ -209,7 +214,7 @@ export function sessionTitleOf(agent: Agent | undefined): string | undefined {
       const ev = events[i] as { type: unknown; data?: { title?: unknown } } | undefined;
       if (ev?.type === "session/title" && typeof ev.data?.title === "string") {
         const title = ev.data.title.trim();
-        return title.length > 0 ? title.slice(0, 40) : undefined;
+        return title.length > 0 ? sanitizeErrorText(title, 40) : undefined;
       }
     }
   } catch {

--- a/packages/dsh-notifier/src/message.ts
+++ b/packages/dsh-notifier/src/message.ts
@@ -49,8 +49,9 @@ export function formatDuration(ms: number): string {
  * 顺序硬约束（对抗评审实测确立）：
  * - DSN 必须先于 JWT/通用长串/密钥赋值：否则 DSN 密码先被劣化为 <token>，
  *   DSN 字符类排除 <> 随即失配，用户名残留明文；
- * - 邮箱必须殿后且带 (?<!<) 界定：避免把 DSN 掩码占位符 <redacted>@host
- *   中的 "redacted@host" 再误判为邮箱产生 <<email>>。
+ * - 邮箱必须殿后且带双负向后行断言（词字符 + 字面 <redacted）界定：避免把
+ *   DSN 掩码占位符 <redacted>@host 中的 "redacted@host" 再误判为邮箱产生
+ *   <<email>>；不整体排除 <，使尖括号引用形态 <user@host> 正常打码。
  * 已证伪不收录（勿加回）：IPv4（UA 版本号 Chrome/120.0.0.0 形态不可区分，
  * 误伤高频）、手机号（订单号误伤、错误文本出现概率趋零）、信用卡
  * （13 位毫秒时间戳 100% 命中，Luhn 校验也救不了）。
@@ -91,8 +92,11 @@ const SANITIZE_RULES: ReadonlyArray<readonly [RegExp, string]> = [
   // 高频误伤成 token=<redacted>（审批理由/提问文本接入后误伤面被放大，评审实测）
   [/\b(password|passwd|token|api[_-]?key|secret|authorization)\b\s*[=:]\s*["']?[^\s"'`,;<>]{3,}/giu, "$1=<redacted>"],
   // 邮箱（严格版：域名首标签须字母开头，排除 image@2x.png / pkg@1.2.3 误伤）→ <email>
-  // 负向后行断言排除词字符与 <：防止从 <redacted>@host 占位符中间起配
-  [/(?<![A-Za-z0-9._%+<>-])[A-Za-z0-9._%+-]+@[A-Za-z][A-Za-z0-9.-]*\.[A-Za-z]{2,}/gu, "<email>"],
+  // 双负向后行断言：① 词字符——防止从占位符/单词中间起配；② 字面 <redacted
+  // ——防止把 DSN 掩码占位符 <redacted>@host 再误判为邮箱产生 <<email>>。
+  // 不整体排除 <：否则尖括号引用形态 <user@host> 整体漏网明文泄漏（issue #30）；
+  // 占位符顺序约束由断言②单独保住。
+  [/(?<![A-Za-z0-9._%+-])(?<!<redacted)[A-Za-z0-9._%+-]+@[A-Za-z][A-Za-z0-9.-]*\.[A-Za-z]{2,}/gu, "<email>"],
 ];
 
 /**

--- a/packages/dsh-notifier/src/toast.ps1
+++ b/packages/dsh-notifier/src/toast.ps1
@@ -7,11 +7,15 @@ param(
 # 失败静默退出（exit 1），宿主只记录日志；不抛出阻塞调用方。
 # -Silent：在 toast XML 中追加 <audio silent="true"/> 静默弹出（用于 notifySound=false）。
 $ErrorActionPreference = "Stop"
-# AUMID 自举：CreateToastNotifier("DSH") 用的 AppUserModelId 若未在
+# AUMID 自举：CreateToastNotifier("DSH.dsh-notifier") 用的 AppUserModelId 若未在
 # HKCU 注册，Win10/11 会静默丢弃 toast（不报错也不弹出）。幂等写 HKCU 键
 # （含 DisplayName 供操作中心显示可读名），无需管理员权限；失败不阻断弹窗尝试。
+# AUMID 用 Company.Product 形态（HKCU\...\AppUserModelId 是公共命名空间，
+# 裸名 DSH 易与其他软件冲突互覆）；历史版本注册的旧键 DSH 残留无害
+# （仅一个空注册表条目），可手动清理：
+#   Remove-Item -Path "HKCU:\SOFTWARE\Classes\AppUserModelId\DSH"
 try {
-  $appIdKey = New-Item -Path "HKCU:\SOFTWARE\Classes\AppUserModelId\DSH" -Force
+  $appIdKey = New-Item -Path "HKCU:\SOFTWARE\Classes\AppUserModelId\DSH.dsh-notifier" -Force
   $null = $appIdKey.SetValue("DisplayName", "DSH", "String")
 } catch {
   # 注册表不可写等场景仍尝试弹窗（旧版 Windows 未注册也可能成功）
@@ -30,7 +34,7 @@ try {
     $null = $template.DocumentElement.AppendChild($audioNode)
   }
   $toast = New-Object Windows.UI.Notifications.ToastNotification $template
-  [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("DSH").Show($toast) | Out-Null
+  [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("DSH.dsh-notifier").Show($toast) | Out-Null
   exit 0
 } catch {
   exit 1

--- a/packages/dsh-notifier/test/unit-sanitize.test.ts
+++ b/packages/dsh-notifier/test/unit-sanitize.test.ts
@@ -98,6 +98,18 @@ assert.equal(
   "mysql://<redacted>@db.example.com down",
   "DSN 与邮箱规则顺序回归"
 );
+// 尖括号引用形态（issue #30）：双断言放行 <user@host>，不再整体漏网
+assert.equal(
+  sanitizeErrorText("From: John <john.doe@corp.example.com> signed"),
+  "From: John <<email>> signed",
+  "尖括号包裹的真实邮箱正常打码"
+);
+// 占位符不被二次破坏（issue #30）：裸 <redacted>@真实域名 形态必须原样保留
+assert.equal(
+  sanitizeErrorText("<redacted>@db.example.com down"),
+  "<redacted>@db.example.com down",
+  "DSN 掩码占位符不被邮箱规则二次命中"
+);
 
 // 规则顺序硬约束回归
 assert.equal(

--- a/packages/dsh-notifier/test/unit-text.test.ts
+++ b/packages/dsh-notifier/test/unit-text.test.ts
@@ -47,9 +47,30 @@ assert.equal(sessionTitleOf({ id: "session-1" }), undefined, "无 session 返回
 assert.equal(sessionTitleOf(undefined), undefined, "无 agent 返回 undefined");
 assert.equal(sessionTitleOf({ id: "session-1", session: { events: "bad" } }), undefined, "events 非数组容错");
 assert.equal(
-  sessionTitleOf({ session: { events: [{ type: "session/title", data: { title: "x".repeat(80) } }] } }),
-  "x".repeat(40),
+  sessionTitleOf({ session: { events: [{ type: "session/title", data: { title: "优".repeat(80) } }] } }),
+  "优".repeat(40),
   "标题截断 40 字符"
+);
+
+// sessionTitleOf 接入脱敏链（issue #30）：标题源自会话内容，进入通知与历史前
+// 敏感片段必须打码；正常标题不含敏感特征、脱敏后原样透传保持可读
+assert.ok(
+  !sessionTitleOf({ session: { events: [{ type: "session/title", data: { title: `修复 ${"a".repeat(48)} 泄漏` } }] } })!.includes("aaaa"),
+  "标题中长 hex 密钥片段被打码为 <token>"
+);
+assert.equal(
+  sessionTitleOf({ session: { events: [{ type: "session/title", data: { title: `修复 ${"f".repeat(30)} 泄漏` } }] } }),
+  "修复 <token> 泄漏",
+  "≥24 位 hex 长串在标题中打码"
+);
+assert.ok(
+  !sessionTitleOf({ session: { events: [{ type: "session/title", data: { title: "联系 admin@corp.example.com 处理部署" } }] } })!.includes("admin@"),
+  "标题中邮箱地址被打码为 <email>"
+);
+assert.equal(
+  sessionTitleOf(titledAgent),
+  "优化 notifier 插件",
+  "正常标题脱敏后原样透传（可读性不受影响）"
 );
 
 // loopback 围栏：回环放行、非回环拒绝


### PR DESCRIPTION
Closes #30

按 issue #30 四个 P3 遗留子项独立实现、独立 commit：

## 变更清单

- [x] **1. 尖括号邮箱脱敏**（b96a5bf）：邮箱规则负向后行断言改双断言 `(?<![A-Za-z0-9._%+-])(?<!<redacted)`——字面占位符断言保住 DSN 掩码 `<redacted>@host` 顺序约束，不再整体排除 `<`，尖括号引用形态正常打码。smoke 正反用例：`From: John <john.doe@corp.example.com> signed` → 打码；裸 `<redacted>@db.example.com` 占位符原样保留
- [x] **2. Windows AUMID 改 `DSH.dsh-notifier`**（540178a）：toast.ps1 注册键与 CreateToastNotifier 参数同步更新（不一致 toast 会被静默丢弃）；双语文档同步，注明历史旧键 `DSH` 残留无害及手动清理方式
- [x] **3. taskTitle 接入脱敏**（90041b3）：sessionTitleOf 是全部 taskTitle 的唯一来源，返回前单点复用 sanitizeErrorText（保守方案：先打码后截断，不新增配置、不改调用方），覆盖 NOTIFY_KINDS 全部模板拼接与历史落盘。smoke：标题中 ≥24 位 hex / 邮箱片段被打码，正常标题原样可读
- [x] **4. SHA 误伤记录为已知行为**（d303029）：双语文档明确 40 位 commit SHA 与「≥24 位 hex 密钥」同形不可区分、会被长串规则打码为 `<token>`，属已知取舍，正则不改动

## 验证

worktree 内五连门禁全绿：`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck`

## 红线确认

未触碰 .github/、package.json 依赖清单、pnpm-lock.yaml、shared/、types 层。