### PR TITLE
docs(meta): 新增 PR 模板（方向 D：客户端截图证据清单）

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+Fixes #<!-- 关联 issue 号；无 issue 留空 -->
+
+## 说明
+
+<!-- 动机/背景，一句话概括 -->
+
+## 改动
+
+<!-- 落点（包名/文件）与关键变化 -->
+
+## 验证
+
+<!-- 门禁结果与实测方式：pnpm build / pnpm test / pnpm contract / pnpm pack:check -->
+
+### 客户端改动截图证据（勾选式）
+
+- [ ] **不涉及客户端改动**（未改动 `src/client/**`、`src/client/style.css`、客户端产物 `lib/client.js`）
+- [ ] **涉及客户端改动**，已在隔离环境实测并归档截图
+  - 包内路径：`packages/dsh-<name>/docs/archive/<issue号>-<行为>.png`
+  - 覆盖场景：双主题 / 窄屏 / 关键交互
+  - 仅插件 UI 截图，不含整窗 / 本机环境 / 凭据
+  - issue 评论与 PR 双向引用

--- a/docs/ISSUE-WORKFLOW.md
+++ b/docs/ISSUE-WORKFLOW.md
@@ -49,7 +49,8 @@
    `37-basename-fallback-overlay.png`）；截图只截插件 UI 本身（headless element
    screenshot），不带浏览器整窗，避免泄露本机环境。归档后双向引用：PR 正文贴图并
    引用文件路径，issue 评论回链 PR。发布边界已核实安全：各包 files 白名单不含
-   `docs/`，截图不入 tarball，不破坏「发布物不含内部文档」约定。纯宿主端 /
+   `docs/`，截图不入 tarball，不破坏「发布物不含内部文档」约定。PR 模板已内置
+   客户端截图证据清单，见 `.github/PULL_REQUEST_TEMPLATE.md`。纯宿主端 /
    文档改动可跳过本步。
 5. **代码复核闸**（触发条件与 oss-pipeline 复核层一致）：diff 超 ~100 行，或触及
    安全面（围栏 / 脱敏 / 凭据）、`shared/` 契约层、聚合包 `dsh-plugins-all`


### PR DESCRIPTION
Fixes #121

## 说明

为 issue #121 方向 D（PR 模板加截图清单）实现 PR 模板，内置客户端截图证据勾选清单，方便贡献者开 PR 时自查。

## 改动

- 新建 `.github/PULL_REQUEST_TEMPLATE.md`，含：说明/改动/验证/客户端改动截图证据（勾选式）
- 在 `docs/ISSUE-WORKFLOW.md` §2.4 验证证据小节补引 PR 模板

## 验证

本次仅改动 `.github/` + `docs/`，不涉及门禁执行路径。