### PR TITLE
feat(dsh-provider-usage): 设置页按提供商重构 + 适配器注入容错补强 (#38)

### DIFF
--- a/packages/dsh-provider-usage/src/client-logic.ts
+++ b/packages/dsh-provider-usage/src/client-logic.ts
@@ -100,3 +100,52 @@ export function rendererLookupKeys(provider: string, adapterId?: string): string
   if (adapterId !== undefined && adapterId !== "") return [`${provider}/${adapterId}`, provider];
   return [provider];
 }
+
+// ------------------------------------------------------------------ 设置页·提供商全集（issue #38）
+
+/** 提供商全集合并的输入（全部来自 adapters.json 响应 + 宿主已知清单）。 */
+export interface ProvidersUnionInput {
+  /** provider → 已注册候选列表（adapters.json host[] 按 providers 分组）。 */
+  candidatesByProvider: Record<string, Array<{ id: string; label: string; source: string }>>;
+  /** 运行时启用映射（provider → adapterId）。 */
+  enabled?: Record<string, string>;
+  /** 内置已知清单（宿主 knownProviders；无候选也展示并给引导）。 */
+  known: string[];
+}
+
+/** 提供商列表项（设置页手风琴一行的数据面）。 */
+export interface ProviderListItem {
+  provider: string;
+  /** 是否有已注册候选（false = 仅出现在已知清单，需展示引导文案）。 */
+  hasCandidates: boolean;
+  /** 当前启用 adapterId（null = 未启用/已清空）。 */
+  enabledId: string | null;
+}
+
+/**
+ * 提供商全集 = 已注册候选覆盖 ∪ 运行时启用映射 ∪ 内置已知清单（issue #38）。
+ * 排序：内置已知在前（引导位），其余按字典序；逐项带候选存在性与启用态，
+ * 面板直接渲染，不再自行拼装。
+ */
+export function unionProviders(input: ProvidersUnionInput): ProviderListItem[] {
+  const providers = new Set<string>();
+  for (const p of Object.keys(input.candidatesByProvider)) providers.add(p);
+  for (const p of Object.keys(input.enabled ?? {})) providers.add(p);
+  for (const p of input.known) providers.add(p);
+  const knownSet = new Set(input.known);
+  const sorted = [...providers].sort((a, b) => {
+    const ka = knownSet.has(a) ? 0 : 1;
+    const kb = knownSet.has(b) ? 0 : 1;
+    return ka !== kb ? ka - kb : a.localeCompare(b);
+  });
+  return sorted.map((provider) => ({
+    provider,
+    hasCandidates: (input.candidatesByProvider[provider]?.length ?? 0) > 0,
+    enabledId: input.enabled?.[provider] ?? null,
+  }));
+}
+
+/** 折叠态徽标文案（issue #38：显示「启用中: <adapter-id>」或「未启用」）。 */
+export function providerBadgeText(item: Pick<ProviderListItem, "enabledId">): string {
+  return item.enabledId !== null ? `启用中: ${item.enabledId}` : "未启用";
+}

--- a/packages/dsh-provider-usage/src/client/core.ts
+++ b/packages/dsh-provider-usage/src/client/core.ts
@@ -25,6 +25,7 @@ export const STATS_URL = __DSH_ROUTES__?.stats ?? "/api/dsh-provider-usage/stats
 export const HISTORY_URL = __DSH_ROUTES__?.history ?? "/api/dsh-provider-usage/history";
 export const ADAPTERS_URL = __DSH_ROUTES__?.adapters ?? "/api/dsh-provider-usage/adapters.json";
 export const SELECT_URL = __DSH_ROUTES__?.select ?? "/api/dsh-provider-usage/adapters/select";
+export const ADD_URL = __DSH_ROUTES__?.add ?? "/api/dsh-provider-usage/adapters/add";
 
 /** 会话提供信息（sessions.currentProvideInfo 的读面，宽松类型）。 */
 export interface SessionMaybeProvide {

--- a/packages/dsh-provider-usage/src/client/settings.ts
+++ b/packages/dsh-provider-usage/src/client/settings.ts
@@ -1,17 +1,22 @@
 /**
- * dsh-provider-usage — 设置面板独立 tab「用量统计」（M3b）。
+ * dsh-provider-usage — 设置面板独立 tab「用量统计」（M3b，issue #38 重构）。
  *
  * 经 slots.inject("settings.section") 注册顶层 tab，React 渲染四区：
- * - 总览：当前会话 provider 识别结果 + 生效适配器
- * - 用量可视化：summary 文案 + 各窗口明细表
- * - 适配器管理：按 provider 分组的候选列表（id/label/来源/enabled），单选切换启用
+ * - 总览：当前生效适配器逐 provider 摘要（enabled 映射驱动，保留）
+ * - 用量可视化：summary 文案 + 各窗口明细表（保留）
+ * - 提供商列表（替代原「适配器管理」平铺区块）：全集 = 已注册候选 ∪ 运行时
+ *   启用 ∪ 内置已知清单（无候选也展示并给引导）；折叠态徽标显示
+ *   「启用中: <adapter-id>」，展开页内管理候选适配器（名称/来源/启用开关单选）、
+ *   [禁用该提供商]、[+ 添加适配器]（本地文件路径登记并热注册）
  * - 配置：常用配置键展示（patch 层为单一事实源，此处只读）
  *
- * 数据面：全部走宿主 loopback 路由（/stats、/adapters.json、POST /adapters/select），
- * 不引入额外 RPC 通道。
+ * 数据面：全部走宿主 loopback 路由（/stats、/adapters.json、POST /adapters/select、
+ * POST /adapters/add），不引入额外 RPC 通道。
  */
 import * as React from "react";
-import { STATS_URL, ADAPTERS_URL, SELECT_URL } from "./core.js";
+import { STATS_URL, ADAPTERS_URL, SELECT_URL, ADD_URL } from "./core.js";
+import { unionProviders, providerBadgeText } from "../client-logic.js";
+import type { ProviderListItem } from "../client-logic.js";
 
 /** 候选条目（adapters.json host[]）。 */
 interface AdapterInfo {
@@ -23,11 +28,21 @@ interface AdapterInfo {
   enabled?: boolean;
 }
 
+/** 错误登记条目（adapters.json errors[]，issue #38）。 */
+interface AdapterErrorEntry {
+  key: string;
+  at: number;
+  kind: string;
+  message: string;
+}
+
 /** adapters.json 响应形状。 */
 interface AdaptersMeta {
   version?: number;
   host?: AdapterInfo[];
   enabled?: Record<string, string>;
+  knownProviders?: string[];
+  errors?: AdapterErrorEntry[];
 }
 
 /** /stats 响应中本页消费的字段。 */
@@ -38,6 +53,13 @@ interface StatsView {
   hasAdapter?: boolean;
   summary?: { text?: string; level?: string; hint?: string } | null;
   usage?: { ok?: boolean; error?: string | null; windows?: Array<{ key: string; name: string; percent: number | null; limit?: number; resetsAt?: string }> } | null;
+}
+
+/** 添加适配器表单值。 */
+interface AddFormValue {
+  id: string;
+  label: string;
+  file: string;
 }
 
 async function jsonGet(url: string): Promise<unknown> {
@@ -104,7 +126,7 @@ function OverviewSection({ statsByProvider }: { statsByProvider: Record<string, 
               ? React.createElement(
                   "div",
                   { style: { color: "var(--dsw-alias-state-error-primary,#d64545)" } },
-                  "该提供商暂无启用的适配器——请在下方「适配器管理」启用一个候选。",
+                  "该提供商暂无启用的适配器——请在下方提供商列表中展开并启用。",
                 )
               : null,
           );
@@ -163,47 +185,263 @@ function UsageSection({ statsByProvider }: { statsByProvider: Record<string, Sta
   );
 }
 
-/** 适配器管理区：候选列表 + 单选启用。 */
-function AdapterSection({ meta, onSwitch, busy }: { meta: AdaptersMeta | null; onSwitch(provider: string, adapterId: string): void; busy: boolean }) {
-  const infos = meta?.host ?? [];
-  // 按 provider 分组
-  const byProvider = new Map<string, AdapterInfo[]>();
-  for (const info of infos) {
+/** 单个提供商手风琴项：折叠头（徽标）+ 展开管理区（候选单选/禁用/添加）。 */
+function ProviderItem({
+  item,
+  candidates,
+  errorByKey,
+  busy,
+  onSwitch,
+  onDisable,
+  onAdd,
+}: {
+  item: ProviderListItem;
+  candidates: Array<{ id: string; label: string; source: string }>;
+  errorByKey: Map<string, AdapterErrorEntry>;
+  busy: boolean;
+  onSwitch(provider: string, adapterId: string): void;
+  onDisable(provider: string): void;
+  onAdd(provider: string, form: AddFormValue): Promise<{ ok: boolean; detail?: string }>;
+}) {
+  const [open, setOpen] = React.useState<boolean>(false);
+  const [showAddForm, setShowAddForm] = React.useState<boolean>(false);
+  const [form, setForm] = React.useState<AddFormValue>({ id: "", label: "", file: "" });
+  const [addMsg, setAddMsg] = React.useState<string | null>(null);
+  const [addErr, setAddErr] = React.useState<boolean>(false);
+  const [adding, setAdding] = React.useState<boolean>(false);
+
+  const submitAdd = (): void => {
+    if (form.id.trim() === "" || form.label.trim() === "" || form.file.trim() === "" || busy || adding) return;
+    setAdding(true);
+    onAdd(item.provider, { id: form.id.trim(), label: form.label.trim(), file: form.file.trim() })
+      .then((r) => {
+        if (r.ok) {
+          setForm({ id: "", label: "", file: "" });
+          setShowAddForm(false);
+          setAddErr(false);
+          setAddMsg(null);
+        } else {
+          setAddErr(true);
+          setAddMsg(r.detail ?? "添加失败");
+        }
+      })
+      .catch(() => {
+        setAddErr(true);
+        setAddMsg("添加失败（网络错误）");
+      })
+      .finally(() => setAdding(false));
+  };
+
+  return React.createElement(
+    "div",
+    { className: "dou-provItem" },
+    // 折叠头：▸/▾ + provider 名 + 徽标（启用中: <adapter-id> / 未启用）
+    React.createElement(
+      "button",
+      {
+        type: "button",
+        className: "dou-provHead",
+        onClick: () => setOpen((v) => !v),
+        "aria-expanded": open,
+      },
+      React.createElement("span", { className: `dou-provArrow${open ? " dou-provArrowOpen" : ""}`, "aria-hidden": "true" }, "▸"),
+      React.createElement("span", { className: "dou-provName" }, item.provider),
+      React.createElement(
+        "span",
+        { className: `dou-provBadge${item.enabledId === null ? " dou-provBadgeOff" : ""}` },
+        providerBadgeText(item),
+      ),
+    ),
+    !open
+      ? null
+      : React.createElement(
+          "div",
+          { className: "dou-provBody" },
+          // 无候选引导（已知清单里的 provider 尚无任何适配器）
+          candidates.length === 0
+            ? React.createElement(
+                "div",
+                { className: "dou-hint" },
+                "该提供商暂无候选适配器——可通过下方 [+ 添加适配器] 注入本地适配器文件，或在 cordis.patch.yml 的 adapters.host 中配置。",
+              )
+            : candidates.map((c) => {
+                const err = errorByKey.get(c.id);
+                return React.createElement(
+                  "div",
+                  { key: c.id },
+                  React.createElement(
+                    "label",
+                    { className: "dou-radioRow" },
+                    React.createElement("input", {
+                      type: "radio",
+                      name: `dou-adm-${item.provider}`,
+                      checked: c.id === item.enabledId,
+                      disabled: busy,
+                      onChange: () => onSwitch(item.provider, c.id),
+                    }),
+                    React.createElement(
+                      "span",
+                      null,
+                      `${c.label}（${c.id}${c.source === "builtin" ? " · 内置" : " · 自定义"}）`,
+                    ),
+                  ),
+                  err !== undefined
+                    ? React.createElement("div", { className: "dou-provErr" }, `最近一次错误：${err.message}`)
+                    : null,
+                );
+              }),
+          // 操作行：禁用该提供商 / + 添加适配器
+          React.createElement(
+            "div",
+            { className: "dou-provActions" },
+            React.createElement(
+              "button",
+              {
+                type: "button",
+                className: "dou-btn",
+                disabled: busy || item.enabledId === null,
+                onClick: () => onDisable(item.provider),
+              },
+              "禁用该提供商",
+            ),
+            React.createElement(
+              "button",
+              {
+                type: "button",
+                className: "dou-btn",
+                disabled: busy,
+                onClick: () => {
+                  setShowAddForm((v) => !v);
+                  setAddMsg(null);
+                },
+              },
+              "+ 添加适配器",
+            ),
+          ),
+          // 添加表单（本期仅文件路径注入；粘贴 JS 落盘后续再加）
+          !showAddForm
+            ? null
+            : React.createElement(
+                "div",
+                { className: "dou-addForm" },
+                React.createElement(
+                  "div",
+                  { className: "dou-addField" },
+                  React.createElement("span", { className: "dou-addLabel" }, "适配器 ID"),
+                  React.createElement("input", {
+                    className: "dou-input",
+                    value: form.id,
+                    maxLength: 128,
+                    placeholder: "须与模块导出 id 一致",
+                    onChange: (e: unknown) => setForm((f) => ({ ...f, id: (e as { target: { value: string } }).target.value })),
+                  }),
+                ),
+                React.createElement(
+                  "div",
+                  { className: "dou-addField" },
+                  React.createElement("span", { className: "dou-addLabel" }, "展示名"),
+                  React.createElement("input", {
+                    className: "dou-input",
+                    value: form.label,
+                    maxLength: 128,
+                    placeholder: "如 My Relay 官方",
+                    onChange: (e: unknown) => setForm((f) => ({ ...f, label: (e as { target: { value: string } }).target.value })),
+                  }),
+                ),
+                React.createElement(
+                  "div",
+                  { className: "dou-addField" },
+                  React.createElement("span", { className: "dou-addLabel" }, "文件路径"),
+                  React.createElement("input", {
+                    className: "dou-input",
+                    value: form.file,
+                    placeholder: "~/.dsh/plugins/provider-usage/my-relay.mjs 或绝对路径",
+                    onChange: (e: unknown) => setForm((f) => ({ ...f, file: (e as { target: { value: string } }).target.value })),
+                  }),
+                ),
+                React.createElement(
+                  "div",
+                  { className: "dou-addField" },
+                  React.createElement("span", { className: "dou-addLabel" }, "归属提供商"),
+                  React.createElement("span", null, item.provider),
+                ),
+                addMsg !== null
+                  ? React.createElement("div", { className: addErr ? "dou-provErr" : "dou-hint" }, addMsg)
+                  : null,
+                React.createElement(
+                  "button",
+                  { type: "button", className: "dou-btn", disabled: busy || adding, onClick: submitAdd },
+                  adding ? "添加中…" : "确认添加",
+                ),
+              ),
+        ),
+  );
+}
+
+/** 提供商列表区（issue #38）：全集合并 + 手风琴展开管理。 */
+function ProviderListSection({
+  meta,
+  items,
+  busy,
+  onSwitch,
+  onDisable,
+  onAdd,
+}: {
+  meta: AdaptersMeta | null;
+  items: ProviderListItem[];
+  busy: boolean;
+  onSwitch(provider: string, adapterId: string): void;
+  onDisable(provider: string): void;
+  onAdd(provider: string, form: AddFormValue): Promise<{ ok: boolean; detail?: string }>;
+}) {
+  // host[] 按 providers 分组为候选映射
+  const candidatesByProvider = new Map<string, Array<{ id: string; label: string; source: string }>>();
+  for (const info of meta?.host ?? []) {
     for (const provider of info.providers) {
-      const list = byProvider.get(provider) ?? [];
-      list.push(info);
-      byProvider.set(provider, list);
+      const list = candidatesByProvider.get(provider) ?? [];
+      list.push({ id: info.id, label: info.label, source: info.source });
+      candidatesByProvider.set(provider, list);
     }
   }
+  const errorByKey = new Map<string, AdapterErrorEntry>();
+  for (const e of meta?.errors ?? []) errorByKey.set(e.key, e);
+  // 用户文件加载失败错误无 provider 归属（登记 key=file:<名>），在列表顶部全局展示一次
+  const fileErrors = [...errorByKey.entries()].filter(([k]) => k.startsWith("file:"));
+
   return React.createElement(
     "div",
     { style: sectionStyle },
-    React.createElement("h4", { style: titleStyle }, "适配器管理"),
-    byProvider.size === 0
-      ? React.createElement("div", { style: { color: "var(--dsw-alias-label-tertiary,#9aa0ab)" } }, "无已注册适配器")
-      : [...byProvider.entries()].map(([provider, candidates]) =>
+    React.createElement("h4", { style: titleStyle }, "提供商"),
+    React.createElement(
+      "div",
+      { className: "dou-hint" },
+      "提供商全集 = 已注册适配器 ∪ 运行时识别 ∪ 内置已知清单；展开某个提供商以切换/禁用其适配器或添加新适配器。",
+    ),
+    fileErrors.length > 0
+      ? fileErrors.map(([k, e]) =>
           React.createElement(
             "div",
-            { key: provider, style: { marginBottom: 8 } },
-            React.createElement("div", { style: { fontWeight: 600 } }, `provider：${provider}`),
-            ...candidates.map((c) =>
-              React.createElement(
-                "label",
-                { key: c.id, style: { display: "flex", alignItems: "center", gap: 6, cursor: busy ? "wait" : "pointer" } },
-                React.createElement("input", {
-                  type: "radio",
-                  name: `dou-adm-${provider}`,
-                  checked: c.enabled === true,
-                  disabled: busy,
-                  onChange: () => onSwitch(provider, c.id),
-                }),
-                React.createElement(
-                  "span",
-                  null,
-                  `${c.label}（${c.id}${c.source === "builtin" ? " · 内置" : " · 自定义"}）`,
-                ),
-              ),
-            ),
+            { key: k, className: "dou-provErr" },
+            `用户文件 ${k.slice(5)} 加载失败：${e.message}`,
+          ),
+        )
+      : null,
+    items.length === 0
+      ? React.createElement("div", { style: { color: "var(--dsw-alias-label-tertiary,#9aa0ab)" } }, "无提供商数据（adapters.json 不可达）")
+      : React.createElement(
+          "div",
+          { className: "dou-provList" },
+          items.map((item) =>
+            React.createElement(ProviderItem, {
+              key: item.provider,
+              item,
+              candidates: candidatesByProvider.get(item.provider) ?? [],
+              errorByKey,
+              busy,
+              onSwitch,
+              onDisable,
+              onAdd,
+            }),
           ),
         ),
   );
@@ -223,17 +461,34 @@ function ConfigSection() {
   );
 }
 
-/** 设置页根组件：按 adapters.json enabled 映射逐 provider 拉取 /stats，渲染四区。 */
+/** 设置页根组件：提供商全集驱动手风琴；总览/可视化仅对启用中的 provider 拉 /stats。 */
 export function SettingsPage() {
   const [statsByProvider, setStatsByProvider] = React.useState<Record<string, StatsView | null>>({});
   const [meta, setMeta] = React.useState<AdaptersMeta | null>(null);
+  const [items, setItems] = React.useState<ProviderListItem[]>([]);
   const [busy, setBusy] = React.useState(false);
 
   const reload = React.useCallback(async (): Promise<void> => {
     try {
-      // issue #27：总览不再硬编码 ?provider=opencode-go——先取 adapters.json 的
-      // enabled 映射（provider → adapterId），再对每个启用 provider 并行拉 /stats。
       const m = (await jsonGet(ADAPTERS_URL).catch(() => null)) as AdaptersMeta | null;
+      if (m !== null) {
+        setMeta(m);
+        // issue #38：提供商全集 = 已注册候选 ∪ 运行时启用 ∪ 内置已知清单
+        const grouped: Record<string, Array<{ id: string; label: string; source: string }>> = {};
+        for (const info of m.host ?? []) {
+          for (const provider of info.providers) {
+            (grouped[provider] ??= []).push({ id: info.id, label: info.label, source: info.source });
+          }
+        }
+        setItems(
+          unionProviders({
+            candidatesByProvider: grouped,
+            enabled: m.enabled,
+            known: m.knownProviders ?? [],
+          }),
+        );
+      }
+      // 总览/可视化：仅对运行时启用的 provider 并行拉 /stats
       const providers = Object.keys(m?.enabled ?? {});
       const pairs = await Promise.all(
         providers.map(async (provider) => {
@@ -243,7 +498,6 @@ export function SettingsPage() {
           return [provider, s] as const;
         }),
       );
-      setMeta(m);
       setStatsByProvider(Object.fromEntries(pairs));
     } catch {
       /* 面板数据拉取失败静默（保留旧值） */
@@ -254,19 +508,60 @@ export function SettingsPage() {
     void reload();
   }, [reload]);
 
+  /** 统一包装：请求期间置 busy，完成后刷新面板数据。 */
+  function mutate(action: () => Promise<unknown>): void {
+    setBusy(true);
+    action()
+      .catch(() => {})
+      .then(() => reload())
+      .finally(() => setBusy(false));
+  }
+
   const onSwitch = React.useCallback(
     (provider: string, adapterId: string): void => {
-      setBusy(true);
-      fetch(SELECT_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ provider, adapterId }),
-      })
-        .then(async () => {
-          await reload();
-        })
-        .catch(() => {})
-        .finally(() => setBusy(false));
+      mutate(() =>
+        fetch(SELECT_URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ provider, adapterId }),
+        }),
+      );
+    },
+    [reload],
+  );
+
+  // issue #38：「禁用该提供商」= select 清空该 provider 启用项（adapterId: null）
+  const onDisable = React.useCallback(
+    (provider: string): void => {
+      mutate(() =>
+        fetch(SELECT_URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ provider, adapterId: null }),
+        }),
+      );
+    },
+    [reload],
+  );
+
+  // issue #38：「+ 添加适配器」= adapters/add 登记本地文件并热注册
+  const onAdd = React.useCallback(
+    async (provider: string, form: AddFormValue): Promise<{ ok: boolean; detail?: string }> => {
+      try {
+        const res = await fetch(ADD_URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: form.id, label: form.label, provider, file: form.file }),
+        });
+        const body = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string; detail?: string };
+        if (!res.ok) {
+          return { ok: false, detail: body.detail ?? body.error ?? `HTTP ${res.status}` };
+        }
+        await reload();
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, detail: e instanceof Error ? e.message : String(e) };
+      }
     },
     [reload],
   );
@@ -276,7 +571,7 @@ export function SettingsPage() {
     { className: "dou-settings", style: { maxWidth: 560 } },
     React.createElement(OverviewSection, { statsByProvider }),
     React.createElement(UsageSection, { statsByProvider }),
-    React.createElement(AdapterSection, { meta, onSwitch, busy }),
+    React.createElement(ProviderListSection, { meta, items, busy, onSwitch, onDisable, onAdd }),
     React.createElement(ConfigSection, null),
   );
 }

--- a/packages/dsh-provider-usage/src/client/style.css
+++ b/packages/dsh-provider-usage/src/client/style.css
@@ -154,3 +154,125 @@
 }
 .dou-legendDot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
 .dou-miniChart { margin-top: 6px; }
+
+/* ---------------------------------------------------------------- 设置页·提供商手风琴列表（issue #38） */
+
+.dou-provList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.dou-provItem {
+  border: 1px solid var(--dsw-alias-border-l2, #e8eaf0);
+  border-radius: 8px;
+  background: var(--dsw-alias-bg-base, #fdfdfd);
+  overflow: hidden;
+}
+.dou-provHead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  background: transparent;
+  font: inherit;
+  font-size: 12px;
+  color: var(--dsw-alias-label-primary, #1c1e26);
+  text-align: left;
+  cursor: pointer;
+}
+.dou-provHead:hover { background: var(--dsw-alias-interactive-bg-hover, #f2f3f6); }
+.dou-provArrow {
+  flex: none;
+  display: inline-block;
+  transition: transform 0.15s ease;
+}
+.dou-provArrowOpen { transform: rotate(90deg); }
+.dou-provName {
+  flex: 1;
+  min-width: 0;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+.dou-provBadge {
+  flex: none;
+  max-width: 55%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  line-height: 1.5;
+  padding: 0 8px;
+  border-radius: 99px;
+  border: 1px solid var(--dsw-alias-border-l1, #d7dae0);
+  background: var(--dsw-alias-bg-layer-1, #f8f9fb);
+}
+.dou-provBadgeOff { color: var(--dsw-alias-label-tertiary, #9aa0ab); border-style: dashed; }
+.dou-provBody {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px 10px 26px;
+  border-top: 1px solid var(--dsw-alias-border-l2, #e8eaf0);
+}
+.dou-radioRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  cursor: pointer;
+}
+.dou-provErr {
+  color: var(--dsw-alias-state-error-primary, #d64545);
+  font-size: 11px;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+.dou-provActions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 2px;
+}
+.dou-addForm {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  border: 1px dashed var(--dsw-alias-border-l1, #d7dae0);
+  border-radius: 6px;
+}
+.dou-addField {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.dou-addLabel {
+  flex: none;
+  min-width: 60px;
+  color: var(--dsw-alias-label-tertiary, #9aa0ab);
+}
+.dou-input {
+  flex: 1 1 180px;
+  min-width: 0;
+  font: inherit;
+  font-size: 12px;
+  padding: 3px 6px;
+  border: 1px solid var(--dsw-alias-border-l1, #d7dae0);
+  border-radius: 5px;
+  background: var(--dsw-alias-bg-base, #fdfdfd);
+  color: var(--dsw-alias-label-primary, #1c1e26);
+}
+.dou-input:focus {
+  outline: none;
+  border-color: var(--dsw-alias-state-info-primary, #4a7dd6);
+}
+
+/* 三端响应式：窄屏收起展开区左缩进，徽标允许换行占整行 */
+@media (max-width: 480px) {
+  .dou-provBody { padding-left: 10px; }
+  .dou-provBadge { max-width: 100%; }
+}

--- a/packages/dsh-provider-usage/src/contracts.ts
+++ b/packages/dsh-provider-usage/src/contracts.ts
@@ -36,6 +36,7 @@ export const ERROR_CODES = [
   "bad-json", // 响应体不可解析
   "adapter-load-failed", // 用户适配器加载失败
   "adapter-crash", // 用户适配器运行抛错
+  "adapter-timeout", // 用户适配器执行超时（护栏拦截，issue #38）
 ] as const;
 
 /** 错误码字符串类型（含 http-<status> 动态形态）。 */
@@ -272,6 +273,24 @@ export function isHostProviderAdapter(v: unknown): v is HostProviderAdapter {
     a.providers.every((p) => typeof p === "string" && p.length > 0) &&
     typeof a.fetchUsage === "function"
   );
+}
+
+/**
+ * 宿主端适配器形状问题明细（issue #38 注入容错：拒收时给出「缺什么」的可排障
+ * 诊断，而非只报一个布尔）。通过校验返回 null。
+ */
+export function describeAdapterShape(v: unknown): string | null {
+  if (typeof v !== "object" || v === null) return `导出不是对象（${v === null ? "null" : typeof v}）`;
+  const a = v as Record<string, unknown>;
+  const missing: string[] = [];
+  if (a.version !== ADAPTER_CONTRACT_VERSION) missing.push(`version 必须 === ${ADAPTER_CONTRACT_VERSION}（实际 ${String(a.version)}）`);
+  if (typeof a.id !== "string" || (a.id as string).length === 0) missing.push("id（非空字符串）");
+  if (typeof a.label !== "string" || (a.label as string).length === 0) missing.push("label（非空字符串）");
+  if (!Array.isArray(a.providers) || a.providers.length === 0 || !a.providers.every((p) => typeof p === "string" && p.length > 0)) {
+    missing.push("providers（非空字符串数组）");
+  }
+  if (typeof a.fetchUsage !== "function") missing.push("fetchUsage（函数）");
+  return missing.length > 0 ? missing.join("、") : null;
 }
 
 /** 校验客户端渲染器结构。 */

--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -9,12 +9,14 @@
  * - GET /api/dsh-provider-usage/stats[?provider=<name>]  用量统计
  * - GET /api/dsh-provider-usage/history[?days=N]          历史采样序列
  * - GET /api/dsh-provider-usage/adapters.json              适配器元数据（M2）
+ * - POST /api/dsh-provider-usage/adapters/select           切换/清空启用适配器
+ * - POST /api/dsh-provider-usage/adapters/add              登记用户适配器文件（issue #38）
  * - GET /api/dsh-provider-usage/health                     健康检查
  */
 import { readFile, writeFile, rename, unlink, mkdir, readdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { isLoopbackRequest } from "../../../shared/loopback.js";
 import { writeJson, readJsonBody } from "../../../shared/host-utils.js";
@@ -36,7 +38,7 @@ import {
   OPENCODE_GO_WINDOWS,
 } from "./adapters/opencode-go.js";
 import type { ProviderUsage, UsageWindow, FetchLike, HostProviderAdapter, SamplePointData, ProviderSummary } from "./contracts.js";
-import { resolvePath } from "./path-resolve.js";
+import { resolvePath, pluginHome } from "./path-resolve.js";
 
 // ------------------------------------------------------------------ 对外 re-export
 // 注意：bundle-host 会把 tsc 产物中的子模块全部内联进 lib/index.js 并清理游离 .js，
@@ -106,6 +108,7 @@ export const ROUTES: Record<string, string> = {
   history: "/api/dsh-provider-usage/history",
   adapters: "/api/dsh-provider-usage/adapters.json",
   select: "/api/dsh-provider-usage/adapters/select",
+  add: "/api/dsh-provider-usage/adapters/add",
   health: "/api/dsh-provider-usage/health",
 };
 
@@ -807,6 +810,81 @@ export async function writeAdapterState(root: string, enabled: Record<string, st
   }
 }
 
+// ------------------------------------------------------------------ 运行时用户适配器清单（issue #38）
+
+/** 用户适配器登记条目（adapters/add 路由写入、启动时合并加载）。 */
+export interface UserAdapterRecord {
+  id: string;
+  label: string;
+  provider: string;
+  file: string;
+}
+
+/** 用户适配器清单文件（历史根目录下，与 adapter-state.json 同区）。 */
+export function userAdaptersFile(root: string): string {
+  return join(root, "user-adapters.json");
+}
+
+/**
+ * 校验 adapters/add 入参的 file 字段：文件存在可读 + 路径规整禁穿越。
+ * 规则：
+ * - 禁 NUL 字节与空串；
+ * - 输入必须已规整（`path.resolve` 前后一致，拒绝 `a/../b`、`./x` 等未规整形态）；
+ * - 绝对路径：规整即可（信任模型同配置注入——本机用户可加载任意本地文件）；
+ * - 相对路径：只允许经 resolvePath 落在 DSH_HOME 或插件 home 之内。
+ * @returns 解析后的绝对路径；非法返回 undefined。
+ */
+export function resolveAddAdapterFile(input: unknown, dshHome = process.env.DSH_HOME ?? join(homedir(), ".dsh")): string | undefined {
+  if (typeof input !== "string") return undefined;
+  const trimmed = input.trim();
+  if (trimmed === "" || trimmed.includes("\0")) return undefined;
+  // 规整性：resolve 前后必须一致（拒绝 .. / . 段穿越形态）
+  if (resolve(trimmed) !== trimmed) return undefined;
+  const resolved = resolvePath(trimmed);
+  if (resolved === undefined) return undefined; // 不存在 / 非常规文件
+  if (!isAbsolute(trimmed)) {
+    // 相对路径：解析结果必须位于 DSH_HOME 或插件 home 之内
+    for (const base of [dshHome, pluginHome(dshHome)]) {
+      const rel = relative(base, resolved);
+      if (rel !== "" && !rel.startsWith("..") && !isAbsolute(rel)) return resolved;
+    }
+    return undefined;
+  }
+  return resolved;
+}
+
+/** 防御式解析用户适配器清单文本（坏文件返回 []）。 */
+export function parseUserAdapters(raw: string | undefined): UserAdapterRecord[] {
+  if (typeof raw !== "string" || raw === "") return [];
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (typeof data !== "object" || data === null) return [];
+  const list = (data as Record<string, unknown>)["adapters"];
+  if (!Array.isArray(list)) return [];
+  const out: UserAdapterRecord[] = [];
+  for (const item of list) {
+    if (typeof item !== "object" || item === null) continue;
+    const rec = item as Record<string, unknown>;
+    const id = typeof rec.id === "string" ? rec.id : "";
+    const label = typeof rec.label === "string" ? rec.label : "";
+    const provider = typeof rec.provider === "string" ? rec.provider : "";
+    const file = typeof rec.file === "string" ? rec.file : "";
+    if (id.length > 0 && label.length > 0 && provider.length > 0 && file.length > 0) {
+      out.push({ id, label, provider, file });
+    }
+  }
+  return out;
+}
+
+/** 读取用户适配器清单（坏文件/不存在返回 []）。 */
+export async function readUserAdapters(root: string): Promise<UserAdapterRecord[]> {
+  return parseUserAdapters(await readHistoryFile(userAdaptersFile(root)));
+}
+
 // ------------------------------------------------------------------ 密钥护栏（stripSecrets，默认开）
 
 /** 疑似密钥值模式（R1 值匹配，与键名扫描互补）。命中即整值脱敏。 */
@@ -921,6 +999,16 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
   const registry = makeHostAdapterRegistry();
   registry.register(openCodeGoHostAdapter, "builtin");
 
+  /**
+   * 用户宿主适配器文件加载链（config.adapters.host 与运行时 adapters/add 清单
+   * 共用，issue #38）：import + default/具名取舍。失败抛出由调用方兜底。
+   */
+  async function loadUserHostAdapterFile(file: string): Promise<unknown> {
+    const url = pathToFileURL(file).href;
+    const mod = (await import(url)) as Record<string, unknown>;
+    return mod.default ?? mod;
+  }
+
   // M2: 加载用户宿主适配器（多个文件依序加载，单个失败不阻断）
   for (const entry of current.adapters.host) {
     const file = resolvePath(entry.file);
@@ -929,9 +1017,7 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
       continue;
     }
     try {
-      const url = pathToFileURL(file).href;
-      const mod = await import(url);
-      const adapter = (mod as Record<string, unknown>).default ?? mod;
+      const adapter = await loadUserHostAdapterFile(file);
       registry.register(adapter, "user-file", file, entry.enabled);
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -955,6 +1041,22 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
 
   // M3b：应用持久化的启用选择（重启保留；仅覆盖仍存在的候选）。
   // 状态文件在历史根下，须在数据割接定根之后读取（回落旧根时同根一致）。
+  // issue #38：运行时 adapters/add 登记的清单先于 savedEnabled 合并加载
+  // （注册默认启用语义与 config.host 一致，随后由 savedEnabled 校正最终态）。
+  for (const rec of await readUserAdapters(root)) {
+    const file = resolvePath(rec.file);
+    if (file === undefined) {
+      console.warn(`[dsh-provider-usage] 运行时登记适配器文件不存在：${basename(rec.file)}，跳过`);
+      continue;
+    }
+    try {
+      const adapter = await loadUserHostAdapterFile(file);
+      registry.register(adapter, "user-file", file);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(`[dsh-provider-usage] 运行时登记适配器加载失败 ${basename(rec.file)}: ${msg}`);
+    }
+  }
   const savedEnabled = await readAdapterState(root);
   for (const [provider, adapterId] of Object.entries(savedEnabled)) {
     registry.select(provider, adapterId);
@@ -1009,6 +1111,21 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
   let adapterStateChain: Promise<void> = Promise.resolve();
   function scheduleWriteAdapterState(enabled: Record<string, string>): void {
     adapterStateChain = adapterStateChain.then(() => writeAdapterState(root, enabled));
+  }
+
+  /** 用户适配器清单落盘串行链（issue #38）：连续 add 的写完成顺序不依赖 IO 时序。 */
+  async function persistUserAdapter(rec: UserAdapterRecord): Promise<void> {
+    const write = async (): Promise<void> => {
+      const list = await readUserAdapters(root);
+      if (list.some((r) => r.id === rec.id)) return; // 幂等：已登记不再追加
+      list.push(rec);
+      await writeHistoryFile(userAdaptersFile(root), JSON.stringify({ version: 1, adapters: list }));
+    };
+    try {
+      await (adapterStateChain = adapterStateChain.then(write));
+    } catch {
+      console.warn("[dsh-provider-usage] 用户适配器清单落盘失败（内存态仍生效）");
+    }
   }
 
   /** 解析某 provider 的 API Key（当前仅 opencode-go 有解析链；M2 扩展）。 */
@@ -1196,6 +1313,70 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
     },
   };
 
+  // issue #38：登记用户适配器文件并热注册（POST /adapters/add）。
+  // 入参 { id, label, provider, file }；校验文件存在可读 + 路径规整禁穿越；
+  // 登记进用户适配器清单（重启保留）并复用 user-file 加载链热注册。
+  // 本期不做「粘贴 JS 落盘」。
+  const addRoute: WebRoute = {
+    kind: "exact",
+    path: ROUTES.add,
+    handler: async (req, res) => {
+      if (!isLoopbackRequest(req)) return writeJson(res, 403, { error: "forbidden: loopback-only" });
+      if (req.method !== "POST") return writeJson(res, 405, { error: `method not allowed: ${req.method}` });
+      let body: Record<string, unknown>;
+      try {
+        const raw = await readJsonBody(req);
+        if (typeof raw !== "object" || raw === null) return writeJson(res, 400, { error: "bad-json" });
+        body = raw as Record<string, unknown>;
+      } catch {
+        return writeJson(res, 400, { error: "bad-json" });
+      }
+      const id = typeof body.id === "string" ? body.id.trim() : "";
+      const label = typeof body.label === "string" ? body.label.trim() : "";
+      const provider = typeof body.provider === "string" ? body.provider.trim() : "";
+      if (
+        id.length === 0 || label.length === 0 || provider.length === 0 ||
+        id.length > 128 || label.length > 128 || provider.length > 128
+      ) {
+        return writeJson(res, 400, { error: "invalid-input" });
+      }
+      const file = resolveAddAdapterFile(body.file);
+      if (file === undefined) {
+        return writeJson(res, 400, { error: "invalid-file", detail: "文件不存在/不可读，或路径未规整（禁穿越）" });
+      }
+      if (registry.snapshot().infos.some((i) => i.id === id)) {
+        return writeJson(res, 409, { error: "duplicate-id", detail: `适配器 id 已存在：${id}` });
+      }
+      let adapter: unknown;
+      try {
+        adapter = await loadUserHostAdapterFile(file);
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return writeJson(res, 422, { error: "adapter-load-failed", detail: msg });
+      }
+      // 登记元数据一致性：实际身份以适配器导出为准，入参 id 填错直接拒绝（防清单与注册表漂移）
+      const actualId = typeof (adapter as Record<string, unknown> | null)?.id === "string"
+        ? ((adapter as Record<string, unknown>).id as string)
+        : undefined;
+      if (actualId !== id) {
+        return writeJson(res, 422, { error: "id-mismatch", detail: `模块导出 id=${actualId ?? "<缺失>"} 与入参 id=${id} 不一致` });
+      }
+      if (!registry.register(adapter, "user-file", file)) {
+        return writeJson(res, 422, { error: "invalid-adapter", detail: "契约校验失败（version/id/label/providers/fetchUsage）" });
+      }
+      await persistUserAdapter({ id, label, provider, file });
+      // 热注册默认成为该 provider 启用者：把新选择固化进启用状态落盘
+      statsEpoch += 1;
+      cache.clear(provider);
+      scheduleWriteAdapterState(registry.snapshot().enabled);
+      writeJson(res, 200, {
+        ok: true,
+        adapter: { id, label, provider, file: basename(file) },
+        enabled: registry.snapshot().enabled,
+      });
+    },
+  };
+
   // 后台采样定时器：采样所有**已启用**适配器的 provider（D10，保持历史连续）
   let backgroundTimer: ReturnType<typeof setInterval> | null = null;
   if (current.sampleIntervalMs > 0) {
@@ -1329,7 +1510,7 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
 
   const disposeRoutes = ctx.effect(
     () => {
-      const routeDisposers = [statsRoute, selectRoute, historyRoute, adaptersRoute, userRoute, healthRoute].map((route) =>
+      const routeDisposers = [statsRoute, selectRoute, addRoute, historyRoute, adaptersRoute, userRoute, healthRoute].map((route) =>
         ctx.webServer.register(route),
       );
       return () => {

--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -126,6 +126,12 @@ export const DEFAULT_CONFIG: NormalizedConfig = {
 };
 
 /**
+ * 内置已知 provider 清单（issue #38：设置页提供商全集的第三路来源——无候选的
+ * 也展示并给引导）。随内置适配器扩展维护。
+ */
+export const KNOWN_PROVIDERS: string[] = [OPENCODE_GO_PROVIDER];
+
+/**
  * 设置面板 schemastery schema（M3b：settings 命名空间用，与 normalizeConfig 同构）。
  * 实测约束：schemastery 3.18 无 `.optional()`；不带 `.required()` 的字段默认可选。
  * 说明：apiKey 不进 schema（避免设置面板回显密钥）；adapters 复杂结构经 patch 层
@@ -1469,6 +1475,8 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
         })),
         enabled: snap.enabled,
         client,
+        // issue #38：内置已知 provider 清单（提供商全集第三路来源）
+        knownProviders: [...KNOWN_PROVIDERS],
         // issue #38：最近一次适配器错误登记（面板排障展示；key=adapterId 或 file:<名>）
         errors: snap.errors.map((e) => ({ key: e.key, at: e.at, kind: e.kind, message: e.message })),
       });

--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -783,17 +783,23 @@ export function adapterStateFile(root: string): string {
   return join(root, "adapter-state.json");
 }
 
-/** 读取持久化的 enabled 映射（provider → adapterId）；坏文件返回 {}。 */
-export async function readAdapterState(root: string): Promise<Record<string, string>> {
+/**
+ * 读取持久化的 enabled 映射（provider → adapterId）；坏文件返回 {}。
+ * 值为 null 表示该 provider 被显式清空禁用（issue #38），重启后保持无启用。
+ */
+export async function readAdapterState(root: string): Promise<Record<string, string | null>> {
   const raw = await readHistoryFile(adapterStateFile(root));
   if (typeof raw !== "string" || raw === "") return {};
   try {
     const data = JSON.parse(raw) as Record<string, unknown>;
-    const out: Record<string, string> = {};
+    const out: Record<string, string | null> = {};
     for (const [provider, id] of Object.entries(data)) {
-      if (typeof provider === "string" && typeof id === "string" && provider.length > 0 && id.length > 0) {
-        out[provider] = id;
+      if (typeof provider !== "string" || provider.length === 0) continue;
+      if (id === null) {
+        out[provider] = null;
+        continue;
       }
+      if (typeof id === "string" && id.length > 0) out[provider] = id;
     }
     return out;
   } catch {
@@ -801,8 +807,8 @@ export async function readAdapterState(root: string): Promise<Record<string, str
   }
 }
 
-/** 原子写 enabled 映射（select 切换时调用；失败只 warn 不阻断切换）。 */
-export async function writeAdapterState(root: string, enabled: Record<string, string>): Promise<void> {
+/** 原子写 enabled 映射（select 切换/清空时调用；失败只 warn 不阻断切换）。 */
+export async function writeAdapterState(root: string, enabled: Record<string, string | null>): Promise<void> {
   try {
     await writeHistoryFile(adapterStateFile(root), JSON.stringify(enabled));
   } catch {
@@ -1109,7 +1115,7 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
    * IO 时序，链上最后一次写入最终生效。
    */
   let adapterStateChain: Promise<void> = Promise.resolve();
-  function scheduleWriteAdapterState(enabled: Record<string, string>): void {
+  function scheduleWriteAdapterState(enabled: Record<string, string | null>): void {
     adapterStateChain = adapterStateChain.then(() => writeAdapterState(root, enabled));
   }
 
@@ -1298,18 +1304,23 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
         return writeJson(res, 400, { error: "bad-json" });
       }
       const provider = typeof body.provider === "string" ? body.provider : "";
+      // issue #38：adapterId 显式 null = 清空该 provider 启用项（「禁用该提供商」）
+      const clearing = body.adapterId === null;
       const adapterId = typeof body.adapterId === "string" ? body.adapterId : "";
-      // 参数长度限制（防异常输入）
-      if (provider.length === 0 || adapterId.length === 0 || provider.length > 128 || adapterId.length > 128) {
+      // 参数长度限制（防异常输入）；缺失/空串仍拒绝（清空必须显式 null）
+      if (!clearing && (provider.length === 0 || adapterId.length === 0 || provider.length > 128 || adapterId.length > 128)) {
         return writeJson(res, 400, { error: "invalid provider/adapterId" });
       }
-      const ok = registry.select(provider, adapterId);
+      const ok = registry.select(provider, clearing ? null : adapterId);
       if (!ok) return writeJson(res, 404, { error: "adapter not found" });
       statsEpoch += 1; // 递增代数：inflight 的旧适配器结果不再回填缓存
       cache.clear(provider); // 切换后清该 provider 缓存（下一个请求走新适配器）
-      // M3b：持久化启用选择（重启保留；经 promise 链串行化，失败只 warn）
-      scheduleWriteAdapterState(registry.snapshot().enabled);
-      writeJson(res, 200, { ok: true, provider, adapterId });
+      // M3b：持久化启用选择（重启保留；经 promise 链串行化，失败只 warn）。
+      // 清空态以显式 null 固化，重启后保持无启用（不回退默认启用）。
+      scheduleWriteAdapterState(
+        clearing ? { ...registry.snapshot().enabled, [provider]: null } : registry.snapshot().enabled,
+      );
+      writeJson(res, 200, { ok: true, provider, adapterId: clearing ? null : adapterId });
     },
   };
 

--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -990,6 +990,13 @@ export function deriveSummary(
 }
 
 
+/** 错误消息路径脱敏（信息面最小披露）：DSH_HOME → ~/.dsh、用户 home → ~。 */
+export function sanitizePathInMessage(s: string): string {
+  const home = homedir();
+  const dshHome = process.env.DSH_HOME ?? join(home, ".dsh");
+  return s.split(dshHome).join("~/.dsh").split(home).join("~");
+}
+
 // ------------------------------------------------------------------ 插件入口
 
 export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Promise<void> {
@@ -1002,7 +1009,9 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
   };
 
   // -------------------------------------------------------- 适配器注册表
-  const registry = makeHostAdapterRegistry();
+  // issue #38：错误登记走注册表（面板可展示每个用户适配器最近一次加载/执行错误），
+  // 消息经路径脱敏维持信息面最小披露。
+  const registry = makeHostAdapterRegistry({ sanitizePath: sanitizePathInMessage });
   registry.register(openCodeGoHostAdapter, "builtin");
 
   /**
@@ -1015,19 +1024,18 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
     return mod.default ?? mod;
   }
 
-  // M2: 加载用户宿主适配器（多个文件依序加载，单个失败不阻断）
+  // M2: 加载用户宿主适配器（多个文件依序加载，单个失败不阻断；失败登记错误供面板排障）
   for (const entry of current.adapters.host) {
     const file = resolvePath(entry.file);
     if (file === undefined) {
-      console.warn(`[dsh-provider-usage] 用户宿主适配器文件不存在：${entry.file}，跳过`);
+      registry.recordError(`file:${basename(entry.file)}`, "load", `文件不存在或不可读：${entry.file}`);
       continue;
     }
     try {
       const adapter = await loadUserHostAdapterFile(file);
       registry.register(adapter, "user-file", file, entry.enabled);
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      console.warn(`[dsh-provider-usage] 用户宿主适配器加载失败 ${entry.file}: ${msg}`);
+      registry.recordError(`file:${basename(file)}`, "load", e instanceof Error ? e.message : String(e));
     }
   }
 
@@ -1052,15 +1060,14 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
   for (const rec of await readUserAdapters(root)) {
     const file = resolvePath(rec.file);
     if (file === undefined) {
-      console.warn(`[dsh-provider-usage] 运行时登记适配器文件不存在：${basename(rec.file)}，跳过`);
+      registry.recordError(`file:${basename(rec.file)}`, "load", `文件不存在或不可读：${rec.file}`);
       continue;
     }
     try {
       const adapter = await loadUserHostAdapterFile(file);
       registry.register(adapter, "user-file", file);
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      console.warn(`[dsh-provider-usage] 运行时登记适配器加载失败 ${basename(rec.file)}: ${msg}`);
+      registry.recordError(`file:${basename(file)}`, "load", e instanceof Error ? e.message : String(e));
     }
   }
   const savedEnabled = await readAdapterState(root);
@@ -1363,6 +1370,7 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
         adapter = await loadUserHostAdapterFile(file);
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
+        registry.recordError(`file:${basename(file)}`, "load", msg);
         return writeJson(res, 422, { error: "adapter-load-failed", detail: msg });
       }
       // 登记元数据一致性：实际身份以适配器导出为准，入参 id 填错直接拒绝（防清单与注册表漂移）
@@ -1461,6 +1469,8 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
         })),
         enabled: snap.enabled,
         client,
+        // issue #38：最近一次适配器错误登记（面板排障展示；key=adapterId 或 file:<名>）
+        errors: snap.errors.map((e) => ({ key: e.key, at: e.at, kind: e.kind, message: e.message })),
       });
     },
   };
@@ -1515,6 +1525,8 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
           ...i,
           file: i.file !== undefined ? basename(i.file) : undefined,
         })),
+        // issue #38：最近一次适配器错误登记（排障展示，消息已路径脱敏）
+        errors: snap.errors.map((e) => ({ key: e.key, at: e.at, kind: e.kind, message: e.message })),
       });
     },
   };

--- a/packages/dsh-provider-usage/src/path-resolve.ts
+++ b/packages/dsh-provider-usage/src/path-resolve.ts
@@ -12,9 +12,13 @@ import { existsSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
 
-/** 插件 home 目录（host 文件逻辑归属区 ~/.dsh/plugins/provider-usage）。 */
-export function pluginHome(): string {
-  return join(process.env.DSH_HOME ?? join(homedir(), ".dsh"), "plugins", "provider-usage");
+/**
+ * 插件 home 目录（host 文件逻辑归属区 ~/.dsh/plugins/provider-usage）。
+ * @param base - DSH_HOME 根（缺省读 env，回落 ~/.dsh）；参数化供调用方在非全局
+ *   env 场景（如路由入参校验）复用同一拼装规则。
+ */
+export function pluginHome(base = process.env.DSH_HOME ?? join(homedir(), ".dsh")): string {
+  return join(base, "plugins", "provider-usage");
 }
 
 /**

--- a/packages/dsh-provider-usage/src/registry.ts
+++ b/packages/dsh-provider-usage/src/registry.ts
@@ -10,12 +10,13 @@
  * - `get(provider)` 只返回启用条目；无启用候选返回 undefined，区分 `no-adapter`
  *   （无候选）与 `no-enabled-adapter`（有候选但全禁用）。
  */
+import { basename } from "node:path";
 import type {
   HostFetchContext,
   HostProviderAdapter,
   ProviderUsage,
 } from "./contracts.js";
-import { isHostProviderAdapter, usageError } from "./contracts.js";
+import { describeAdapterShape, isHostProviderAdapter, usageError } from "./contracts.js";
 
 /** 注册条目来源。 */
 export type AdapterSource = "builtin" | "user-file";
@@ -25,6 +26,20 @@ export type AdapterSource = "builtin" | "user-file";
  * 赋值（加载失败在 apply 层直接不注册），故只保留 active。
  */
 export type AdapterStatus = "active";
+
+/**
+ * 最近一次适配器错误登记（issue #38 注入容错：面板排障展示用）。
+ * kind=load：文件装载/契约校验失败；kind=exec：fetchUsage/summarize 执行抛错或超时。
+ * key：已注册候选用 adapter id；未注册成功的用户文件用 `file:<basename>`。
+ */
+export interface AdapterErrorInfo {
+  at: number;
+  kind: "load" | "exec";
+  message: string;
+}
+
+/** 护栏超时哨兵（区别于适配器自身抛错）。 */
+class AdapterGuardTimeout extends Error {}
 
 /** 注册表诊断条目（health / 设置面板候选展示用）。 */
 export interface AdapterRegistrationInfo {
@@ -58,15 +73,60 @@ interface AdapterEntry {
 /**
  * 宿主适配器注册表（候选 + 唯一启用）。
  * @param opts.diag - 诊断收集器（可选；缺省 console.warn）。
+ * @param opts.sanitizePath - 错误消息路径脱敏函数（可选；登记前把绝对路径归约成
+ *   `~` 形态，维持信息面最小披露）。
  */
-export function makeHostAdapterRegistry(opts: { diag?: (m: string) => void } = {}) {
+export function makeHostAdapterRegistry(opts: { diag?: (m: string) => void; sanitizePath?: (s: string) => string } = {}) {
   const diag = opts.diag ?? ((m: string): void => console.warn("[dsh-provider-usage]", m));
+  const sanitizePath = opts.sanitizePath ?? ((s: string): string => s);
   /** provider → 有序候选条目（注册顺序）。 */
   const candidatesByProvider = new Map<string, AdapterEntry[]>();
   /** provider → 当前启用 adapterId。 */
   const enabledIds = new Map<string, string>();
   /** 已注册 adapter id 集合（同 id 重复拒绝）。 */
   const registeredIds = new Set<string>();
+  /** 最近一次错误登记表（key = adapterId 或 file:<basename>）。 */
+  const lastErrors = new Map<string, AdapterErrorInfo>();
+
+  /**
+   * 登记一次适配器错误（warn + 记录最近一次；同 key 覆盖）。
+   * 加载失败（文件不存在/import 抛错/契约拒收）走 kind=load；执行抛错或护栏
+   * 超时走 kind=exec。调用方无需再自行 warn。
+   */
+  function recordError(key: string, kind: "load" | "exec", message: string): void {
+    lastErrors.set(key, { at: Date.now(), kind, message: sanitizePath(message) });
+    diag(`适配器 ${key} ${kind === "load" ? "加载" : "执行"}错误：${sanitizePath(message)}`);
+  }
+
+  /**
+   * 执行护栏：限时竞速。适配器 promise 在时限内 settle 则透传；超时则拒绝
+   * AdapterGuardTimeout（底层 promise 无法强杀，其结果被丢弃，采样循环不再被
+   * 挂起阻塞——同步死循环仍会阻塞事件循环，那需要 worker 隔离，超出本期）。
+   */
+  function withGuard<T>(p: Promise<T>, ms: number): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new AdapterGuardTimeout()), ms);
+      p.then(
+        (v) => { clearTimeout(timer); resolve(v); },
+        (e) => { clearTimeout(timer); reject(e); },
+      );
+    });
+  }
+
+  /** 护栏时长：跟随 ctx.timeoutMs（下限 50ms 防误配），与网络超时同源同量级。 */
+  function guardMs(ctx: HostFetchContext): number {
+    return Math.max(50, typeof ctx.timeoutMs === "number" && Number.isFinite(ctx.timeoutMs) ? ctx.timeoutMs : 15000);
+  }
+
+  /** 执行期异常归类：护栏超时 → adapter-timeout；其余 → adapter-crash。 */
+  function execFailure(provider: string, entryId: string, error: unknown): ProviderUsage {
+    if (error instanceof AdapterGuardTimeout) {
+      recordError(entryId, "exec", "执行超时（疑似死循环/长挂起，已被护栏拦截）");
+      return usageError(provider, "adapter-timeout", provider, Date.now());
+    }
+    recordError(entryId, "exec", error instanceof Error ? error.message : String(error));
+    return usageError(provider, "adapter-crash", provider, Date.now());
+  }
 
   /** 获取某 provider 的候选列表（不存在则建空）。 */
   function candidates(provider: string): AdapterEntry[] {
@@ -98,8 +158,13 @@ export function makeHostAdapterRegistry(opts: { diag?: (m: string) => void } = {
     enabledHint?: boolean,
   ): boolean {
     if (!isHostProviderAdapter(adapter)) {
-      const at = file === undefined ? "内置适配器" : `用户适配器 ${file}`;
-      diag(`${at} 契约校验失败（version/id/label/providers/fetchUsage），不注册`);
+      // issue #38：拒收时输出缺失成员明细（可排障），用户文件场景登记加载错误
+      const detail = describeAdapterShape(adapter) ?? "未知形状问题";
+      if (file === undefined) {
+        diag(`内置适配器 契约校验失败（${detail}），不注册`);
+      } else {
+        recordError(`file:${basename(file)}`, "load", `契约校验失败（${detail}），已拒收`);
+      }
       return false;
     }
     if (registeredIds.has(adapter.id)) {
@@ -161,7 +226,11 @@ export function makeHostAdapterRegistry(opts: { diag?: (m: string) => void } = {
     return true;
   }
 
-  /** 取某 provider 的归一化结果（启用适配器；区分 no-adapter / no-enabled-adapter）。 */
+  /**
+   * 取某 provider 的归一化结果（启用适配器；区分 no-adapter / no-enabled-adapter）。
+   * issue #38：执行受超时护栏约束——适配器挂起/死循环不再阻塞采样循环，
+   * 超时返回 adapter-timeout 错误态。
+   */
   async function fetchUsage(provider: string, ctx: HostFetchContext): Promise<ProviderUsage> {
     const entry = getEntry(provider);
     if (entry === undefined) {
@@ -170,10 +239,9 @@ export function makeHostAdapterRegistry(opts: { diag?: (m: string) => void } = {
       return usageError(provider, code, provider, Date.now());
     }
     try {
-      return await entry.adapter.fetchUsage(ctx);
+      return await withGuard(entry.adapter.fetchUsage(ctx), guardMs(ctx));
     } catch (error) {
-      diag(`适配器 ${entry.id}（provider ${provider}）运行抛错：${error instanceof Error ? error.message : String(error)}`);
-      return usageError(provider, "adapter-crash", provider, Date.now());
+      return execFailure(provider, entry.id, error);
     }
   }
 
@@ -189,10 +257,10 @@ export function makeHostAdapterRegistry(opts: { diag?: (m: string) => void } = {
     if (entry === undefined) return { entry: undefined, summary: null };
     if (typeof entry.adapter.summarize !== "function") return { entry, summary: null };
     try {
-      const summary = await entry.adapter.summarize(ctx);
+      const summary = await withGuard(entry.adapter.summarize(ctx), guardMs(ctx));
       return { entry, summary: summary ?? null };
     } catch (error) {
-      diag(`适配器 ${entry.id} summarize 抛错：${error instanceof Error ? error.message : String(error)}`);
+      execFailure(provider, entry.id, error);
       return { entry, summary: null };
     }
   }
@@ -210,12 +278,15 @@ export function makeHostAdapterRegistry(opts: { diag?: (m: string) => void } = {
   /**
    * 注册表快照（health / 设置面板适配器候选管理）。
    * - infos：全部候选条目（含 enabled 标记）；
-   * - enabled：provider → enabledAdapterId 映射。
+   * - enabled：provider → enabledAdapterId 映射；
+   * - errors：最近一次适配器错误登记（issue #38，面板排障展示；含未注册成功的
+   *   用户文件条目，key = `file:<basename>`）。
    */
   function snapshot(): {
     infos: AdapterRegistrationInfo[];
     enabled: Record<string, string>;
     enabledProviders: string[];
+    errors: Array<AdapterErrorInfo & { key: string }>;
   } {
     const infos: AdapterRegistrationInfo[] = [];
     const seen = new Set<string>();
@@ -238,11 +309,13 @@ export function makeHostAdapterRegistry(opts: { diag?: (m: string) => void } = {
     }
     const enabled: Record<string, string> = {};
     for (const [provider, id] of enabledIds) enabled[provider] = id;
-    return { infos, enabled, enabledProviders: [...enabledIds.keys()] };
+    const errors = [...lastErrors.entries()].map(([key, e]) => ({ key, ...e }));
+    return { infos, enabled, enabledProviders: [...enabledIds.keys()], errors };
   }
 
   return {
     register,
+    recordError,
     get,
     getEntry,
     select,

--- a/packages/dsh-provider-usage/src/registry.ts
+++ b/packages/dsh-provider-usage/src/registry.ts
@@ -146,10 +146,15 @@ export function makeHostAdapterRegistry(opts: { diag?: (m: string) => void } = {
   }
 
   /**
-   * 运行时切换某 provider 的启用适配器。
-   * @returns 是否切换成功（provider 与 adapterId 均存在）。
+   * 运行时切换某 provider 的启用适配器；adapterId = null 清空该 provider 启用项
+   * （issue #38：「禁用该提供商」，幂等，无候选也返回 true）。
+   * @returns 是否成功（切换要求 provider 与 adapterId 均存在；清空恒成功）。
    */
-  function select(provider: string, adapterId: string): boolean {
+  function select(provider: string, adapterId: string | null): boolean {
+    if (adapterId === null) {
+      enabledIds.delete(provider);
+      return true;
+    }
     const entry = findEntry(provider, adapterId);
     if (entry === undefined) return false;
     enabledIds.set(provider, adapterId);

--- a/packages/dsh-provider-usage/test/smoke-pure.ts
+++ b/packages/dsh-provider-usage/test/smoke-pure.ts
@@ -29,6 +29,7 @@ import {
   makeHostAdapterRegistry,
   isHostProviderAdapter,
   isClientProviderRenderer,
+  describeAdapterShape,
   OPENCODE_GO_PROVIDER,
   OPENCODE_GO_ADAPTER_ID,
   openCodeGoHostAdapter,
@@ -208,6 +209,64 @@ assert.ok(!isClientProviderRenderer({ version: 1, providers: ["x"] }), "缺 rend
   assert.equal(snap.enabled["opencode-go"], OPENCODE_GO_ADAPTER_ID, "enabled 映射 provider→adapterId");
   const myRelayInfo = snap.infos.find((i) => i.id === "my-relay");
   assert.equal(myRelayInfo?.enabled, false, "禁用候选 enabled=false");
+
+  // issue #38：select(null) 清空启用项（幂等）
+  assert.equal(reg.select(OPENCODE_GO_PROVIDER, null), true, "清空内置 provider 启用项成功");
+  assert.equal(reg.get(OPENCODE_GO_PROVIDER), undefined, "清空后无启用者");
+  assert.equal(reg.hasCandidates(OPENCODE_GO_PROVIDER), true, "候选仍在（no-enabled-adapter 语义）");
+  assert.equal(reg.select("never-seen", null), true, "清空未知 provider 幂等成功");
+}
+
+// ---------------------------------------------------------------- 形状明细诊断 + 超时护栏 + 错误登记（issue #38）
+
+{
+  // describeAdapterShape：拒收时给出「缺什么」明细
+  assert.equal(describeAdapterShape(openCodeGoHostAdapter), null, "合法适配器无形状问题");
+  assert.ok(describeAdapterShape(null)?.includes("不是对象"), "null 导出 → 非对象描述");
+  assert.ok(describeAdapterShape({ version: 2 })?.includes("fetchUsage"), "缺 fetchUsage 出现在明细中");
+  assert.ok(describeAdapterShape({ version: 1, id: "a", label: "A" })?.includes("providers"), "缺 providers 出现在明细中");
+  assert.ok(describeAdapterShape({ version: 9, id: "", label: "", providers: ["x"] })?.includes("version"), "版本不符出现在明细中");
+
+  const diags: string[] = [];
+  const reg = makeHostAdapterRegistry({
+    diag: (m) => diags.push(m),
+    sanitizePath: (s) => s.replaceAll("/home/secret-user", "~"),
+  });
+
+  // 契约拒收 → 明细诊断 + 错误登记（file:<名> 键，消息经脱敏）
+  reg.register({ version: 1, id: "bad-shape", label: "B", providers: [] }, "user-file", "/home/secret-user/x/bad.mjs");
+  const loadErr = reg.snapshot().errors.find((e) => e.key === "file:bad.mjs");
+  assert.ok(loadErr, "契约拒收已登记错误");
+  assert.equal(loadErr?.kind, "load");
+  assert.ok(loadErr?.message.includes("providers"), "登记消息含缺失成员明细");
+  assert.ok(!loadErr?.message.includes("/home/secret-user"), "登记消息已经路径脱敏");
+  assert.ok(diags.some((m) => m.includes("providers")), "诊断输出含明细");
+
+  // recordError（加载链 import 失败场景）+ 同 key 覆盖取最近一次
+  reg.recordError("file:gone.mjs", "load", "ENOENT: /x/gone.mjs");
+  reg.recordError("file:gone.mjs", "load", "第二次错误（覆盖）");
+  const goneErrs = reg.snapshot().errors.filter((e) => e.key === "file:gone.mjs");
+  assert.equal(goneErrs.length, 1, "同 key 只保留最近一次");
+  assert.equal(goneErrs[0]?.message, "第二次错误（覆盖）", "最近一次错误生效");
+
+  // 超时护栏：挂起适配器限时拦截为 adapter-timeout + exec 登记
+  const hangReg = makeHostAdapterRegistry({ diag: (m) => diags.push(m) });
+  hangReg.register(
+    {
+      version: 1,
+      id: "hang",
+      label: "H",
+      providers: ["hang"],
+      fetchUsage: async () => new Promise<ProviderUsage>(() => {}),
+    },
+    "builtin",
+  );
+  const before = Date.now();
+  const guarded = await hangReg.fetchUsage("hang", { provider: "hang", fetch, timeoutMs: 80 });
+  assert.equal(guarded.error, "adapter-timeout", "挂起适配器被护栏拦截");
+  assert.ok(Date.now() - before >= 50 && Date.now() - before < 5000, "护栏按时触发且不永久阻塞");
+  const hangErr = hangReg.snapshot().errors.find((e) => e.key === "hang");
+  assert.ok(hangErr?.kind === "exec" && hangErr.message.includes("超时"), "超时登记 kind=exec");
 }
 
 // ---------------------------------------------------------------- 密钥护栏（stripSecrets 值模式 + 键名）

--- a/packages/dsh-provider-usage/test/smoke-pure.ts
+++ b/packages/dsh-provider-usage/test/smoke-pure.ts
@@ -52,6 +52,9 @@ import {
   derivePillTitle,
   shouldHideFloat,
   rendererLookupKeys,
+  // 设置页提供商全集（issue #38）
+  unionProviders,
+  providerBadgeText,
 } from "../lib/index.js";
 
 // ---------------------------------------------------------------- 共享桩（导出给集成区复用）
@@ -674,4 +677,39 @@ function mkSummary(overrides: Partial<ProviderSummary> = {}): ProviderSummary {
     openCodeGoHostAdapter.providers.length,
     "providers 数组无重复",
   );
+}
+
+// ---------------------------------------------------------------- 设置页·提供商全集（issue #38）
+
+{
+  const items = unionProviders({
+    candidatesByProvider: {
+      "opencode-go": [{ id: "opencode-go-builtin", label: "OpenCode Go 官方", source: "builtin" }],
+      "z-relay": [{ id: "z-relay-user", label: "Z Relay", source: "user-file" }],
+    },
+    enabled: { "opencode-go": "opencode-go-builtin", "runtime-only": "x" },
+    known: ["opencode-go", "future-provider"],
+  });
+  // 全集三路合并去重：候选 ∪ 启用 ∪ 已知
+  assert.deepEqual(
+    items.map((i) => i.provider),
+    ["future-provider", "opencode-go", "runtime-only", "z-relay"],
+    "全集 = 候选 ∪ 运行时启用 ∪ 内置已知（已知在前，其余字典序）",
+  );
+  const ocg = items.find((i) => i.provider === "opencode-go");
+  assert.ok(ocg?.hasCandidates && ocg.enabledId === "opencode-go-builtin", "已知且有候选：带启用态");
+  const future = items.find((i) => i.provider === "future-provider");
+  assert.equal(future?.hasCandidates, false, "仅已知清单项无候选（引导位）");
+  assert.equal(items.find((i) => i.provider === "runtime-only")?.enabledId, "x", "运行时启用映射入全集");
+  // 空输入 → 空列表
+  assert.deepEqual(unionProviders({ candidatesByProvider: {}, known: [] }), [], "空输入空列表");
+}
+
+{
+  assert.equal(
+    providerBadgeText({ enabledId: "opencode-go-builtin" }),
+    "启用中: opencode-go-builtin",
+    "折叠徽标显示启用中 adapter-id",
+  );
+  assert.equal(providerBadgeText({ enabledId: null }), "未启用", "清空/未启用徽标文案");
 }

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -80,14 +80,14 @@ function makeFakeCtx(overrides = {}) {
   assert.equal(routes.length, 0, "enabled:false 不注册路由");
 }
 
-// 注册 stats + select + history + adapters + user + health 六路由
+// 注册 stats + select + add + history + adapters + user + health 七路由
 {
   const { ctx, routes } = makeFakeCtx();
   await apply(ctx, {});
   assert.deepEqual(
     routes.map((r) => r.path).sort(),
-    [ROUTES.health, ROUTES.history, ROUTES.adapters, ROUTES.stats, ROUTES.select, "/api/dsh-provider-usage/user/"].sort(),
-    "注册六条路由",
+    [ROUTES.health, ROUTES.history, ROUTES.adapters, ROUTES.stats, ROUTES.select, ROUTES.add, "/api/dsh-provider-usage/user/"].sort(),
+    "注册七条路由",
   );
   assert.ok(routes.every((r) => r.kind === "exact" || r.kind === "prefix"), "路由 exact 或 prefix");
 }
@@ -194,6 +194,109 @@ function makeFakeCtx(overrides = {}) {
   );
   assert.equal(payload.ok, true, "select 重选内置成功");
   assert.equal(payload.adapterId, "opencode-go-builtin");
+}
+
+// ---------------------------------------------------------------- adapters/add 路由（issue #38）：围栏 / 校验 / 登记热注册 / 重启合并
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dou-add-"));
+  const adapterFile = join(dir, "added-relay.mjs");
+  writeFileSync(
+    adapterFile,
+    [
+      "export default {",
+      "  version: 1,",
+      '  id: "added-relay",',
+      '  label: "Added Relay",',
+      '  providers: ["added-relay-provider"],',
+      '  async fetchUsage() { return { ok: true, provider: "added-relay-provider", label: "Added", fetchedAt: 0 }; },',
+      "};",
+    ].join("\n"),
+  );
+  const { ctx, routes } = makeFakeCtx();
+  await apply(ctx, {
+    persistFile: join(dir, "history.json"),
+    credentialsFile: join(here, "no-such-credentials.yaml"),
+    authFile: join(here, "no-such-auth.json"),
+  });
+  const add = routes.find((r) => r.path === ROUTES.add);
+  assert.ok(add, "add 路由存在");
+  const responses = [];
+  const res = { writeHead: () => {}, end: (chunk) => responses.push(JSON.parse(chunk)) };
+  const resCode = { writeHead: (code) => { responses.push({ __code: code }); }, end: () => {} };
+  const post = (body, target = resCode) => add.handler(fakeReq({ method: "POST", body }), target);
+
+  // 围栏：403 / 405
+  await add.handler(fakeReq({ socket: { remoteAddress: "10.0.0.2" } }), res);
+  assert.equal(responses.at(-1).error, "forbidden: loopback-only", "add 非回环 403");
+  await add.handler(fakeReq({ method: "GET" }), resCode);
+  assert.equal(responses.at(-1).__code, 405, "add 非 POST 405");
+
+  // 400：缺字段 / 坏 body
+  await post(undefined);
+  assert.equal(responses.at(-1).__code, 400, "add 空 body 400");
+  await post(JSON.stringify({ id: "x", label: "y" }));
+  assert.equal(responses.at(-1).__code, 400, "add 缺 provider/file 400");
+  await post(JSON.stringify({ id: `x`.repeat(129), label: "y", provider: "p", file: adapterFile }));
+  assert.equal(responses.at(-1).__code, 400, "add 超长 id 400");
+
+  // 400：文件不存在 / 未规整穿越形态
+  await post(JSON.stringify({ id: "a", label: "b", provider: "p", file: join(dir, "no-such.mjs") }));
+  assert.equal(responses.at(-1).__code, 400, "add 不存在文件 400");
+  await post(JSON.stringify({ id: "a", label: "b", provider: "p", file: `${dir}/sub/../added-relay.mjs` }));
+  assert.equal(responses.at(-1).__code, 400, "add 含 .. 未规整路径 400（禁穿越）");
+
+  // 422：合法文件但模块导出畸形（缺 fetchUsage）/ id 与入参不一致
+  const badExport = join(dir, "bad-export.mjs");
+  writeFileSync(badExport, 'export default { version: 1, id: "bad-export", label: "Bad", providers: ["p"] };');
+  await post(JSON.stringify({ id: "bad-export", label: "Bad", provider: "p", file: badExport }));
+  assert.equal(responses.at(-1).__code, 422, "add 畸形导出（缺 fetchUsage）422");
+
+  const mismatched = join(dir, "mismatched.mjs");
+  writeFileSync(mismatched, 'export default { version: 1, id: "actual-id", label: "M", providers: ["p"], async fetchUsage() {} };');
+  await post(JSON.stringify({ id: "claimed-id", label: "M", provider: "p", file: mismatched }));
+  assert.equal(responses.at(-1).__code, 422, "add 导出 id 与入参不一致 422");
+
+  // 200：成功登记 + 热注册 + 清单落盘
+  let payload;
+  const res200 = { writeHead: () => {}, end: (chunk) => { payload = JSON.parse(chunk); } };
+  await post(JSON.stringify({ id: "added-relay", label: "Added Relay", provider: "added-relay-provider", file: adapterFile }), res200);
+  assert.equal(payload.ok, true, "add 成功");
+  assert.equal(payload.adapter.id, "added-relay");
+  assert.ok(!JSON.stringify(payload).includes(dir), "add 响应不外泄绝对路径（只披露文件名）");
+
+  // 热注册生效：adapters.json 出现新候选并默认启用；stats 可取该 provider（no-api-key 错误态即证明走通了适配器）
+  const adaptersRoute = routes.find((r) => r.path === ROUTES.adapters);
+  let meta;
+  const metaRes = { writeHead: () => {}, end: (chunk) => { meta = JSON.parse(chunk); } };
+  adaptersRoute.handler(fakeReq(), metaRes);
+  const addedInfo = meta.host.find((h) => h.id === "added-relay");
+  assert.ok(addedInfo, "热注册后候选可见");
+  assert.equal(addedInfo.enabled, true, "新添加适配器默认启用");
+  assert.equal(meta.enabled["added-relay-provider"], "added-relay", "enabled 映射含新 provider");
+  const stats = routes.find((r) => r.path === ROUTES.stats);
+  let statsPayload;
+  const statsRes = { writeHead: () => {}, end: (chunk) => { statsPayload = JSON.parse(chunk); } };
+  await stats.handler(fakeReq({ url: `${ROUTES.stats}?provider=added-relay-provider` }), statsRes);
+  assert.equal(statsPayload.hasAdapter, true, "stats 走通热注册适配器");
+
+  // 清单落盘：重启后合并加载（无需再 add）
+  const listFile = join(dir, "user-adapters.json");
+  assert.equal(await waitFor(() => existsSync(listFile)), true, "清单已落盘");
+  const { ctx: ctx2, routes: routes2 } = makeFakeCtx();
+  await apply(ctx2, {
+    persistFile: join(dir, "history.json"),
+    credentialsFile: join(here, "no-such-credentials.yaml"),
+    authFile: join(here, "no-such-auth.json"),
+  });
+  let meta2;
+  const metaRes2 = { writeHead: () => {}, end: (chunk) => { meta2 = JSON.parse(chunk); } };
+  routes2.find((r) => r.path === ROUTES.adapters).handler(fakeReq(), metaRes2);
+  assert.ok(meta2.host.find((h) => h.id === "added-relay"), "重启后清单合并加载恢复候选");
+
+  // 409：同 id 重复登记
+  await post(JSON.stringify({ id: "added-relay", label: "Added Relay", provider: "added-relay-provider", file: adapterFile }));
+  assert.equal(responses.at(-1).__code, 409, "重复 id 409");
 }
 
 // user 路由：403 / 405 / 404
@@ -579,7 +682,7 @@ async function waitFor(cond, timeoutMs = 5000, stepMs = 50) {
   assertClientSourceContract(join(here, ".."));
   assertClientProductContract(join(here, ".."));
   const literals = new Set(client.match(/\/api\/[A-Za-z0-9_/.-]+/gu) ?? []);
-  const hostPaths = new Set([ROUTES.stats, ROUTES.history, ROUTES.health, ROUTES.adapters, ROUTES.select]);
+  const hostPaths = new Set([ROUTES.stats, ROUTES.history, ROUTES.health, ROUTES.adapters, ROUTES.select, ROUTES.add]);
   for (const lit of literals) {
     assert.ok(hostPaths.has(lit), `client 字面量 ${lit} 在 host ROUTES 中存在`);
   }

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -666,6 +666,106 @@ async function waitFor(cond, timeoutMs = 5000, stepMs = 50) {
   assert.equal(stats2.hasAdapter, false, "重启后显式清空态保持（不回退内置默认启用）");
 }
 
+// ---------------------------------------------------------------- 注入容错补强（issue #38）：执行抛错 / 超时护栏 / 错误登记披露
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dou-fault-"));
+  // 执行抛错适配器
+  const crashFile = join(dir, "crash-adapter.mjs");
+  writeFileSync(
+    crashFile,
+    [
+      "export default {",
+      "  version: 1,",
+      '  id: "crash-adapter",',
+      '  label: "Crash",',
+      '  providers: ["crash-relay"],',
+      '  async fetchUsage() { throw new Error("boom-crash"); },',
+      "};",
+    ].join("\n"),
+  );
+  // 挂起适配器（永不 resolve 的 promise：护栏必须放行采样循环）
+  const hangFile = join(dir, "hang-adapter.mjs");
+  writeFileSync(
+    hangFile,
+    [
+      "export default {",
+      "  version: 1,",
+      '  id: "hang-adapter",',
+      '  label: "Hang",',
+      '  providers: ["hang-relay"],',
+      "  async fetchUsage() { return new Promise(() => {}); },",
+      "};",
+    ].join("\n"),
+  );
+  // 畸形导出（缺 fetchUsage）：放 DSH_HOME 下以同时验证错误消息路径脱敏
+  const badRel = "plugins/provider-usage/bad-shape.mjs";
+  const badAbs = join(process.env.DSH_HOME, "plugins", "provider-usage");
+  mkdirSync(badAbs, { recursive: true });
+  writeFileSync(join(badAbs, "bad-shape.mjs"), 'export default { version: 1, id: "bad-shape", label: "Bad", providers: ["p"] };');
+
+  const t0 = Date.now();
+  const { ctx, routes } = makeFakeCtx();
+  await apply(ctx, {
+    persistFile: join(dir, "history.json"),
+    timeoutMs: 120,
+    credentialsFile: join(here, "no-such-credentials.yaml"),
+    authFile: join(here, "no-such-auth.json"),
+    adapters: {
+      host: [
+        { provider: "crash-relay", file: crashFile },
+        { provider: "hang-relay", file: hangFile },
+        { provider: "p", file: badRel },
+      ],
+    },
+  });
+
+  const adaptersRoute = routes.find((r) => r.path === ROUTES.adapters);
+  const stats = routes.find((r) => r.path === ROUTES.stats);
+  let meta;
+  const metaRes = { writeHead: () => {}, end: (chunk) => { meta = JSON.parse(chunk); } };
+  let statsPayload;
+  const statsRes = { writeHead: () => {}, end: (chunk) => { statsPayload = JSON.parse(chunk); } };
+
+  // 加载期：畸形导出拒收 + 错误登记（消息含明细、DSH_HOME 绝对路径已脱敏）
+  adaptersRoute.handler(fakeReq(), metaRes);
+  assert.ok(!meta.host.some((h) => h.id === "bad-shape"), "畸形导出不注册");
+  const loadErr = meta.errors.find((e) => e.key === "file:bad-shape.mjs");
+  assert.ok(loadErr, "加载错误已登记");
+  assert.equal(loadErr.kind, "load");
+  assert.ok(loadErr.message.includes("fetchUsage"), "错误消息含缺失成员明细");
+  assert.ok(!JSON.stringify(meta).includes(process.env.DSH_HOME), "adapters.json 错误消息不含 DSH_HOME 绝对路径");
+
+  // 执行抛错：stats 降级 adapter-crash + exec 错误登记
+  await stats.handler(fakeReq({ url: `${ROUTES.stats}?provider=crash-relay` }), statsRes);
+  assert.equal(statsPayload.usage.ok, false);
+  assert.equal(statsPayload.usage.error, "adapter-crash", "执行抛错降级 adapter-crash");
+  adaptersRoute.handler(fakeReq(), metaRes);
+  const crashErr = meta.errors.find((e) => e.key === "crash-adapter");
+  assert.ok(crashErr && crashErr.kind === "exec" && crashErr.message === "boom-crash", "执行错误已登记（最近一次）");
+
+  // 超时护栏：挂起适配器被限时拦截，返回 adapter-timeout 且调用方不再无限等待
+  const before = Date.now();
+  await stats.handler(fakeReq({ url: `${ROUTES.stats}?provider=hang-relay` }), statsRes);
+  const elapsed = Date.now() - before;
+  assert.equal(statsPayload.usage.ok, false);
+  assert.equal(statsPayload.usage.error, "adapter-timeout", "挂起适配器被护栏拦截为 adapter-timeout");
+  assert.ok(elapsed < 5000, `护栏及时放行（耗时 ${elapsed}ms，未阻塞请求链）`);
+  assert.ok(elapsed >= 100, "护栏时长 ≥ ctx.timeoutMs");
+  adaptersRoute.handler(fakeReq(), metaRes);
+  const hangErr = meta.errors.find((e) => e.key === "hang-adapter");
+  assert.ok(hangErr && hangErr.kind === "exec" && hangErr.message.includes("超时"), "超时错误已登记");
+
+  // health 同步披露错误登记
+  const health = routes.find((r) => r.path === ROUTES.health);
+  let healthPayload;
+  const healthRes = { writeHead: () => {}, end: (chunk) => { healthPayload = JSON.parse(chunk); } };
+  health.handler(fakeReq(), healthRes);
+  assert.ok(Array.isArray(healthPayload.errors) && healthPayload.errors.length >= 3, "health 披露错误登记");
+  assert.ok(!JSON.stringify(healthPayload).includes(process.env.DSH_HOME), "health 错误消息同样路径脱敏");
+  assert.ok(Date.now() - t0 < 15000, "整组容错用例未出现死等");
+}
+
 // stats：无 key 时 usage.error=no-api-key（不网络；路径指向不存在文件）
 {
   const { ctx, routes } = makeFakeCtx();

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -132,6 +132,7 @@ function makeFakeCtx(overrides = {}) {
   assert.equal(payload.host[0].id, "opencode-go-builtin", "候选带 id");
   assert.equal(payload.host[0].enabled, true, "候选带 enabled");
   assert.equal(payload.enabled["opencode-go"], "opencode-go-builtin", "enabled 映射 provider→adapterId");
+  assert.deepEqual(payload.knownProviders, ["opencode-go"], "knownProviders 内置已知清单（issue #38）");
   assert.deepEqual(payload.client, [], "无客户端适配器时为 []");
   // 带客户端适配器配置
   const { ctx: ctx3, routes: routes3 } = makeFakeCtx();
@@ -823,6 +824,14 @@ async function waitFor(cond, timeoutMs = 5000, stepMs = 50) {
   assert.ok(client.includes('"settings.section"'), "注册 settings.section 顶层 tab");
   assert.ok(client.includes("用量统计"), "tab 标签「用量统计」");
   assert.ok(client.includes("adapters/select"), "适配器管理走 select 接口");
+
+  // issue #38：设置页按提供商重构（总览 + 提供商手风琴列表）
+  assert.ok(client.includes("adapters/add"), "添加适配器走 add 接口");
+  assert.ok(client.includes("禁用该提供商"), "提供商展开页内禁用按钮");
+  assert.ok(client.includes("+ 添加适配器"), "提供商展开页内添加入口");
+  assert.ok(client.includes("dou-provHead"), "手风琴折叠头样式类");
+  assert.ok(client.includes("dou-provErr"), "错误登记展示（候选执行/文件加载最近一次错误）");
+  assert.ok(client.includes("knownProviders"), "消费宿主内置已知清单");
 
   // issue #27：总览不再硬编码 opencode-go，按 adapters.json enabled 映射逐 provider 拉取
   assert.ok(!client.includes("?provider=opencode-go"), "settings 总览移除硬编码 ?provider=opencode-go");

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -607,6 +607,65 @@ async function waitFor(cond, timeoutMs = 5000, stepMs = 50) {
   assert.equal(settled, true, "连续 select 串行化落盘：最终态 = 最后一次选择");
 }
 
+// ---------------------------------------------------------------- select 清空（adapterId: null，issue #38）
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dou-clear-"));
+  const { ctx, routes } = makeFakeCtx();
+  await apply(ctx, {
+    apiKey: "sk-test",
+    persistFile: join(dir, "history.json"),
+    fetchImpl: async () => fakeRes(200, OK_BODY),
+  });
+  const select = routes.find((r) => r.path === ROUTES.select);
+  const stats = routes.find((r) => r.path === ROUTES.stats);
+  const responses = [];
+  const resCode = { writeHead: (code) => { responses.push({ __code: code }); }, end: () => {} };
+  let payload;
+  const res200 = { writeHead: () => {}, end: (chunk) => { payload = JSON.parse(chunk); } };
+  let statsPayload;
+  const statsRes = { writeHead: () => {}, end: (chunk) => { statsPayload = JSON.parse(chunk); } };
+
+  // adapterId 缺失/空串仍 400（清空必须显式 null）
+  await select.handler(fakeReq({ method: "POST", body: JSON.stringify({ provider: OPENCODE_GO_PROVIDER }) }), resCode);
+  assert.equal(responses.at(-1).__code, 400, "adapterId 缺失仍 400");
+
+  // 清空：200 + adapterId null；stats → no-enabled-adapter（有候选全禁用）
+  await select.handler(
+    fakeReq({ method: "POST", body: JSON.stringify({ provider: OPENCODE_GO_PROVIDER, adapterId: null }) }),
+    res200,
+  );
+  assert.equal(payload.ok, true, "清空成功");
+  assert.equal(payload.adapterId, null, "响应 adapterId null");
+  await stats.handler(fakeReq({ url: `${ROUTES.stats}?provider=${OPENCODE_GO_PROVIDER}` }), statsRes);
+  assert.equal(statsPayload.hasAdapter, false, "清空后无启用适配器（浮窗隐藏语义）");
+  assert.equal(statsPayload.reason, "no-enabled-adapter", "清空后 reason 为 no-enabled-adapter");
+
+  // 落盘为显式 null；重启后保持禁用（不回退默认启用）
+  const stateFile = join(dir, "adapter-state.json");
+  assert.equal(
+    await waitFor(() => {
+      try {
+        return JSON.parse(readFileSync(stateFile, "utf8"))[OPENCODE_GO_PROVIDER] === null;
+      } catch {
+        return false;
+      }
+    }),
+    true,
+    "清空态以显式 null 落盘",
+  );
+  const { ctx: ctx2, routes: routes2 } = makeFakeCtx();
+  await apply(ctx2, {
+    apiKey: "sk-test",
+    persistFile: join(dir, "history.json"),
+    fetchImpl: async () => fakeRes(200, OK_BODY),
+  });
+  let stats2;
+  const statsRes2 = { writeHead: () => {}, end: (chunk) => { stats2 = JSON.parse(chunk); } };
+  await routes2.find((r) => r.path === ROUTES.stats).handler(fakeReq(), statsRes2);
+  assert.equal(stats2.hasAdapter, false, "重启后显式清空态保持（不回退内置默认启用）");
+}
+
 // stats：无 key 时 usage.error=no-api-key（不网络；路径指向不存在文件）
 {
   const { ctx, routes } = makeFakeCtx();


### PR DESCRIPTION
Closes #38

## 概要

对齐 DSH 模型配置页交互范式：设置面板「用量统计」tab 的「适配器管理」平铺区块重构为**提供商手风琴列表**；配套后端 adapters/add 路由、select 清空语义与适配器注入容错补强（形状校验/超时护栏/错误登记）。

## 验收清单（对应 issue 五个子项）

- [x] **设置页按提供商重构**：总览 + 用量可视化保留；提供商手风琴列表（折叠态徽标「启用中: <adapter-id>」/未启用，展开页内候选单选/禁用该提供商/+添加适配器）；提供商全集 = 已注册候选 ∪ 运行时启用 ∪ 内置已知清单，无候选 provider 也展示并给引导
- [x] **添加适配器路由**：POST /api/dsh-provider-usage/adapters/add（loopback 围栏内），入参 {id, label, provider, file}；文件存在可读/路径规整禁穿越，登记 user-adapters.json 清单并热注册，重启保留
- [x] **禁用清空语义**：/adapters/select 支持 adapterId: null 清空该 provider 启用项（幂等），显式 null 固化落盘不回退内置默认
- [x] **注入容错补强**：register 形状校验（缺 fetchUsage 等必要成员拒收 + 缺失明细 warn）；执行超时护栏（ctx.timeoutMs 限时竞速，挂起/死循环归一 adapter-timeout 不阻塞采样循环）；错误登记表（加载失败 file:<名> / 执行抛错·超时 adapterId，路径脱敏）
- [x] **smoke 断言锁定**：坏文件/畸形导出/执行抛错三类容错链路 + 超时护栏限时拦截；add 围栏 403/405 与 select(null) 全链路；unionProviders 全集合并与徽标文案纯逻辑断言；客户端契约断言（dou-provHead/dou-provErr/adapters/add/knownProviders）

## 门禁

`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 本地全绿。