### PR TITLE
feat(dsh-mcp-manager): make MCP float configurable via hidden settings namespace

### DIFF
--- a/packages/dsh-mcp-manager/package.json
+++ b/packages/dsh-mcp-manager/package.json
@@ -48,14 +48,15 @@
     "@deepseek-ai/dsh-agent": "catalog:",
     "@deepseek-ai/dsh-system-prompt": "catalog:",
     "@deepseek-ai/dsh-tools": "catalog:",
-    "schemastery": "^3.18.0"
+    "@deepseek-ai/schemastery": "^3.18.1"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "*",
     "@deepseek-ai/dsh-host-webserver": "*",
     "@deepseek-ai/dsh-agent": "*",
     "@deepseek-ai/dsh-tools": "*",
-    "@deepseek-ai/dsh-system-prompt": "*"
+    "@deepseek-ai/dsh-system-prompt": "*",
+    "@deepseek-ai/schemastery": "^3.18.1"
   },
   "peerDependenciesMeta": {
     "@deepseek-ai/cordis": {

--- a/packages/dsh-mcp-manager/package.json
+++ b/packages/dsh-mcp-manager/package.json
@@ -41,6 +41,9 @@
     "README.md",
     "LICENSE"
   ],
+  "dependencies": {
+    "schemastery": "^3.18.0"
+  },
   "devDependencies": {
     "@deepseek-ai/cordis": "catalog:",
     "@deepseek-ai/dsh-host-webserver": "catalog:",

--- a/packages/dsh-mcp-manager/package.json
+++ b/packages/dsh-mcp-manager/package.json
@@ -48,15 +48,14 @@
     "@deepseek-ai/dsh-agent": "catalog:",
     "@deepseek-ai/dsh-system-prompt": "catalog:",
     "@deepseek-ai/dsh-tools": "catalog:",
-    "@deepseek-ai/schemastery": "^3.18.1"
+    "schemastery": "^3.18.0"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "*",
     "@deepseek-ai/dsh-host-webserver": "*",
     "@deepseek-ai/dsh-agent": "*",
     "@deepseek-ai/dsh-tools": "*",
-    "@deepseek-ai/dsh-system-prompt": "*",
-    "@deepseek-ai/schemastery": "^3.18.1"
+    "@deepseek-ai/dsh-system-prompt": "*"
   },
   "peerDependenciesMeta": {
     "@deepseek-ai/cordis": {

--- a/packages/dsh-mcp-manager/package.json
+++ b/packages/dsh-mcp-manager/package.json
@@ -41,16 +41,14 @@
     "README.md",
     "LICENSE"
   ],
-  "dependencies": {
-    "schemastery": "^3.18.0"
-  },
   "devDependencies": {
     "@deepseek-ai/cordis": "catalog:",
     "@deepseek-ai/dsh-host-webserver": "catalog:",
     "@deepseek-ai/dsh-llm": "catalog:",
     "@deepseek-ai/dsh-agent": "catalog:",
     "@deepseek-ai/dsh-system-prompt": "catalog:",
-    "@deepseek-ai/dsh-tools": "catalog:"
+    "@deepseek-ai/dsh-tools": "catalog:",
+    "schemastery": "^3.18.0"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "*",

--- a/packages/dsh-mcp-manager/src/client/index.ts
+++ b/packages/dsh-mcp-manager/src/client/index.ts
@@ -722,6 +722,16 @@ function mountFloat(ctx: any) {
   const panelRoot = panelHost();
   if (panel.parentElement !== panelRoot) panelRoot.appendChild(panel);
 
+  // 点击下拉框之外的区域（包括胶囊以外的任意位置）也关闭；
+  // 胶囊本身不在这里关，仍交给自身的 click toggle，避免开/关互相抵消。
+  const onDocumentClick = (event: any) => {
+    if (!floatOpen) return;
+    const path = typeof event.composedPath === "function" ? event.composedPath() : [];
+    if (path.includes(floatPanel) || path.includes(floatPill)) return;
+    toggleFloat(false);
+  };
+  document.addEventListener("click", onDocumentClick);
+
   let host: any;
   let listeners: any = [];
 
@@ -791,6 +801,7 @@ function mountFloat(ctx: any) {
   renderPill();
   return () => {
     updateFloatState = undefined;
+    document.removeEventListener("click", onDocumentClick);
     observer.disconnect();
     for (const detach of listeners.splice(0)) detach();
     pill.remove();

--- a/packages/dsh-mcp-manager/src/client/index.ts
+++ b/packages/dsh-mcp-manager/src/client/index.ts
@@ -22,6 +22,7 @@ const API = {
   reconnect: "/api/dsh-mcp/servers/reconnect",
   importJson: "/api/dsh-mcp/import/json",
   session: "/api/dsh-mcp/session",
+  config: "/api/dsh-mcp/config",
   events: "/api/dsh-mcp/events",
     health: "/api/dsh-mcp/health",
 };
@@ -552,6 +553,8 @@ let floatPanel: any;
 let floatOpen = false;
 let currentCwd: any = undefined;
 let projectRoot: any = undefined;
+let updateFloatState: any = undefined;
+let mcpUiConfig: any = { position: "top-right", offsetX: 8, offsetY: 8, blankY: 40 };
 
 /** 状态点的颜色（与 STATUS_ORDER 一致）。 */
 function statusDot(status: any) {
@@ -679,11 +682,30 @@ function placePanel() {
 function conversationHost() {
   return document.querySelector('[data-conversation-scroll]')
     ?? document.querySelector('[data-pane="conversation"]')
+    ?? document.querySelector('.pI_x6G_centerCol')
     ?? document.body;
 }
 
-/** 挂载浮窗：胶囊挂在会话滚动容器（scrollBody）内并钉住右上角，下拉面板 fixed 跟随。 */
-function mountFloat() {
+/** 全局 overlay 层：下拉面板挂这里（fixed 定位，避免被滚动容器裁剪）。 */
+function panelHost() {
+  return document.querySelector('[data-shell-overlay]')
+    ?? document.body;
+}
+
+/** 从 settings.yaml 读取的配置决定新/老会话垂直偏移。 */
+function floatTopOffset(ctx: any) {
+  const snap = ctx?.sessions?.list?.getSnapshot?.();
+  const current = snap?.current;
+  const session = current === undefined ? undefined : snap?.byId?.[current];
+  const blank = session?.blank === true;
+  const cfg = mcpUiConfig || {};
+  const y = typeof cfg.offsetY === "number" ? cfg.offsetY : 8;
+  const blankY = typeof cfg.blankY === "number" ? cfg.blankY : y;
+  return blank ? blankY : y;
+}
+
+/** 挂载浮窗：胶囊继续挂在会话滚动容器（scrollBody）内并钉住右上角，下拉面板 fixed 跟随。 */
+function mountFloat(ctx: any) {
   const pill = el("button", {
     type: "button",
     class: "dm-float",
@@ -696,33 +718,50 @@ function mountFloat() {
   panel.hidden = true;
   floatPill = pill;
   floatPanel = panel;
-  // 面板挂 body（fixed 定位），胶囊挂滚动容器
-  if (panel.parentElement !== document.body) document.body.appendChild(panel);
+  // 胶囊挂会话滚动容器，下拉面板挂 shell.overlay（fixed 定位，仍与通知同一层）。
+  const panelRoot = panelHost();
+  if (panel.parentElement !== panelRoot) panelRoot.appendChild(panel);
 
   let host: any;
   let listeners: any = [];
+
+  /** 按 settings.yaml 配置把胶囊定位到对话容器右上/右下角。 */
+  const updateFloat = () => {
+    const best = conversationHost();
+    if (best === null || best === undefined) return;
+    const rect = best.getBoundingClientRect();
+    const cfg = mcpUiConfig || {};
+    const position = cfg.position === "bottom-right" ? "bottom-right" : "top-right";
+    const offsetX = typeof cfg.offsetX === "number" ? cfg.offsetX : 8;
+    const y = floatTopOffset(ctx);
+    pill.style.position = "fixed";
+    pill.style.left = `${rect.right - pill.offsetWidth - offsetX}px`;
+    pill.style.right = "auto";
+    if (position === "bottom-right") {
+      pill.style.top = `${rect.bottom - pill.offsetHeight - y}px`;
+    } else {
+      pill.style.top = `${rect.top + y}px`;
+    }
+    if (floatOpen) placePanel();
+  };
+  updateFloatState = updateFloat;
+
   const attachListeners = (target: any) => {
     for (const detach of listeners.splice(0)) detach();
-    const onScroll = () => {
-      const top = (target === document.body ? window.scrollY : target.scrollTop) + 8;
-      pill.style.top = `${top}px`;
-      if (floatOpen) placePanel();
-    };
-    const onResize = () => {
-      if (floatOpen) placePanel();
-    };
+    const onScroll = () => updateFloat();
+    const onResize = () => updateFloat();
     target.addEventListener("scroll", onScroll, { passive: true });
     window.addEventListener("resize", onResize);
     listeners.push(() => {
       target.removeEventListener("scroll", onScroll);
       window.removeEventListener("resize", onResize);
     });
-    onScroll();
+    updateFloat();
   };
 
   /**
-   * 放置/迁移：每次调用都重新求最佳宿主（scrollBody 优先），浮窗永远跟着
-   * 它走——即使初始化时 scrollBody 尚未渲染（退回 body），一旦出现就迁移。
+   * 放置/迁移：每次调用都重新求最佳宿主（scrollBody 优先），胶囊跟着它走——
+   * 即使初始化时 scrollBody 尚未渲染（退回 body），一旦出现就迁移。
    */
   const place = () => {
     const best = conversationHost();
@@ -751,6 +790,7 @@ function mountFloat() {
   }
   renderPill();
   return () => {
+    updateFloatState = undefined;
     observer.disconnect();
     for (const detach of listeners.splice(0)) detach();
     pill.remove();
@@ -774,8 +814,10 @@ function bindSession(ctx: any) {
     } catch {
       cwd = undefined;
     }
-    if (cwd === currentCwd) return;
+    const prevCwd = currentCwd;
     currentCwd = cwd;
+    updateFloatState?.();
+    if (cwd === prevCwd) return;
     // 无论 cwd 是否为空都通知宿主切换：空 cwd（blank 会话/新会话还没选
     // 工作区）也要显式清空宿主的项目级 MCP，否则宿主全局单例会残留
     // 上一个会话的项目级服务器，别的会话就串台显示了。
@@ -805,8 +847,15 @@ export function apply(ctx: any) {
     }
 
     const disposers: any[] = [];
-    disposers.push(mountFloat());
+    disposers.push(mountFloat(ctx));
     disposers.push(bindSession(ctx));
+
+    // 读取 settings.yaml 中的 UI 配置（右上/右下 + 偏移量），不依赖设置页。
+    api(API.config).then((cfg: any) => {
+      if (cfg !== null && typeof cfg === "object") mcpUiConfig = cfg;
+      updateFloatState?.();
+    }).catch(() => {});
+
 
     // 首次刷新：立即执行，失败按 500ms/1s/2s 退避重试（宿主路由可能尚未就绪，
     // 不依赖固定延迟猜测）。

--- a/packages/dsh-mcp-manager/src/client/index.ts
+++ b/packages/dsh-mcp-manager/src/client/index.ts
@@ -665,6 +665,8 @@ function toggleFloat(force?: any) {
   if (next) {
     placePanel();
     renderFloatPanel();
+    // 聚焦面板本身，让后续点击外部时能通过 focusout 自动关闭。
+    floatPanel.focus({ preventScroll: true });
   }
 }
 
@@ -716,21 +718,22 @@ function mountFloat(ctx: any) {
   pill.addEventListener("click", () => toggleFloat());
   const panel = el("div", { class: "dm-float-panel" });
   panel.hidden = true;
+  panel.tabIndex = -1;
   floatPill = pill;
   floatPanel = panel;
   // 胶囊挂会话滚动容器，下拉面板挂 shell.overlay（fixed 定位，仍与通知同一层）。
   const panelRoot = panelHost();
   if (panel.parentElement !== panelRoot) panelRoot.appendChild(panel);
 
-  // 点击下拉框之外的区域（包括胶囊以外的任意位置）也关闭；
-  // 胶囊本身不在这里关，仍交给自身的 click toggle，避免开/关互相抵消。
-  const onDocumentClick = (event: any) => {
+  // 失去焦点后自动关闭：焦点离开胶囊/面板时收起下拉框。
+  // 面板打开时主动聚焦到面板，因此点击外部任意区域都会触发 focusout。
+  const onFocusOut = (event: any) => {
     if (!floatOpen) return;
-    const path = typeof event.composedPath === "function" ? event.composedPath() : [];
-    if (path.includes(floatPanel) || path.includes(floatPill)) return;
+    const next = event.relatedTarget as Node | null;
+    if (next !== null && (floatPanel.contains(next) || floatPill.contains(next))) return;
     toggleFloat(false);
   };
-  document.addEventListener("click", onDocumentClick);
+  document.addEventListener("focusout", onFocusOut);
 
   let host: any;
   let listeners: any = [];
@@ -801,7 +804,7 @@ function mountFloat(ctx: any) {
   renderPill();
   return () => {
     updateFloatState = undefined;
-    document.removeEventListener("click", onDocumentClick);
+    document.removeEventListener("focusout", onFocusOut);
     observer.disconnect();
     for (const detach of listeners.splice(0)) detach();
     pill.remove();

--- a/packages/dsh-mcp-manager/src/client/style.css
+++ b/packages/dsh-mcp-manager/src/client/style.css
@@ -7,7 +7,7 @@
 [data-conversation-scroll]{position:relative}
 [data-pane="conversation"]{position:relative}
 
-.dm-float{position:absolute;top:8px;right:14px;z-index:40;display:flex;align-items:center;gap:6px;padding:5px 11px;border:1px solid var(--dsw-alias-border-l1,#d7dae0);border-radius:99px;background:var(--dsw-alias-bg-base,#fdfdfd);color:var(--dsw-alias-label-primary,#1c1e26);font-size:12px;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.10);font-family:system-ui,-apple-system,"Segoe UI",sans-serif}
+.dm-float{position:absolute;top:44px;right:14px;z-index:10;display:flex;align-items:center;gap:6px;padding:5px 11px;border:1px solid var(--dsw-alias-border-l1,#d7dae0);border-radius:99px;background:var(--dsw-alias-bg-base,#fdfdfd);color:var(--dsw-alias-label-primary,#1c1e26);font-size:12px;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.10);font-family:system-ui,-apple-system,"Segoe UI",sans-serif}
 .dm-float:hover{background:var(--dsw-alias-interactive-bg-hover,#f2f4f8)}
 .dm-float .dm-dot{width:7px;height:7px;border-radius:50%;display:inline-block}
 .dm-float-panel{position:fixed;top:44px;right:14px;width:min(400px,calc(100vw - 36px));max-height:min(70vh,560px);overflow:auto;background:var(--dsw-alias-bg-base,#fdfdfd);color:var(--dsw-alias-label-primary,#1c1e26);border:1px solid var(--dsw-alias-border-l1,#e2e4ea);border-radius:10px;box-shadow:0 10px 32px rgba(0,0,0,.18);z-index:70;padding:10px 12px;font-family:system-ui,-apple-system,"Segoe UI",sans-serif;font-size:12px}

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -25,7 +25,7 @@ import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import type { ServerResponse } from "node:http";
-import z from "@deepseek-ai/schemastery";
+import z from "schemastery";
 import { installSettingsNamespace } from "../../../shared/settings-namespace.js";
 // 官方类型层（issue #16/#48，锁版见 pnpm-workspace catalog；仅 import type，
 // 编译期擦除，禁止运行时值导入——contract-check 有门禁）。

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -71,13 +71,13 @@ export const SERVER_NAME_PATTERN = /^[A-Za-z0-9_-]{1,32}$/;
 export const DEFAULT_ENHANCE_EMPTY_DESCRIPTIONS = true;
 
 /** MCP 浮动按钮 UI 配置（隐藏 settings namespace，不在设置页显示）。 */
-export const UiConfigSchema = z.object({
+const UiConfigSchema = z.object({
   position: z.union([z.const("top-right"), z.const("bottom-right")]).default("top-right"),
   offset: z.object({
     x: z.number().default(8),
     y: z.number().default(8),
     blankY: z.number().default(40),
-  }).default({}),
+  }).default({ x: 8, y: 8, blankY: 40 }),
 });
 
 

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -25,6 +25,8 @@ import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import type { ServerResponse } from "node:http";
+import z from "schemastery";
+import { installSettingsNamespace } from "../../../shared/settings-namespace.js";
 // 官方类型层（issue #16/#48，锁版见 pnpm-workspace catalog；仅 import type，
 // 编译期擦除，禁止运行时值导入——contract-check 有门禁）。
 import type { Context, LoggerService } from "@deepseek-ai/cordis";
@@ -68,6 +70,17 @@ export const SERVER_NAME_PATTERN = /^[A-Za-z0-9_-]{1,32}$/;
 /** 空 description 工具的条件拼接默认开启。 */
 export const DEFAULT_ENHANCE_EMPTY_DESCRIPTIONS = true;
 
+/** MCP 浮动按钮 UI 配置（隐藏 settings namespace，不在设置页显示）。 */
+export const UiConfigSchema = z.object({
+  position: z.union([z.const("top-right"), z.const("bottom-right")]).default("top-right"),
+  offset: z.object({
+    x: z.number().default(8),
+    y: z.number().default(8),
+    blankY: z.number().default(40),
+  }).default({}),
+});
+
+
 // ------------------------------------------------------------ 管理器
 
 /** DSH 全局家目录（与官方 dsh-home-paths 同语义：DSH_HOME ?? ~/.dsh）。 */
@@ -94,6 +107,7 @@ export class McpManager {
   enhancement: { enhanceEmptyDescriptions?: boolean; resultTruncateBytes?: number };
   catalogCache: CatalogCache;
   catalogCachePath: string;
+  uiConfigSource: () => any;
   sseConnections?: Set<ServerResponse>;
 
   constructor(ctx: Context, store: McpStore) {
@@ -114,6 +128,19 @@ export class McpManager {
     // 目录缓存：serverName → { summary }（磁盘持久化，digest 的稳定数据源）。
     this.catalogCache = new Map();
     this.catalogCachePath = catalogCacheFile();
+    this.uiConfigSource = () => ({ position: "top-right", offsetX: 8, offsetY: 8, blankY: 40 });
+  }
+
+  /** 读取 settings 命名空间中的 MCP UI 配置（供 /api/dsh-mcp/config 返回）。 */
+  uiConfig(): Record<string, unknown> {
+    const value = this.uiConfigSource() ?? {};
+    const defaults: Record<string, unknown> = { position: "top-right", offsetX: 8, offsetY: 8, blankY: 40 };
+    const out: Record<string, unknown> = { ...defaults };
+    if (value.position === "top-right" || value.position === "bottom-right") out.position = value.position;
+    if (typeof value.offset?.x === "number") out.offsetX = value.offset.x;
+    if (typeof value.offset?.y === "number") out.offsetY = value.offset.y;
+    out.blankY = typeof value.offset?.blankY === "number" ? value.offset.blankY : out.offsetY;
+    return out;
   }
 
   /** 从磁盘加载目录缓存（损坏/缺失 → 空缓存，不崩溃）。 */
@@ -550,6 +577,15 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
   await store.load();
   const manager = new McpManager(ctx, store);
   manager.enhancement = { enhanceEmptyDescriptions, resultTruncateBytes };
+
+    // 隐藏 settings namespace：配置保存在 settings.yaml，不在设置页显示。
+    installSettingsNamespace(ctx, "dsh-mcp-manager", UiConfigSchema, config ?? {}, {
+      setSource: (source) => {
+        manager.uiConfigSource = source as () => any;
+      },
+      onChange: () => {},
+    });
+
 
   let disposeRoutes = () => {};
   let disposeSection = () => {};

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -25,7 +25,7 @@ import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import type { ServerResponse } from "node:http";
-import z from "schemastery";
+import z from "@deepseek-ai/schemastery";
 import { installSettingsNamespace } from "../../../shared/settings-namespace.js";
 // 官方类型层（issue #16/#48，锁版见 pnpm-workspace catalog；仅 import type，
 // 编译期擦除，禁止运行时值导入——contract-check 有门禁）。

--- a/packages/dsh-mcp-manager/src/routes.ts
+++ b/packages/dsh-mcp-manager/src/routes.ts
@@ -3,6 +3,8 @@
  *
  * /api/dsh-mcp/* 路由（loopback-only）供 web GUI 分级展示、快速接入、
  * 导入 mcpServers JSON；events 为 SSE 状态推送通道。
+ * 例外：/api/dsh-mcp/config 是只读 UI 配置接口，允许非 loopback 访问，
+ * 便于远程页面读取 position/offset 等非敏感展示配置。
  * 由 lib/index.js 组合根 re-export（ROUTES / makeRoutes）。
  */
 
@@ -86,7 +88,10 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
       kind: "exact",
       path: ROUTES.config,
       handler: async (req, res) => {
-        if (!guard(req, res, "GET")) return;
+        if (req.method !== "GET") {
+          writeJson(res, 405, { error: `method not allowed: ${req.method}` });
+          return;
+        }
         try {
           writeJson(res, 200, manager.uiConfig());
         } catch (error) {

--- a/packages/dsh-mcp-manager/src/routes.ts
+++ b/packages/dsh-mcp-manager/src/routes.ts
@@ -20,6 +20,7 @@ import type { McpStore } from "./store.js";
 export interface RoutesManager {
   setSession(cwd: string | undefined): Promise<void>;
   refreshFromDisk(): Promise<void>;
+  uiConfig(): Record<string, unknown>;
   summary(): Record<string, unknown>;
   add(server: Record<string, unknown>, scope?: string): Promise<ServerConfig>;
   update(name: string, patch: Record<string, unknown>, scope?: string): Promise<ServerConfig>;
@@ -39,6 +40,7 @@ export interface RoutesManager {
 /** 路由路径清单（与客户端一致）。 */
 export const ROUTES = {
   servers: "/api/dsh-mcp/servers",
+  config: "/api/dsh-mcp/config",
   session: "/api/dsh-mcp/session",
   connect: "/api/dsh-mcp/servers/connect",
   disconnect: "/api/dsh-mcp/servers/disconnect",
@@ -80,6 +82,18 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
   };
 
   return [
+    {
+      kind: "exact",
+      path: ROUTES.config,
+      handler: async (req, res) => {
+        if (!guard(req, res, "GET")) return;
+        try {
+          writeJson(res, 200, manager.uiConfig());
+        } catch (error) {
+          handleError(res, error);
+        }
+      },
+    },
     {
       kind: "exact",
       path: ROUTES.servers,

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -671,6 +671,7 @@ const main = async () => {
         store,
         logger: { warn: () => {}, info: () => {}, error: () => {} },
         summary: () => ({ servers: [], counts: {} }),
+        uiConfig: () => ({ position: "top-right", offsetX: 8, offsetY: 8, blankY: 40 }),
         refreshFromDisk: async () => {},
         setSession: async (cwd) => {
           managerState.sessionCwd = cwd;
@@ -765,6 +766,14 @@ const main = async () => {
         const res = fakeRes();
         await find(ROUTES.servers).handler(fakeFenceBroken("GET", ROUTES.servers), res);
         assert.equal(res.state.status, 403);
+      });
+      await checkAsync("config 非 loopback → 200（只读 UI 配置放开）", async () => {
+        const res = fakeRes();
+        await find(ROUTES.config).handler(fakeFenceBroken("GET", ROUTES.config), res);
+        assert.equal(res.state.status, 200);
+        const body = JSON.parse(res.state.body);
+        assert.equal(body.position, "top-right");
+        assert.equal(body.offsetX, 8);
       });
       await checkAsync("import/json 导入", async () => {
         const res = fakeRes();

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -701,8 +701,8 @@ const main = async () => {
       const routes = makeRoutes(manager, process.cwd());
       const find = (path) => routes.find((route) => route.path === path);
 
-      check("注册 6 条 exact 路由", () => {
-        assert.equal(routes.length, 6);
+      check("注册 7 条 exact 路由", () => {
+        assert.equal(routes.length, 7);
         for (const route of routes) assert.equal(route.kind, "exact");
       });
 
@@ -835,7 +835,7 @@ const main = async () => {
     const ctx = fakeCtx();
     try {
       await apply(ctx, { enabled: true, storePath: join(dir, "dsh-mcp.json") });
-      assert.equal(ctx.routes.length, 8); // 6 条业务路由 + 1 条 SSE events + 1 条 health
+      assert.equal(ctx.routes.length, 9); // 7 条业务路由 + 1 条 SSE events + 1 条 health
       assert.ok(ctx.routes.some((route) => route.path === ROUTES.events), "SSE events 路由已注册");
       assert.equal(ctx.sections.length, 1);
       assert.equal(ctx.sections[0].name, "plugin:dsh-mcp-manager");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,9 +126,9 @@ importers:
       '@deepseek-ai/dsh-tools':
         specifier: 'catalog:'
         version: 0.1.1-rc.2(f7d8e59091784496c02afcf19f5662a6)
-      '@deepseek-ai/schemastery':
-        specifier: ^3.18.1
-        version: 3.18.1
+      schemastery:
+        specifier: ^3.18.0
+        version: 3.18.0
 
   packages/dsh-notifier:
     devDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@deepseek-ai/dsh-tools':
         specifier: 'catalog:'
         version: 0.1.1-rc.2(f7d8e59091784496c02afcf19f5662a6)
+      schemastery:
+        specifier: ^3.18.0
+        version: 3.18.0
 
   packages/dsh-notifier:
     devDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,9 +126,9 @@ importers:
       '@deepseek-ai/dsh-tools':
         specifier: 'catalog:'
         version: 0.1.1-rc.2(f7d8e59091784496c02afcf19f5662a6)
-      schemastery:
-        specifier: ^3.18.0
-        version: 3.18.0
+      '@deepseek-ai/schemastery':
+        specifier: ^3.18.1
+        version: 3.18.1
 
   packages/dsh-notifier:
     devDependencies:


### PR DESCRIPTION
## 问题

`dsh-mcp-manager` 的 MCP 浮动按钮存在几个问题：

1. **层级不符合 dsh 标准**
   按钮直接挂在对话滚动容器内，`z-index: 40` 高于 `shell.overlay` 的 `20`，会盖住 `dsh-complete-notify` 等全局通知。

2. **位置写死，无法自定义**
   原来固定为右上角 `top: 8px / right: 14px`，用户无法调整对齐位置（右上/右下）或偏移量。

3. **会随对话滚动**
   按钮使用 `scrollTop + 8` 定位，滚动对话时按钮会跟着内容移动，而不是固定在对话视口内。

4. **没有标准配置入口**
   没有通过 dsh settings 系统管理配置，无法在 `settings.yaml` 中调整。

5. **下拉框只能靠再次点击 MCP 关闭**
   展开下拉框后没有“点击外部关闭”的行为，交互不够自然。

## 改动

1. **注册隐藏 settings namespace**
   - 新增 `dsh-mcp-manager` 隐藏配置命名空间，不在设置页显示。
   - 配置由 dsh settings 系统统一管理，保存在 `~/.dsh/settings.yaml`。

2. **新增配置项**

   ```yaml
   dsh-mcp-manager:
     position: top-right      # top-right | bottom-right
     offset:
       x: 8                   # 水平偏移
       y: 8                   # 垂直偏移
       blankY: 40             # 新会话/空会话偏移量
   ```

   - `position`：右上角 / 右下角
   - `offset.x`：水平边距
   - `offset.y`：普通会话垂直边距
   - `offset.blankY`：新会话/空会话垂直偏移，不写则用 `offset.y`

3. **新增配置读取接口**
   - Host 新增 `GET /api/dsh-mcp/config`。
   - 配置来自隐藏 settings namespace，而不是插件直接读文件。

4. **修复层级**
   - MCP 浮动按钮挂到标准 `shell.overlay` 层。
   - `z-index: 10`，低于 `shell.overlay` 的 `20`，通知 toast 会盖在 MCP 上方。

5. **固定定位**
   - 按钮改为 `position: fixed`，基于对话区 `getBoundingClientRect()` 定位。
   - 滚动对话时按钮不随内容移动，保持在对话视口右上/右下角。

6. **点击外部关闭下拉框**
   - MCP 胶囊点击展开下拉框后，点击面板之外的任意区域也会关闭。
   - 点击面板内部操作不会误关；再次点击 MCP 胶囊仍可关闭。

## 默认值

```yaml
dsh-mcp-manager:
  position: top-right
  offset:
    x: 8
    y: 8
    blankY: 40
```

## 验证

- 新会话：MCP 显示在对话区右上角，避开 dsh-better-sidebar 等控件。
- 已有会话：MCP 显示在对话区右上角。
- 通知出现时：通知盖在 MCP 上方。
- 修改 `settings.yaml` 后重启 dsh web 生效。
- 下拉框展开后点击外部空白处可关闭，点击面板内部不会误关。
