### PR TITLE
fix(dsh-provider-usage): 用量设置页提供商全集补全运行时识别与内置清单 (#38)

### DIFF
--- a/packages/dsh-provider-usage/src/client-logic.ts
+++ b/packages/dsh-provider-usage/src/client-logic.ts
@@ -109,6 +109,11 @@ export interface ProvidersUnionInput {
   candidatesByProvider: Record<string, Array<{ id: string; label: string; source: string }>>;
   /** 运行时启用映射（provider → adapterId）。 */
   enabled?: Record<string, string>;
+  /**
+   * 运行时识别到的 provider（adapters.json recognizedProviders：历史采样桶 ∪
+   * 启用状态文件键；issue #38 第二路来源——无候选无启用的也留在全集可见）。
+   */
+  recognized?: string[];
   /** 内置已知清单（宿主 knownProviders；无候选也展示并给引导）。 */
   known: string[];
 }
@@ -123,14 +128,15 @@ export interface ProviderListItem {
 }
 
 /**
- * 提供商全集 = 已注册候选覆盖 ∪ 运行时启用映射 ∪ 内置已知清单（issue #38）。
- * 排序：内置已知在前（引导位），其余按字典序；逐项带候选存在性与启用态，
- * 面板直接渲染，不再自行拼装。
+ * 提供商全集 = 已注册候选覆盖 ∪ 运行时启用映射 ∪ 运行时识别 ∪ 内置已知清单
+ * （issue #38）。排序：内置已知在前（引导位），其余按字典序；逐项带候选存在性
+ * 与启用态，面板直接渲染，不再自行拼装。
  */
 export function unionProviders(input: ProvidersUnionInput): ProviderListItem[] {
   const providers = new Set<string>();
   for (const p of Object.keys(input.candidatesByProvider)) providers.add(p);
   for (const p of Object.keys(input.enabled ?? {})) providers.add(p);
+  for (const p of input.recognized ?? []) providers.add(p);
   for (const p of input.known) providers.add(p);
   const knownSet = new Set(input.known);
   const sorted = [...providers].sort((a, b) => {

--- a/packages/dsh-provider-usage/src/client/settings.ts
+++ b/packages/dsh-provider-usage/src/client/settings.ts
@@ -5,9 +5,10 @@
  * - 总览：当前生效适配器逐 provider 摘要（enabled 映射驱动，保留）
  * - 用量可视化：summary 文案 + 各窗口明细表（保留）
  * - 提供商列表（替代原「适配器管理」平铺区块）：全集 = 已注册候选 ∪ 运行时
- *   启用 ∪ 内置已知清单（无候选也展示并给引导）；折叠态徽标显示
- *   「启用中: <adapter-id>」，展开页内管理候选适配器（名称/来源/启用开关单选）、
- *   [禁用该提供商]、[+ 添加适配器]（本地文件路径登记并热注册）
+ *   识别（recognizedProviders）∪ 运行时启用 ∪ 内置已知清单（无候选也展示并给
+ *   引导）；折叠态徽标显示「启用中: <adapter-id>」，展开页内管理候选适配器
+ *   （名称/来源/启用开关单选）、[禁用该提供商]、[+ 添加适配器]（本地文件路径
+ *   登记并热注册）
  * - 配置：常用配置键展示（patch 层为单一事实源，此处只读）
  *
  * 数据面：全部走宿主 loopback 路由（/stats、/adapters.json、POST /adapters/select、
@@ -42,6 +43,8 @@ interface AdaptersMeta {
   host?: AdapterInfo[];
   enabled?: Record<string, string>;
   knownProviders?: string[];
+  /** 运行时识别到的 provider（issue #38 第二路来源：历史采样 ∪ 启用状态文件键）。 */
+  recognizedProviders?: string[];
   errors?: AdapterErrorEntry[];
 }
 
@@ -484,6 +487,7 @@ export function SettingsPage() {
           unionProviders({
             candidatesByProvider: grouped,
             enabled: m.enabled,
+            recognized: m.recognizedProviders ?? [],
             known: m.knownProviders ?? [],
           }),
         );

--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -127,9 +127,54 @@ export const DEFAULT_CONFIG: NormalizedConfig = {
 
 /**
  * 内置已知 provider 清单（issue #38：设置页提供商全集的第三路来源——无候选的
- * 也展示并给引导）。随内置适配器扩展维护。
+ * 也展示并给引导）。
+ *
+ * 权威依据：dsh 模型配置生态（llm-pi-ai）内置 catalog 的 provider 路由键集，
+ * 即 @earendil-works/pi-ai `providers/all` 的 `BuiltinProvider` 枚举
+ * （`MODELS` 一级键，锁版见 dsh pnpm-workspace catalog 同源 pi-ai 0.82.x），
+ * 覆盖 deepseek / openai / anthropic / google(Gemini) / openrouter /
+ * qwen-token-plan 等；模型配置页可添加的 provider 与此处一一对应。
+ * 升级 pi-ai 后新增 provider 时同步维护本清单。
  */
-export const KNOWN_PROVIDERS: string[] = [OPENCODE_GO_PROVIDER];
+export const KNOWN_PROVIDERS: string[] = [
+  "amazon-bedrock",
+  "ant-ling",
+  "anthropic",
+  "azure-openai-responses",
+  "cerebras",
+  "cloudflare-ai-gateway",
+  "cloudflare-workers-ai",
+  "deepseek",
+  "fireworks",
+  "github-copilot",
+  "google",
+  "google-vertex",
+  "groq",
+  "huggingface",
+  "kimi-coding",
+  "minimax",
+  "minimax-cn",
+  "mistral",
+  "moonshotai",
+  "moonshotai-cn",
+  OPENCODE_GO_PROVIDER, // opencode-go
+  "nvidia",
+  "openai",
+  "openai-codex",
+  "opencode",
+  "openrouter",
+  "qwen-token-plan",
+  "qwen-token-plan-cn",
+  "together",
+  "vercel-ai-gateway",
+  "xai",
+  "xiaomi",
+  "xiaomi-token-plan-ams",
+  "xiaomi-token-plan-cn",
+  "xiaomi-token-plan-sgp",
+  "zai",
+  "zai-coding-cn",
+];
 
 /**
  * 设置面板 schemastery schema（M3b：settings 命名空间用，与 normalizeConfig 同构）。
@@ -1081,6 +1126,12 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
     registry.select(provider, adapterId);
   }
 
+  // issue #38：宿主侧「运行时识别到的 provider」持久化产物之一——启用状态文件
+  // 中出现过的键（含显式清空 null 的：该 provider 从 enabled 映射消失，但仍算
+  // 运行时见过，须留在设置页全集里可见、可再启用）。历史采样桶为另一路产物，
+  // 在 /adapters 响应组装时动态并入（见 adaptersRoute）。
+  const stateRecognizedProviders = new Set<string>(Object.keys(savedEnabled));
+
   const store = makeHistoryStore({
     maxAgeDays: current.maxAgeDays,
     diag: (m): void => console.warn(`[dsh-provider-usage]`, m),
@@ -1477,6 +1528,16 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
         client,
         // issue #38：内置已知 provider 清单（提供商全集第三路来源）
         knownProviders: [...KNOWN_PROVIDERS],
+        // issue #38：运行时识别到的 provider（提供商全集第二路来源）= 历史采样桶
+        // 覆盖的 provider ∪ 启用状态文件出现过的键。排序输出便于客户端直接消费。
+        recognizedProviders: (() => {
+          const recognized = new Set<string>(stateRecognizedProviders);
+          for (const key of store.keys()) {
+            const provider = key.split("/")[0] ?? "";
+            if (provider !== "") recognized.add(provider);
+          }
+          return [...recognized].sort((a, b) => a.localeCompare(b));
+        })(),
         // issue #38：最近一次适配器错误登记（面板排障展示；key=adapterId 或 file:<名>）
         errors: snap.errors.map((e) => ({ key: e.key, at: e.at, kind: e.kind, message: e.message })),
       });

--- a/packages/dsh-provider-usage/test/smoke-pure.ts
+++ b/packages/dsh-provider-usage/test/smoke-pure.ts
@@ -688,18 +688,24 @@ function mkSummary(overrides: Partial<ProviderSummary> = {}): ProviderSummary {
       "z-relay": [{ id: "z-relay-user", label: "Z Relay", source: "user-file" }],
     },
     enabled: { "opencode-go": "opencode-go-builtin", "runtime-only": "x" },
+    recognized: ["hist-only", "runtime-only", "opencode-go"],
     known: ["opencode-go", "future-provider"],
   });
-  // 全集三路合并去重：候选 ∪ 启用 ∪ 已知
+  // 全集四路合并去重：候选 ∪ 启用 ∪ 运行时识别 ∪ 已知
   assert.deepEqual(
     items.map((i) => i.provider),
-    ["future-provider", "opencode-go", "runtime-only", "z-relay"],
-    "全集 = 候选 ∪ 运行时启用 ∪ 内置已知（已知在前，其余字典序）",
+    ["future-provider", "opencode-go", "hist-only", "runtime-only", "z-relay"],
+    "全集 = 候选 ∪ 运行时启用 ∪ 运行时识别 ∪ 内置已知（已知在前，其余字典序）",
   );
   const ocg = items.find((i) => i.provider === "opencode-go");
   assert.ok(ocg?.hasCandidates && ocg.enabledId === "opencode-go-builtin", "已知且有候选：带启用态");
   const future = items.find((i) => i.provider === "future-provider");
   assert.equal(future?.hasCandidates, false, "仅已知清单项无候选（引导位）");
+  // 运行时识别项：无候选无启用也入全集；与 enabled 重叠的 provider 去重只出现一次
+  const hist = items.find((i) => i.provider === "hist-only");
+  assert.equal(hist?.hasCandidates, false, "运行时识别项无候选");
+  assert.equal(hist?.enabledId, null, "运行时识别项未启用");
+  assert.equal(items.filter((i) => i.provider === "runtime-only").length, 1, "识别与启用重叠去重");
   assert.equal(items.find((i) => i.provider === "runtime-only")?.enabledId, "x", "运行时启用映射入全集");
   // 空输入 → 空列表
   assert.deepEqual(unionProviders({ candidatesByProvider: {}, known: [] }), [], "空输入空列表");

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -23,6 +23,7 @@ import {
   apply,
   ROUTES,
   DEFAULT_CONFIG,
+  KNOWN_PROVIDERS,
   OPENCODE_GO_PROVIDER,
   OPENCODE_GO_ADAPTER_ID,
   LEGACY_ADAPTER_ID,
@@ -132,7 +133,12 @@ function makeFakeCtx(overrides = {}) {
   assert.equal(payload.host[0].id, "opencode-go-builtin", "候选带 id");
   assert.equal(payload.host[0].enabled, true, "候选带 enabled");
   assert.equal(payload.enabled["opencode-go"], "opencode-go-builtin", "enabled 映射 provider→adapterId");
-  assert.deepEqual(payload.knownProviders, ["opencode-go"], "knownProviders 内置已知清单（issue #38）");
+  assert.deepEqual(payload.knownProviders, KNOWN_PROVIDERS, "knownProviders = 内置已知权威清单（issue #38）");
+  // 权威清单关键成员（dsh 模型配置生态常见 provider，pi-ai catalog 路由键）
+  for (const p of ["deepseek", "openai", "anthropic", "google", "openrouter", "qwen-token-plan", OPENCODE_GO_PROVIDER]) {
+    assert.ok(KNOWN_PROVIDERS.includes(p), `内置已知清单含 ${p}`);
+  }
+  assert.equal(new Set(KNOWN_PROVIDERS).size, KNOWN_PROVIDERS.length, "内置已知清单无重复");
   assert.deepEqual(payload.client, [], "无客户端适配器时为 []");
   // 带客户端适配器配置
   const { ctx: ctx3, routes: routes3 } = makeFakeCtx();
@@ -195,6 +201,56 @@ function makeFakeCtx(overrides = {}) {
   );
   assert.equal(payload.ok, true, "select 重选内置成功");
   assert.equal(payload.adapterId, "opencode-go-builtin");
+}
+
+// ---------------------------------------------------------------- 运行时识别 provider 注入 /adapters（issue #38）
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dou-recog-"));
+  // 预置宿主侧运行时识别产物（两路持久化状态）：
+  // 1) 历史采样桶：hist-relay 经 legacy 桶采过样（v3 多文件格式）
+  mkdirSync(join(dir, "history", "hist-relay"), { recursive: true });
+  writeFileSync(
+    join(dir, "history", "hist-relay", `${LEGACY_ADAPTER_ID}.json`),
+    JSON.stringify({
+      version: 3,
+      provider: "hist-relay",
+      adapterId: LEGACY_ADAPTER_ID,
+      columns: [{ key: "col-1", name: "col-1" }],
+      samples: [[Date.now() - 60000, 5]],
+    }),
+  );
+  // 2) 启用状态文件键（含显式清空 null 的 cleared-relay：已从 enabled 映射消失，
+  //    但属运行时见过的 provider，须留在全集可见、可再启用）
+  writeFileSync(
+    join(dir, "adapter-state.json"),
+    JSON.stringify({ "cleared-relay": null, [OPENCODE_GO_PROVIDER]: OPENCODE_GO_ADAPTER_ID }),
+  );
+
+  const { ctx, routes } = makeFakeCtx();
+  await apply(ctx, {
+    persistFile: join(dir, "history.json"),
+    fetchImpl: async () => fakeRes(200, OK_BODY),
+    credentialsFile: join(here, "no-such-credentials.yaml"),
+    authFile: join(here, "no-such-auth.json"),
+  });
+  const adaptersRoute = routes.find((r) => r.path === ROUTES.adapters);
+  let payload;
+  const res = { writeHead: () => {}, end: (chunk) => { payload = JSON.parse(chunk); } };
+  adaptersRoute.handler(fakeReq(), res);
+
+  assert.ok(Array.isArray(payload.recognizedProviders), "adapters.json 带 recognizedProviders 字段");
+  for (const p of ["hist-relay", "cleared-relay"]) {
+    assert.ok(payload.recognizedProviders.includes(p), `recognizedProviders 含历史桶/状态文件识别的 ${p}`);
+  }
+  assert.deepEqual(
+    payload.recognizedProviders,
+    [...payload.recognizedProviders].sort((a, b) => a.localeCompare(b)),
+    "recognizedProviders 排序输出",
+  );
+  // 显式清空的 provider 不在 enabled 映射（select(null) 即删），只能经识别来源留在全集
+  assert.equal(payload.enabled["cleared-relay"], undefined, "清空态不进 enabled 映射");
+  assert.equal(payload.enabled[OPENCODE_GO_PROVIDER], OPENCODE_GO_ADAPTER_ID, "启用态照常保留");
 }
 
 // ---------------------------------------------------------------- adapters/add 路由（issue #38）：围栏 / 校验 / 登记热注册 / 重启合并
@@ -832,6 +888,7 @@ async function waitFor(cond, timeoutMs = 5000, stepMs = 50) {
   assert.ok(client.includes("dou-provHead"), "手风琴折叠头样式类");
   assert.ok(client.includes("dou-provErr"), "错误登记展示（候选执行/文件加载最近一次错误）");
   assert.ok(client.includes("knownProviders"), "消费宿主内置已知清单");
+  assert.ok(client.includes("recognizedProviders"), "消费宿主运行时识别清单（提供商全集第二路来源）");
 
   // issue #27：总览不再硬编码 opencode-go，按 adapters.json enabled 映射逐 provider 拉取
   assert.ok(!client.includes("?provider=opencode-go"), "settings 总览移除硬编码 ?provider=opencode-go");


### PR DESCRIPTION
Refs #38

## 根因

维护者实测：用量统计设置页提供商列表只有 `opencode-go` 一项，与模型配置页可配 provider 数量不符。

`packages/dsh-provider-usage/src/index.ts` 中内置已知清单退化为单元素：

```ts
export const KNOWN_PROVIDERS: string[] = [OPENCODE_GO_PROVIDER];
```

客户端 `unionProviders` 的并集（已注册候选 ∪ 运行时启用 ∪ 内置已知）因此恒等于单提供商；且「运行时识别到的 provider」一路在宿主侧没有任何通道进入 /adapters 响应，issue #38 验收的三路全集实际缺了两路。

## 修复说明

### 1. 运行时识别到的 provider 纳入并集（第二路来源）

排查宿主侧已有的 provider 识别产物，共两路持久化状态，均注入 /adapters 响应新字段 `recognizedProviders`（排序输出）：

- **历史采样桶**（`history/<provider>/<adapterId>.json`）：真实采样过的 provider，响应组装时从 history store 动态读取；
- **启用状态文件键**（`adapter-state.json`）：用户 select 过或显式清空过的 provider——含显式清空 null 态的语义价值：该 provider 从 enabled 映射消失后仍留在设置页全集里可见、可再启用。

客户端 `unionProviders` 的 `ProvidersUnionInput` 增加 `recognized` 来源，设置页消费 `recognizedProviders` 字段。路由契约不变（仅新增响应字段）。

### 2. 内置已知清单扩充（第三路来源）

`KNOWN_PROVIDERS` 从单元素扩充为 **37 个** dsh 模型配置生态权威 provider 路由键。

**清单依据**：DSH 模型配置（Settings → Models / llm-pi-ai 适配器）的内置 catalog 来自 `@earendil-works/pi-ai/providers/all`，其 `BuiltinProvider` 枚举（`models.generated.js` 的 `MODELS` 一级键，与 pnpm-workspace catalog 同源的 pi-ai 0.82.x）即模型配置页可添加的 provider 全集，逐项核对收录：deepseek / openai / anthropic / google(Gemini) / openrouter / qwen-token-plan(+cn) / xai / groq / mistral / moonshotai(+cn) / nvidia / zai 等 37 个。任务描述中的 gemini/qwen 在该枚举中的实际 id 为 google / qwen-token-plan，以可查证的实际枚举为准。

### 3. 无候选 provider 引导文案

确认现有 UI 已满足验收：`ProviderItem` 在 `candidates.length === 0` 时渲染引导文案（提示经 [+ 添加适配器] 注入本地适配器文件或在 cordis.patch.yml 的 adapters.host 配置），本次未改动。

## 测试

- `smoke-pure.ts`（强类型区）：`unionProviders` 多来源合并去重排序行为断言——识别项无候选无启用的语义、识别与启用重叠去重、已知在前引导位排序
- `smoke.ts`：
  - 新增集成块：预置 v3 历史桶文件 + adapter-state.json（含 null 清空态）走真实 apply 加载链路，断言 /adapters 响应 `recognizedProviders` 含两路产物、排序输出、清空态不进 enabled 映射
  - `knownProviders` 断言升级为 deepEqual 权威清单 + 关键成员（deepseek/openai/anthropic/google/openrouter/qwen-token-plan/opencode-go）+ 无重复
  - 客户端 bundle 消费面断言（`recognizedProviders`）

## 验收勾选（issue #38）

- [x] 提供商全集 = 已注册适配器的 providers ∪ 运行时识别到的 provider ∪ 内置已知清单
- [x] 无候选的 provider 也展示并给出引导文案（现有 UI 已满足）
- [x] smoke 断言锁死：/adapters 响应含 recognizedProviders 与扩充后的 knownProviders；客户端并集多来源去重排序
- [x] 门禁全绿：pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck