### PR TITLE
fix(dsh-provider-usage): 用量设置页提供商列表对齐模型配置 (#38)

### DIFF
--- a/packages/dsh-provider-usage/README.md
+++ b/packages/dsh-provider-usage/README.md
@@ -106,7 +106,7 @@ Authorization: Bearer <OPENCODE_GO_API_KEY>
 | --- | --- |
 | `GET /api/dsh-provider-usage/stats[?provider=X]` | 用量统计 + 内嵌 `summary` 子树（胶囊轻量内容）+ `adapterId`/`hasAdapter` |
 | `GET /api/dsh-provider-usage/history[?provider=&adapterId=&days=N]` | 历史采样序列（含 `columns` 列声明） |
-| `GET /api/dsh-provider-usage/adapters.json` | 适配器候选元数据（id/label/providers/source/file/enabled） |
+| `GET /api/dsh-provider-usage/adapters.json` | 适配器候选元数据（id/label/providers/source/file/enabled）+ `modelProviders`（模型配置页提供商路由，设置页主列表同源） |
 | `POST /api/dsh-provider-usage/adapters/select` | 切换启用适配器（body `{provider, adapterId}`） |
 | `GET /api/dsh-provider-usage/user/<n>.js` | 用户客户端渲染器静态服务 |
 | `GET /api/dsh-provider-usage/health` | 健康检查 + 适配器快照 |

--- a/packages/dsh-provider-usage/src/client-logic.ts
+++ b/packages/dsh-provider-usage/src/client-logic.ts
@@ -101,54 +101,55 @@ export function rendererLookupKeys(provider: string, adapterId?: string): string
   return [provider];
 }
 
-// ------------------------------------------------------------------ 设置页·提供商全集（issue #38）
+// ------------------------------------------------------------------ 设置页·提供商列表（issue #38 维护者意图修正）
 
-/** 提供商全集合并的输入（全部来自 adapters.json 响应 + 宿主已知清单）。 */
-export interface ProvidersUnionInput {
+/** 提供商列表拆分的输入（全部来自 adapters.json 响应）。 */
+export interface ProviderListInput {
   /** provider → 已注册候选列表（adapters.json host[] 按 providers 分组）。 */
   candidatesByProvider: Record<string, Array<{ id: string; label: string; source: string }>>;
   /** 运行时启用映射（provider → adapterId）。 */
   enabled?: Record<string, string>;
-  /**
-   * 运行时识别到的 provider（adapters.json recognizedProviders：历史采样桶 ∪
-   * 启用状态文件键；issue #38 第二路来源——无候选无启用的也留在全集可见）。
-   */
-  recognized?: string[];
-  /** 内置已知清单（宿主 knownProviders；无候选也展示并给引导）。 */
-  known: string[];
+  /** 模型配置页提供商路由（adapters.json modelProviders，主列表权威清单）。 */
+  modelProviders?: string[];
 }
 
 /** 提供商列表项（设置页手风琴一行的数据面）。 */
 export interface ProviderListItem {
   provider: string;
-  /** 是否有已注册候选（false = 仅出现在已知清单，需展示引导文案）。 */
+  /** 是否有已注册候选（false = 无候选，展示引导文案）。 */
   hasCandidates: boolean;
   /** 当前启用 adapterId（null = 未启用/已清空）。 */
   enabledId: string | null;
 }
 
-/**
- * 提供商全集 = 已注册候选覆盖 ∪ 运行时启用映射 ∪ 运行时识别 ∪ 内置已知清单
- * （issue #38）。排序：内置已知在前（引导位），其余按字典序；逐项带候选存在性
- * 与启用态，面板直接渲染，不再自行拼装。
- */
-export function unionProviders(input: ProvidersUnionInput): ProviderListItem[] {
-  const providers = new Set<string>();
-  for (const p of Object.keys(input.candidatesByProvider)) providers.add(p);
-  for (const p of Object.keys(input.enabled ?? {})) providers.add(p);
-  for (const p of input.recognized ?? []) providers.add(p);
-  for (const p of input.known) providers.add(p);
-  const knownSet = new Set(input.known);
-  const sorted = [...providers].sort((a, b) => {
-    const ka = knownSet.has(a) ? 0 : 1;
-    const kb = knownSet.has(b) ? 0 : 1;
-    return ka !== kb ? ka - kb : a.localeCompare(b);
-  });
-  return sorted.map((provider) => ({
+function toListItem(input: ProviderListInput, provider: string): ProviderListItem {
+  return {
     provider,
     hasCandidates: (input.candidatesByProvider[provider]?.length ?? 0) > 0,
     enabledId: input.enabled?.[provider] ?? null,
-  }));
+  };
+}
+
+/**
+ * 设置页提供商列表拆分（取代 #68 的四路并集 unionProviders——那会把用户未
+ * 配置的内置清单提供商也列出来，偏离维护者意图）：
+ * - main：与模型配置页提供商列表精确一致（= modelProviders，数量与集合对齐、
+ *   顺序随宿主；无候选的保留展示并给引导文案）；
+ * - extra：候选或启用态指向不在 modelProviders 的 provider（用户适配器自定义
+ *   路由），收进尾部独立分组避免静默消失，不计入主列表数量。
+ */
+export function splitProviderList(input: ProviderListInput): { main: ProviderListItem[]; extra: ProviderListItem[] } {
+  const modelSet = new Set(input.modelProviders ?? []);
+  const main = (input.modelProviders ?? []).map((p) => toListItem(input, p));
+  const extraKeys = new Set<string>();
+  for (const p of Object.keys(input.candidatesByProvider)) {
+    if (!modelSet.has(p)) extraKeys.add(p);
+  }
+  for (const p of Object.keys(input.enabled ?? {})) {
+    if (!modelSet.has(p)) extraKeys.add(p);
+  }
+  const extra = [...extraKeys].sort((a, b) => a.localeCompare(b)).map((p) => toListItem(input, p));
+  return { main, extra };
 }
 
 /** 折叠态徽标文案（issue #38：显示「启用中: <adapter-id>」或「未启用」）。 */

--- a/packages/dsh-provider-usage/src/client/settings.ts
+++ b/packages/dsh-provider-usage/src/client/settings.ts
@@ -4,11 +4,13 @@
  * 经 slots.inject("settings.section") 注册顶层 tab，React 渲染四区：
  * - 总览：当前生效适配器逐 provider 摘要（enabled 映射驱动，保留）
  * - 用量可视化：summary 文案 + 各窗口明细表（保留）
- * - 提供商列表（替代原「适配器管理」平铺区块）：全集 = 已注册候选 ∪ 运行时
- *   识别（recognizedProviders）∪ 运行时启用 ∪ 内置已知清单（无候选也展示并给
- *   引导）；折叠态徽标显示「启用中: <adapter-id>」，展开页内管理候选适配器
- *   （名称/来源/启用开关单选）、[禁用该提供商]、[+ 添加适配器]（本地文件路径
- *   登记并热注册）
+ * - 提供商列表（替代原「适配器管理」平铺区块）：主列表与 dsh 模型配置页的
+ *   提供商列表精确一致（adapters.json modelProviders = ctx.llm.listProviders()
+ *   注册路由，issue #38 维护者意图修正）；无候选的保留展示并给引导；候选或
+ *   启用态指向不在模型配置中的 provider 收进尾部独立分组「未在模型配置中的
+ *   适配器」（避免静默消失，不计入主列表数量）。折叠态徽标显示
+ *   「启用中: <adapter-id>」，展开页内管理候选适配器（名称/来源/启用开关单选）、
+ *   [禁用该提供商]、[+ 添加适配器]（本地文件路径登记并热注册）
  * - 配置：常用配置键展示（patch 层为单一事实源，此处只读）
  *
  * 数据面：全部走宿主 loopback 路由（/stats、/adapters.json、POST /adapters/select、
@@ -16,7 +18,7 @@
  */
 import * as React from "react";
 import { STATS_URL, ADAPTERS_URL, SELECT_URL, ADD_URL } from "./core.js";
-import { unionProviders, providerBadgeText } from "../client-logic.js";
+import { splitProviderList, providerBadgeText } from "../client-logic.js";
 import type { ProviderListItem } from "../client-logic.js";
 
 /** 候选条目（adapters.json host[]）。 */
@@ -42,9 +44,8 @@ interface AdaptersMeta {
   version?: number;
   host?: AdapterInfo[];
   enabled?: Record<string, string>;
-  knownProviders?: string[];
-  /** 运行时识别到的 provider（issue #38 第二路来源：历史采样 ∪ 启用状态文件键）。 */
-  recognizedProviders?: string[];
+  /** 模型配置页提供商路由（与 dsh 设置「模型」页同源，主列表权威清单）。 */
+  modelProviders?: string[];
   errors?: AdapterErrorEntry[];
 }
 
@@ -381,17 +382,19 @@ function ProviderItem({
   );
 }
 
-/** 提供商列表区（issue #38）：全集合并 + 手风琴展开管理。 */
+/** 提供商列表区（issue #38 意图修正）：主列表对齐模型配置页 + 额外 provider 独立分组。 */
 function ProviderListSection({
   meta,
-  items,
+  main,
+  extra,
   busy,
   onSwitch,
   onDisable,
   onAdd,
 }: {
   meta: AdaptersMeta | null;
-  items: ProviderListItem[];
+  main: ProviderListItem[];
+  extra: ProviderListItem[];
   busy: boolean;
   onSwitch(provider: string, adapterId: string): void;
   onDisable(provider: string): void;
@@ -411,6 +414,25 @@ function ProviderListSection({
   // 用户文件加载失败错误无 provider 归属（登记 key=file:<名>），在列表顶部全局展示一次
   const fileErrors = [...errorByKey.entries()].filter(([k]) => k.startsWith("file:"));
 
+  /** 手风琴渲染复用（主分组与额外分组同构）。 */
+  const accordion = (items: ProviderListItem[]): React.ReactElement =>
+    React.createElement(
+      "div",
+      { className: "dou-provList" },
+      items.map((item) =>
+        React.createElement(ProviderItem, {
+          key: item.provider,
+          item,
+          candidates: candidatesByProvider.get(item.provider) ?? [],
+          errorByKey,
+          busy,
+          onSwitch,
+          onDisable,
+          onAdd,
+        }),
+      ),
+    );
+
   return React.createElement(
     "div",
     { style: sectionStyle },
@@ -418,7 +440,7 @@ function ProviderListSection({
     React.createElement(
       "div",
       { className: "dou-hint" },
-      "提供商全集 = 已注册适配器 ∪ 运行时识别 ∪ 内置已知清单；展开某个提供商以切换/禁用其适配器或添加新适配器。",
+      `提供商列表与模型配置页保持一致（共 ${main.length} 个）；展开某个提供商以切换/禁用其适配器或添加新适配器。`,
     ),
     fileErrors.length > 0
       ? fileErrors.map(([k, e]) =>
@@ -429,24 +451,28 @@ function ProviderListSection({
           ),
         )
       : null,
-    items.length === 0
+    main.length === 0
       ? React.createElement("div", { style: { color: "var(--dsw-alias-label-tertiary,#9aa0ab)" } }, "无提供商数据（adapters.json 不可达）")
-      : React.createElement(
+      : accordion(main),
+    // 尾部独立分组：候选/启用态指向不在模型配置中的 provider（避免静默消失，
+    // 不计入上方主列表数量）
+    extra.length > 0
+      ? React.createElement(
           "div",
-          { className: "dou-provList" },
-          items.map((item) =>
-            React.createElement(ProviderItem, {
-              key: item.provider,
-              item,
-              candidates: candidatesByProvider.get(item.provider) ?? [],
-              errorByKey,
-              busy,
-              onSwitch,
-              onDisable,
-              onAdd,
-            }),
+          null,
+          React.createElement(
+            "h4",
+            { style: titleStyle },
+            "未在模型配置中的适配器",
           ),
-        ),
+          React.createElement(
+            "div",
+            { className: "dou-hint" },
+            "以下提供商不在模型配置页的提供商列表中（用户适配器指向的自定义路由），不计入上方数量。",
+          ),
+          accordion(extra),
+        )
+      : null,
   );
 }
 
@@ -464,11 +490,11 @@ function ConfigSection() {
   );
 }
 
-/** 设置页根组件：提供商全集驱动手风琴；总览/可视化仅对启用中的 provider 拉 /stats。 */
+/** 设置页根组件：模型配置提供商列表驱动手风琴；总览/可视化仅对启用中的 provider 拉 /stats。 */
 export function SettingsPage() {
   const [statsByProvider, setStatsByProvider] = React.useState<Record<string, StatsView | null>>({});
   const [meta, setMeta] = React.useState<AdaptersMeta | null>(null);
-  const [items, setItems] = React.useState<ProviderListItem[]>([]);
+  const [list, setList] = React.useState<{ main: ProviderListItem[]; extra: ProviderListItem[] }>({ main: [], extra: [] });
   const [busy, setBusy] = React.useState(false);
 
   const reload = React.useCallback(async (): Promise<void> => {
@@ -476,19 +502,19 @@ export function SettingsPage() {
       const m = (await jsonGet(ADAPTERS_URL).catch(() => null)) as AdaptersMeta | null;
       if (m !== null) {
         setMeta(m);
-        // issue #38：提供商全集 = 已注册候选 ∪ 运行时启用 ∪ 内置已知清单
+        // issue #38 意图修正：主列表 = modelProviders（与模型配置页精确一致），
+        // 额外 provider 收进独立分组
         const grouped: Record<string, Array<{ id: string; label: string; source: string }>> = {};
         for (const info of m.host ?? []) {
           for (const provider of info.providers) {
             (grouped[provider] ??= []).push({ id: info.id, label: info.label, source: info.source });
           }
         }
-        setItems(
-          unionProviders({
+        setList(
+          splitProviderList({
             candidatesByProvider: grouped,
             enabled: m.enabled,
-            recognized: m.recognizedProviders ?? [],
-            known: m.knownProviders ?? [],
+            modelProviders: m.modelProviders ?? [],
           }),
         );
       }
@@ -575,7 +601,7 @@ export function SettingsPage() {
     { className: "dou-settings", style: { maxWidth: 560 } },
     React.createElement(OverviewSection, { statsByProvider }),
     React.createElement(UsageSection, { statsByProvider }),
-    React.createElement(ProviderListSection, { meta, items, busy, onSwitch, onDisable, onAdd }),
+    React.createElement(ProviderListSection, { meta, main: list.main, extra: list.extra, busy, onSwitch, onDisable, onAdd }),
     React.createElement(ConfigSection, null),
   );
 }

--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -101,7 +101,9 @@ function isUnknownArray(v: unknown): v is readonly unknown[] {
 // ------------------------------------------------------------------ 常量
 
 export const name = "provider-usage";
-export const inject: string[] = ["webServer"];
+// issue #38 维护者意图修正：llm 服务只读（模型配置页提供商路由清单同源），
+// 不向其注册/写入任何状态。
+export const inject: string[] = ["webServer", "llm"];
 
 export const ROUTES: Record<string, string> = {
   stats: "/api/dsh-provider-usage/stats",
@@ -126,55 +128,30 @@ export const DEFAULT_CONFIG: NormalizedConfig = {
 };
 
 /**
- * 内置已知 provider 清单（issue #38：设置页提供商全集的第三路来源——无候选的
- * 也展示并给引导）。
+ * 模型配置页提供商路由清单（issue #38 维护者意图修正，取代 #68 的
+ * knownProviders/recognizedProviders 超集路径）：读 `ctx.llm.listProviders()`
+ * 逐项 detached 元数据的 id 字段——与 dsh 设置「模型」页提供商列表同源，
+ * 用量设置页主列表据此与其数量、集合精确对齐。
  *
- * 权威依据：dsh 模型配置生态（llm-pi-ai）内置 catalog 的 provider 路由键集，
- * 即 @earendil-works/pi-ai `providers/all` 的 `BuiltinProvider` 枚举
- * （`MODELS` 一级键，锁版见 dsh pnpm-workspace catalog 同源 pi-ai 0.82.x），
- * 覆盖 deepseek / openai / anthropic / google(Gemini) / openrouter /
- * qwen-token-plan 等；模型配置页可添加的 provider 与此处一一对应。
- * 升级 pi-ai 后新增 provider 时同步维护本清单。
+ * 防御式只读：llm 服务缺失 / listProviders 异常 / 返回形状不符时回落空数组，
+ * 插件自身不因宿主形态差异而挂；绝不向 llm 写入任何状态。
  */
-export const KNOWN_PROVIDERS: string[] = [
-  "amazon-bedrock",
-  "ant-ling",
-  "anthropic",
-  "azure-openai-responses",
-  "cerebras",
-  "cloudflare-ai-gateway",
-  "cloudflare-workers-ai",
-  "deepseek",
-  "fireworks",
-  "github-copilot",
-  "google",
-  "google-vertex",
-  "groq",
-  "huggingface",
-  "kimi-coding",
-  "minimax",
-  "minimax-cn",
-  "mistral",
-  "moonshotai",
-  "moonshotai-cn",
-  OPENCODE_GO_PROVIDER, // opencode-go
-  "nvidia",
-  "openai",
-  "openai-codex",
-  "opencode",
-  "openrouter",
-  "qwen-token-plan",
-  "qwen-token-plan-cn",
-  "together",
-  "vercel-ai-gateway",
-  "xai",
-  "xiaomi",
-  "xiaomi-token-plan-ams",
-  "xiaomi-token-plan-cn",
-  "xiaomi-token-plan-sgp",
-  "zai",
-  "zai-coding-cn",
-];
+export function readModelProviderIds(ctx: Context): string[] {
+  try {
+    const llm = (ctx as { llm?: { listProviders?: () => unknown } }).llm;
+    if (typeof llm?.listProviders !== "function") return [];
+    const listed = llm.listProviders();
+    if (!isUnknownArray(listed)) return [];
+    const ids = new Set<string>();
+    for (const item of listed) {
+      const id = (item as { id?: unknown } | null)?.id;
+      if (typeof id === "string" && id !== "") ids.add(id);
+    }
+    return [...ids].sort((a, b) => a.localeCompare(b));
+  } catch {
+    return [];
+  }
+}
 
 /**
  * 设置面板 schemastery schema（M3b：settings 命名空间用，与 normalizeConfig 同构）。
@@ -1126,12 +1103,6 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
     registry.select(provider, adapterId);
   }
 
-  // issue #38：宿主侧「运行时识别到的 provider」持久化产物之一——启用状态文件
-  // 中出现过的键（含显式清空 null 的：该 provider 从 enabled 映射消失，但仍算
-  // 运行时见过，须留在设置页全集里可见、可再启用）。历史采样桶为另一路产物，
-  // 在 /adapters 响应组装时动态并入（见 adaptersRoute）。
-  const stateRecognizedProviders = new Set<string>(Object.keys(savedEnabled));
-
   const store = makeHistoryStore({
     maxAgeDays: current.maxAgeDays,
     diag: (m): void => console.warn(`[dsh-provider-usage]`, m),
@@ -1526,18 +1497,10 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
         })),
         enabled: snap.enabled,
         client,
-        // issue #38：内置已知 provider 清单（提供商全集第三路来源）
-        knownProviders: [...KNOWN_PROVIDERS],
-        // issue #38：运行时识别到的 provider（提供商全集第二路来源）= 历史采样桶
-        // 覆盖的 provider ∪ 启用状态文件出现过的键。排序输出便于客户端直接消费。
-        recognizedProviders: (() => {
-          const recognized = new Set<string>(stateRecognizedProviders);
-          for (const key of store.keys()) {
-            const provider = key.split("/")[0] ?? "";
-            if (provider !== "") recognized.add(provider);
-          }
-          return [...recognized].sort((a, b) => a.localeCompare(b));
-        })(),
+        // issue #38 维护者意图修正（取代 #68 knownProviders/recognizedProviders）：
+        // 提供商主列表与 dsh 模型配置页精确一致 = ctx.llm.listProviders() 的
+        // 注册路由 id 集；用户适配器指向的额外 provider 由客户端收进独立分组。
+        modelProviders: readModelProviderIds(ctx),
         // issue #38：最近一次适配器错误登记（面板排障展示；key=adapterId 或 file:<名>）
         errors: snap.errors.map((e) => ({ key: e.key, at: e.at, kind: e.kind, message: e.message })),
       });

--- a/packages/dsh-provider-usage/test/smoke-pure.ts
+++ b/packages/dsh-provider-usage/test/smoke-pure.ts
@@ -52,8 +52,8 @@ import {
   derivePillTitle,
   shouldHideFloat,
   rendererLookupKeys,
-  // 设置页提供商全集（issue #38）
-  unionProviders,
+  // 设置页提供商列表拆分（issue #38 维护者意图修正）
+  splitProviderList,
   providerBadgeText,
 } from "../lib/index.js";
 
@@ -665,7 +665,15 @@ function mkSummary(overrides: Partial<ProviderSummary> = {}): ProviderSummary {
 
 {
   // 无调用方的导出已从导出面移除（防回归）
-  for (const key of ["CONFIG_KEYS", "defaultPersistFile", "resolvePathWeak", "OPENCODE_GO_DEFAULT_ENABLED"] as const) {
+  for (const key of [
+    "CONFIG_KEYS",
+    "defaultPersistFile",
+    "resolvePathWeak",
+    "OPENCODE_GO_DEFAULT_ENABLED",
+    // issue #38 维护者意图修正：knownProviders/recognizedProviders 超集路径移除
+    "KNOWN_PROVIDERS",
+    "unionProviders",
+  ] as const) {
     assert.equal(key in libIndex, false, `死代码 ${key} 已从导出面移除`);
   }
   // 注册表不再暴露 unregisterProvider（无调用方）
@@ -679,36 +687,58 @@ function mkSummary(overrides: Partial<ProviderSummary> = {}): ProviderSummary {
   );
 }
 
-// ---------------------------------------------------------------- 设置页·提供商全集（issue #38）
+// ---------------------------------------------------------------- 设置页·提供商列表拆分（issue #38 维护者意图修正）
 
 {
-  const items = unionProviders({
+  const input = {
     candidatesByProvider: {
       "opencode-go": [{ id: "opencode-go-builtin", label: "OpenCode Go 官方", source: "builtin" }],
       "z-relay": [{ id: "z-relay-user", label: "Z Relay", source: "user-file" }],
     },
-    enabled: { "opencode-go": "opencode-go-builtin", "runtime-only": "x" },
-    recognized: ["hist-only", "runtime-only", "opencode-go"],
-    known: ["opencode-go", "future-provider"],
-  });
-  // 全集四路合并去重：候选 ∪ 启用 ∪ 运行时识别 ∪ 已知
+    enabled: { "opencode-go": "opencode-go-builtin" },
+    modelProviders: ["anthropic", "opencode-go", "deepseek"],
+  };
+  const { main, extra } = splitProviderList(input);
+  // 主列表与模型配置页精确一致：数量与顺序严格等于 modelProviders
   assert.deepEqual(
-    items.map((i) => i.provider),
-    ["future-provider", "opencode-go", "hist-only", "runtime-only", "z-relay"],
-    "全集 = 候选 ∪ 运行时启用 ∪ 运行时识别 ∪ 内置已知（已知在前，其余字典序）",
+    main.map((i) => i.provider),
+    ["anthropic", "opencode-go", "deepseek"],
+    "主列表 = modelProviders 精确一致（数量与模型配置页对齐）",
   );
-  const ocg = items.find((i) => i.provider === "opencode-go");
-  assert.ok(ocg?.hasCandidates && ocg.enabledId === "opencode-go-builtin", "已知且有候选：带启用态");
-  const future = items.find((i) => i.provider === "future-provider");
-  assert.equal(future?.hasCandidates, false, "仅已知清单项无候选（引导位）");
-  // 运行时识别项：无候选无启用也入全集；与 enabled 重叠的 provider 去重只出现一次
-  const hist = items.find((i) => i.provider === "hist-only");
-  assert.equal(hist?.hasCandidates, false, "运行时识别项无候选");
-  assert.equal(hist?.enabledId, null, "运行时识别项未启用");
-  assert.equal(items.filter((i) => i.provider === "runtime-only").length, 1, "识别与启用重叠去重");
-  assert.equal(items.find((i) => i.provider === "runtime-only")?.enabledId, "x", "运行时启用映射入全集");
-  // 空输入 → 空列表
-  assert.deepEqual(unionProviders({ candidatesByProvider: {}, known: [] }), [], "空输入空列表");
+  const ocg = main.find((i) => i.provider === "opencode-go");
+  assert.ok(ocg?.hasCandidates && ocg.enabledId === "opencode-go-builtin", "主列表项带候选存在性与启用态");
+  // 无适配器候选的 modelProvider 保留展示（引导位）
+  assert.equal(main.find((i) => i.provider === "anthropic")?.hasCandidates, false, "无候选的 modelProvider 保留展示（引导文案）");
+  assert.equal(main.find((i) => i.provider === "deepseek")?.enabledId, null, "无启用的 modelProvider enabledId null");
+  // 用户适配器指向不在 modelProviders 的 provider → 收进尾部独立分组，不计入主列表数量
+  assert.deepEqual(extra.map((i) => i.provider), ["z-relay"], "额外 provider 进独立分组（字典序）");
+  assert.equal(extra[0]?.hasCandidates, true, "额外分组项带候选存在性");
+  assert.equal(extra[0]?.enabledId, null, "额外分组项未启用时 enabledId null");
+
+  // 启用态指向额外 provider 同样进独立分组（带启用态）
+  const onlyEnabled = splitProviderList({
+    candidatesByProvider: {},
+    enabled: { "ghost-relay": "ghost-a" },
+    modelProviders: ["opencode-go"],
+  });
+  assert.deepEqual(onlyEnabled.main.map((i) => i.provider), ["opencode-go"], "主列表不受额外启用影响");
+  assert.deepEqual(onlyEnabled.extra.map((i) => i.provider), ["ghost-relay"], "启用态指向的额外 provider 进独立分组");
+  assert.equal(onlyEnabled.extra[0]?.enabledId, "ghost-a", "额外分组项带启用态");
+
+  // 空 modelProviders → 主列表空，候选仍经独立分组可见（不静默消失）
+  const emptyModel = splitProviderList({
+    candidatesByProvider: { solo: [{ id: "solo-a", label: "S", source: "user-file" }] },
+    modelProviders: [],
+  });
+  assert.deepEqual(emptyModel.main, [], "空 modelProviders → 主列表空");
+  assert.deepEqual(emptyModel.extra.map((i) => i.provider), ["solo"], "无模型配置时候选仍可见（独立分组）");
+
+  // 双空输入 → 双空列表
+  assert.deepEqual(
+    splitProviderList({ candidatesByProvider: {}, modelProviders: [] }),
+    { main: [], extra: [] },
+    "空输入双空列表",
+  );
 }
 
 {

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -23,7 +23,6 @@ import {
   apply,
   ROUTES,
   DEFAULT_CONFIG,
-  KNOWN_PROVIDERS,
   OPENCODE_GO_PROVIDER,
   OPENCODE_GO_ADAPTER_ID,
   LEGACY_ADAPTER_ID,
@@ -63,6 +62,17 @@ function makeFakeCtx(overrides = {}) {
       register(route) {
         routes.push(route);
         return () => {};
+      },
+    },
+    // 模型配置页同源 llm 服务桩（issue #38 维护者意图修正）：默认注册路由集，
+    // 用例经 overrides.llm 覆盖以验证 modelProviders 与注入服务的一致性。
+    llm: {
+      listProviders() {
+        return [
+          { id: "anthropic", name: "Anthropic" },
+          { id: "deepseek", name: "DeepSeek" },
+          { id: OPENCODE_GO_PROVIDER, name: "OpenCode Go" },
+        ];
       },
     },
     effect(fn) {
@@ -133,12 +143,58 @@ function makeFakeCtx(overrides = {}) {
   assert.equal(payload.host[0].id, "opencode-go-builtin", "候选带 id");
   assert.equal(payload.host[0].enabled, true, "候选带 enabled");
   assert.equal(payload.enabled["opencode-go"], "opencode-go-builtin", "enabled 映射 provider→adapterId");
-  assert.deepEqual(payload.knownProviders, KNOWN_PROVIDERS, "knownProviders = 内置已知权威清单（issue #38）");
-  // 权威清单关键成员（dsh 模型配置生态常见 provider，pi-ai catalog 路由键）
-  for (const p of ["deepseek", "openai", "anthropic", "google", "openrouter", "qwen-token-plan", OPENCODE_GO_PROVIDER]) {
-    assert.ok(KNOWN_PROVIDERS.includes(p), `内置已知清单含 ${p}`);
+  // issue #38 维护者意图修正：modelProviders = 注入 llm 服务注册路由的 id 集
+  // （与模型配置页同源），排序去重输出；knownProviders/recognizedProviders 超集路径移除
+  assert.deepEqual(
+    payload.modelProviders,
+    ["anthropic", "deepseek", OPENCODE_GO_PROVIDER],
+    "adapters.json modelProviders 与注入 llm 服务的注册路由一致",
+  );
+  assert.equal("knownProviders" in payload, false, "knownProviders 路径已移除（意图修正）");
+  assert.equal("recognizedProviders" in payload, false, "recognizedProviders 路径已移除（意图修正）");
+  assert.equal(new Set(payload.modelProviders).size, payload.modelProviders.length, "modelProviders 无重复");
+  // 防御式只读：llm 缺失 / listProviders 抛错 / 形状不符 → 回落空数组或剔除非法项，不挂
+  {
+    const { ctx: ctxNoLlm, routes: routesNoLlm } = makeFakeCtx({ llm: undefined });
+    await apply(ctxNoLlm, {});
+    const noLlmRoute = routesNoLlm.find((r) => r.path === ROUTES.adapters);
+    let noLlmPayload;
+    const noLlmRes = { writeHead: () => {}, end: (chunk) => { noLlmPayload = JSON.parse(chunk); } };
+    noLlmRoute.handler(fakeReq(), noLlmRes);
+    assert.deepEqual(noLlmPayload.modelProviders, [], "llm 服务缺失时 modelProviders 回落空数组");
+
+    const { ctx: ctxThrow, routes: routesThrow } = makeFakeCtx({
+      llm: { listProviders() { throw new Error("boom-llm"); } },
+    });
+    await apply(ctxThrow, {});
+    const throwRoute = routesThrow.find((r) => r.path === ROUTES.adapters);
+    let throwPayload;
+    const throwRes = { writeHead: () => {}, end: (chunk) => { throwPayload = JSON.parse(chunk); } };
+    throwRoute.handler(fakeReq(), throwRes);
+    assert.deepEqual(throwPayload.modelProviders, [], "listProviders 抛错时 modelProviders 回落空数组");
+
+    const { ctx: ctxShape, routes: routesShape } = makeFakeCtx({
+      llm: { listProviders: () => [{ name: "无 id" }, null, { id: 42 }, { id: "valid-relay", name: "V" }] },
+    });
+    await apply(ctxShape, {});
+    const shapeRoute = routesShape.find((r) => r.path === ROUTES.adapters);
+    let shapePayload;
+    const shapeRes = { writeHead: () => {}, end: (chunk) => { shapePayload = JSON.parse(chunk); } };
+    shapeRoute.handler(fakeReq(), shapeRes);
+    assert.deepEqual(shapePayload.modelProviders, ["valid-relay"], "形状不符项剔除，仅收合法字符串 id");
   }
-  assert.equal(new Set(KNOWN_PROVIDERS).size, KNOWN_PROVIDERS.length, "内置已知清单无重复");
+  // 自定义 llm 路由集照实透传（排序），不掺任何内置清单
+  {
+    const { ctx: ctxCustom, routes: routesCustom } = makeFakeCtx({
+      llm: { listProviders: () => [{ id: "z-custom", name: "Z" }, { id: "a-custom", name: "A" }] },
+    });
+    await apply(ctxCustom, {});
+    const customRoute = routesCustom.find((r) => r.path === ROUTES.adapters);
+    let customPayload;
+    const customRes = { writeHead: () => {}, end: (chunk) => { customPayload = JSON.parse(chunk); } };
+    customRoute.handler(fakeReq(), customRes);
+    assert.deepEqual(customPayload.modelProviders, ["a-custom", "z-custom"], "自定义 llm 路由集照实透传（排序）");
+  }
   assert.deepEqual(payload.client, [], "无客户端适配器时为 []");
   // 带客户端适配器配置
   const { ctx: ctx3, routes: routes3 } = makeFakeCtx();
@@ -203,12 +259,12 @@ function makeFakeCtx(overrides = {}) {
   assert.equal(payload.adapterId, "opencode-go-builtin");
 }
 
-// ---------------------------------------------------------------- 运行时识别 provider 注入 /adapters（issue #38）
+// ---------------------------------------------------------------- 历史桶/状态文件键不进提供商列表（issue #38 维护者意图修正）
 
 {
   const dir = mkdtempSync(join(tmpdir(), "dou-recog-"));
-  // 预置宿主侧运行时识别产物（两路持久化状态）：
-  // 1) 历史采样桶：hist-relay 经 legacy 桶采过样（v3 多文件格式）
+  // 预置旧「识别路径」的持久化产物（#68 曾据此扩充列表，现应只作数据保留、
+  // 不再驱动展示）：1) 历史采样桶 hist-relay；2) 启用状态文件显式清空键 cleared-relay
   mkdirSync(join(dir, "history", "hist-relay"), { recursive: true });
   writeFileSync(
     join(dir, "history", "hist-relay", `${LEGACY_ADAPTER_ID}.json`),
@@ -220,14 +276,15 @@ function makeFakeCtx(overrides = {}) {
       samples: [[Date.now() - 60000, 5]],
     }),
   );
-  // 2) 启用状态文件键（含显式清空 null 的 cleared-relay：已从 enabled 映射消失，
-  //    但属运行时见过的 provider，须留在全集可见、可再启用）
   writeFileSync(
     join(dir, "adapter-state.json"),
     JSON.stringify({ "cleared-relay": null, [OPENCODE_GO_PROVIDER]: OPENCODE_GO_ADAPTER_ID }),
   );
 
-  const { ctx, routes } = makeFakeCtx();
+  // llm 桩收窄到仅 opencode-go：modelProviders 必须与注册路由精确一致
+  const { ctx, routes } = makeFakeCtx({
+    llm: { listProviders: () => [{ id: OPENCODE_GO_PROVIDER, name: "OpenCode Go" }] },
+  });
   await apply(ctx, {
     persistFile: join(dir, "history.json"),
     fetchImpl: async () => fakeRes(200, OK_BODY),
@@ -239,16 +296,12 @@ function makeFakeCtx(overrides = {}) {
   const res = { writeHead: () => {}, end: (chunk) => { payload = JSON.parse(chunk); } };
   adaptersRoute.handler(fakeReq(), res);
 
-  assert.ok(Array.isArray(payload.recognizedProviders), "adapters.json 带 recognizedProviders 字段");
+  // 主列表严格等于模型配置页提供商路由：历史桶/状态文件键不掺入
+  assert.deepEqual(payload.modelProviders, [OPENCODE_GO_PROVIDER], "modelProviders 仅含注入 llm 的注册路由");
   for (const p of ["hist-relay", "cleared-relay"]) {
-    assert.ok(payload.recognizedProviders.includes(p), `recognizedProviders 含历史桶/状态文件识别的 ${p}`);
+    assert.equal(payload.modelProviders.includes(p), false, `${p} 不因历史桶/状态文件键混入主列表`);
   }
-  assert.deepEqual(
-    payload.recognizedProviders,
-    [...payload.recognizedProviders].sort((a, b) => a.localeCompare(b)),
-    "recognizedProviders 排序输出",
-  );
-  // 显式清空的 provider 不在 enabled 映射（select(null) 即删），只能经识别来源留在全集
+  // 启用状态照常生效：opencode-go 默认启用保留、显式清空不回 enabled 映射
   assert.equal(payload.enabled["cleared-relay"], undefined, "清空态不进 enabled 映射");
   assert.equal(payload.enabled[OPENCODE_GO_PROVIDER], OPENCODE_GO_ADAPTER_ID, "启用态照常保留");
 }
@@ -331,6 +384,8 @@ function makeFakeCtx(overrides = {}) {
   assert.ok(addedInfo, "热注册后候选可见");
   assert.equal(addedInfo.enabled, true, "新添加适配器默认启用");
   assert.equal(meta.enabled["added-relay-provider"], "added-relay", "enabled 映射含新 provider");
+  // 用户适配器指向的自定义路由不混入 modelProviders（客户端收进独立分组）
+  assert.equal(meta.modelProviders.includes("added-relay-provider"), false, "自定义路由 provider 不进 modelProviders");
   const stats = routes.find((r) => r.path === ROUTES.stats);
   let statsPayload;
   const statsRes = { writeHead: () => {}, end: (chunk) => { statsPayload = JSON.parse(chunk); } };
@@ -887,8 +942,8 @@ async function waitFor(cond, timeoutMs = 5000, stepMs = 50) {
   assert.ok(client.includes("+ 添加适配器"), "提供商展开页内添加入口");
   assert.ok(client.includes("dou-provHead"), "手风琴折叠头样式类");
   assert.ok(client.includes("dou-provErr"), "错误登记展示（候选执行/文件加载最近一次错误）");
-  assert.ok(client.includes("knownProviders"), "消费宿主内置已知清单");
-  assert.ok(client.includes("recognizedProviders"), "消费宿主运行时识别清单（提供商全集第二路来源）");
+  assert.ok(client.includes("modelProviders"), "消费宿主模型配置提供商清单（与模型配置页同源）");
+  assert.ok(client.includes("未在模型配置中的适配器"), "额外 provider 独立分组展示（不静默消失）");
 
   // issue #27：总览不再硬编码 opencode-go，按 adapters.json enabled 映射逐 provider 拉取
   assert.ok(!client.includes("?provider=opencode-go"), "settings 总览移除硬编码 ?provider=opencode-go");


### PR DESCRIPTION
## 维护者意图修正

维护者实测后转向：用量统计设置页展示的提供商须**与 dsh 模型配置页的提供商列表保持一致**，而非「注册 ∪ 识别 ∪ 内置」超集。#68 的三路并集方向偏离意图——会把用户未配置的内置清单提供商（KNOWN_PROVIDERS 全量 36 项）也列出来。本 PR 在 #65/#68 之上修正展示语义。

## 数据源说明

- 权威来源：官方类型层 `@deepseek-ai/dsh-llm`（lib/types/index.d.ts）
  - `ctx.llm.listProviders(): LlmProviderInfo[]` —— 已注册适配器的提供商路由，**模型配置页同源**
- 宿主侧 `/adapters.json` 响应以 `modelProviders: string[]` 携带该清单（逐项 detached 元数据的 `id` 字段，去重排序），取代 #68 引入的 `knownProviders` / `recognizedProviders` 路径
- `inject` 增声明 `llm` 服务：**只读不写入**；llm 缺失 / listProviders 抛错 / 返回形状不符时防御式回落空数组或剔除非法项，插件不因宿主形态差异而挂
- 红线遵守：未触碰 `.github/`、package.json 依赖清单、pnpm-lock.yaml、shared/、types 层

## 改动

宿主侧（src/index.ts）：
- 删除 `KNOWN_PROVIDERS` 内置清单、历史桶/状态文件识别来源（`stateRecognizedProviders`）及其响应组装逻辑
- `modelProviders = readModelProviderIds(ctx)`

客户端（client-logic.ts / client/settings.ts）：
- `splitProviderList` 取代 `unionProviders` 四路并集：
  - **主列表严格等于 modelProviders**（数量与模型配置页对齐，顺序随宿主）
  - 无适配器候选的 modelProvider **保留展示并给引导文案**（沿用现有空态）
  - 候选/启用态指向不在 modelProviders 的 provider 收进尾部独立分组**「未在模型配置中的适配器」**（避免静默消失，不计入主列表数量）

测试与文档：smoke-pure 行为级断言重写 + smoke 集成断言更新 + README 同步。

## 验收勾选

- [x] 宿主侧 /adapters 响应携带 `modelProviders: string[]`（来自 `ctx.llm.listProviders()` 的 id 列表，取 detached 元数据 id 字段），knownProviders / recognizedProviders 路径移除
- [x] 客户端设置页提供商主列表与 modelProviders 精确一致（数量与模型配置页对齐）；每项挂候选适配器与启用态
- [x] 指向不在 modelProviders 中 provider 的用户适配器收进尾部独立分组「未在模型配置中的适配器」，不计入主列表数量
- [x] 无适配器候选的 modelProvider 保留展示并给引导文案（沿用现有空态）
- [x] smoke 更新：modelProviders 与注入 llm 服务注册路由一致；主列表严格等于 modelProviders；额外 provider 进独立分组；旧字段移除防回归
- [x] 五连门禁全绿：`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck`

Refs #38