### PR TITLE
docs(dsh-provider-usage): 新增架构图解——启动/取数/面板时序、适配器注入与客户端交互流程图

### DIFF
--- a/packages/dsh-provider-usage/README.en.md
+++ b/packages/dsh-provider-usage/README.en.md
@@ -61,6 +61,10 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-provider-usage
 
 ## Data Source
 
+> **Note**: this English README still describes pre-v2 behavior and lags behind the
+> current implementation. The Chinese [README.md](README.md) is authoritative; for
+> architecture diagrams (flow / sequence charts) see [architecture.md](docs/architecture.md).
+
 The plugin calls the official OpenCode Go usage interface directly:
 
 ```http

--- a/packages/dsh-provider-usage/README.en.md
+++ b/packages/dsh-provider-usage/README.en.md
@@ -2,226 +2,195 @@
 [![npm](https://img.shields.io/npm/v/@wingsky-1/dsh-provider-usage)](https://www.npmjs.com/package/@wingsky-1/dsh-provider-usage)
 [![GitHub Releases](https://img.shields.io/github/v/release/wingsky-1/dsh-plugin-hub)](https://github.com/wingsky-1/dsh-plugin-hub/releases)
 
-A DSH (DeepSeek Harness) Web GUI plugin: **OpenCode Go plan-usage floating pill + three-window mini charts**.
+DSH (DeepSeek Harness) Web GUI plugin: **usage statistics float widget** (v2 contract rewrite).
 
-A persistent floating capsule sits at the top-right of the chat interface, showing the real-time
-consumption percentage of the three OpenCode Go plan windows (color shifts with usage level:
-\>80% yellow, \>95% red). Click to expand a detail panel:
+A persistent capsule at the top-right of the chat view shows usage for the current model
+provider; click it to open a detail panel. Rendering happens on the **host side** — user
+adapters return HTML, the client only injects it.
 
-- Three mini-chart cards (rolling 5-hour / weekly / monthly), each window with independently
-  adaptive y-axis and x-axis time ticks, a 100% quota reference dashed line, and a reset marker
-  line (derived back from `resetsAt`)
-- Background sampling keeps history continuous (continues even when the browser is closed); data
-  comes from the official `/v1/usage` interface (authoritative data, zero local computation)
+> 中文文档：[README.md](README.md)（authoritative）。架构图解（flow / sequence charts）：
+> [docs/architecture.md](docs/architecture.md)；适配器开发引导：[docs/adapter-guide.md](docs/adapter-guide.md)。
 
-## Installation
+## Install
 
-Prerequisite: DeepSeek Harness installed and `dsh web` running normally (for running dsh
-without a global install, see "Without a global dsh install" below).
+Prerequisite: DeepSeek Harness installed and `dsh web` runnable (if `dsh` is not globally
+installed, see below).
 
-### Install plugins (add)
+### Add
 
 ```sh
 dsh plugin --profile web add @wingsky-1/dsh-provider-usage
 ```
 
-### Uninstall plugins (remove)
+### Remove
 
 ```sh
 dsh plugin --profile web remove @wingsky-1/dsh-provider-usage
 ```
 
-### Update plugins (update)
+### Update
 
 ```sh
 dsh plugin --profile web update @wingsky-1/dsh-provider-usage
 ```
 
-> After install / uninstall / update, **restart `dsh web` once** (bundle layers are only
-> composed at startup) for changes to take effect.
-
-### Pin a version (@version)
-
-Omitting `@version` installs the default latest (recommended). Only when the registry has not synced the latest yet, or the latest has issues in your environment, append `@version` to the package name:
-
-```sh
-dsh plugin --profile web add @wingsky-1/dsh-provider-usage@<version>
-```
+> Restart `dsh web` once after add / remove / update (bundles are composed at startup only).
 
 ### Without a global dsh install
 
-If there is no global `dsh` command on the machine, use `npx` to run it on the fly (`dsh plugin`
-calls `pnpm` under the hood, so `pnpm` and `Node.js` must still be installed locally):
-
 ```sh
 npx @deepseek-ai/dsh plugin --profile web add @wingsky-1/dsh-provider-usage
-npx @deepseek-ai/dsh plugin --profile web remove @wingsky-1/dsh-provider-usage
-npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-provider-usage
 ```
 
-## Data Source
+## How it works (v2)
 
-> **Note**: this English README still describes pre-v2 behavior and lags behind the
-> current implementation. The Chinese [README.md](README.md) is authoritative; for
-> architecture diagrams (flow / sequence charts) see [architecture.md](docs/architecture.md).
-
-The plugin calls the official OpenCode Go usage interface directly:
-
-```http
-GET https://opencode.ai/zen/go/v1/usage
-Authorization: Bearer <OPENCODE_GO_API_KEY>
+```
+Host (Node)                                    Client (browser)
+─────────────────────────────                 ─────────────────────
+Warmup timer (5min) ─┐
+                     ├→ getStats()             60s polling /stats
+Client polling ──────┘   │ Mutex                  ↓
+                         │ 60s cache           Capsule frame ← capsuleHtml
+                         │ 2s fetch timeout     Panel frame ← panelHtml (/history)
+                         ↓
+                   adapter.fetchData(ctx)   ← user .mjs (apiEndpoint/staticPath/apiKey injected)
+                         ↓
+                   daily-sharded JSONL history
+                         ↓
+                   adapter.formatCapsule/Panel() → sanitize → HTML
 ```
 
-The response is cached with a 30-second TTL (configurable) to avoid high-frequency requests.
-
-## API Key Resolution Order
-
-1. Plugin config `config.apiKey` (explicit, optional)
-2. Environment variable `OPENCODE_GO_API_KEY`
-3. DSH credentials file `<DSH_HOME>/.credentials.yaml` (DSH_HOME takes priority, default `~/.dsh`)
-   with `OPENCODE_GO_API_KEY`
-4. OpenCode's own `~/.local/share/opencode/auth.json` entry `opencode-go`
-   (falling back to `opencode`)
+The built-in adapter `opencode-go-builtin` (OpenCode Go official `/v1/usage`, three
+windows) works out of the box.
 
 ## Configuration
 
 | Key | Default | Meaning |
 | --- | --- | --- |
-| `enabled` | `true` | Plugin on/off switch |
-| `baseUrl` | `https://opencode.ai/zen/go/v1/usage` | Built-in opencode-go usage interface address (**configurable, i.e. the token-forwarding target**) |
-| `timeoutMs` | `15000` | Request timeout (ms) |
-| `cacheTtlMs` | `30000` | Usage cache TTL (ms) |
-| `limits` | `{rolling:12, weekly:30, monthly:60}` | Display limits (USD/window) |
-| `apiKey` | none | Explicit API Key (falls back to the credential resolution chain when absent) |
-| `maxAgeDays` | `30` | History sampling retention days (1–365) |
-| `sampleIntervalMs` | `300000` | Host background sampling interval (30s–1h; iterates all enabled adapters) |
-| `persistFile` | none (default history root `<DSH_HOME>/dsh-provider-usage/`, multi-file buckets under its `history/` subdirectory) | History root override (its directory becomes the history root) |
-| `adapters.host[]` | none | Custom host fetch-adapter candidates (`provider`/`file`/`enabled`, see below) |
-| `adapters.client[]` | none | Custom client renderer files (`file`) |
+| `enabled` | `true` | Plugin switch |
+| `adapter` | none | User adapter mjs path (built-in opencode-go by default) |
+| `provider` | `opencode-go` | Model provider name to associate |
+| `staticPath` | none | API path (injected into fetchData, appended to apiEndpoint) |
+| `apiEndpoint` | none | API base URL (optional; explicit config wins over credential chain) |
+| `apiKey` | none | Explicit key (optional; falls back to the credential chain, never echoed in settings) |
+| `historyDir` | `<DSH_HOME>/dsh-provider-usage/` | History storage root |
+| `warmupIntervalMs` | `300000` | Background warmup interval |
+| `cacheDurationMs` | `60000` | Cache freshness (ms) |
+| `fetchTimeoutMs` | `2000` | Forced fetchData timeout (500–30000ms) |
+| `autoReload` | `false` | Hot reload on adapter file edits |
 
-### Adapter candidates and enabling
+## API key resolution order (V1 config chain)
 
-One provider may have multiple adapter candidates (built-in + user-injected); **only one is
-enabled at any moment**:
-
-- The built-in `opencode-go-builtin` is enabled by default;
-- User adapters explicitly listed in the config are enabled by default (becoming the
-  provider's current enabled adapter); `enabled: false` disables a candidate explicitly;
-- Runtime switching: the settings panel (M3b) or `POST /api/dsh-provider-usage/adapters/select`
-  (body `{ provider, adapterId }`); that provider's cache is invalidated immediately;
-- When the current session's provider has no enabled adapter, the float widget hides and
-  reappears automatically once an adapter is enabled.
+1. Plugin config `apiKey` (explicit)
+2. Environment variable `{PROVIDER}_API_KEY` (uppercase, hyphens → underscores)
+3. opencode-go legacy env var `OPENCODE_GO_API_KEY`
+4. `{PROVIDER}_API_KEY` in `<DSH_HOME>/.credentials.yaml`
+   (opencode-go also probes the legacy name `OPENCODE_GO_API_KEY`)
+5. opencode-go compatibility: `~/.local/share/opencode/auth.json` entry
+   `opencode-go` (or `opencode`)
 
 ## Routes (all loopback-fenced)
 
 | Route | Description |
 | --- | --- |
-| `GET /api/dsh-provider-usage/stats[?provider=X]` | Usage statistics + embedded `summary` subtree (pill lightweight content) + `adapterId`/`hasAdapter` |
-| `GET /api/dsh-provider-usage/history[?provider=&adapterId=&days=N]` | History sampling series (with `columns` declaration) |
-| `GET /api/dsh-provider-usage/adapters.json` | Adapter candidate metadata (id/label/providers/source/file/enabled) |
-| `POST /api/dsh-provider-usage/adapters/select` | Switch the enabled adapter (body `{provider, adapterId}`) |
-| `GET /api/dsh-provider-usage/user/<n>.js` | User client renderer static serving |
-| `GET /api/dsh-provider-usage/health` | Health check + adapter snapshot |
+| `GET /api/dsh-provider-usage/stats?provider=X` | Usage stats + `capsuleHtml` + `status`/`adapterVersion` |
+| `GET /api/dsh-provider-usage/history?provider=X&days=N` | History query + `panelHtml` + query `range` |
+| `GET /api/dsh-provider-usage/health` | Health check + adapter snapshot + error log |
+| `GET /api/dsh-provider-usage/adapters.json` | Adapter candidate metadata (same source as the settings page list, incl. `modelProviders`) |
+| `POST /api/dsh-provider-usage/adapters/select` | Switch / clear the enabled adapter |
+| `POST /api/dsh-provider-usage/adapters/inspect` | Preview an adapter file (echo exports, no registration) |
+| `POST /api/dsh-provider-usage/adapters/add` | Register a user adapter file (settings page flow) |
 
-## Provider Adapter Development Guide
+## Adapter development guide (v2 contract)
 
-Adapting a custom relay takes two files (full example in
-`docs/opt/usage-provider-adapter/examples/my-relay/`):
-
-**1. Host fetch adapter `.mjs`** (default-exported contract object):
-
-```js
-export default {
-  version: 1,
-  id: "my-relay",            // unique adapter id (shown in the settings candidates list)
-  label: "My Relay",
-  providers: ["my-relay"],   // claimed provider names
-  async fetchUsage(ctx) {    // required: fetch and normalize
-    const res = await ctx.fetch("https://relay.example.com/v1/usage");
-    const body = await res.json();
-    return { ok: true, provider: "my-relay", label: "My Relay",
-             fetchedAt: Date.now(), data: body };   // data format is yours
-  },
-  // optional summarize(ctx): custom pill text (derive from ctx.usage only, no network)
-  // optional samplePoint(usage): declare history sample columns { cols, values }
-};
-```
-
-Factory shortcut (auto-derives summarize/samplePoint):
+Any data source plugs in with one mjs file (full example:
+`examples/usage-adapter.example.mjs`; agent-oriented walkthrough:
+[docs/adapter-guide.md](docs/adapter-guide.md)):
 
 ```js
-import { defineUsageAdapter } from "@wingsky-1/dsh-provider-usage";
-export default defineUsageAdapter({
-  id: "my-relay", label: "My Relay", providers: ["my-relay"],
-  windows: [{ key: "credit", name: "Credit", limit: 100 }],
-  async fetchUsage(ctx) { /* ...return data containing windows */ },
-});
+// my-stats.mjs
+export const version = 2;                    // required: contract version (fixed 2)
+export const name = "my-stats";              // required: unique name (^[A-Za-z0-9_-]{2,64}$)
+export const label = "My Stats";             // optional: display name
+export const providers = ["my-relay"];       // required: claimed providers
+export const retention = { maxAgeDays: 30 }; // optional: retention policy
+
+/** Required: fetch raw data (runs on the host; args injected by the plugin) */
+export async function fetchData({ apiEndpoint, staticPath, apiKey, signal, timeoutMs }) {
+  const res = await fetch(apiEndpoint + staticPath, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal,
+  });
+  if (!res.ok) throw new Error(`http-${res.status}`);
+  return res.json(); // return only the minimal dataset needed for display
+}
+
+/** Required: capsule content (host side, returns an HTML string) */
+export function formatCapsule({ data, status, esc }) {
+  return `<span style="font-weight:600">${esc(data.visits ?? 0)} visits</span>`;
+}
+
+/** Required: panel content (host side, returns an HTML string) */
+export function formatPanel({ entries, range, truncated, esc }) {
+  const rows = entries.slice(-60).map((e) =>
+    `<tr><td>${esc(new Date(e.time).toLocaleString())}</td><td>${esc(e.data.visits)}</td></tr>`).join("");
+  return `<table>${rows}</table>`;
+}
 ```
 
-**2. Client renderer `.js`** (self-registers via the global bridge):
+**Wiring** — recommended via the settings page (no config-file editing, no restart):
 
-```js
-window.__DSH_USAGE__?.registerRenderer({
-  version: 1,
-  providers: ["my-relay"],
-  adapterId: "my-relay",     // optional: bind to an adapter; default renderer otherwise
-  pill(summary) { return null; },  // optional: custom pill text
-  render(ctx) {              // required: draw into ctx.mount; return cleanup (optional)
-    const div = document.createElement("div");
-    div.textContent = JSON.stringify(ctx.data?.data ?? {});
-    ctx.mount.appendChild(div);
-  },
-});
-```
+1. Open dsh Settings → Plugins → "Usage Stats"
+2. Under the target provider click "+ Add adapter", enter the mjs file path
+   (`~` expansion / absolute paths supported)
+3. Click "Inspect" to echo the exports → confirm add (auto-persisted and hot-registered
+   as the provider's enabled adapter)
+4. Toggle candidates on/off; changes take effect immediately and persist
 
-**Wiring** (cordis.patch.yml / user patch layer):
+Alternatively declare in cordis.patch.yml (optional overlay, loaded at startup):
 
 ```yml
 plugins:
-  ui-dsh-provider-usage:
-    adapters:
-      host:
-        - provider: my-relay
-          file: ~/.dsh/my-relay-host.mjs
-      client:
-        - file: ~/.dsh/my-relay-client.js
+  '@wingsky-1/dsh-provider-usage':
+    adapter: ~/dsh/my-stats.mjs
+    provider: my-relay
+    staticPath: /api/usage
+    autoReload: true        # hot-reload after editing the mjs
 ```
 
-Paths support `~` expansion / absolute paths / DSH_HOME-relative. Load failures only warn
-and skip that candidate without blocking the rest of the plugin.
+Load failures are rejected fail-fast and logged (visible in the settings panel) without
+affecting other plugin features. Path safety: relative paths must land inside `DSH_HOME`
+or the plugin home; non-normalized forms (`../` traversal) are rejected with 400.
 
-## Security Model
+## Security model
 
-- **Token is never written to disk, never logged, never sent to the browser side**: the API Key
-  lives only in host-process memory; the browser only fetches display fields via `/stats`
-- **`baseUrl` is configurable = your token is sent to that address**: only configure a trusted
-  usage interface; default is the official `https://opencode.ai/zen/go/v1/usage`
-- **stripSecrets guard (on by default; disable with `stripSecrets: false`)**: two-layer
-  redaction over normalized returns (including summary text fields) — keys matching
-  `secret/token/key/apikey` with string values (≥8 chars) are replaced with `<redacted>`;
-  values matching secret-like patterns (`Bearer xxx` / `sk-xxx` / `api_key=xxx` / long hex)
-  are redacted wholesale. Best-effort — **no absolute isolation is promised**
-- **User host js runs with full Node permissions** (network/files/env), equivalent to writing
-  your own plugin process; only load local files you trust — the plugin never pulls code from
-  the network for execution
-- **User client js** shares the trust level of other web plugins (browser sandbox); registered
-  through the versioned bridge (contract mismatch only warns and skips)
-- History sampling persists as multi-file storage (one file per `(provider, adapterId)` bucket,
-  `0600` permissions tmp+rename atomic write); when upgrading from the legacy single file it is
-  renamed to `.bak` and **kept (never deleted — cleanup is left to the user)**
-- All routes are loopback-fenced (non-loopback 403 / wrong method 405); the `select` API limits
-  parameter length to 128
-- Official interface request frequency is controlled: GUI polling ≤1 request/60s + background
-  sampling ≤1 request/5min (each with an additional 30s TTL cache suppressing duplicate
-  requests), so it will not hit rate limits
+- **Adapter code = full Node permissions on the host** (network/fs/env), equivalent to
+  writing your own in-process plugin; only load local files you trust — the plugin never
+  pulls code from the network for execution
+- **Keys never reach the browser**: apiKey lives only in host-process memory and is
+  injected into fetchData as an argument; adapter files never contain key values
+- **Two-layer XSS defense**: external API strings must be escaped with `esc()` before
+  being placed into HTML (documented obligation); the plugin additionally sanitizes all
+  format output on the host (script/iframe/on* attributes/javascript: removal)
+- **Hot reload is off by default**; when enabled it polls mtime+size, atomically swaps in
+  the new version only after validation passes, and keeps the old version on failure
+- **Timeout discipline**: fetchData gets a forced 2s timeout + AbortSignal; when the lock
+  is busy requests degrade to cache instead of queueing — page requests are never blocked
+- **Fail-fast loading**: missing exports / wrong types / invalid names are rejected with
+  diagnosable errors
+- **History**: daily-sharded JSONL (`0600` permissions) with automatic age/size pruning;
+  raw data is serialization-checked before persistence
+- All routes loopback-fenced (403 non-loopback / 405 wrong method); minimal information
+  disclosure on admin endpoints (user files shown as basename only); request rate is
+  bounded (polling ≤1/60s + warmup ≤1/5min + 60s TTL cache)
 
-## Verification
+## Verify
 
 ```sh
 # Health check (loopback)
 curl -s http://127.0.0.1:3080/api/dsh-provider-usage/health
 
-# Source is in src/, must build after changes
+# Source lives in src/, rebuild after changes
 pnpm --filter @wingsky-1/dsh-provider-usage build
 node test/smoke.ts
 ```

--- a/packages/dsh-provider-usage/README.md
+++ b/packages/dsh-provider-usage/README.md
@@ -76,26 +76,30 @@ npx @deepseek-ai/dsh plugin --profile web add @wingsky-1/dsh-provider-usage
 | `cacheDurationMs` | `60000` | 缓存新鲜度（毫秒） |
 | `fetchTimeoutMs` | `2000` | fetchData 强制超时（500–30000ms） |
 | `autoReload` | `false` | 热更新开关（编辑适配器文件后自动加载） |
-| `maxDetailRows` | `5000` | /history 单次查询行数上限 |
 | `maxAgeDays` | `30` | 历史保留天数 |
 | `maxSizeMB` | `20` | 历史大小上限（MB，超限从最旧日文件删） |
 
 ## 密钥解析顺序（V1 配置链）
 
 1. 插件配置 `apiKey`（显式指定）
-2. 环境变量 `{PROVIDER}_API_KEY`（大写，连字符换下划线，如 `OPENCODE_GO_API_KEY`）
-3. `<DSH_HOME>/.credentials.yaml` 中的 `{PROVIDER}_API_KEY`
-4. opencode-go 兼容：环境变量 `OPENCODE_GO_API_KEY`、
-   `~/.local/share/opencode/auth.json` 的 `opencode-go` 条目
+2. 环境变量 `{PROVIDER}_API_KEY`（大写，连字符换下划线）
+3. opencode-go 兼容旧环境变量 `OPENCODE_GO_API_KEY`
+4. `<DSH_HOME>/.credentials.yaml` 的 `{PROVIDER}_API_KEY`
+   （opencode-go 在标准 key 未命中时再查旧名 `OPENCODE_GO_API_KEY`）
+5. opencode-go 兼容：`~/.local/share/opencode/auth.json` 的
+   `opencode-go`（或 `opencode`）条目
 
 ## 路由（全部 loopback 围栏）
 
 | 路由 | 说明 |
 | --- | --- |
 | `GET /api/dsh-provider-usage/stats?provider=X` | 用量统计 + `capsuleHtml`（胶囊内容）+ `status`/`adapterVersion` |
-| `GET /api/dsh-provider-usage/history?provider=X&days=N` | 历史查询 + `panelHtml`（面板内容）+ `truncated` 标记 |
+| `GET /api/dsh-provider-usage/history?provider=X&days=N` | 历史查询 + `panelHtml`（面板内容）+ 查询 `range` |
 | `GET /api/dsh-provider-usage/health` | 健康检查 + 适配器快照 + 错误登记 |
-| `GET /api/dsh-provider-usage/adapter.mjs` | 用户适配器文件静态服务（供浏览器查看；未配置时 404） |
+| `GET /api/dsh-provider-usage/adapters.json` | 适配器候选元数据（设置页主列表同源，含 `modelProviders`） |
+| `POST /api/dsh-provider-usage/adapters/select` | 切换/清空启用适配器 |
+| `POST /api/dsh-provider-usage/adapters/inspect` | 预览适配器文件（回显导出信息，不注册） |
+| `POST /api/dsh-provider-usage/adapters/add` | 登记用户适配器文件（设置页承载） |
 
 ## 适配器开发指南（v2 契约）
 

--- a/packages/dsh-provider-usage/README.md
+++ b/packages/dsh-provider-usage/README.md
@@ -59,6 +59,8 @@ npx @deepseek-ai/dsh plugin --profile web add @wingsky-1/dsh-provider-usage
 
 内置适配器 `opencode-go-builtin`（OpenCode Go 官方 `/v1/usage` 三窗口用量）开箱即用。
 
+> **图解文档**：完整的流程图 / 时序图（启动装配、`/stats` 取数全链路、`/history` 面板、自定义适配器注入三条路径与热更新、客户端交互、密钥解析链）见 [docs/architecture.md](docs/architecture.md)。
+
 ## 配置
 
 | 键 | 默认值 | 含义 |

--- a/packages/dsh-provider-usage/docs/adapter-guide.md
+++ b/packages/dsh-provider-usage/docs/adapter-guide.md
@@ -25,7 +25,7 @@
 
 用户从设置页「用量统计」→「接入自定义适配器」复制引导指令发到会话，即触发本流程。指令包含本文档的 **GitHub 链接**（任何工作目录下的 Agent 都能读取）：
 
-> 请为提供商 `<provider>` 创建用量统计适配器（v2 契约）：以该提供商在模型配置中的 API 端点（baseUrl）为起点，自行确认用量接口与鉴权方式，自主设计适配器方案（name/展示名/接口路径），先给我审核方案（含 API 端点），确认后生成 .mjs 文件、告诉保存路径并引导我在 cordis.patch.yml 中声明。按用量统计适配器开发引导文档（https://github.com/wingsky-1/dsh-plugin-hub/blob/main/packages/dsh-provider-usage/docs/adapter-guide.md）执行引导流程。
+> 请为提供商 `<provider>` 创建用量统计适配器（v2 契约）：以该提供商在模型配置中的 API 端点（baseUrl）为起点，自行确认用量接口与鉴权方式，自主设计适配器方案（name/展示名/接口路径），先给我审核方案（含 API 端点），确认后生成 .mjs 文件、告诉保存路径并引导我在「用量统计」设置页添加适配器。按用量统计适配器开发引导文档（https://github.com/wingsky-1/dsh-plugin-hub/blob/main/packages/dsh-provider-usage/docs/adapter-guide.md）执行引导流程。
 
 收到后按以下流程执行（默认全程自主，只保留审核点）：
 
@@ -73,10 +73,16 @@
 
 ### 2.5 步骤 5：引导用户接线
 
-告知用户：
+**主路径：设置页「用量统计」（运行时热注册，无需重启）**。告知用户：
 
 ```
-适配器文件已保存到 `<路径>`。请在用户层 cordis.patch.yml 添加以下配置：
+适配器文件已保存到 `<路径>`。请打开 dsh 设置 → 插件 →「用量统计」：
+1. 在目标 provider 下点「+ 添加适配器」，输入路径 `<路径>`
+2. 点「检测文件」确认导出信息（name/label/providers）
+3. 确认添加——自动注册并成为该 provider 启用者，胶囊下个轮询周期（≤60s）即出数据
+```
+
+**可选叠加**：也可在用户层 cordis.patch.yml 声明（启动时加载，改后需重启 dsh web）：
 
 ```yml
 plugins:
@@ -85,9 +91,6 @@ plugins:
     provider: <provider>
     staticPath: <用量接口路径>
     # autoReload: true    # 编辑 mjs 后自动热更新，无需重启
-```
-
-完成后重启 dsh web（或开启 autoReload 免重启），用量胶囊即出现在聊天界面右上角。
 ```
 
 ---
@@ -158,5 +161,5 @@ export const retention = { maxAgeDays: 30, maxSizeMB: 20 };  // 留存策略
 | `export default { version:1, id, label, providers, fetchUsage }` | 具名导出 `version:2, name, providers, fetchData` |
 | 客户端渲染器 `.js` + `window.__DSH_USAGE__` 桥接 | `formatCapsule`/`formatPanel` 返回 HTML（宿主端渲染） |
 | `summarize`/`samplePoint`/windows 归一化 | 移除，胶囊/面板直接由 format 函数产出 |
-| 设置页运行时 add/select 适配器 | `cordis.patch.yml` 声明 + 热更新 |
+| 设置页运行时 add/select 适配器 | **保留并增强**：设置页「用量统计」承载检测/添加/切换/停用；cordis.patch.yml 声明降为可选叠加 |
 | 历史 v3 多文件 JSON 桶 | 按天分片 JSONL（旧数据启动时自动迁移） |

--- a/packages/dsh-provider-usage/docs/adapter-guide.md
+++ b/packages/dsh-provider-usage/docs/adapter-guide.md
@@ -3,6 +3,7 @@
 > 适用插件：`@wingsky-1/dsh-provider-usage`（v2 契约重构版）。
 > 本文是 Agent 自主引导用户接入自定义数据源的权威流程手册。
 > 快速参考：契约细节见第 7 节；完整示例见 `examples/usage-adapter.example.mjs`。
+> 插件内部运行机制（取数管道 / 注册表 / 热更新 / 设置页交互）的图解见 [architecture.md](architecture.md)。
 
 ---
 

--- a/packages/dsh-provider-usage/docs/architecture.md
+++ b/packages/dsh-provider-usage/docs/architecture.md
@@ -141,7 +141,7 @@ sequenceDiagram
     G->>G: history.append({time,data}) 管线返回后落盘<br/>仅当 ok && fresh && rawData（失败仅记日志）
     G->>G: cache.set(provider, result) 成功与失败结果都缓存
     G-->>B: 200 {capsuleHtml?, status=fresh|stale, adapterName,...}
-    Note over B: renderPill(): label.innerHTML = capsuleHtml<br/>状态点 fresh/cached→绿 stale→黄<br/>configured=false 且无内容 → 胶囊整体隐藏
+    Note over B: renderPill(): label.innerHTML = capsuleHtml<br/>状态点 fresh/cached→绿 stale→黄<br/>未配置 → 红点错误态胶囊（provider 名，点击看引导）
 ```
 
 降级语义速查（客户端状态点颜色由这些字段决定）：
@@ -152,7 +152,7 @@ sequenceDiagram
 | 60s 缓存命中 | `status=cached` | 绿点，tooltip 标「缓存」 |
 | 锁忙（取数进行中） | `ok=true, reason=busy, status=stale` | 黄点，「取数进行中，稍候自动刷新」 |
 | 取数失败/超时 | `ok=false, error=...` | 黄点 + tooltip 错误详情 |
-| 无候选适配器 | `configured=false, reason=no-adapter` | 胶囊整体隐藏（无数据不渲染）；接入引导由设置页承载 |
+| 无候选适配器 | `configured=false, reason=no-adapter` | 红点错误态胶囊（显示 provider 名）；点开面板见接入引导 + 复制引导指令 |
 | 有候选但全禁用 | `configured=false, reason=no-enabled-adapter` | 同上 |
 
 注意：失败与 no-\* 结果同样会写入缓存，TTL 内重复请求直接复用缓存条目（status 改标 `cached`），不会反复打外部 API。

--- a/packages/dsh-provider-usage/docs/architecture.md
+++ b/packages/dsh-provider-usage/docs/architecture.md
@@ -33,7 +33,7 @@ flowchart LR
         ROUTES --> PIPEPANEL
         GETSTATS --> REG
         GETSTATS --> PIPE
-        PIPE --> HIST
+        GETSTATS --> HIST
         PIPEPANEL --> HIST
         HOT --> REG
         WARM --> GETSTATS
@@ -45,7 +45,7 @@ flowchart LR
 
     PILL -->|"GET /stats"| ROUTES
     PANEL -->|"GET /history"| ROUTES
-    SETTINGS -->|"adapters.json / select / inspect / add"| ROUTES
+    SETTINGS -->|"GET /stats · adapters.json /<br/>select / inspect / add"| ROUTES
     PIPE -->|"apiEndpoint/apiKey 注入"| ADAPTER
     ADAPTER -->|"fetch()"| API
     HIST --- DISK
@@ -60,7 +60,7 @@ flowchart LR
 
 ## 2. 插件启动流程（`apply(ctx, config)`）
 
-宿主端入口按固定顺序装配。任何一步失败都不阻断启动——适配器加载失败走 fail-fast 拒收并登记错误，其余功能照常。
+插件本身不改 DSH 源码——经 `cordis.patch.yml` + profile 机制挂载到 `dsh web`，`apply(ctx, config)` 在宿主启动时被调用。宿主端入口按固定顺序装配。任何一步失败都不阻断启动——适配器加载失败走 fail-fast 拒收并登记错误，其余功能照常。
 
 ```mermaid
 flowchart TD
@@ -89,6 +89,8 @@ flowchart TD
 | `user-adapters.json` | 设置页 add | 用户适配器清单 `{version:1, adapters:[{id,label,providers,file}]}`，tmp+rename 原子写、mode 0600 |
 | `adapter-state.json` | select / add | provider → 启用适配器 name 映射（`null` 表示显式清空），串行链写入 |
 
+关于末步的 `installSettingsNamespace`：它把插件 Config schema 以**只读镜像**形式暴露到设置面板 UI（`setSource`/`onChange` 均为空实现，纯展示；rc.7 的 keyed 渲染约束下不提供运行时写回）——真正的运行时管理由设置页 tab 经 `adapters.json / select / inspect / add` 路由承载，apiKey 不进 schema 故不回显。
+
 ---
 
 ## 3. 核心时序：`GET /stats` 取数全链路
@@ -105,7 +107,6 @@ sequenceDiagram
     participant P as runV2Pipeline<br/>(safeFetchData)
     participant AD as adapter.fetchData()
     participant API as 外部用量 API
-    participant H as HistoryStore
     participant F as adapter.formatCapsule()
 
     B->>R: GET /stats?provider=X
@@ -125,25 +126,22 @@ sequenceDiagram
             else 有启用适配器
                 G->>P: runV2Pipeline(adapter, config, timeoutMs)
                 Note over P: resolveProviderConfig 密钥链(§7)<br/>组装 FetchContext 入参
-                P->>AD: fetchData({apiEndpoint, staticPath,<br/>apiKey, timeoutMs, signal})
+                P->>AD: fetchData({apiEndpoint, staticPath, apiKey,<br/>provider, timeoutMs, signal, fetch})
                 AD->>API: fetch(apiEndpoint + staticPath)
                 API-->>AD: JSON 数据
                 AD-->>P: 返回对象（最小数据集）
-                alt 抛错 / 超 2s 强制超时 / 不可序列化
-                    P-->>G: ok=false, reason=fetch-failed<br/>status=stale（绝不外抛异常）
-                else 成功
-                    P->>H: append({time,data}) 按天分片 JSONL
-                    P->>F: formatCapsule({time,data,status:fresh,esc})
-                    F-->>P: HTML 字符串
-                    Note over P: sanitizeHtml 净化兜底<br/>(script/iframe/on*/javascript:)
-                    P-->>G: V2PipelineResult(capsuleHtml)
-                    G->>G: cache.set(provider, result)
-                    G-->>B: 200 {capsuleHtml, status=fresh, adapterName,...}
-                end
+                Note over P,G: 失败（抛错 / 超 2s 强制超时 / 不可序列化）:<br/>ok=false, reason=fetch-failed, status=stale<br/>（绝不外抛异常；此形态不 format、不落盘）
+                P->>F: formatCapsule({time,data,status:fresh,esc})
+                F-->>P: HTML 字符串
+                Note over P: sanitizeHtml 净化兜底<br/>(script/iframe/on*/javascript:)
+                P-->>G: V2PipelineResult(capsuleHtml?, rawData?)
             end
         end
     end
-    Note over B: renderPill(): label.innerHTML = capsuleHtml<br/>状态点 fresh/cached→绿 stale→黄 !configured→红
+    G->>G: history.append({time,data}) 管线返回后落盘<br/>仅当 ok && fresh && rawData（失败仅记日志）
+    G->>G: cache.set(provider, result) 成功与失败结果都缓存
+    G-->>B: 200 {capsuleHtml?, status=fresh|stale, adapterName,...}
+    Note over B: renderPill(): label.innerHTML = capsuleHtml<br/>状态点 fresh/cached→绿 stale→黄<br/>configured=false 且无内容 → 胶囊整体隐藏
 ```
 
 降级语义速查（客户端状态点颜色由这些字段决定）：
@@ -154,8 +152,10 @@ sequenceDiagram
 | 60s 缓存命中 | `status=cached` | 绿点，tooltip 标「缓存」 |
 | 锁忙（取数进行中） | `ok=true, reason=busy, status=stale` | 黄点，「取数进行中，稍候自动刷新」 |
 | 取数失败/超时 | `ok=false, error=...` | 黄点 + tooltip 错误详情 |
-| 无候选适配器 | `configured=false, reason=no-adapter` | 红点；面板展示引导 |
-| 有候选但全禁用 | `configured=false, reason=no-enabled-adapter` | 红点；面板提示去设置页启用 |
+| 无候选适配器 | `configured=false, reason=no-adapter` | 胶囊整体隐藏（无数据不渲染）；接入引导由设置页承载 |
+| 有候选但全禁用 | `configured=false, reason=no-enabled-adapter` | 同上 |
+
+注意：失败与 no-\* 结果同样会写入缓存，TTL 内重复请求直接复用缓存条目（status 改标 `cached`），不会反复打外部 API。
 
 ---
 
@@ -201,7 +201,7 @@ sequenceDiagram
 flowchart TD
     U(["用户写好 my-stats.mjs<br/>(契约: version=2 + name + providers +<br/>fetchData/formatCapsule/formatPanel)"]) --> PATH
 
-    subgraph PATH [" "]
+    subgraph PATH ["注入路径"]
         direction LR
         P1["路径 A: cordis.patch.yml 声明<br/>adapter: ~/my-stats.mjs<br/>(启动时加载，兼容态)"]
         P2["路径 B: 设置页添加<br/>(运行时热注册，推荐)"]
@@ -214,6 +214,10 @@ flowchart TD
 
     L1 & L2 & L3 --> REG["AdapterRegistry.register → 契约校验 fail-fast：<br/>缺导出/name 非法/version≠2 拒收 + recordError<br/>通过后默认成为该 provider 启用者<br/>(或按 adapter-state.json 恢复的选择)"]
 ```
+
+设置页主列表的数据源 `GET /adapters.json` 除返回注册表快照（host/enabled/errors）外，还经 `ctx.llm.listProviders()`（插件 `inject` 含 `llm`）带上模型配置页的提供商列表 `modelProviders`，用于把「模型配置中的 provider」与「已注册适配器认领的 provider」对齐展示。
+
+> 注意：运行时注册表**只收 v2 契约（`version === 2`）**；`contracts.ts` 保留的 v1 deprecated 类型仅为编译期引用兼容，不再有加载路径。
 
 ### 5.2 时序：设置页「检测 → 添加」（运行时注入的主路径）
 
@@ -299,7 +303,7 @@ flowchart TD
     A --> B["slots.inject settings.section<br/>注册独立 tab「用量统计」<br/>(独立 try/catch 不连坐浮窗)"]
     A --> C["mountFloat(): 胶囊 button + 面板 div<br/>MutationObserver 自动重挂位<br/>scroll/resize 跟随定位"]
     C --> D["立即 refreshStats() 一次<br/>+ setInterval 60s 轮询<br/>+ visibilitychange 转可见补刷"]
-    A --> E["provider 检测:<br/>sessions.currentProvideInfo subscribe<br/>→ sessions.models(sessionId)<br/>→ current.provider ?? 回落 opencode-go"]
+    A --> E["provider 检测:<br/>sessions.currentProvideInfo subscribe<br/>(不可用回落 sessions.list subscribe)<br/>→ sessions.models(sessionId)<br/>→ current.provider ?? 回落 opencode-go"]
     E -->|"provider 变化"| F["renderGeneration+1 防竞态<br/>清 lastStats/lastHistory → 重新拉取"]
 ```
 
@@ -310,7 +314,7 @@ flowchart TD
     P(["用户点击胶囊"]) --> T["toggleFloat(): 展开面板<br/>refreshHistory() 拉 /history"]
     T --> K{"renderPanel 内容优先级"}
     K -->|"panelHtml 有值"| L["innerHTML 注入图表<br/>(stats 失败但历史有图仍展示)"]
-    K -->|"no-adapter / no-enabled-adapter"| M["引导分支: 说明文案 +<br/>「复制引导指令」按钮(指向 adapter-guide.md)"]
+    K -->|"no-adapter / no-enabled-adapter<br/>或 历史未拉到且 stats 已示未配置"| M["引导分支: 说明文案 +<br/>「复制引导指令」按钮(指向 adapter-guide.md)"]
     K -->|"其他错误"| N["errorMessage(code) 映射中文提示"]
     K -->|"尚无数据"| O["加载中…"]
 ```
@@ -318,7 +322,7 @@ flowchart TD
 防竞态与一致性细节：
 
 - **renderGeneration 代 token**：provider 切换/卸载时自增，迟到的旧请求响应直接丢弃；
-- **adapterVersion 变化即全量重置**：热更新换版后丢弃旧 `lastHistory`，防止「新数据 × 旧模板」混搭；
+- **adapterVersion 重置机制（预留）**：客户端在响应 `adapterVersion` 变化时会丢弃旧 `lastHistory`，防止「新数据 × 旧模板」混搭；当前服务端 `/stats` 恒返回 `adapterVersion: 0`，该路径暂不触发（为换版语义预留）；
 - **所有异常只 warn**：任何请求失败都不会让 GUI 启动失败或挂起（客户端请求统一 2s 超时）。
 
 ---
@@ -335,9 +339,9 @@ flowchart TD
     B -->|命中| DONE
     B -->|未命中| C{"provider=opencode-go?<br/>旧变量 OPENCODE_GO_API_KEY"}
     C -->|命中| DONE
-    C -->|否| D{"DSH_HOME/.credentials.yaml<br/>{PROVIDER}_API_KEY 字段"}
+    C -->|否| D{"DSH_HOME/.credentials.yaml<br/>先查 {PROVIDER}_API_KEY 字段<br/>(opencode-go 再查旧名 OPENCODE_GO_API_KEY)"}
     D -->|命中| DONE
-    D -->|未命中| E{"provider=opencode-go?<br/>~/.local/share/opencode/auth.json<br/>opencode-go 条目(type=api,key=...)"}
+    D -->|未命中| E{"provider=opencode-go?<br/>~/.local/share/opencode/auth.json<br/>opencode-go 或 opencode 条目(type=api,key=...)"}
     E -->|命中| DONE
     E -->|未命中| NONE["apiKey=undefined<br/>(适配器可自行抛 no-api-key)"]
 ```
@@ -353,16 +357,18 @@ flowchart TD
 | 路由围栏 | 所有路由 loopback 才放行（非回环 403）、方法白名单（405） | 每个 route handler 入口 |
 | 取数超时 | `safeFetchData`: Promise.race + AbortController，强制 timeoutMs（默认 2s）；结果必须过 JSON 序列化校验 | `core/guards.ts` |
 | 渲染超时 | `safeFormat`: 异步 format 2s 超时 + 返回类型校验（同步死循环为文档化风险） | `core/guards.ts` |
-| XSS 兜底 | `sanitizeHtml` 白名单式正则净化：script/iframe/frame/object/embed/meta/link/base、on* 事件、javascript:/data:text-html 协议 | `sanitize.ts` |
+| XSS 兜底 | `sanitizeHtml` 白名单式正则净化：script/iframe/frame/object/embed/meta/link/base 标签、on* 事件、`javascript:`/`data:text/html` 协议、CSS `expression(` | `sanitize.ts` |
 | 密钥隔离 | apiKey 仅宿主内存，不入设置面板 schema、不下发浏览器 | `provider-config.ts` / `index.ts` |
 | 路径安全 | add/inspect 拒绝 `\0`、未规整相对路径；相对路径限 DSH_HOME / 插件 home 内；历史目录名 `safeSegment` 防穿越 | `index.ts` / `contracts.ts` |
 | 信息最小披露 | health/errors 中用户文件路径脱敏为 basename 或 `~` 形态 | `index.ts` / `registry.ts` |
-| 历史文件 | 按天分片 JSONL，mode 0600，超龄（30 天）/超量（20MB）自动清理；清单文件 tmp+rename 原子写 | `core/history.ts` / `index.ts` |
+| 历史文件 | 按天分片 JSONL，mode 0600；清理在每次 append 后惰性触发——先删过期日文件，再在总大小超限时从最旧删起且恒保留最后 1 个文件防清零；清单文件 tmp+rename 原子写 | `core/history.ts` / `index.ts` |
 | fail-fast 加载 | 缺导出 / 类型错 / name 不合白名单 → 拒收并登记可排障错误，不影响插件其余功能 | `contracts.ts` / `registry.ts` |
 
 ---
 
 ## 9. 关键模块索引
+
+构建链：`src/*.ts` 经 tsc 编译后由 bundle-host 把全部子模块**内联进单一 `lib/index.js`**（发布物自包含、无运行时 npm 依赖），因此契约与核心模块一律在 `src/index.ts` re-export——smoke/lint 只能从 `lib/index.js` 导入。各模块职责：
 
 | 模块 | 职责 |
 | --- | --- |
@@ -375,6 +381,9 @@ flowchart TD
 | `src/hotreload.ts` | mtime+size 轮询热更新 + 原子切换 |
 | `src/provider-config.ts` | 密钥五级解析链 |
 | `src/sanitize.ts` | HTML 结构化净化 |
+| `src/adapters/opencode-go.ts` | 内置适配器 opencode-go-builtin：OpenCode Go `/v1/usage` 三窗口用量 |
 | `src/client/index.ts` | 客户端入口：胶囊/面板挂载、轮询、provider 检测 |
 | `src/client/settings.ts` | 设置页 tab：适配器管理（检测/添加/切换/停用） |
 | `src/client/core.ts` | 客户端数据层：fetch 封装、响应类型、会话 provider 解析 |
+| `src/client-logic.ts` | 设置页纯函数：provider 列表拆分与徽标文案 |
+| `src/path-resolve.ts` | 路径解析：`~` 展开、DSH_HOME 相对路径解析（pluginHome） |

--- a/packages/dsh-provider-usage/docs/architecture.md
+++ b/packages/dsh-provider-usage/docs/architecture.md
@@ -1,0 +1,380 @@
+# dsh-provider-usage 架构与运行机制（图解）
+
+> 基于 v2 契约重构版源码（`src/index.ts` 及 `src/` 各模块）整理。
+> 本文用流程图 / 时序图讲清三件事：**整个插件怎么跑起来、自定义适配器怎么注入、客户端与服务端怎么交互**。
+> 配套文档：适配器开发引导见 [adapter-guide.md](adapter-guide.md)；快速上手见 [../README.md](../README.md)。
+
+---
+
+## 1. 总体架构：一次渲染，两端分工
+
+v2 的核心设计是**宿主端渲染**：用户适配器在 Node 侧产出 HTML，浏览器端只做「拉数据 + 注入 DOM」，不再维护任何渲染器注册表（v1 的 `window.__DSH_USAGE__` 桥接已废弃）。
+
+```mermaid
+flowchart LR
+    subgraph browser["浏览器（dsh web GUI）"]
+        PILL["悬浮胶囊 dou-float<br/>60s 轮询 · capsuleHtml 注入"]
+        PANEL["详情面板<br/>panelHtml 注入"]
+        SETTINGS["设置页 tab「用量统计」<br/>settings.ts (React)"]
+        PILL -->|点击展开| PANEL
+    end
+
+    subgraph host["宿主进程（dsh web · Node）"]
+        ROUTES["7 条 HTTP 路由<br/>loopback 围栏 (403/405)"]
+        GETSTATS["getStats()<br/>缓存 TTL + Mutex 互斥"]
+        REG["AdapterRegistry<br/>候选 + 唯一启用"]
+        PIPE["runV2Pipeline<br/>fetchData → formatCapsule → sanitize"]
+        PIPEPANEL["runV2PanelPipeline<br/>query → formatPanel → sanitize"]
+        HIST["HistoryStore<br/>按天分片 JSONL"]
+        HOT["HotReloadableAdapter<br/>热更新换版"]
+        WARM["预热定时器 5min"]
+
+        ROUTES --> GETSTATS
+        ROUTES --> PIPEPANEL
+        GETSTATS --> REG
+        GETSTATS --> PIPE
+        PIPE --> HIST
+        PIPEPANEL --> HIST
+        HOT --> REG
+        WARM --> GETSTATS
+    end
+
+    ADAPTER["用户适配器 .mjs<br/>fetchData / formatCapsule / formatPanel"]
+    API["外部用量 API"]
+    DISK[("持久化文件<br/>user-adapters.json / adapter-state.json<br/>historyDir/YYYY-MM-DD.jsonl")]
+
+    PILL -->|"GET /stats"| ROUTES
+    PANEL -->|"GET /history"| ROUTES
+    SETTINGS -->|"adapters.json / select / inspect / add"| ROUTES
+    PIPE -->|"apiEndpoint/apiKey 注入"| ADAPTER
+    ADAPTER -->|"fetch()"| API
+    HIST --- DISK
+```
+
+要点：
+
+- **同一条链路，两个触发方**：客户端 60s 轮询和宿主端 5min 预热定时器都汇入同一个 `getStats()`；互斥锁保证任一时刻只有一个取数在飞。
+- **适配器代码只活在宿主进程内**：密钥不进浏览器；HTML 在下发前经净化兜底。
+
+---
+
+## 2. 插件启动流程（`apply(ctx, config)`）
+
+宿主端入口按固定顺序装配。任何一步失败都不阻断启动——适配器加载失败走 fail-fast 拒收并登记错误，其余功能照常。
+
+```mermaid
+flowchart TD
+    S(["dsh web 启动<br/>cordis.patch.yml 挂载插件"]) --> A{"enabled === false ?"}
+    A -->|是| Z0["不注册任何路由，直接返回"]
+    A -->|否| B["normalizeConfig 归一化配置<br/>+ makeAdapterRegistry(路径脱敏)<br/>(钳制 warmup≥60s / cache≥5s / timeout 0.5~30s)"]
+    B --> C["HistoryStore 就绪<br/>+ migrateLegacyV3 旧桶迁移(幂等)"]
+    C --> D["register 内置 opencode-go<br/>(source=builtin，默认启用)"]
+    D --> E{"用户适配器来源"}
+    E -->|"config.adapter 声明"| F["动态 import + 契约校验<br/>→ register(user-file)<br/>失败 fail-fast → recordError"]
+    E -->|"user-adapters.json 清单"| G["逐条 import + 校验 + register"]
+    F --> G
+    G --> H{"autoReload === true?"}
+    H -->|是| I["每个用户文件建 HotReloadableAdapter<br/>(2s mtime+size 轮询)"]
+    H -->|否| J
+    I --> J["读 adapter-state.json 恢复启用映射(null=显式清空)<br/>+ 初始化缓存 Map 与 async-mutex"]
+    J --> K["注册 7 条路由(loopback 围栏):<br/>stats / history / adapters.json /<br/>select / inspect / add / health"]
+    K --> L["预热定时器 setInterval(unref)<br/>(warmupIntervalMs>0 时；启动即取数一次)"]
+    L --> M["installSettingsNamespace 只读镜像(apiKey 不回显)<br/>+ ctx.effect 注册卸载清理:<br/>dispose 路由 / 清定时器 / 停热更新 / mutex.cancel"]
+```
+
+启动后落盘的两份状态文件（均在历史根目录下）：
+
+| 文件 | 写入方 | 内容 |
+| --- | --- | --- |
+| `user-adapters.json` | 设置页 add | 用户适配器清单 `{version:1, adapters:[{id,label,providers,file}]}`，tmp+rename 原子写、mode 0600 |
+| `adapter-state.json` | select / add | provider → 启用适配器 name 映射（`null` 表示显式清空），串行链写入 |
+
+---
+
+## 3. 核心时序：`GET /stats` 取数全链路
+
+这是整个插件最热的一条路径。客户端每 60 秒打一次，后台预热每 5 分钟打一次。
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as 浏览器客户端
+    participant R as stats 路由<br/>(loopback 围栏 403/405)
+    participant G as getStats()<br/>(缓存 Map + Mutex)
+    participant RG as AdapterRegistry
+    participant P as runV2Pipeline<br/>(safeFetchData)
+    participant AD as adapter.fetchData()
+    participant API as 外部用量 API
+    participant H as HistoryStore
+    participant F as adapter.formatCapsule()
+
+    B->>R: GET /stats?provider=X
+    R->>G: getStats(prov)
+    G->>G: cacheFresh() 未过 TTL(默认 60s)?
+    alt 缓存新鲜
+        G-->>B: status=cached（不重新取数）
+    else 缓存过期/不存在
+        G->>G: mutex.isLocked()?
+        alt 锁忙（上次取数还在进行）
+            G-->>B: reason=busy, status=stale<br/>（不排队不报红，黄点提示）
+        else 锁空闲 → runExclusive()
+            G->>RG: getEntry(provider)
+            alt 无启用条目
+                Note over RG,G: hasCandidates 区分:<br/>无候选=no-adapter / 有候选全禁用=no-enabled-adapter
+                RG-->>B: configured=false, status=stale
+            else 有启用适配器
+                G->>P: runV2Pipeline(adapter, config, timeoutMs)
+                Note over P: resolveProviderConfig 密钥链(§7)<br/>组装 FetchContext 入参
+                P->>AD: fetchData({apiEndpoint, staticPath,<br/>apiKey, timeoutMs, signal})
+                AD->>API: fetch(apiEndpoint + staticPath)
+                API-->>AD: JSON 数据
+                AD-->>P: 返回对象（最小数据集）
+                alt 抛错 / 超 2s 强制超时 / 不可序列化
+                    P-->>G: ok=false, reason=fetch-failed<br/>status=stale（绝不外抛异常）
+                else 成功
+                    P->>H: append({time,data}) 按天分片 JSONL
+                    P->>F: formatCapsule({time,data,status:fresh,esc})
+                    F-->>P: HTML 字符串
+                    Note over P: sanitizeHtml 净化兜底<br/>(script/iframe/on*/javascript:)
+                    P-->>G: V2PipelineResult(capsuleHtml)
+                    G->>G: cache.set(provider, result)
+                    G-->>B: 200 {capsuleHtml, status=fresh, adapterName,...}
+                end
+            end
+        end
+    end
+    Note over B: renderPill(): label.innerHTML = capsuleHtml<br/>状态点 fresh/cached→绿 stale→黄 !configured→红
+```
+
+降级语义速查（客户端状态点颜色由这些字段决定）：
+
+| 场景 | 返回形态 | 客户端表现 |
+| --- | --- | --- |
+| 正常新取 | `status=fresh` | 绿点，实时数据 |
+| 60s 缓存命中 | `status=cached` | 绿点，tooltip 标「缓存」 |
+| 锁忙（取数进行中） | `ok=true, reason=busy, status=stale` | 黄点，「取数进行中，稍候自动刷新」 |
+| 取数失败/超时 | `ok=false, error=...` | 黄点 + tooltip 错误详情 |
+| 无候选适配器 | `configured=false, reason=no-adapter` | 红点；面板展示引导 |
+| 有候选但全禁用 | `configured=false, reason=no-enabled-adapter` | 红点；面板提示去设置页启用 |
+
+---
+
+## 4. 面板时序：`GET /history` 历史查询
+
+面板内容不走实时取数，而是**从本地历史读**——所以即使外部 API 暂时不可达，已落盘的历史图表依然可用。
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as 浏览器客户端
+    participant R as history 路由<br/>(loopback 围栏)
+    participant RG as AdapterRegistry
+    participant H as HistoryStore
+    participant F as adapter.formatPanel()
+
+    B->>R: GET /history?provider=X&days=N
+    R->>RG: getEntry(provider)
+    alt 无启用适配器
+        RG-->>R: undefined
+        R-->>B: 200 {ok:false, panelHtml:null,<br/>reason: no-adapter | no-enabled-adapter}
+        Note over B: 展示引导文案 + 「复制引导指令」按钮<br/>（指令含 adapter-guide.md 链接，交给 Agent 自主接入）
+    else 有启用适配器
+        R->>R: 计算 range（days 钳制 ≤ maxAgeDays，缺省 1 天）
+        R->>H: query(provider, name, range)
+        H->>H: 只扫 range 覆盖的日文件 YYYY-MM-DD.jsonl<br/>过滤 + 按 time 升序稳定排序
+        H-->>R: entries 全量返回（不截断）
+        R->>F: formatPanel({entries, range, truncated:false, esc})
+        F-->>R: HTML 字符串
+        Note over R: sanitizeHtml 净化后下发
+        R-->>B: 200 {panelHtml}
+        Note over B: 面板内容区 innerHTML = panelHtml<br/>优先级：panelHtml > 错误提示 > 加载中
+    end
+```
+
+---
+
+## 5. 自定义适配器注入：三条路径
+
+### 5.1 总览
+
+```mermaid
+flowchart TD
+    U(["用户写好 my-stats.mjs<br/>(契约: version=2 + name + providers +<br/>fetchData/formatCapsule/formatPanel)"]) --> PATH
+
+    subgraph PATH [" "]
+        direction LR
+        P1["路径 A: cordis.patch.yml 声明<br/>adapter: ~/my-stats.mjs<br/>(启动时加载，兼容态)"]
+        P2["路径 B: 设置页添加<br/>(运行时热注册，推荐)"]
+        P3["路径 C: autoReload 热更新<br/>(编辑文件自动换版)"]
+    end
+
+    P1 --> L1["apply 启动序列中<br/>resolvePath → import → 契约校验<br/>→ register(user-file)"]
+    P2 --> L2["inspect 先检测回显<br/>add 确认后注册 + 双文件落盘"]
+    P3 --> L3["HotReloadableAdapter<br/>2s mtime+size 轮询"]
+
+    L1 & L2 & L3 --> REG["AdapterRegistry.register → 契约校验 fail-fast：<br/>缺导出/name 非法/version≠2 拒收 + recordError<br/>通过后默认成为该 provider 启用者<br/>(或按 adapter-state.json 恢复的选择)"]
+```
+
+### 5.2 时序：设置页「检测 → 添加」（运行时注入的主路径）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as 用户
+    participant SP as 设置页 settings.ts<br/>(React tab「用量统计」)
+    participant IR as POST /adapters/inspect
+    participant AR as POST /adapters/add
+    participant V as resolveAddAdapterFile<br/>+ 契约校验
+    participant RG as AdapterRegistry
+    participant D as 磁盘
+
+    U->>SP: 输入 mjs 文件路径(~ 展开/绝对路径)
+    U->>SP: 点「检测文件」
+    SP->>IR: {file: "/path/to/my-stats.mjs"}
+    IR->>V: 路径安全校验
+    Note over V: 拒绝 NUL 字符与未规整形态(a/../b)；<br/>相对路径必须落在 DSH_HOME 或插件 home 内<br/>否则 400 invalid-file
+    V->>V: 动态 import + describeUsageStatsAdapterShape
+    alt 契约不符
+        IR-->>SP: 422 {error, detail:缺失导出明细}
+        SP-->>U: 回显排障信息
+    else 校验通过
+        IR-->>SP: 200 {adapter:{name,label,providers,version}}
+        SP-->>U: 回显导出信息（不注册）
+        U->>SP: 确认添加
+        SP->>AR: {file}
+        AR->>V: 同上校验 + import
+        AR->>RG: hasName 重名→409 / register(adapter, "user-file", file)
+        AR->>D: persistUserAdapter 幂等追加 user-adapters.json<br/>(tmp 写 + rename 原子替换, mode 0600, 串行链)<br/>+ scheduleWriteAdapterState → adapter-state.json
+        AR-->>SP: 200 {ok:true, enabled 映射}
+        Note over RG,D: 新登记的适配器默认成为该 provider 启用者；<br/>cache.clear() 使下一轮轮询立即用新适配器取数
+        SP-->>U: 列表刷新，胶囊下个轮询周期即出新数据
+    end
+```
+
+切换/停用走 `POST /adapters/select`（body 为 `{provider, adapterName}` 或 `{provider, adapterName:null}` 显式清空）：`registry.select()` → `cache.clear()` → 启用映射串行落盘，全程无需重启。
+
+### 5.3 时序：autoReload 热更新
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as HotReloadableAdapter<br/>(2s setInterval, unref)
+    participant FS as stat(file)
+    participant IMP as import(url?t=mtimeMs)
+    participant V as isUsageStatsAdapter
+    participant RG as AdapterRegistry
+    participant C as 结果缓存
+
+    T->>FS: 每 2s 读 mtimeMs + size
+    alt stamp 未变
+        FS-->>T: 相同 → 本轮结束
+    else 文件被删除
+        Note over T: 保留当前版本继续服务，不切换
+    else stamp 变化
+        T->>IMP: import(pathToFileURL(file) + "?t=" + mtimeMs)<br/>(query 参数绕开 ESM 模块缓存)
+        IMP->>V: default ?? 具名导出做契约校验
+        alt 新版校验失败
+            V-->>T: error
+            T->>RG: recordError("热更新失败：...", 保留旧版)
+        else 校验通过
+            T->>RG: removeByFile(file) 先移除旧注册<br/>(改名场景不误报重复)
+            T->>RG: register(hr.current, "user-file", file)
+            T->>C: cache.clear()
+            Note over RG: recordError 登记成功信息<br/>（health/adapters.json 可见）
+        end
+    end
+```
+
+---
+
+## 6. 客户端交互流程
+
+客户端是一个干净模块（`export function apply(ctx)` + `export const inject=[]`），构建期由 `__DSH_ROUTES__` 注入真实路由表。按职责拆两张图：挂载与刷新循环、点击后的面板分支。
+
+### 6.1 挂载与刷新循环
+
+```mermaid
+flowchart TD
+    S(["客户端 apply(ctx)"]) --> A["injectStyle 幂等注入样式<br/>ctx.get sessions / connection"]
+    A --> B["slots.inject settings.section<br/>注册独立 tab「用量统计」<br/>(独立 try/catch 不连坐浮窗)"]
+    A --> C["mountFloat(): 胶囊 button + 面板 div<br/>MutationObserver 自动重挂位<br/>scroll/resize 跟随定位"]
+    C --> D["立即 refreshStats() 一次<br/>+ setInterval 60s 轮询<br/>+ visibilitychange 转可见补刷"]
+    A --> E["provider 检测:<br/>sessions.currentProvideInfo subscribe<br/>→ sessions.models(sessionId)<br/>→ current.provider ?? 回落 opencode-go"]
+    E -->|"provider 变化"| F["renderGeneration+1 防竞态<br/>清 lastStats/lastHistory → 重新拉取"]
+```
+
+### 6.2 点击胶囊：面板渲染分支
+
+```mermaid
+flowchart TD
+    P(["用户点击胶囊"]) --> T["toggleFloat(): 展开面板<br/>refreshHistory() 拉 /history"]
+    T --> K{"renderPanel 内容优先级"}
+    K -->|"panelHtml 有值"| L["innerHTML 注入图表<br/>(stats 失败但历史有图仍展示)"]
+    K -->|"no-adapter / no-enabled-adapter"| M["引导分支: 说明文案 +<br/>「复制引导指令」按钮(指向 adapter-guide.md)"]
+    K -->|"其他错误"| N["errorMessage(code) 映射中文提示"]
+    K -->|"尚无数据"| O["加载中…"]
+```
+
+防竞态与一致性细节：
+
+- **renderGeneration 代 token**：provider 切换/卸载时自增，迟到的旧请求响应直接丢弃；
+- **adapterVersion 变化即全量重置**：热更新换版后丢弃旧 `lastHistory`，防止「新数据 × 旧模板」混搭；
+- **所有异常只 warn**：任何请求失败都不会让 GUI 启动失败或挂起（客户端请求统一 2s 超时）。
+
+---
+
+## 7. 密钥解析链（`resolveProviderConfig`）
+
+`apiKey` 从不要求写在适配器源码里，每次取数前按以下优先级解析（首个命中即返回）：
+
+```mermaid
+flowchart TD
+    S(["取数前解析 apiKey"]) --> A{"插件配置 apiKey<br/>显式指定?"}
+    A -->|是| DONE["使用显式值"]
+    A -->|否| B{"环境变量<br/>{PROVIDER}_API_KEY<br/>(大写, 连字符→下划线)"}
+    B -->|命中| DONE
+    B -->|未命中| C{"provider=opencode-go?<br/>旧变量 OPENCODE_GO_API_KEY"}
+    C -->|命中| DONE
+    C -->|否| D{"DSH_HOME/.credentials.yaml<br/>{PROVIDER}_API_KEY 字段"}
+    D -->|命中| DONE
+    D -->|未命中| E{"provider=opencode-go?<br/>~/.local/share/opencode/auth.json<br/>opencode-go 条目(type=api,key=...)"}
+    E -->|命中| DONE
+    E -->|未命中| NONE["apiKey=undefined<br/>(适配器可自行抛 no-api-key)"]
+```
+
+`apiEndpoint` 只有两级：插件显式配置 > 无（由适配器用 `staticPath` 与自身逻辑组合）。密钥仅存在于宿主进程内存，经 `fetchData` 入参注入，不进浏览器端、不进设置面板 schema。
+
+---
+
+## 8. 安全机制一览
+
+| 机制 | 实现 | 位置 |
+| --- | --- | --- |
+| 路由围栏 | 所有路由 loopback 才放行（非回环 403）、方法白名单（405） | 每个 route handler 入口 |
+| 取数超时 | `safeFetchData`: Promise.race + AbortController，强制 timeoutMs（默认 2s）；结果必须过 JSON 序列化校验 | `core/guards.ts` |
+| 渲染超时 | `safeFormat`: 异步 format 2s 超时 + 返回类型校验（同步死循环为文档化风险） | `core/guards.ts` |
+| XSS 兜底 | `sanitizeHtml` 白名单式正则净化：script/iframe/frame/object/embed/meta/link/base、on* 事件、javascript:/data:text-html 协议 | `sanitize.ts` |
+| 密钥隔离 | apiKey 仅宿主内存，不入设置面板 schema、不下发浏览器 | `provider-config.ts` / `index.ts` |
+| 路径安全 | add/inspect 拒绝 `\0`、未规整相对路径；相对路径限 DSH_HOME / 插件 home 内；历史目录名 `safeSegment` 防穿越 | `index.ts` / `contracts.ts` |
+| 信息最小披露 | health/errors 中用户文件路径脱敏为 basename 或 `~` 形态 | `index.ts` / `registry.ts` |
+| 历史文件 | 按天分片 JSONL，mode 0600，超龄（30 天）/超量（20MB）自动清理；清单文件 tmp+rename 原子写 | `core/history.ts` / `index.ts` |
+| fail-fast 加载 | 缺导出 / 类型错 / name 不合白名单 → 拒收并登记可排障错误，不影响插件其余功能 | `contracts.ts` / `registry.ts` |
+
+---
+
+## 9. 关键模块索引
+
+| 模块 | 职责 |
+| --- | --- |
+| `src/index.ts` | 宿主端入口：配置归一化、装配顺序、7 条路由、预热定时器、持久化读写 |
+| `src/contracts.ts` | v2 契约（UsageStatsAdapter/FetchContext/CapsuleInput/PanelInput）、esc、校验器、v1 deprecated 类型 |
+| `src/registry.ts` | 适配器注册表：per-provider 候选列表 + 唯一启用 + 错误登记 + 快照 |
+| `src/pipeline/v2.ts` | 取数管道与面板管道：组装入参 → safe 执行 → 净化 → 归一化结果 |
+| `src/core/guards.ts` | 用户代码安全执行包装（超时/序列化校验/错误隔离） |
+| `src/core/history.ts` | 按天分片 JSONL 存储 + 旧 v3 桶迁移 |
+| `src/hotreload.ts` | mtime+size 轮询热更新 + 原子切换 |
+| `src/provider-config.ts` | 密钥五级解析链 |
+| `src/sanitize.ts` | HTML 结构化净化 |
+| `src/client/index.ts` | 客户端入口：胶囊/面板挂载、轮询、provider 检测 |
+| `src/client/settings.ts` | 设置页 tab：适配器管理（检测/添加/切换/停用） |
+| `src/client/core.ts` | 客户端数据层：fetch 封装、响应类型、会话 provider 解析 |

--- a/packages/dsh-provider-usage/src/client/index.ts
+++ b/packages/dsh-provider-usage/src/client/index.ts
@@ -124,11 +124,14 @@ function renderPill(): void {
   const labelEl = floatPill.querySelector(`.${PILL_PREFIX}label`);
   const dotEl = floatPill.querySelector(`.${PILL_PREFIX}dot`);
   const stats = lastStats;
-  // 未配置适配器 → 隐藏浮窗（保留轮询探测恢复）
-  const hide = stats === null || (!stats.configured && !stats.capsuleHtml);
+  // 仅在首帧（尚无任何响应）时隐藏；未配置适配器保留错误态胶囊（红点 + provider 名），
+  // 点击展开面板可见接入引导（复制引导指令按钮可达）
+  const hide = stats === null;
   floatPill.hidden = hide;
   if (stats !== null) {
-    if (stats.error !== null && stats.error !== undefined) {
+    if (!stats.configured) {
+      floatPill.title = `${currentProvider} · 未配置适配器，点击查看接入引导`;
+    } else if (stats.error !== null && stats.error !== undefined) {
       floatPill.title = `用量获取失败：${stats.error}`;
     } else if ((stats as { reason?: string | null }).reason === "busy") {
       floatPill.title = `${stats.adapterName} · 取数进行中，稍候自动刷新`;

--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -383,8 +383,8 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
     if (cached !== undefined) return { ...cached, status: 'cached' };
 
     if (mutex.isLocked()) {
-      const last = cache.get(provider);
-      if (last !== undefined) return { ...last, status: 'cached' };
+      // 到这里缓存必为空：cacheFresh 同步删除了过期条目，新鲜条目已在上方返回；
+      // 与持锁取数之间无 await 交错，不存在可复用的残留条目（防御性读取已删）。
       // busy ≠ 未配置：适配器已就绪，仅上一次取数仍在进行（不报红，客户端按 stale 处理）
       const entryName = registry.getEntry(provider)?.name ?? "unknown";
       return {

--- a/packages/dsh-provider-usage/src/provider-config.ts
+++ b/packages/dsh-provider-usage/src/provider-config.ts
@@ -4,11 +4,12 @@
  * 评审结论：V2（settings 命名空间读取）不可行，因为 LlmConfigurableProvider
  * 无标准化 apiKey/baseURL 字段。永久方案为 V1 配置链。
  *
- * 配置链优先级（从高到低）：
+ * 配置链优先级（从高到低；与 resolveApiKey 实现一致）：
  * 1. 插件配置中的显式 apiEndpoint / apiKey
  * 2. 环境变量 {PROVIDER}_API_KEY（大写，连字符替换为下划线）
- * 3. .credentials.yaml 文件中的 {PROVIDER}_API_KEY 字段
- * 4. opencode-go 兼容旧环境变量 OPENCODE_GO_API_KEY
+ * 3. opencode-go 兼容旧环境变量 OPENCODE_GO_API_KEY
+ * 4. .credentials.yaml 文件：先查 {PROVIDER}_API_KEY 字段，
+ *    opencode-go 在标准 key 未命中时再查旧名 OPENCODE_GO_API_KEY
  * 5. auth.json 文件（仅 opencode-go 兼容）
  */
 import { readFile } from "node:fs/promises";
@@ -77,11 +78,12 @@ export function opencodeAuthFile(): string {
  *   1. 显式配置 input.apiEndpoint
  *   2. 无（必须由适配器 staticPath + 插件配置组合）
  *
- * 返回的 apiKey 优先级：
+ * 返回的 apiKey 优先级（与实现一致）：
  *   1. 显式配置 input.apiKey
  *   2. 环境变量 {PROVIDER}_API_KEY
- *   3. .credentials.yaml 中的 {PROVIDER}_API_KEY
- *   4. opencode-go 兼容旧环境变量
+ *   3. opencode-go 兼容旧环境变量 OPENCODE_GO_API_KEY
+ *   4. .credentials.yaml 的 {PROVIDER}_API_KEY
+ *      （opencode-go 标准 key 未命中时再查旧名）
  *   5. auth.json（仅 opencode-go）
  */
 export async function resolveProviderConfig(


### PR DESCRIPTION
## 概述

为 `dsh-provider-usage`（v2 契约重构版）补充图解文档 `packages/dsh-provider-usage/docs/architecture.md`，用 10 张 Mermaid 流程图 / 时序图讲清插件完整运行机制。纯文档改动，不含任何代码变更。

## 内容

1. **总体架构**：浏览器端 / 宿主进程 / 用户适配器 / 外部 API 的分工（v2 宿主端渲染核心设计）
2. **启动装配流程**：`apply()` 全序列（配置归一化 → 注册表 → 历史迁移 → 适配器加载 → 路由注册 → 预热定时器）
3. **`GET /stats` 取数全链路时序**：缓存 TTL / Mutex 互斥 / 密钥链注入 / fetchData 强制超时 / 净化下发，附降级语义速查表
4. **`GET /history` 面板时序**：本地历史查询路径（API 不可达时图表仍可用）
5. **自定义适配器注入三条路径**：cordis.patch.yml 声明、设置页 inspect→add 热注册（主时序）、autoReload mtime+size 热更新原子切换（时序）
6. **客户端交互两张图**：挂载与刷新循环、点击胶囊后的面板渲染分支（含无适配器引导分支）
7. **密钥五级解析链**
8. **安全机制一览表 + 关键模块索引**

同时更新 `README.md` 与 `docs/adapter-guide.md` 的交叉引用。

## 说明

- 图表语法只用 GitHub 原生支持的核心 Mermaid（flowchart / sequenceDiagram），打开文件即渲染；
- 绘制过程按 diagram-design skill 做过复杂度预算收敛（时序图生命线 ≤9、多张图达标），个别总览/线性装配图为工程文档忠实性保留略超预算的节点数。

关联 issue：无（维护者直接请求的纯文档补充）。