### PR TITLE
chore(release): v0.1.12

### DIFF
--- a/docs/release-notes/v0.1.12.md
+++ b/docs/release-notes/v0.1.12.md
@@ -1,0 +1,61 @@
+# v0.1.12 发布说明 / Release Notes
+
+> **[中文](#zh)** · **[English](#en)**
+
+<a id="zh"></a>
+
+## 中文
+
+本次发布聚焦插件体系的体验稳定性与工程化：用量统计插件完成 v2 契约重构与胶囊/面板定位优化，局域网 MCP 管理器浮窗配置迁移与面板定位改进，构建脚本修复 Windows 跨平台缺陷并按职能分目录。建议所有用户升级。
+
+### 新功能
+
+- [dsh-provider-usage] **v2 新契约体系**（#100）：宿主端渲染 + 设置页管理 + 热更新 + 按天分片存储；设置页适配器名与 provider 同名时省略关键字段（#101）；`.mjs` 适配器引导按提供商类型（大平台 / coding plan / 中转站）分叉（#89）。
+- [dsh-provider-usage] **胶囊位置可配置、autoReload 默认开启**（#108）：`position` / `offset` 经设置页保存即热更新，无需重启。
+- [dsh-mcp-manager] **浮窗位置配置迁移 + 面板定位改进**（#117）：浮窗 `position` / `offset` 可配置由 **@Yiklek** 贡献（#102，经隐蔽 settings namespace）；本轮迁入插件自身 `Config.ui`，走标准 cordis 配置注入，配置变更经既有 SSE 通道推送，客户端就地热更新浮窗位置（无需重启 / 无轮询）；并修两包 `bottom-right`/`bottom-left` 模式面板向上弹出不溢出视口（顶部锚点仍向下）。
+- [dsh-mcp-manager] **设置页插件卡可编辑浮窗 position/offset**（#123）：Plugin config 出现 MCP 管理器卡，可编辑 `position` + `offset`，保存经既有 SSE 通道即热更新（无需重启）。
+- [docs] 新增 dsh-provider-usage 架构图解（#103）：启动 / 取数 / 面板时序、适配器注入与客户端交互流程图。
+
+### 修复
+
+- [scripts] **Windows 构建修复**（#114）：`bundle-host.ts` 改用 esbuild **JS API**（`build()`），替代 spawn esbuild CLI（`.cmd` 未带 shell 导致 `EINVAL`）；`DEVELOPMENT.md` §0 补「安装依赖」步骤与 `npm install` 失败警告。
+- [dsh-provider-usage] **凭据链接入 DSH 通用凭据 seam**（#113）：内置 `deepseek-official` 等提供商标识命中标准键名，消除 `no-api-key`；胶囊面板间距默认 10px。
+- [dsh-provider-usage] **适配器添加链路三处修复**（#96）：`~` 路径误拦、输入框纵向撑爆、慢远端并发占满。
+- [dsh-provider-usage] **胶囊避让去除**（#118）：移除对 MCP 浮窗的动态避让（`data-dsh-mcp-float` 探测叠加 34px），改 `position: fixed` 固定定位消除滚动 jitter；默认右上角、`offsetX=0` 右侧对齐贴右缘，默认 `offsetY=48` 使胶囊位于 MCP 浮窗正下方、两胶囊默认不重叠。
+- [dsh-mcp-manager] **保存按钮 400 修复**（#126）：`settings.update` 保留 `this`，`POST /api/dsh-mcp/config` 不再 400。
+
+### 维护与工程化
+
+- [scripts] **按职能分目录**（#115）：`build/`、`gate/`、`lib/`、`release/`、`test/`、`data/` 分类重整 + `scripts/README.md` 索引；全部脚本 / 包 build / 根 package.json / CI workflow / 内部 import / 文档引用同步。
+- [meta] `AGENTS.md` 增开发隔离纪律——worktree 强制 + 隔离验证环境 + `needs-proposal-review` 标签（#95）；维护编排工作流进化——#67 七项改进 + #58 复核层（#90）；删除误入库的内部维护草稿目录并加入忽略规则（#77）；oss-report health 启用状态描述修正（#84）。
+- [meta] **维护编排「重开原 issue」纪律**（#127）：合并后同域未满/新 bug 重开原 issue 继续修，仅跨领域另开。
+- [docs] release notes 语言跳转锚点改为显式 HTML 标记 + ASCII id（中文标题 slug 各渲染器不可靠）（#78）。
+
+<a id="en"></a>
+
+## English
+
+This release focuses on plugin-stability and engineering improvements: provider-usage reaches a v2 contract with capsule/panel placement improvements, dsh-mcp-manager float position configuration is moved into its own config schema, and the build scripts gain a Windows cross-platform fix plus a role-based re-organization. Recommended for all users.
+
+### Features
+
+- [dsh-provider-usage] **v2 contract** (#100): host-side rendering, settings-page management, hot reload, and per-day sharded storage; settings-page adapter names omit redundant fields when identical to the provider (#101); the `.mjs` adapter walkthrough forks by provider type (major platform / coding plan / relay) (#89).
+- [dsh-provider-usage] **Configurable capsule position with autoReload on by default** (#108): `position` / `offset` update on settings save with hot reload, no restart needed.
+- [dsh-mcp-manager] **Float position configuration migration + panel placement improvement** (#117): configurable `position` / `offset` contributed by **@Yiklek** (#102, via a hidden settings namespace); migrated this release into the plugin's own `Config.ui` with standard cordis injection, with config changes broadcast over the existing SSE channel and in-place client repositioning (no restart / no polling); it also makes the `bottom-right` / `bottom-left` panels open upward without overflowing the viewport in both packages (top anchors still open downward).
+- [dsh-mcp-manager] **Editable float position/offset from a settings-page plugin card** (#123): an MCP-manager card appears under Plugin config; `position` and `offset` are editable and, on save, apply over the existing SSE channel with hot reload (no restart needed).
+- [docs] New dsh-provider-usage architecture diagrams (#103): startup / sampling / panel sequence and adapter-injection / client-interaction flows.
+
+### Bug Fixes
+
+- [scripts] **Windows build fix** (#114): `bundle-host.ts` now uses the esbuild **JS API** (`build()`) instead of spawning the esbuild CLI, which raised `EINVAL` on `.cmd` without a shell; §0 of `DEVELOPMENT.md` gains an install step and an `npm install` failure warning.
+- [dsh-provider-usage] **Credentials through the generic DSH seam** (#113): built-in providers such as `deepseek-official` now resolve their key correctly, eliminating `no-api-key`; the capsule panel gap defaults to 10px.
+- [dsh-provider-usage] **Adapter-add chain fixes** (#96): `~` path blocking, input-box vertical overflow, and slow-remote concurrency saturation.
+- [dsh-provider-usage] **Capsule avoidance removed** (#118): dynamic avoidance of the MCP float (a `data-dsh-mcp-float` 34px overlap probe) is replaced with fixed positioning, eliminating scroll jitter; defaults stay top-right with `offsetX=0` right-aligned to the edge and `offsetY=48` so the capsule sits just below the MCP float without overlapping by default.
+- [dsh-mcp-manager] **Save-button 400 fix** (#126): `settings.update` now preserves `this`, so `POST /api/dsh-mcp/config` no longer returns 400.
+
+### Maintenance
+
+- [scripts] **Role-based re-organization** (#115): `build/`, `gate/`, `lib/`, `release/`, `test/`, `data/` plus a `scripts/README.md` index; all script / per-package build / root package.json / CI workflow / internal import / doc references synchronized.
+- [meta] `AGENTS.md` adds the development-isolation discipline (forced worktrees, isolated verification envs, `needs-proposal-review` label) (#95); the maintenance-orchestration workflow evolves (#90); the mistakenly committed internal draft directory is removed and ignored (#77); oss-report health wording corrected (#84).
+- [meta] **Maintenance-orchestration "reopen the original issue" discipline** (#127): after merge, same-domain unfinished work or new bugs reopen the original issue for continued fixing; only cross-domain work opens a new issue.
+- [docs] Release-note language-toggle anchors switched to explicit HTML markers with ASCII ids (Chinese heading slugs are unreliable across renderers) (#78).

--- a/packages/dsh-idle-archive/package.json
+++ b/packages/dsh-idle-archive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-idle-archive",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "会话闲置自动提醒：超过 X 小时未对话的会话弹窗询问是否归档，拒绝后 Y 小时不重复提示",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-lan-proxy/package.json
+++ b/packages/dsh-lan-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-lan-proxy",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "局域网访问 dsh web UI：在 0.0.0.0:<port> 监听，把 HTTP/HTTPS 与 WebSocket/wss 转发到回环 web 服务器（默认 127.0.0.1:3080）。重写 Host/Origin 以通过 /api 浏览器信任围栏，仅接受 IP 字面量或 localhost 的 Host 头（DNS 重绑定防护）。HTTPS 默认并存（3443），证书可配置或自动生成自签名。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-mcp-manager/package.json
+++ b/packages/dsh-mcp-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-mcp-manager",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "DSH MCP 管理器：Web 侧边栏「MCP」入口，面板按状态分级展示 MCP 服务器（运行中/连接中/已配置/失败），支持快速接入（stdio / streamable-http 表单）与粘贴 mcpServers JSON 导入。已连接服务器的工具以 mcp__<server>__<tool> 注册给模型直接调用。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-notifier/package.json
+++ b/packages/dsh-notifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-notifier",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "审批/完成/错误事件通知：浏览器 Notification + 系统原生 toast（Windows PowerShell WinRT / macOS osascript / Linux notify-send，均无需额外安装）；提示音可配、每条通知独立显示不互相替换、非安全上下文自动降级横幅",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-plugins-all/package.json
+++ b/packages/dsh-plugins-all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-plugins-all",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "DSH 插件全家桶聚合包：一键安装全部功能插件（idle-archive / notifier / provider-usage / mcp-manager / lan-proxy / web-file-preview）。装它 = 子包 dependencies 拉齐 + 聚合 cordis patch 激活。dsh-gzip 已退役（压缩合并进 lan-proxy），不再随全家桶分发。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-provider-usage/package.json
+++ b/packages/dsh-provider-usage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-provider-usage",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "用量统计悬浮框（v2 契约）：胶囊 + 详情面板，宿主端渲染 HTML 注入；用户 mjs 适配器三函数接入任意数据源（fetchData/formatCapsule/formatPanel），密钥配置链注入、按天分片 JSONL 历史、热更新可选；内置 OpenCode Go 官方用量适配器",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-web-file-preview/package.json
+++ b/packages/dsh-web-file-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-web-file-preview",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "点击对话中的文件链接在 web 端预览：宿主端按 MIME 服务会话工作区内文件（图片直出/文本 UTF-8 直出 + git diff），客户端拦截文件链接弹出预览 Modal（Markdown/代码高亮/Diff/图片灯箱）",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
chore(release): v0.1.12

## 本版要点

- **依赖现代化**：全包第三方依赖由构建期 esbuild 内联，发布物自包含，不新增运行时 npm 依赖。
- **provider-usage v2 契约**：宿主端渲染 + 设置页管理 + 热更新 + 按天分片存储；胶囊位置可配置、autoReload 默认开启；胶囊去除对 MCP 浮窗的动态避让改固定定位；凭据解析接入 DSH 通用凭据 seam；适配器添加链路三处修复。
- **mcp-manager 浮窗配置**：浮窗 position/offset 迁移到插件自身 Config.ui 走标准 cordis 注入，配置变更经既有 SSE 通道推送、客户端就地热更新；双包面板底部锚点上弹。
- **构建修复**：bundle-host 改用 esbuild JS API 修复 Windows 下 pnpm build 失败。
- **脚本分目录**：scripts/ 按 build/gate/lib/release/test/data 职能重整并同步引用。

Release notes 已入库：`docs/release-notes/v0.1.12.md`（中文/英文分节、HTML 锚点、无 emoji）。