### PR TITLE
fix(dsh-provider-usage): 适配器添加链路三处修复——~路径误拦/输入框纵向撑爆/慢远端并发占满 (#87)

### DIFF
--- a/packages/dsh-provider-usage/package.json
+++ b/packages/dsh-provider-usage/package.json
@@ -55,7 +55,8 @@
   "devDependencies": {
     "@deepseek-ai/cordis": "catalog:",
     "@deepseek-ai/dsh-host-webserver": "catalog:",
-    "schemastery": "^3.18.0"
+    "schemastery": "^3.18.0",
+    "untildify": "^6.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/dsh-provider-usage/src/client/core.ts
+++ b/packages/dsh-provider-usage/src/client/core.ts
@@ -28,6 +28,14 @@ export const SELECT_URL = __DSH_ROUTES__?.select ?? "/api/dsh-provider-usage/ada
 export const INSPECT_URL = __DSH_ROUTES__?.inspect ?? "/api/dsh-provider-usage/adapters/inspect";
 export const ADD_URL = __DSH_ROUTES__?.add ?? "/api/dsh-provider-usage/adapters/add";
 
+/** 客户端请求超时（issue #87）：与宿主取数护栏同量级，防慢响应占满浏览器同域并发。 */
+const CLIENT_TIMEOUT_MS = 2000;
+
+/** 带超时的 fetch（issue #87：所有插件请求统一走此封装）。 */
+export function fetchTimeout(url: string, init?: RequestInit): Promise<Response> {
+  return fetch(url, { ...init, signal: AbortSignal.timeout(CLIENT_TIMEOUT_MS) });
+}
+
 /** 会话提供信息（sessions.currentProvideInfo 的读面，宽松类型）。 */
 export interface SessionMaybeProvide {
   sessionId?: string;
@@ -205,7 +213,7 @@ export async function fetchStats(
   hasAdapter: boolean;
   cached?: boolean;
 }> {
-  const res = await fetch(`${STATS_URL}?provider=${encodeURIComponent(provider)}`, {
+  const res = await fetchTimeout(`${STATS_URL}?provider=${encodeURIComponent(provider)}`, {
     headers: { Accept: "application/json" },
     cache: "no-store",
   });
@@ -230,7 +238,7 @@ export async function fetchHistory(
 ): Promise<{ samples?: number[][]; columns?: import("../contracts.js").SampleColumn[]; provider?: string; adapterId?: string }> {
   const base = `${HISTORY_URL}?provider=${encodeURIComponent(provider)}&adapterId=${encodeURIComponent(adapterId)}`;
   const url = days === undefined ? base : `${base}&days=${days}`;
-  const res = await fetch(url, { headers: { Accept: "application/json" }, cache: "no-store" });
+  const res = await fetchTimeout(url, { headers: { Accept: "application/json" }, cache: "no-store" });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return (await res.json()) as { samples?: number[][]; columns?: import("../contracts.js").SampleColumn[]; provider?: string; adapterId?: string };
 }
@@ -240,7 +248,7 @@ export async function fetchAdapterMeta(): Promise<{
   version?: number;
   client?: Array<{ file?: string | null; url?: string; resolved?: boolean }>;
 }> {
-  const res = await fetch(ADAPTERS_URL, { headers: { Accept: "application/json" }, cache: "no-store" });
+  const res = await fetchTimeout(ADAPTERS_URL, { headers: { Accept: "application/json" }, cache: "no-store" });
   if (!res.ok) return {};
   return (await res.json()) as { version?: number; client?: Array<{ file?: string | null; url?: string; resolved?: boolean }> };
 }
@@ -254,7 +262,7 @@ export async function loadUserRenderers(registry: RendererRegistry): Promise<num
   for (const entry of meta.client) {
     if (!entry.url) continue;
     try {
-      const res = await fetch(entry.url, { headers: { Accept: "application/javascript" }, cache: "no-store" });
+      const res = await fetchTimeout(entry.url, { headers: { Accept: "application/javascript" }, cache: "no-store" });
       if (!res.ok) {
         console.warn(`[dsh-provider-usage] 用户渲染器 ${entry.url} 加载失败（HTTP ${res.status}）`);
         continue;

--- a/packages/dsh-provider-usage/src/client/settings.ts
+++ b/packages/dsh-provider-usage/src/client/settings.ts
@@ -14,7 +14,7 @@
  * POST /adapters/inspect、POST /adapters/add），不引入额外 RPC 通道。
  */
 import * as React from "react";
-import { STATS_URL, ADAPTERS_URL, SELECT_URL, INSPECT_URL, ADD_URL } from "./core.js";
+import { STATS_URL, ADAPTERS_URL, SELECT_URL, INSPECT_URL, ADD_URL, fetchTimeout } from "./core.js";
 import { splitProviderList, providerBadgeText } from "../client-logic.js";
 import type { ProviderListItem } from "../client-logic.js";
 
@@ -78,7 +78,7 @@ interface AddResult {
 }
 
 async function jsonGet(url: string): Promise<unknown> {
-  const res = await fetch(url, { headers: { Accept: "application/json" }, cache: "no-store" });
+  const res = await fetchTimeout(url, { headers: { Accept: "application/json" }, cache: "no-store" });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json();
 }
@@ -328,7 +328,14 @@ function ProviderItem({
       ),
       React.createElement(
         "button",
-        { type: "button", className: "dou-btn", disabled: busy || adding || inspected === null, onClick: submitAdd },
+        {
+          type: "button",
+          className: "dou-btn",
+          disabled: busy || adding || inspected === null,
+          onClick: submitAdd,
+          // issue #87：检测未通过时按钮禁用态不再是无声的——悬停提示引导先检测
+          title: inspected === null ? "请先通过「检测文件」后再确认添加" : undefined,
+        },
         adding ? "添加中…" : "确认添加",
       ),
       React.createElement("button", { type: "button", className: "dou-btn", disabled: busy || adding, onClick: toggleAdd }, "取消"),
@@ -577,7 +584,7 @@ export function SettingsPage() {
   const onSwitch = React.useCallback(
     (provider: string, adapterId: string): void => {
       mutate(() =>
-        fetch(SELECT_URL, {
+        fetchTimeout(SELECT_URL, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ provider, adapterId }),
@@ -591,7 +598,7 @@ export function SettingsPage() {
   const onDisable = React.useCallback(
     (provider: string): void => {
       mutate(() =>
-        fetch(SELECT_URL, {
+        fetchTimeout(SELECT_URL, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ provider, adapterId: null }),
@@ -604,7 +611,7 @@ export function SettingsPage() {
   /** 检测文件：仅回显导出信息，不登记。 */
   const onInspect = React.useCallback(async (file: string): Promise<InspectResult> => {
     try {
-      const res = await fetch(INSPECT_URL, {
+      const res = await fetchTimeout(INSPECT_URL, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ file }),
@@ -623,7 +630,7 @@ export function SettingsPage() {
   const onAdd = React.useCallback(
     async (_provider: string, form: { file: string }): Promise<AddResult> => {
       try {
-        const res = await fetch(ADD_URL, {
+        const res = await fetchTimeout(ADD_URL, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ file: form.file }),

--- a/packages/dsh-provider-usage/src/client/style.css
+++ b/packages/dsh-provider-usage/src/client/style.css
@@ -329,12 +329,15 @@
   min-width: 60px;
   color: var(--dsw-alias-label-tertiary, #9aa0ab);
 }
+/* 纵向表单（dou-addForm 为 column 布局）中的单行输入框：
+   禁用 flex 伸缩——column 下 flex-basis 会变成高度起点导致输入框纵向撑爆（issue #87） */
 .dou-input {
-  flex: 1 1 180px;
+  width: 100%;
+  flex: none;
   min-width: 0;
   font: inherit;
   font-size: 12px;
-  padding: 3px 6px;
+  padding: 4px 8px;
   border: 1px solid var(--dsw-alias-border-l1, #d7dae0);
   border-radius: 5px;
   background: var(--dsw-alias-bg-base, #fdfdfd);

--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -39,7 +39,7 @@ import {
   OPENCODE_GO_WINDOWS,
 } from "./adapters/opencode-go.js";
 import type { ProviderUsage, UsageWindow, FetchLike, HostProviderAdapter, SamplePointData, ProviderSummary } from "./contracts.js";
-import { resolvePath, pluginHome } from "./path-resolve.js";
+import { resolvePath, pluginHome, expandHomePath } from "./path-resolve.js";
 
 // ------------------------------------------------------------------ 对外 re-export
 // 注意：bundle-host 会把 tsc 产物中的子模块全部内联进 lib/index.js 并清理游离 .js，
@@ -118,7 +118,9 @@ export const ROUTES: Record<string, string> = {
 
 export const DEFAULT_CONFIG: NormalizedConfig = {
   baseUrl: DEFAULT_BASE_URL,
-  timeoutMs: 15000,
+  // issue #87：余额/用量类轻接口取数超时 15s → 2s（慢远端不再长时间占住 stats 请求，
+  // 防浏览器同域并发被挂起请求占满）；normalizeConfig 上限保持不变，可配置调回。
+  timeoutMs: 2000,
   cacheTtlMs: 30000,
   limits: { rolling: 12, weekly: 30, monthly: 60 },
   apiKey: undefined,
@@ -314,20 +316,26 @@ export async function loadApiKey(
 
 // ------------------------------------------------------------------ 缓存
 
+/** 失败结果的防风暴节流缓存时长（issue #87）：慢远端场景下页面每次刷新都重新
+ * 打满护栏时长会占满浏览器同域并发连接——失败态也短缓存，10s 内直接回同一错误态。 */
+export const FAILURE_CACHE_TTL_MS = 10000;
+
 export function makeUsageCache<T>({ ttlMs, now = () => Date.now() }: { ttlMs: number; now?: () => number }) {
-  const entries = new Map<string, { ts: number; value: T }>();
+  // 每条目独立过期时刻（issue #87）：支持 set 时按条目覆盖 TTL（失败短缓存），
+  // 默认仍用构造期统一 TTL，行为与旧版兼容。
+  const entries = new Map<string, { expiresAt: number; value: T }>();
   return {
     get(key: string): T | undefined {
       const entry = entries.get(key);
       if (entry === undefined) return undefined;
-      if (now() - entry.ts >= ttlMs) {
+      if (now() >= entry.expiresAt) {
         entries.delete(key);
         return undefined;
       }
       return entry.value;
     },
-    set(key: string, value: T): void {
-      entries.set(key, { ts: now(), value });
+    set(key: string, value: T, opts?: { ttlMs?: number }): void {
+      entries.set(key, { expiresAt: now() + Math.max(0, opts?.ttlMs ?? ttlMs), value });
     },
     clear(key?: string): void {
       if (key === undefined) entries.clear();
@@ -878,8 +886,10 @@ export function resolveAddAdapterFile(input: unknown, dshHome = process.env.DSH_
   const trimmed = input.trim();
   if (trimmed === "" || trimmed.includes("\0")) return undefined;
   // 规整性：resolve 前后必须一致（拒绝 .. / . 段穿越形态）
-  if (resolve(trimmed) !== trimmed) return undefined;
-  const resolved = resolvePath(trimmed);
+  // ~ 展开（单一事实源 expandHomePath），后续校验一律在展开形态上进行（issue #87）
+  const expandedForCheck = expandHomePath(trimmed);
+  if (resolve(expandedForCheck) !== expandedForCheck) return undefined;
+  const resolved = resolvePath(expandedForCheck);
   if (resolved === undefined) return undefined; // 不存在 / 非常规文件
   if (!isAbsolute(trimmed)) {
     // 相对路径：解析结果必须位于 DSH_HOME 或插件 home 之内
@@ -1239,7 +1249,11 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
         const fetchCtx = {
           provider,
           apiKey,
-          baseUrl: current.baseUrl,
+          // issue #87：current.baseUrl 是 OpenCode Go 全局地址（官方类型层 LlmProviderInfo
+          // 仅 { id, name }，插件拿不到各 provider 自己的 baseURL）——只对内置 opencode-go
+          // 透传；其余 provider 传 undefined，让适配器自身的 fallback 地址生效，
+          // 避免把 OpenCode Go 主机拼进第三方适配器的请求 URL。
+          baseUrl: provider === OPENCODE_GO_PROVIDER ? current.baseUrl : undefined,
           timeoutMs: current.timeoutMs,
           fetch: fetchImpl,
           signal: undefined as AbortSignal | undefined,
@@ -1277,9 +1291,9 @@ export async function apply(ctx: Context, config: OpenCodePluginConfig = {}): Pr
           store.append(result.provider, entry.id, sample.cols, [result.fetchedAt, ...sample.values]);
           schedulePersist(result.provider, entry.id);
         }
-        if (usage.ok) {
-          cache.set(provider, result);
-        }
+        // issue #87：失败结果也短缓存（FAILURE_CACHE_TTL_MS 防风暴节流）——此前仅
+        // 缓存成功态，慢远端场景下页面每次刷新都重新打满护栏时长。
+        cache.set(provider, result, usage.ok ? undefined : { ttlMs: FAILURE_CACHE_TTL_MS });
 
         lastStatus = { at: result.fetchedAt, error: result.error, configured: true };
         return result;

--- a/packages/dsh-provider-usage/src/path-resolve.ts
+++ b/packages/dsh-provider-usage/src/path-resolve.ts
@@ -11,6 +11,11 @@
 import { existsSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
+// issue #87：~ 展开复用成熟开源实现 untildify（与 dsh-web-file-preview 同源同版，
+// devDependency + 构建期 esbuild 内联，发布物零运行时依赖）。
+// 行为边界：仅展开开头的 `~`；`~user/...` 形态不展开、原样返回（旧手写实现把
+// ~user 误展开到当前用户 home 的权宜语义一并移除——UI placeholder 只承诺 ~/.dsh/...）。
+import untildify from "untildify";
 
 /**
  * 插件 home 目录（host 文件逻辑归属区 ~/.dsh/plugins/provider-usage）。
@@ -22,6 +27,14 @@ export function pluginHome(base = process.env.DSH_HOME ?? join(homedir(), ".dsh"
 }
 
 /**
+ * `~` 前缀展开（issue #87 单一事实源：resolvePath 与 resolveAddAdapterFile 共用，
+ * 保证「UI 承诺支持 ~ 路径」与校验行为一致）。
+ */
+export function expandHomePath(p: string): string {
+  return untildify(p);
+}
+
+/**
  * 解析路径（支持 `~`、`~user`、绝对路径、相对 DSH_HOME/插件 home）。
  * @param p - 原始路径。
  * @returns 解析后的绝对路径，或 undefined（解析失败/文件不存在）。
@@ -30,18 +43,11 @@ export function resolvePath(p: string): string | undefined {
   if (typeof p !== "string" || p.trim() === "") return undefined;
   const trimmed = p.trim();
 
-  // 1. ~ 展开
+  // 1. ~ 展开与绝对路径判定（expandHomePath 统一处理，issue #87）
+  const expandedHome = expandHomePath(trimmed);
   let expanded: string;
-  if (trimmed.startsWith("~")) {
-    // ~ 或 ~user
-    const slashIdx = trimmed.indexOf("/");
-    const userPart = slashIdx === -1 ? trimmed : trimmed.slice(0, slashIdx);
-    if (userPart === "~" || userPart === "~root") {
-      expanded = join(homedir(), trimmed.slice(userPart.length));
-    } else {
-      // ~user 在非 root 环境较复杂，统一用当前用户 home 展开（大多数场景）
-      expanded = join(homedir(), trimmed.slice(1));
-    }
+  if (expandedHome !== trimmed) {
+    expanded = expandedHome;
   } else if (isAbsolute(trimmed)) {
     expanded = trimmed;
   } else {

--- a/packages/dsh-provider-usage/test/smoke-pure.ts
+++ b/packages/dsh-provider-usage/test/smoke-pure.ts
@@ -16,7 +16,7 @@
 import { mkdtempSync, writeFileSync, readFileSync, readdirSync, mkdirSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { tmpdir, homedir } from "node:os";
 import assert from "node:assert/strict";
 import type { FetchLike, ProviderSummary, ProviderUsage, SummaryLevel } from "../lib/index.js";
 import * as libIndex from "../lib/index.js";
@@ -46,6 +46,9 @@ import {
   makeHistoryStore,
   writeHistoryFile,
   readHistoryFile,
+  // issue #87：~ 展开单一事实源 + add 入参校验
+  expandHomePath,
+  resolveAddAdapterFile,
   // 客户端行为纯函数（issue #28：宿主侧可导入，client bundle 同源内联）
   derivePillLabel,
   derivePillLevel,
@@ -597,6 +600,39 @@ assert.equal(resolveApiKey({}), undefined, "全缺返回 undefined");
   cache.set("b", { x: 1 });
   cache.clear();
   assert.equal(cache.get("b"), undefined, "clear 全清");
+}
+
+// ---------------------------------------------------------------- issue #87：条目级 TTL（失败短缓存）
+
+{
+  let now = 0;
+  const cache = makeUsageCache<{ ok: boolean }>({ ttlMs: 30000, now: () => now });
+  cache.set("ok-provider", { ok: true });
+  cache.set("bad-provider", { ok: false }, { ttlMs: 10 });
+  now = 5;
+  assert.deepEqual(cache.get("bad-provider"), { ok: false }, "条目 TTL 未到期可命中");
+  now = 11;
+  assert.equal(cache.get("bad-provider"), undefined, "条目 TTL 覆盖生效（失败短缓存先过期）");
+  assert.deepEqual(cache.get("ok-provider"), { ok: true }, "默认 TTL 不受条目覆盖影响");
+}
+
+// ---------------------------------------------------------------- issue #87：~ 展开与 add 路径校验修订
+
+{
+  // issue #87：~ 展开复用 untildify（单一事实源，与 dsh-web-file-preview 同源同版）
+  const realHome = homedir();
+  assert.equal(expandHomePath("~"), realHome, "~ 展开到用户 home");
+  assert.equal(expandHomePath("~/a/b.mjs"), join(realHome, "a/b.mjs"), "~/相对段 展开");
+  assert.equal(expandHomePath("/abs/noop.mjs"), "/abs/noop.mjs", "非 ~ 前缀原样返回");
+  assert.equal(expandHomePath("~other/x.mjs"), "~other/x.mjs", "~user 形态不展开（untildify 边界）");
+
+  // resolveAddAdapterFile：~ 前缀先展开再校验（issue #87）。untildify 内部 join 会把
+  // ~/a/../b 规范化为 home/b——~ 形态展开后等价于直接输入绝对路径（同一信任模型：
+  // 本机文件可加载），故穿越段不构成提权；拒绝分支由「未规整形态」与「文件不存在」兜底。
+  assert.equal(resolveAddAdapterFile("~/nonexistent-dir-xyz/a.mjs"), undefined, "~ 展开为不存在路径 → 拒绝");
+  assert.equal(resolveAddAdapterFile("rel/../x.mjs"), undefined, "相对路径穿越拒绝");
+  assert.equal(resolveAddAdapterFile(""), undefined, "空串拒绝");
+  assert.equal(resolveAddAdapterFile("/nonexistent-dir-xyz/a.mjs"), undefined, "不存在的绝对路径拒绝");
 }
 
 // ---------------------------------------------------------------- 客户端行为纯函数（issue #28：替代 bundle includes 断言）

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -498,6 +498,51 @@ function makeFakeCtx(overrides = {}) {
   assert.equal(responses.at(-1).__code, 404, "user 不存在的索引 404");
 }
 
+// ---------------------------------------------------------------- issue #87：fetchCtx.baseUrl 按 provider 区分 + 失败结果短缓存
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dou-issue87-"));
+  // probe adapter：捕获 fetchUsage 收到的 ctx；固定返回失败态（测失败短缓存）
+  const probeFile = join(dir, "probe-relay.mjs");
+  writeFileSync(
+    probeFile,
+    [
+      "export default {",
+      "  version: 1,",
+      '  id: "issue87-probe",',
+      '  label: "Issue87 Probe",',
+      '  providers: ["probe-relay"],',
+      "  async fetchUsage(ctx) {",
+      "    globalThis.__douIssue87 = { baseUrl: ctx.baseUrl, timeoutMs: ctx.timeoutMs };",
+      "    return { ok: false, provider: ctx.provider, label: this.label, fetchedAt: Date.now(), error: 'http-500' };",
+      "  },",
+      "};",
+    ].join("\n"),
+  );
+
+  const { ctx, routes } = makeFakeCtx();
+  await apply(ctx, { adapters: { host: [{ provider: "probe-relay", file: probeFile }] } });
+  const statsRoute = routes.find((r) => r.path === ROUTES.stats);
+  assert.ok(statsRoute, "stats 路由存在");
+  try {
+    let payload;
+    const res200 = { writeHead: () => {}, end: (chunk) => { payload = JSON.parse(chunk); } };
+
+    // 第一次请求：与启动补采共享 inflight/缓存，顺带完成 ctx 探针
+    await statsRoute.handler(fakeReq({ url: `${ROUTES.stats}?provider=probe-relay` }), res200);
+    const probe = globalThis.__douIssue87 ?? {};
+    assert.equal(probe.baseUrl, undefined, "非 opencode-go provider 不透传全局 baseUrl（issue #87）");
+    assert.equal(probe.timeoutMs, DEFAULT_CONFIG.timeoutMs, "timeoutMs 走默认配置（2000）");
+    assert.equal(payload.usage?.ok, false, "probe adapter 固定返回失败态");
+
+    // 第二次请求：失败态命中 10s 防风暴短缓存（旧版失败不缓存 → 每次重新打满护栏）
+    await statsRoute.handler(fakeReq({ url: `${ROUTES.stats}?provider=probe-relay` }), res200);
+    assert.equal(payload.cached, true, "失败结果被短缓存（第二次 cached=true）");
+  } finally {
+    delete globalThis.__douIssue87;
+  }
+}
+
 // stats 200 全链路：注入 fetchImpl + apiKey（不落盘、不网络）
 {
   const { ctx, routes } = makeFakeCtx();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       schemastery:
         specifier: ^3.18.0
         version: 3.18.0
+      untildify:
+        specifier: ^6.0.0
+        version: 6.0.0
 
   packages/dsh-web-file-preview:
     devDependencies:


### PR DESCRIPTION
## 关联 issue

Closes #87

## 改动摘要

| # | 修复项 | 说明 |
|---|--------|------|
| P1 | 设置页添加表单输入框纵向撑爆 | `.dou-input` 在 column 布局下 flex-basis 变成高度起点（180px）；改 `width:100%; flex:none` |
| P2 | `~` 开头路径被 inspect/add 误拦 | `path.resolve("~/.dsh/x.mjs")` 把 `~` 拼上 cwd 导致规整性检查误判；改为先经 `untildify` 展开再校验（复用仓库已有依赖，与 dsh-web-file-preview 同源同版） |
| P3a | 慢远端 stats 长挂 + 浏览器并发占满 | 取数超时 15s → 2s；失败结果 10s 短缓存防风暴（此前失败不缓存，页面每次刷新重新打满护栏时长） |
| P3b | 客户端 fetch 无超时 | 统一 `AbortSignal.timeout(2000)`（core.ts 导出 fetchTimeout，settings.ts 复用） |
| P3c | 非 opencode-go 适配器收到错误 baseUrl | 插件把 OpenCode Go 全局地址传给所有 provider；已核实 `LlmProviderInfo` 仅 `{id,name}`，非 opencode-go 传 undefined 让适配器 fallback 生效 |
| P3d | 检测失败后添加按钮无声禁用 | 补悬停提示「请先通过检测文件后再确认添加」 |

## 测试

- smoke 新增：`~` 展开/拒绝分支（untildify 语义边界）、fetchCtx.baseUrl 按 provider 区分、失败结果短缓存断言
- `pnpm build && pnpm test && pnpm contract && pnpm pack:check` 全绿
