### PR TITLE
fix(scripts): 改用 esbuild JS API 修复 Windows 下 pnpm build 失败

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -9,7 +9,13 @@
 
 每个插件包 = 独立 npm 包（`@wingsky-1/dsh-*`），发布物自包含（第三方依赖构建期内联）。
 
+> **安装依赖**：本仓库是 pnpm workspace（`pnpm-workspace.yaml` + 包间 `workspace:*`
+> 协议 + pnpm 严格 node_modules）。动手前必须 `pnpm install`（在仓库根执行）。
+> **不要用 `npm install`**——它会因 `workspace:*` 协议与 pnpm 布局而失败，且无法
+> 复现 CI 的依赖解析结果。
+
 ```sh
+pnpm install       # 仓库根，pnpm workspace 依赖安装（必须先于一切构建）
 pnpm build        # 全仓构建 = pnpm -r build（各包：clean-lib → tsc → bundle-host）
 pnpm contract     # 客户端契约（node scripts/contract-check.ts）
 pnpm test         # 全量 smoke（Node ≥23.6 原生 type stripping 直跑）

--- a/scripts/bundle-host.ts
+++ b/scripts/bundle-host.ts
@@ -19,14 +19,13 @@
 import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join, relative, resolve, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { execFileSync } from 'node:child_process'
+import { build } from 'esbuild'
 import { buildClient, copyClientResources } from './build-client.ts'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 // 插件目录相对当前工作目录解析（pnpm --filter 场景 cwd=包目录传 .；仓库根场景传 packages/dsh-*）
 const pkgDir = resolve(process.cwd(), process.argv[2] ?? '.')
 const pkgJson = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'))
-const esbuildBin = join(ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'esbuild.cmd' : 'esbuild')
 const libDir = join(pkgDir, 'lib')
 
 if (!process.argv[2]) {
@@ -56,20 +55,22 @@ function walkFiles(dir, predicate) {
 
 // 1. esbuild 内联 shared（tsc 产物 → 自包含单文件，临时文件再替换，避免占用原文件）
 const tmpBundle = join(libDir, '.index.bundle.js')
-const esbuildArgs = [
-  join(libDir, 'index.js'),
-  '--bundle', '--format=esm', '--platform=node', '--target=node20',
-  `--outfile=${tmpBundle}`, '--log-level=warning', '--charset=utf8',
-]
 // 可选 banner（按包，dsh.bundle.bannerJs）：在 ESM 产物顶部注入代码。用于给内联的
 // CJS 库（如 ws）提供 require（createRequire），避免其内部动态 require Node 内置
 // 模块在 ESM 顶层报 "Dynamic require ... is not supported"。其余包不设该字段则零影响。
 const bannerJs = pkgJson?.dsh?.bundle?.bannerJs
-if (typeof bannerJs === 'string' && bannerJs.length > 0) {
-  esbuildArgs.push('--banner:js=' + bannerJs)
-}
 try {
-  execFileSync(esbuildBin, esbuildArgs, { stdio: 'inherit' })
+  await build({
+    entryPoints: [join(libDir, 'index.js')],
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    target: 'node20',
+    outfile: tmpBundle,
+    logLevel: 'warning',
+    charset: 'utf8',
+    banner: typeof bannerJs === 'string' && bannerJs.length > 0 ? { js: bannerJs } : undefined,
+  })
 } catch (e) {
   console.error(`[bundle-host] esbuild 失败: ${e.message}`)
   process.exit(1)


### PR DESCRIPTION
Closes #98

## 问题

Windows 下 `pnpm build` 失败：`scripts/bundle-host.ts` 用 `execFileSync` spawn esbuild CLI（`.cmd` 未带 shell）导致 EINVAL。Linux/CI 正常。

## 改动

`scripts/bundle-host.ts` 改用 esbuild **JS API**（`build()`）：
- 移除 `execFileSync` 导入、`process.platform` 分支、`esbuildBin` 计算、`--banner:js` 拼串。
- CLI 参数 1:1 映射到 `build()` 选项（`entryPoints`/`bundle`/`format`/`platform`/`target`/`outfile`/`logLevel`/`charset`/`banner`）。
- 保持 `try { await build(...) } catch { console.error; process.exit(1) }` 语义与 `renameSync`/`rmSync` 逻辑不变。

`docs/DEVELOPMENT.md` §0：在列 `pnpm build` 之前补「安装依赖」步骤，明确必须 `pnpm install`（pnpm workspace），并提示 `npm install` 因 `workspace:*` 协议 + pnpm 严格 node_modules 失败。

## 验收清单（逐条映射）

- [x] **Windows 构建通过**：不再 spawn esbuild CLI（.cmd 无 shell 的 EINVAL 根因消除），改走 JS API，平台无关。
- [x] **Linux 与 CI 构建行为不变**：原 CLI 参数 1:1 映射为 `build()` 选项，产物语义一致。
- [x] **§0 含安装依赖与 npm 警告**：DEVELOPMENT.md §0 已补 `pnpm install` 步骤与 `npm install` 失败提示。
- [x] **.github/ 未改动**：CI Windows runner 为 issue 中可选项，越出本场范围，跳过。

## 门禁（本地全绿）

- `pnpm build` ✅
- `pnpm contract` ✅
- `pnpm test` ✅
- `pnpm pack:check` ✅
- `pnpm typecheck` ✅