### PR TITLE
docs(release): 修正 v0.1.11 notes 语言跳转锚点为显式 HTML 标记

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,9 @@ Conventional Commits（`type(scope): subject`；type：`feat` / `fix` / `docs` /
   tag 校验。
 - GitHub Release 更新说明**每版入库**为 `docs/release-notes/vX.Y.Z.md`，由发版 agent
   从上一 tag 至今的常规提交生成、**中文与英文各自成节分开呈现（不逐条混排）**、
-  **文件头提供语言锚点跳转导航**（如 `> [中文](#中文) · [English](#english)`）、
+  **文件头提供语言跳转导航，锚点用显式 HTML 标记 + ASCII id**
+  （各渲染器标题 slug 规则不一，中文锚点不可靠。如：
+  头部 `> [中文](#zh) · [English](#en)`，分节前 `<a id="zh"></a>` / `<a id="en"></a>`）、
   随 `chore(release):` 提交；
   管线优先引用该文件，缺失则回退 GitHub 自动 notes。**禁止 emoji**（覆盖文档与提交信息）。
 - 合并方式：CI 全绿后 squash merge（见 CONTRIBUTING.md 开发流程）。

--- a/docs/release-notes/v0.1.11.md
+++ b/docs/release-notes/v0.1.11.md
@@ -1,6 +1,8 @@
 # v0.1.11 发布说明 / Release Notes
 
-> **[中文](#中文)** · **[English](#english)**
+> **[中文](#zh)** · **[English](#en)**
+
+<a id="zh"></a>
 
 ## 中文
 
@@ -27,6 +29,8 @@
 - [dsh-notifier] 宿主入口按职责拆分（config/message/history/quiet-hours/server，最大源文件 1326→535 行）、smoke 测试按功能重组（单文件 ≤400 行，断言 265→271）。
 - [types] 删除自建类型层 `types/dsh.d.ts`，宿主端全量切换官方 `@deepseek-ai/*` 类型导出（catalog 锁版，仅 import type）。
 - [docs] agent 规程交叉引用补全；lan-proxy 安全模型节披露 health 元数据经代理对局域网可见。
+
+<a id="en"></a>
 
 ## English
 


### PR DESCRIPTION
## 缘由

v0.1.11 发布说明的文件头语言跳转使用 `(#中文)` / `(#english)` 标题锚点——各渲染器对标题 slug 的生成规则不一，中文锚点不可靠，实测跳转失效。

## 变更
- 分节前插入显式 HTML 锚点 `<a id="zh"></a>` / `<a id="en"></a>`
- 头部导航改为 `[中文](#zh) · [English](#en)`
- AGENTS.md 发布纪律同步固化该写法（ASCII id + 显式锚点），后续版本遵循

纯文档改动；GitHub Release 正文将随本 PR 合并后同步更新。