### PR TITLE
feat(dsh-mcp-manager): 设置页插件卡可编辑浮窗 position/offset

### DIFF
--- a/packages/dsh-mcp-manager/src/client/index.ts
+++ b/packages/dsh-mcp-manager/src/client/index.ts
@@ -2,16 +2,22 @@
 // 由 scripts/build/build-client.ts 统一生成——源码不写任何 loader 痕迹。
 // 样式：独立 style.css（见同目录），build-client 的 .css text-loader 构建期内联为字符串
 import STYLE from "./style.css";
+// React 由 dsh web 的 factory require("react") 注入（build-client externals 路径）；
+// 设置页 `settings.plugin.item` 卡由宿主 React 渲染，故客户端必须提供 React 组件。
+import * as React from "react";
 /**
- * dsh-mcp-manager — 浏览器端。运行在 dsh web GUI 中，纯 DOM 实现
- * （无 React、无构建工具）：侧边栏注入「MCP」入口按钮，点击打开模态面板：
+ * dsh-mcp-manager — 浏览器端。运行在 dsh web GUI 中：侧边栏注入「MCP」入口按钮，
+ * 点击打开模态面板（纯 DOM 渲染）：
  *  - 「服务器」页：按状态分级展示 MCP 服务器（运行中 / 连接中 / 重连中 /
  *    已停用 / 未连接 / 失败），每台卡片显示传输、端点、工具数、可展开的
  *    工具名，以及 连接 / 断开 / 重连 / 编辑 / 删除 操作；
  *  - 「快速接入」页：手工表单（stdio / streamable-http）与粘贴
  *    mcpServers JSON 导入（仅支持 JSON 格式，不预设任何服务器）。
  *
- * 失败策略与 dsh-ssh / dsh-skill-explorer 一致：DOM 挂载问题只 warn 不抛。
+ * 设置页插件卡（settings.plugin.item，浮窗位置/偏移编辑区）由宿主 React 渲染，
+ * 故额外用 React（经 build-client externals 注入）提供一个轻量卡片组件；主面板
+ * 与管理逻辑仍为纯 DOM。失败策略与 dsh-ssh / dsh-skill-explorer 一致：DOM 挂载
+ * 问题只 warn 不抛。
  */
 
 /** 与 host 端 ROUTES 一致的路径。 */
@@ -853,6 +859,114 @@ function bindSession(ctx: any) {
 }
 
 /**
+ * 设置页插件卡（settings.plugin.item）：浮窗位置 / 偏移编辑区。
+ * 与 provider-usage「胶囊位置」编辑区同构友好度（锚点下拉 + 水平/垂直偏移 + 空白偏移 +
+ * 保存），读/写走 /api/dsh-mcp/config（GET 读 / POST 写），保存后经 SSE 热更新。
+ */
+function SettingsCard() {
+  const useState = React.useState;
+  const useEffect = React.useEffect;
+  const [cfg, setCfg] = useState(null);
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState(null);
+
+  useEffect(() => {
+    let live = true;
+    api(API.config).then((c: any) => {
+      if (live && c !== null && typeof c === "object") setCfg(c);
+    }).catch(() => {});
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  if (cfg === null) {
+    return React.createElement("li", { className: "dm-set-card" }, "MCP 管理器：加载中…");
+  }
+
+  const set = (patch: any) => setCfg((c: any) => (c !== null ? Object.assign({}, c, patch) : c));
+  const numInput = (key: string, label: string) =>
+    React.createElement("label", { className: "dm-set-field" },
+      label,
+      React.createElement("input", {
+        className: "dm-set-input",
+        type: "number",
+        min: 0,
+        max: 2000,
+        value: String(cfg[key]),
+        onChange: (e: any) => {
+          const v = Number(e.target.value);
+          set({ [key]: Number.isFinite(v) ? Math.min(2000, Math.max(0, Math.round(v))) : 0 });
+        },
+      }),
+    );
+  const save = async () => {
+    setSaving(true);
+    setMsg(null);
+    try {
+      await api(API.config, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(cfg),
+      });
+      setMsg({ ok: true, text: "已保存——浮窗位置即时生效（无需重启）" });
+      setTimeout(() => setMsg(null), 2400);
+    } catch (e) {
+      setMsg({ ok: false, text: `保存失败：${e instanceof Error ? e.message : String(e)}` });
+    }
+    setSaving(false);
+  };
+
+  return React.createElement("li", { className: "dm-set-card" + (open ? " dm-set-cardOpen" : "") },
+    React.createElement("button", {
+      type: "button",
+      className: "dm-set-head",
+      "aria-expanded": open,
+      onClick: () => setOpen(!open),
+    },
+      React.createElement("span", { className: "dm-set-headText" },
+        React.createElement("span", { className: "dm-set-name" }, "MCP 管理器（dsh-mcp-manager）"),
+        React.createElement("span", { className: "dm-set-description" }, "浮窗位置 / 水平·垂直·空白偏移"),
+      ),
+      React.createElement("span", { className: "dm-set-chevron" + (open ? " dm-set-chevronOpen" : "") }, "▾"),
+    ),
+    open ? React.createElement("div", { className: "dm-set-body" },
+      React.createElement("div", { className: "dm-set-row" },
+        React.createElement("label", { htmlFor: "dm-set-position" }, "锚点"),
+        React.createElement("select", {
+          id: "dm-set-position",
+          className: "dm-set-input",
+          value: cfg.position,
+          onChange: (e: any) => set({ position: e.target.value }),
+        },
+          React.createElement("option", { value: "top-right" }, "右上（top-right）"),
+          React.createElement("option", { value: "bottom-right" }, "右下（bottom-right）"),
+        ),
+      ),
+      React.createElement("div", { className: "dm-set-row" },
+        numInput("offsetX", "水平偏移"),
+        numInput("offsetY", "垂直偏移"),
+        numInput("blankY", "空白偏移"),
+      ),
+      React.createElement("div", { className: "dm-set-hint" },
+        "保存即热更新：宿主经 SSE events 通道广播一变，所有标签页的浮窗即刻原位更新，无需重启 dsh web。"),
+      React.createElement("div", { className: "dm-set-foot" },
+        msg !== null
+          ? React.createElement("span", { className: msg.ok ? "dm-set-saved" : "dm-set-error" }, msg.text)
+          : null,
+        React.createElement("button", {
+          type: "button",
+          className: "dm-set-save",
+          disabled: saving,
+          onClick: () => { void save(); },
+        }, saving ? "保存中…" : "保存"),
+      ),
+    ) : null,
+  );
+}
+
+/**
  * 挂载浏览器端：注入样式 + 右上角浮窗（会话跟随）+ 管理面板。
  * @param {import("@deepseek-ai/dsh-client-runtime/client").ClientContext} ctx
  * @returns {void}
@@ -867,6 +981,18 @@ export function apply(ctx: any) {
     }
 
     const disposers: any[] = [];
+
+    // 设置页插件卡（settings.plugin.item）：rc.7 起由 list(id) 改为 keyed(key)，
+    // 需 id 与 key 双写且 key = 宿主端 installSettingsNamespace 注册的命名空间
+    // （dsh-mcp-manager），才会被 configurable 面板派发（对照 dsh-lan-proxy）。
+    const slots = ctx.get("slots");
+    if (slots && typeof slots.inject === "function") {
+      slots.inject("settings.plugin.item", () => slots.register(
+        { name: "settings.plugin.item", id: "dsh-mcp-manager", key: "dsh-mcp-manager", order: 60 },
+        () => React.createElement(SettingsCard, null),
+      ));
+    }
+
     disposers.push(mountFloat(ctx));
     disposers.push(bindSession(ctx));
 
@@ -990,5 +1116,6 @@ export function apply(ctx: any) {
 }
 
 // ---- 客户端契约：apply/inject 由 build-client 经 factory 装配（干净模块）----
-// 注入 sessions 服务以跟随当前会话（cwd 切换项目级 MCP）。
-export const inject: string[] = ["sessions"];
+// 注入 sessions 服务以跟随当前会话（cwd 切换项目级 MCP）；slots 服务用于
+// 注册设置页插件卡（settings.plugin.item）。
+export const inject: string[] = ["sessions", "slots"];

--- a/packages/dsh-mcp-manager/src/client/react-shim.d.ts
+++ b/packages/dsh-mcp-manager/src/client/react-shim.d.ts
@@ -1,0 +1,7 @@
+// 浏览器半区 React 类型 shim（仅类型面）。
+// React 运行时由 dsh web 的 factory require("react") 注入（build-client externals 路径），
+// 此处只提供编译期类型（any 兜底），不引入 @types/react 运行时/编译依赖。
+declare module "react" {
+  const React: any;
+  export = React;
+}

--- a/packages/dsh-mcp-manager/src/client/style.css
+++ b/packages/dsh-mcp-manager/src/client/style.css
@@ -85,3 +85,27 @@
 .dm-paste-box{border:1px solid var(--dsw-alias-border-l1,#e5e7eb);border-radius:8px;padding:12px;background:var(--dsw-alias-bg-layer-1,#fafbfc);max-width:640px}
 .dm-result{font-size:12px;color:var(--dsw-alias-state-success-primary,#0f7a50);margin-top:8px;line-height:1.6}
 .dm-result .dm-skip{color:var(--dsw-alias-state-warn-primary,#b45309)}
+
+/* 设置页插件卡（settings.plugin.item）——浮窗位置 / 偏移编辑区。
+ * 前缀 dm-，颜色走 --dsw-alias-* 主题变量 + 浅色回退，明暗自适应。 */
+.dm-set-card{list-style:none;margin:0 0 10px;padding:0;border:1px solid var(--dsw-alias-border-l1,#d7dae0);border-radius:10px;background:var(--dsw-alias-bg-layer-1,#fafbfc);overflow:hidden}
+.dm-set-head{width:100%;display:flex;align-items:center;gap:8px;padding:10px 12px;background:transparent;border:none;cursor:pointer;text-align:left;color:var(--dsw-alias-label-primary,#1c1e26)}
+.dm-set-head:hover{background:var(--dsw-alias-interactive-bg-hover,#eef1f5)}
+.dm-set-headText{flex:1;min-width:0}
+.dm-set-name{display:block;font-size:13px;font-weight:600;color:var(--dsw-alias-label-primary,#1c1e26)}
+.dm-set-description{display:block;margin-top:2px;font-size:11px;color:var(--dsw-alias-label-secondary,#8a8f9c)}
+.dm-set-chevron{flex:none;color:var(--dsw-alias-label-secondary,#8a8f9c);font-size:12px;transition:transform .15s ease}
+.dm-set-chevronOpen{transform:rotate(180deg)}
+.dm-set-body{padding:4px 12px 12px;border-top:1px solid var(--dsw-alias-border-l1,#eef0f3)}
+.dm-set-row{display:flex;align-items:center;gap:12px;margin:10px 0;flex-wrap:wrap}
+.dm-set-row>label{font-size:12px;color:var(--dsw-alias-label-secondary,#525866);font-weight:600;white-space:nowrap}
+.dm-set-field{display:inline-flex;flex-direction:column;gap:3px;font-size:11px;color:var(--dsw-alias-label-secondary,#525866);font-weight:600}
+.dm-set-input{min-width:88px;padding:4px 7px;border:1px solid var(--dsw-alias-border-l1,#d7dae0);border-radius:6px;font-size:12px;color:var(--dsw-alias-label-primary,#1c1e26);background:var(--dsw-alias-bg-layer-1,#fff);box-sizing:border-box}
+.dm-set-input:focus{outline:none;border-color:var(--dsw-alias-brand-primary,#4f6ef7)}
+.dm-set-hint{margin-top:8px;font-size:11px;color:var(--dsw-alias-label-secondary,#8a8f9c);line-height:1.6}
+.dm-set-foot{display:flex;align-items:center;gap:10px;margin-top:10px}
+.dm-set-foot .dm-set-saved{font-size:11px;color:var(--dsw-alias-state-success-primary,#0f7a50)}
+.dm-set-foot .dm-set-error{font-size:11px;color:var(--dsw-alias-state-error-primary,#b42318)}
+.dm-set-save{border:1px solid var(--dsw-alias-border-l1,#d7dae0);background:var(--dsw-alias-bg-base,#fff);color:var(--dsw-alias-label-primary,#3a3f4b);border-radius:6px;padding:5px 14px;font-size:12px;cursor:pointer}
+.dm-set-save:hover{background:var(--dsw-alias-interactive-bg-hover,#eef1f5)}
+.dm-set-save:disabled{opacity:.5;cursor:not-allowed}

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -126,6 +126,19 @@ export function panelAnchorForPosition(position: string | undefined): "top" | "b
   return position === "bottom-right" ? "bottom" : "top";
 }
 
+/**
+ * 把客户端扁平形态（{position, offsetX, offsetY, blankY}）归一化为写入 `Config.ui`
+ * 的嵌套补丁（{position, offset:{x,y,blankY}}）。走 normalizeUiConfig 的净化为唯一
+ * 入口：非法值安全回退默认，负数 clamp 到 0，四舍五入。
+ */
+export function buildConfigUiPatch(raw: unknown): UiPlacementConfig {
+  const cfg = normalizeUiConfig(raw);
+  return {
+    position: cfg.position,
+    offset: { x: cfg.offsetX, y: cfg.offsetY, blankY: cfg.blankY },
+  };
+}
+
 /** 面板垂直定位纯函数（供 smoke 断言翻转分支；clamp 到视口内，不溢出）。 */
 export function panelTopForAnchor(
   anchor: "top" | "bottom",
@@ -189,6 +202,8 @@ export class McpManager {
   catalogCache: CatalogCache;
   catalogCachePath: string;
   uiConfigSource: () => any;
+  /** 设置命名空间写入 sink（apply 时经 ctx.inject(["settings"]) 注入；注入不到则写不可用）。 */
+  uiUpdate?: (patch: Record<string, unknown>) => Promise<unknown>;
   sseConnections?: Set<ServerResponse>;
 
   constructor(ctx: Context, store: McpStore) {
@@ -215,6 +230,20 @@ export class McpManager {
   /** 读取 settings 命名空间中的 MCP UI 配置（供 /api/dsh-mcp/config 返回）。 */
   uiConfig(): ClientUiConfig {
     return normalizeUiConfig(this.uiConfigSource());
+  }
+
+  /**
+   * 写入浮窗 UI 配置（/api/dsh-mcp/config POST）。
+   * 把客户端扁平形态归一化为 `Config.ui` 嵌套补丁，经设置命名空间持久化
+   * （settings.update 落盘 → scope.watch → onChange → SSE 广播一帧），随后返回
+   * 归一化后的最新配置。settings 服务不可用时抛错（写不可用）。
+   */
+  async updateUiConfig(raw: unknown): Promise<ClientUiConfig> {
+    if (typeof this.uiUpdate !== "function") {
+      throw new Error("ui config is not writable: settings service unavailable");
+    }
+    await this.uiUpdate({ ui: buildConfigUiPatch(raw) });
+    return this.uiConfig();
   }
 
   /** 从磁盘加载目录缓存（损坏/缺失 → 空缓存，不崩溃）。 */
@@ -674,6 +703,20 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
       broadcastUiConfigChanged();
     },
   });
+
+  // 写入 sink：设置页卡片经 POST /api/dsh-mcp/config 写配置时，通过 settings 服务
+  // 的 namespace update 落盘并触发 scope.watch → onChange → SSE 广播。settings 服务
+  // 未挂载时 uiUpdate 保持 undefined → 写路由返回「不可写」（卡片/设置页本就不渲染）。
+  if (typeof ctx.inject === "function") {
+    ctx.inject(["settings"], (sctx) => {
+      // sctx 注入 settings 服务（cordis 类型面未声明该服务，经 unknown 中转取最小面）。
+      const settings = (sctx as unknown as { settings?: { update?: (ns: string, patch: Record<string, unknown>) => Promise<unknown> } } | undefined)?.settings;
+      if (settings && typeof settings.update === "function") {
+        const update = settings.update;
+        manager.uiUpdate = (patch) => update("dsh-mcp-manager", patch);
+      }
+    });
+  }
 
 
   let disposeRoutes = () => {};

--- a/packages/dsh-mcp-manager/src/routes.ts
+++ b/packages/dsh-mcp-manager/src/routes.ts
@@ -24,6 +24,7 @@ export interface RoutesManager {
   setSession(cwd: string | undefined): Promise<void>;
   refreshFromDisk(): Promise<void>;
   uiConfig(): ClientUiConfig;
+  updateUiConfig(raw: unknown): Promise<ClientUiConfig>;
   summary(): Record<string, unknown>;
   add(server: Record<string, unknown>, scope?: string): Promise<ServerConfig>;
   update(name: string, patch: Record<string, unknown>, scope?: string): Promise<ServerConfig>;
@@ -89,15 +90,42 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
       kind: "exact",
       path: ROUTES.config,
       handler: async (req, res) => {
-        if (req.method !== "GET") {
-          writeJson(res, 405, { error: `method not allowed: ${req.method}` });
+        // GET：只读 UI 配置（允许非 loopback，供远程页面读取非敏感的展示配置）。
+        if (req.method === "GET") {
+          try {
+            writeJson(res, 200, manager.uiConfig());
+          } catch (error) {
+            handleError(res, error);
+          }
           return;
         }
-        try {
-          writeJson(res, 200, manager.uiConfig());
-        } catch (error) {
-          handleError(res, error);
+        // POST：写入浮窗 UI 配置（position / offset）。写操作只对 loopback 开放；
+        // 经设置命名空间落盘（Config.ui），触发 scope.watch → onChange → SSE 广播一帧，
+        // 客户端收到后重新 GET /config 就地更新浮窗位置，无需重启/轮询。
+        if (req.method === "POST") {
+          if (!isLoopbackRequest(req)) {
+            writeJson(res, 403, { error: "forbidden: loopback-only" });
+            return;
+          }
+          let body: unknown;
+          try {
+            body = await readJsonBody(req);
+          } catch {
+            writeJson(res, 400, { error: "invalid JSON body" });
+            return;
+          }
+          if (typeof body !== "object" || body === null) {
+            writeJson(res, 400, { error: "invalid JSON body" });
+            return;
+          }
+          try {
+            writeJson(res, 200, await manager.updateUiConfig(body));
+          } catch (error) {
+            handleError(res, error);
+          }
+          return;
         }
+        writeJson(res, 405, { error: `method not allowed: ${req.method}` });
       },
     },
     {

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -23,6 +23,7 @@ const pkgDir = join(dirname(fileURLToPath(import.meta.url)), "..");
 import {
   apply,
   broadcastFrame,
+  buildConfigUiPatch,
   buildToolDefinition,
   composeCatalogEntries,
   Config,
@@ -167,6 +168,11 @@ const main = async () => {
   });
   check("client source contract（load id/IIFE/use strict/load once）", () => assertClientSourceContract(pkgDir));
   check("client product contract（执行断言：arrive 可解析/apply/inject）", () => assertClientProductContract(pkgDir));
+  check("client 注册 settings.plugin.item 卡（id/key = 宿主命名空间 dsh-mcp-manager）", () => {
+    const clientSrc = readFileSync(new URL("../lib/client.js", import.meta.url), "utf8");
+    assert.ok(clientSrc.includes("settings.plugin.item"), "settings.plugin.item 卡已注册");
+    assert.ok(clientSrc.includes("dsh-mcp-manager"), "卡片 key/id 引用宿主命名空间 dsh-mcp-manager");
+  });
 
   console.log("Config schema（浮窗 UI 配置迁移到插件自身 Config.ui）");
   check("Config 导出且含 ui 子对象（默认值与合法值域）", () => {
@@ -203,6 +209,23 @@ const main = async () => {
     assert.deepEqual(normalizeUiConfig({ position: "middle-left" }), { position: "top-right", offsetX: 8, offsetY: 8, blankY: 40 });
     assert.deepEqual(normalizeUiConfig({ ui: { position: "nope", offset: { x: "abc" } } }), { position: "top-right", offsetX: 8, offsetY: 8, blankY: 40 });
     assert.deepEqual(normalizeUiConfig({ offset: {} }), { position: "top-right", offsetX: 8, offsetY: 8, blankY: 40 });
+  });
+  check("buildConfigUiPatch：客户端扁平形态 → Config.ui 嵌套补丁（写路径）", () => {
+    // 客户端 POST 的扁平形态 → 宿主写入 Config.ui 的嵌套补丁
+    assert.deepEqual(
+      buildConfigUiPatch({ position: "bottom-right", offsetX: 12, offsetY: 20, blankY: 60 }),
+      { position: "bottom-right", offset: { x: 12, y: 20, blankY: 60 } },
+    );
+    // 缺省 → 安全回退默认
+    assert.deepEqual(
+      buildConfigUiPatch(undefined),
+      { position: "top-right", offset: { x: 8, y: 8, blankY: 40 } },
+    );
+    // 非法 position → 回退 top-right；负偏移 clamp 到 0
+    assert.deepEqual(
+      buildConfigUiPatch({ position: "middle-left", offsetX: -5, offsetY: 3.6, blankY: 40 }),
+      { position: "top-right", offset: { x: 0, y: 4, blankY: 40 } },
+    );
   });
   check("README 含 position/offset 配置说明（键名与默认值，中英）", () => {
     for (const file of ["README.md", "README.en.md"]) {
@@ -756,11 +779,17 @@ const main = async () => {
     const { store, cleanup } = tempStore();
     try {
       const managerState = { sessionCwd: undefined, lastScope: undefined };
+      // 浮窗 UI 配置（可变，验证 config 读/写回传）。
+      let uiCfg = { position: "top-right", offsetX: 8, offsetY: 8, blankY: 40 };
       const manager = {
         store,
         logger: { warn: () => {}, info: () => {}, error: () => {} },
         summary: () => ({ servers: [], counts: {} }),
-        uiConfig: () => ({ position: "top-right", offsetX: 8, offsetY: 8, blankY: 40 }),
+        uiConfig: () => uiCfg,
+        updateUiConfig: async (raw) => {
+          uiCfg = normalizeUiConfig(raw);
+          return uiCfg;
+        },
         refreshFromDisk: async () => {},
         setSession: async (cwd) => {
           managerState.sessionCwd = cwd;
@@ -856,7 +885,17 @@ const main = async () => {
         await find(ROUTES.servers).handler(fakeFenceBroken("GET", ROUTES.servers), res);
         assert.equal(res.state.status, 403);
       });
-      await checkAsync("config 非 loopback → 200（只读 UI 配置放开）", async () => {
+      await checkAsync("config GET → 200 读回（默认 top-right/8/8/40）", async () => {
+        const res = fakeRes();
+        await find(ROUTES.config).handler(fakeReq("GET", ROUTES.config), res);
+        assert.equal(res.state.status, 200);
+        const body = JSON.parse(res.state.body);
+        assert.equal(body.position, "top-right");
+        assert.equal(body.offsetX, 8);
+        assert.equal(body.offsetY, 8);
+        assert.equal(body.blankY, 40);
+      });
+      await checkAsync("config 非 loopback GET → 200（只读 UI 配置放开）", async () => {
         const res = fakeRes();
         await find(ROUTES.config).handler(fakeFenceBroken("GET", ROUTES.config), res);
         assert.equal(res.state.status, 200);
@@ -864,9 +903,30 @@ const main = async () => {
         assert.equal(body.position, "top-right");
         assert.equal(body.offsetX, 8);
       });
-      await checkAsync("config 非 GET → 405（方法错围栏）", async () => {
+      await checkAsync("config POST 写 → 200 且读回更新（配置读写）", async () => {
+        const write = fakeRes();
+        await find(ROUTES.config).handler(
+          fakeReq("POST", ROUTES.config, { position: "bottom-right", offsetX: 12, offsetY: 20, blankY: 60 }),
+          write,
+        );
+        assert.equal(write.state.status, 200);
+        const written = JSON.parse(write.state.body);
+        assert.equal(written.position, "bottom-right");
+        assert.equal(written.offsetX, 12);
+        // 读回：POST 后 GET /config 应反映新值（宿主经设置命名空间持久化后的归一化结果）。
+        const read = fakeRes();
+        await find(ROUTES.config).handler(fakeReq("GET", ROUTES.config), read);
+        const readBack = JSON.parse(read.state.body);
+        assert.deepEqual(readBack, { position: "bottom-right", offsetX: 12, offsetY: 20, blankY: 60 });
+      });
+      await checkAsync("config POST 非 loopback → 403（写操作不开放远程页面）", async () => {
         const res = fakeRes();
-        await find(ROUTES.config).handler(fakeReq("POST", ROUTES.config, { position: "bottom-right" }), res);
+        await find(ROUTES.config).handler(fakeFenceBroken("POST", ROUTES.config, { position: "bottom-right" }), res);
+        assert.equal(res.state.status, 403);
+      });
+      await checkAsync("config PUT → 405（仅 GET/POST 合法；方法错围栏）", async () => {
+        const res = fakeRes();
+        await find(ROUTES.config).handler(fakeReq("PUT", ROUTES.config, { position: "bottom-right" }), res);
         assert.equal(res.state.status, 405);
       });
       await checkAsync("events 非 loopback → 403 / 方法错 → 405（围栏不回归）", async () => {


### PR DESCRIPTION
Closes #122

## 摘要

为 dsh-mcp-manager 补**设置页插件卡**，使浮窗 `position` / `offset` 可在「设置 → 插件 → MCP 管理器」卡内编辑（#106 验收项 A1）。此前客户端未注册 `settings.plugin.item` 卡，导致设置→Plugins→Plugin configuration 仅渲染 Shell / Agent loop / Web search / 局域网访问，MCP 管理器卡缺失。

## 逐条映射（意图级验收）

| 验收项 | 落实 | 证据 |
|---|---|---|
| 设置→Plugins→Plugin configuration 出现 **MCP 管理器**卡，可编辑 `position`（top-right/bottom-right）与 `offset`（x/y/blankY） | 客户端注册 `settings.plugin.item`（id/key 双写 = 宿主命名空间 `dsh-mcp-manager`，对照 dsh-lan-proxy），React 卡片含锚点下拉 + 水平/垂直/空白偏移 + 保存 | `src/client/index.ts`（SettingsCard + slots 注册）、`inject` 增 `slots`；smoke `client 注册 settings.plugin.item 卡` |
| 保存后经既有 SSE `ui-config-changed` 通道热更新（沿用 #117 的 `uiConfigChangedFrame`/`broadcastFrame`），无需重启、无轮询；读回 `/api/dsh-mcp/config` 确认落盘 | `/api/dsh-mcp/config` 增 POST 写（loopback-only），经设置命名空间 `settings.update("dsh-mcp-manager", { ui })` 持久化 `Config.ui` → `scope.watch` → `onChange` → `broadcastUiConfigChanged` → SSE `ui-config-changed`，客户端重 GET `/config` 就地更新浮窗 | `src/index.ts`（`manager.updateUiConfig` + `uiUpdate` sink）、`src/routes.ts`（POST handler）；smoke `config POST 写 → 200 且读回更新` |
| 客户端保持干净模块；设置卡注册走标准 `settings.plugin.item`（对照 lan-proxy）；读/写走 `Config.ui`（`normalizeUiConfig`/`DEFAULT_UI_CONFIG`） | 干净模块仍只 `export apply/inject`；React 经 build-client externals 注入（新增 `react-shim.d.ts`）；写入走 `buildConfigUiPatch`（`normalizeUiConfig` 净化入口，非法值安全回退默认） | `contract` 门禁 6 项全 ✓（load id 恰好一次、apply/inject 装配） |
| smoke 断言：注册 `settings.plugin.item` 卡、配置读写、`/api/dsh-mcp/config` 非 GET/POST → 405、路由围栏 403/405、client 契约不漂移 | 新增/更新断言 | `test/smoke.ts`：`client 注册 settings.plugin.item 卡`、`buildConfigUiPatch`、`config GET/POST/PUT`、`config POST 非 loopback → 403`、`events/health 403/405`、`assertClientSourceContract`/`assertClientProductContract` |
| 设置卡 UI 与 provider-usage「胶囊位置」编辑区同构友好度（锚点下拉 + 水平/垂直偏移 + 空白偏移 + 保存） | 同构组合 | `src/client/index.ts`（SettingsCard，`dm-set-*` 样式，明暗自适应） |

## 边界核实

- 不改依赖清单、`pnpm-lock.yaml`、`.github/`、`shared/` 契约层、DSH 源码。
- 仅动 `packages/dsh-mcp-manager/{src/**, src/client/**, test/smoke.ts}`（新增 `src/client/react-shim.d.ts`）。
- 不改 provider-usage（避免 #116 回归）。
- 客户端干净模块，patch id 仍 `ui-dsh-mcp-manager`；路由保持 loopback 围栏（config 读仍开放非 loopback，写开放给 loopback）。

## 门禁（worktree 内全绿）

```sh
pnpm build   # exit 0
pnpm contract # exit 0（mcp-manager 6/6 契约 ✓）
pnpm test    # exit 0（mcp-manager all checks passed）
pnpm pack:check # exit 0
pnpm typecheck  # exit 0
```

> 说明：实现 + smoke 断言完成（`coder` 交付物）。隔离环境浏览器实测（Plugin configuration 出现卡且可编辑、保存即热更新）建议在合入前由验证步骤复核。