### PR TITLE
fix(dsh-provider-usage): 设置页适配器名与 provider 同名时省略避免连读

### DIFF
--- a/packages/dsh-provider-usage/src/client/settings.ts
+++ b/packages/dsh-provider-usage/src/client/settings.ts
@@ -141,7 +141,9 @@ function UsageSection({ statsByProvider }: { statsByProvider: Record<string, Sta
               verticalAlign: "middle",
             },
           });
-          const meta = `${s?.adapterName ?? "-"} · ${STATUS_LABEL[s?.status ?? ""] ?? "未配置"}${
+          // 适配器名与 provider 同名时省略，避免「rjkrjk」式连读
+          const adapterPart = s?.adapterName && s.adapterName !== provider ? `${s.adapterName} · ` : "";
+          const meta = `${adapterPart}${STATUS_LABEL[s?.status ?? ""] ?? "未配置"}${
             typeof s?.fetchedAt === "number"
               ? ` · 更新于 ${new Date(s.fetchedAt).toLocaleTimeString("zh-CN", { hour12: false })}`
               : ""


### PR DESCRIPTION
rjk 适配器的 provider 与 name 同为 rjk 时，用量可视化区显示「rjkrjk」。同名时省略适配器名部分。