### PR TITLE
refactor(dsh-mcp-manager): 客户端入口按职责拆分

### DIFF
--- a/packages/dsh-mcp-manager/src/client/constants.ts
+++ b/packages/dsh-mcp-manager/src/client/constants.ts
@@ -1,0 +1,44 @@
+/**
+ * dsh-mcp-manager — 客户端常量与状态映射。
+ *
+ * 状态排序、文案、状态点颜色、API 路径等纯常量，不依赖任何状态。
+ */
+
+/** 与宿主端 ROUTES 一致的路径。 */
+export const API = {
+  servers: "/api/dsh-mcp/servers",
+  connect: "/api/dsh-mcp/servers/connect",
+  disconnect: "/api/dsh-mcp/servers/disconnect",
+  reconnect: "/api/dsh-mcp/servers/reconnect",
+  importJson: "/api/dsh-mcp/import/json",
+  session: "/api/dsh-mcp/session",
+  config: "/api/dsh-mcp/config",
+  events: "/api/dsh-mcp/events",
+  health: "/api/dsh-mcp/health",
+};
+
+/** 状态分组排序（按优先级降序）。 */
+export const STATUS_ORDER = [
+  { key: "connected", title: "运行中", dot: "var(--dsw-alias-state-success-primary,#0f9d6e)" },
+  { key: "connecting", title: "连接中", dot: "var(--dsw-alias-state-business-primary,#2f7bf6)" },
+  { key: "reconnecting", title: "重连中", dot: "var(--dsw-alias-state-warn-primary,#e08b1e)" },
+  { key: "stopped", title: "未连接", dot: "var(--dsw-alias-label-tertiary,#9aa1ad)" },
+  { key: "disabled", title: "已停用", dot: "var(--dsw-alias-label-tertiary,#9aa1ad)" },
+  { key: "failed", title: "失败", dot: "var(--dsw-alias-state-error-primary,#e0483e)" },
+];
+
+/** 状态 → 中文文案映射。 */
+export const STATUS_TEXT: Record<string, string> = {
+  connected: "运行中",
+  connecting: "连接中",
+  reconnecting: "重连中",
+  stopped: "未连接",
+  disabled: "已停用",
+  failed: "失败",
+};
+
+/** 状态点颜色（与 STATUS_ORDER 一致）。 */
+export function statusDot(status: string): string {
+  const group = STATUS_ORDER.find((entry) => entry.key === status);
+  return group !== undefined ? group.dot : "var(--dsw-alias-label-tertiary,#9aa1ad)";
+}

--- a/packages/dsh-mcp-manager/src/client/dom.ts
+++ b/packages/dsh-mcp-manager/src/client/dom.ts
@@ -15,7 +15,7 @@ export function el(tag: any, attrs: any = {}, children?: any): any {
     if (key === "class") node.className = value as string;
     else if (key === "text") node.textContent = String(value);
     else if (key === "dataset") Object.assign(node.dataset, value as any);
-    else if (key.startsWith("on")) (node as any)[key] = value;
+    else if (key.startsWith("on")) node.addEventListener(key.slice(2), value);
     else if (key === "checked") (node as any).checked = value;
     else if (key === "disabled") (node as any).disabled = value;
     else if (key === "children") continue;

--- a/packages/dsh-mcp-manager/src/client/dom.ts
+++ b/packages/dsh-mcp-manager/src/client/dom.ts
@@ -1,0 +1,47 @@
+/**
+ * dsh-mcp-manager — 客户端 DOM 工具函数。
+ *
+ * DOM 元素创建、HTTP API 请求等纯工具函数。
+ * 仅 export 纯函数，不依赖任何状态。
+ */
+
+/** 创建带属性/子节点的 DOM 元素。 */
+export function el(tag: any, attrs: any = {}, children?: any): any {
+  // children 兼容两种传法：第三个位置参数，或 attrs.children（本插件调用点
+  // 一直把 children 放进 attrs——早期版本只读第三参数导致子节点从未挂载）。
+  if (children === undefined) children = attrs.children ?? [];
+  const node = document.createElement(tag);
+  for (const [key, value] of Object.entries(attrs)) {
+    if (key === "class") node.className = value as string;
+    else if (key === "text") node.textContent = String(value);
+    else if (key === "dataset") Object.assign(node.dataset, value as any);
+    else if (key.startsWith("on")) (node as any)[key] = value;
+    else if (key === "checked") (node as any).checked = value;
+    else if (key === "disabled") (node as any).disabled = value;
+    else if (key === "children") continue;
+    else node.setAttribute(key, String(value));
+  }
+  for (const child of children) {
+    if (child === undefined || child === null) continue;
+    node.appendChild(typeof child === "string" ? document.createTextNode(child) : child);
+  }
+  return node;
+}
+
+/**
+ * HTTP API 请求。
+ * 返回 JSON 解析后的 body；非 2xx 抛 Error。
+ */
+export async function api(path: any, options: any = {}): Promise<any> {
+  const response = await fetch(path, options);
+  let body: any;
+  try {
+    body = await response.json();
+  } catch {
+    body = undefined;
+  }
+  if (!response.ok) {
+    throw new Error(body?.error ?? `HTTP ${response.status}`);
+  }
+  return body;
+}

--- a/packages/dsh-mcp-manager/src/client/float.ts
+++ b/packages/dsh-mcp-manager/src/client/float.ts
@@ -1,0 +1,271 @@
+/**
+ * dsh-mcp-manager — 客户端右上角浮窗。
+ *
+ * 浮窗胶囊（状态点 + 摘要计数）挂在会话滚动容器右上角，点击展开下拉面板
+ * 展示项目/全局 MCP 服务器列表 + 快捷操作（连接/断开/禁用）。
+ * 跨模块动作（showPanel / refresh）经 actions 注入，不直接引用 panel 模块。
+ */
+
+import { el, api } from "./dom.js";
+import { STATUS_ORDER, STATUS_TEXT, statusDot } from "./constants.js";
+import type { McpState, UiActions } from "./state.js";
+
+/** 渲染浮窗胶囊（状态点 + 摘要计数）。 */
+export function renderPill(state: McpState): void {
+  if (state.floatPill === undefined) return;
+  const ok = state.counts.connected ?? 0;
+  const bad = (state.counts.failed ?? 0) + (state.counts.reconnecting ?? 0);
+  const dot = bad > 0
+    ? "var(--dsw-alias-state-error-primary,#e0483e)"
+    : ok > 0
+      ? "var(--dsw-alias-state-success-primary,#0f9d6e)"
+      : "var(--dsw-alias-label-tertiary,#9aa1ad)";
+  const label = state.servers.length > 0 ? `MCP ${ok}/${state.servers.length}` : "MCP";
+  state.floatPill.innerHTML = `<span class="dm-dot" style="background:${dot}"></span><span>${label}</span>`;
+}
+
+/** 浮窗面板里的一行服务器。 */
+function renderFloatRow(server: any, state: McpState, actions: UiActions): any {
+  const row = el("div", { class: "dm-float-row" });
+  row.appendChild(el("span", { class: "dm-dot", style: `background:${statusDot(server.status)}` }));
+  row.appendChild(el("span", { class: "dm-float-name", text: server.name, title: server.name }));
+  const tools = Array.isArray(server.tools) ? server.tools.length : 0;
+  row.appendChild(el("span", { class: "dm-float-meta", text: `${STATUS_TEXT[server.status] ?? server.status} · ${tools} 工具` }));
+  const actionsEl = el("div", { class: "dm-float-actions" });
+  const action = el("button", { class: "dm-float-action" });
+  if (server.status === "connected") {
+    action.textContent = "断开";
+    action.addEventListener("click", () => {
+      void api(`${state.API.disconnect}?name=${encodeURIComponent(server.name)}&scope=${server.scope}`, { method: "POST" })
+        .then(() => actions.refresh())
+        .catch((error: any) => console.warn("[dsh-mcp-manager] disconnect failed:", error));
+    });
+  } else if (server.status === "disabled") {
+    action.textContent = "启用";
+    action.addEventListener("click", () => {
+      void api(`${state.API.servers}?name=${encodeURIComponent(server.name)}&scope=${server.scope}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      }).then(() => actions.refresh())
+        .catch((error: any) => console.warn("[dsh-mcp-manager] enable failed:", error));
+    });
+  } else {
+    action.textContent = "连接";
+    action.addEventListener("click", () => {
+      void api(`${state.API.connect}?name=${encodeURIComponent(server.name)}&scope=${server.scope}`, { method: "POST" })
+        .then(() => actions.refresh())
+        .catch((error: any) => console.warn("[dsh-mcp-manager] connect failed:", error));
+    });
+  }
+  actionsEl.appendChild(action);
+  // 禁用开关：非 disabled 状态可一键禁用（PATCH enabled:false → 宿主断开并注销工具）
+  if (server.status !== "disabled") {
+    const disable = el("button", { class: "dm-float-action" });
+    disable.textContent = "禁用";
+    disable.addEventListener("click", () => {
+      void api(`${state.API.servers}?name=${encodeURIComponent(server.name)}&scope=${server.scope}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: false }),
+      }).then(() => actions.refresh())
+        .catch((error: any) => console.warn("[dsh-mcp-manager] disable failed:", error));
+    });
+    actionsEl.appendChild(disable);
+  }
+  row.appendChild(actionsEl);
+  return row;
+}
+
+/** 渲染浮窗下拉面板（项目/全局分组 + 状态 + 快捷操作）。 */
+export function renderFloatPanel(state: McpState, actions: UiActions): void {
+  if (state.floatPanel === undefined) return;
+  state.floatPanel.textContent = "";
+  const head = el("div", { class: "dm-float-head" });
+  const projectName = typeof state.projectRoot === "string" && state.projectRoot !== ""
+    ? (state.projectRoot.split(/[\\/]/).filter(Boolean).pop() ?? state.projectRoot)
+    : "全局会话";
+  head.appendChild(el("span", { class: "dm-float-title", text: projectName }));
+  head.appendChild(el("button", { text: "管理", onclick: () => { toggleFloat(state, actions, false); actions.showPanel(); } }));
+  state.floatPanel.appendChild(head);
+
+  if (state.servers.length === 0) {
+    state.floatPanel.appendChild(el("div", { class: "dm-status", text: "没有 MCP 服务器，点「管理」添加" }));
+    return;
+  }
+  for (const scope of ["project", "global"]) {
+    const list = state.servers.filter((server: any) => server.scope === scope);
+    if (list.length === 0) continue;
+    const section = el("section", { class: "dm-float-group" });
+    section.appendChild(el("div", { class: "dm-float-group-title", text: scope === "project" ? "项目级" : "全局" }));
+    for (const server of [...list].sort((a: any, b: any) => a.name.localeCompare(b.name))) {
+      section.appendChild(renderFloatRow(server, state, actions));
+    }
+    state.floatPanel.appendChild(section);
+  }
+}
+
+/** 切换浮窗展开/收起。 */
+export function toggleFloat(state: McpState, actions: UiActions, force?: boolean): void {
+  if (state.floatPanel === undefined) return;
+  const next = force !== undefined ? force : !state.floatOpen;
+  state.floatOpen = next;
+  state.floatPanel.hidden = !next;
+  if (next) {
+    placePanel(state);
+    renderFloatPanel(state, actions);
+    // 聚焦面板本身，让后续点击外部时能通过 focusout 自动关闭。
+    state.floatPanel.focus({ preventScroll: true });
+  }
+}
+
+/** 下拉面板定位（fixed 跟随胶囊，避免被滚动容器裁剪）。 */
+export function placePanel(state: McpState): void {
+  if (state.floatPill === undefined || state.floatPanel === undefined) return;
+  const rect = state.floatPill.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) return;
+  const anchorBottom = state.mcpUiConfig.position === "bottom-right";
+  const gap = 6;
+  state.floatPanel.style.top = anchorBottom
+    ? `${Math.max(6, rect.top - state.floatPanel.offsetHeight - gap)}px`
+    : `${Math.max(6, rect.bottom + gap)}px`;
+  state.floatPanel.style.right = `${Math.max(10, Math.round(window.innerWidth - rect.right))}px`;
+  state.floatPanel.style.left = "auto";
+}
+
+/** 会话滚动容器：聊天消息实际滚动的区域（shell 的 data-conversation-scroll）。 */
+export function conversationHost(): any {
+  return document.querySelector('[data-conversation-scroll]')
+    ?? document.querySelector('[data-pane="conversation"]')
+    ?? document.querySelector('.pI_x6G_centerCol')
+    ?? document.body;
+}
+
+/** 全局 overlay 层：下拉面板挂这里（fixed 定位，避免被滚动容器裁剪）。 */
+export function panelHost(): any {
+  return document.querySelector('[data-shell-overlay]')
+    ?? document.body;
+}
+
+/** 从 settings.yaml 读取的配置决定新/老会话垂直偏移。 */
+export function floatTopOffset(ctx: any, state: McpState): number {
+  const snap = ctx?.sessions?.list?.getSnapshot?.();
+  const current = snap?.current;
+  const session = current === undefined ? undefined : snap?.byId?.[current];
+  const blank = session?.blank === true;
+  const cfg = state.mcpUiConfig || {};
+  const y = typeof cfg.offsetY === "number" ? cfg.offsetY : 8;
+  const blankY = typeof cfg.blankY === "number" ? cfg.blankY : y;
+  return blank ? blankY : y;
+}
+
+/**
+ * 挂载浮窗：胶囊继续挂在会话滚动容器（scrollBody）内并钉住右上角，下拉面板
+ * fixed 跟随。返回 disposer 函数。
+ */
+export function mountFloat(ctx: any, state: McpState, actions: UiActions): () => void {
+  const pill = el("button", {
+    type: "button",
+    class: "dm-float",
+    "aria-label": "MCP 管理器",
+    title: "MCP 管理器（点击展开）",
+  });
+  pill.dataset.dshMcpFloat = "";
+  pill.addEventListener("click", () => toggleFloat(state, actions));
+  const panel = el("div", { class: "dm-float-panel" });
+  panel.hidden = true;
+  panel.tabIndex = -1;
+  state.floatPill = pill;
+  state.floatPanel = panel;
+  // 胶囊挂会话滚动容器，下拉面板挂 shell.overlay（fixed 定位，仍与通知同一层）。
+  const panelRoot = panelHost();
+  if (panel.parentElement !== panelRoot) panelRoot.appendChild(panel);
+
+  // 失去焦点后自动关闭：焦点离开胶囊/面板时收起下拉框。
+  const onFocusOut = (event: any) => {
+    if (!state.floatOpen) return;
+    const next = event.relatedTarget as Node | null;
+    if (next !== null && (state.floatPanel?.contains(next) || state.floatPill?.contains(next))) return;
+    toggleFloat(state, actions, false);
+  };
+  document.addEventListener("focusout", onFocusOut);
+
+  let host: any;
+  let listeners: any[] = [];
+
+  /** 按 settings.yaml 配置把胶囊定位到对话容器右上/右下角。 */
+  const updateFloat = () => {
+    const best = conversationHost();
+    if (best === null || best === undefined) return;
+    const rect = best.getBoundingClientRect();
+    const cfg = state.mcpUiConfig || {};
+    const position = cfg.position === "bottom-right" ? "bottom-right" : "top-right";
+    const offsetX = typeof cfg.offsetX === "number" ? cfg.offsetX : 8;
+    const y = floatTopOffset(ctx, state);
+    pill.style.position = "fixed";
+    pill.style.left = `${rect.right - pill.offsetWidth - offsetX}px`;
+    pill.style.right = "auto";
+    if (position === "bottom-right") {
+      pill.style.top = `${rect.bottom - pill.offsetHeight - y}px`;
+    } else {
+      pill.style.top = `${rect.top + y}px`;
+    }
+    if (state.floatOpen) placePanel(state);
+  };
+  state.updateFloatState = updateFloat;
+
+  const attachListeners = (target: any) => {
+    for (const detach of listeners.splice(0)) detach();
+    const onScroll = () => updateFloat();
+    const onResize = () => updateFloat();
+    target.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onResize);
+    listeners.push(() => {
+      target.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onResize);
+    });
+    updateFloat();
+  };
+
+  /**
+   * 放置/迁移：每次调用都重新求最佳宿主（scrollBody 优先），胶囊跟着它走——
+   * 即使初始化时 scrollBody 尚未渲染（退回 body），一旦出现就迁移。
+   */
+  const place = () => {
+    const best = conversationHost();
+    if (best === null || best === undefined) return false;
+    if (host !== best || pill.parentElement !== best) {
+      host = best;
+      if (pill.parentElement !== null) pill.remove();
+      best.appendChild(pill);
+      attachListeners(best);
+    }
+    return true;
+  };
+  const observer = new MutationObserver(() => {
+    place();
+  });
+  if (place()) {
+    observer.observe(document.body, { childList: true, subtree: true });
+  } else {
+    const wait = new MutationObserver(() => {
+      if (place()) {
+        wait.disconnect();
+        observer.observe(document.body, { childList: true, subtree: true });
+      }
+    });
+    wait.observe(document.body, { childList: true, subtree: true });
+  }
+  renderPill(state);
+  return () => {
+    state.updateFloatState = undefined;
+    document.removeEventListener("focusout", onFocusOut);
+    observer.disconnect();
+    for (const detach of listeners.splice(0)) detach();
+    pill.remove();
+    panel.remove();
+    state.floatPill = undefined;
+    state.floatPanel = undefined;
+    state.floatOpen = false;
+  };
+}

--- a/packages/dsh-mcp-manager/src/client/index.ts
+++ b/packages/dsh-mcp-manager/src/client/index.ts
@@ -1,978 +1,45 @@
-// 客户端干净模块：只导出 apply/inject，契约外壳（IIFE/load/Symbol.toStringTag 装配）
-// 由 scripts/build/build-client.ts 统一生成——源码不写任何 loader 痕迹。
-// 样式：独立 style.css（见同目录），build-client 的 .css text-loader 构建期内联为字符串
-import STYLE from "./style.css";
-// React 由 dsh web 的 factory require("react") 注入（build-client externals 路径）；
-// 设置页 `settings.plugin.item` 卡由宿主 React 渲染，故客户端必须提供 React 组件。
-import * as React from "react";
 /**
- * dsh-mcp-manager — 浏览器端。运行在 dsh web GUI 中：侧边栏注入「MCP」入口按钮，
- * 点击打开模态面板（纯 DOM 渲染）：
- *  - 「服务器」页：按状态分级展示 MCP 服务器（运行中 / 连接中 / 重连中 /
- *    已停用 / 未连接 / 失败），每台卡片显示传输、端点、工具数、可展开的
- *    工具名，以及 连接 / 断开 / 重连 / 编辑 / 删除 操作；
- *  - 「快速接入」页：手工表单（stdio / streamable-http）与粘贴
- *    mcpServers JSON 导入（仅支持 JSON 格式，不预设任何服务器）。
+ * dsh-mcp-manager — 浏览器端客户端入口（装配层）。
  *
- * 设置页插件卡（settings.plugin.item，浮窗位置/偏移编辑区）由宿主 React 渲染，
- * 故额外用 React（经 build-client externals 注入）提供一个轻量卡片组件；主面板
- * 与管理逻辑仍为纯 DOM。失败策略与 dsh-ssh / dsh-skill-explorer 一致：DOM 挂载
- * 问题只 warn 不抛。
+ * 仅含装配逻辑，不含业务实现。业务实现在 constants/dom/servers/quick-add/
+ * panel/float/session/settings-card 各模块中。
+ *
+ * 挂载浏览器端：注入样式 + 右上角浮窗（会话跟随）+ 管理面板 + 设置页插件卡。
+ * 失败策略：只 warn 不抛，绝不让 GUI 启动失败。
+ *
+ * 客户端干净模块：只导出 apply/inject，契约外壳（IIFE/load/Symbol.toStringTag 装配）
+ * 由 scripts/build/build-client.ts 统一生成——源码不写任何 loader 痕迹。
+ * 样式：独立 style.css（见同目录），build-client 的 .css text-loader 构建期内联为字符串。
+ *
+ * React 由 dsh web 的 factory require("react") 注入（build-client externals 路径）；
+ * 设置页 `settings.plugin.item` 卡由宿主 React 渲染，故客户端必须提供 React 组件。
  */
 
-/** 与 host 端 ROUTES 一致的路径。 */
-const API = {
-  servers: "/api/dsh-mcp/servers",
-  connect: "/api/dsh-mcp/servers/connect",
-  disconnect: "/api/dsh-mcp/servers/disconnect",
-  reconnect: "/api/dsh-mcp/servers/reconnect",
-  importJson: "/api/dsh-mcp/import/json",
-  session: "/api/dsh-mcp/session",
-  config: "/api/dsh-mcp/config",
-  events: "/api/dsh-mcp/events",
-    health: "/api/dsh-mcp/health",
-};
+import STYLE from "./style.css";
+import * as React from "react";
 
-/** 面板样式（dm- 前缀避免与 shell / 其他插件样式冲突）。 */
+import { createState, type McpState, type UiActions } from "./state.js";
+import { api } from "./dom.js";
+import { refresh, switchTab, close, showPanel } from "./panel.js";
+import { resetForm, beginEdit } from "./quick-add.js";
+import { toggleFloat, mountFloat } from "./float.js";
+import { bindSession } from "./session.js";
+import { SettingsCard } from "./settings-card.js";
 
-// ----------------------------------------------------------------- 状态
+export function apply(ctx: any): void {
+  const state: McpState = createState();
+  const actions: UiActions = {
+    refresh: () => refresh(state, actions),
+    switchTab: (tab: string) => switchTab(state, actions, tab),
+    close: () => close(state),
+    showPanel: () => showPanel(state, actions),
+    toggleFloat: (force?: boolean) => toggleFloat(state, actions, force),
+    resetForm: () => resetForm(state),
+    beginEdit: (server: any) => beginEdit(state, actions, server),
+  };
 
-let overlay: any;
-let card: any;
-let bodyEl: any;
-let open = false;
-let activeTab = "servers";
-let servers: any = [];
-let counts: any = {};
-let editingName: any = undefined;
-let editing: any = undefined;
-
-// ------------------------------------------------------------- DOM 工具
-
-function el(tag: any, attrs: any = {}, children?: any) {
-  // children 兼容两种传法：第三个位置参数，或 attrs.children（本插件调用点
-  // 一直把 children 放进 attrs——早期版本只读第三参数导致子节点从未挂载）。
-  if (children === undefined) children = attrs.children ?? [];
-  const node = document.createElement(tag);
-  for (const [key, value] of Object.entries(attrs)) {
-    if (key === "class") node.className = value;
-    else if (key === "text") node.textContent = value;
-    else if (key === "dataset") Object.assign(node.dataset, value);
-    else if (key.startsWith("on")) node.addEventListener(key.slice(2), value);
-    else if (key === "checked") node.checked = value;
-    else if (key === "disabled") node.disabled = value;
-    else if (key === "children") continue;
-    else node.setAttribute(key, value);
-  }
-  for (const child of children) {
-    if (child === undefined || child === null) continue;
-    node.appendChild(typeof child === "string" ? document.createTextNode(child) : child);
-  }
-  return node;
-}
-
-async function api(path: any, options = {}) {
-  const response = await fetch(path, options);
-  let body: any;
   try {
-    body = await response.json();
-  } catch {
-    body = undefined;
-  }
-  if (!response.ok) {
-    throw new Error(body?.error ?? `HTTP ${response.status}`);
-  }
-  return body;
-}
-
-// ------------------------------------------------------- 服务器列表页
-
-const STATUS_ORDER = [
-  { key: "connected", title: "运行中", dot: "var(--dsw-alias-state-success-primary,#0f9d6e)" },
-  { key: "connecting", title: "连接中", dot: "var(--dsw-alias-state-business-primary,#2f7bf6)" },
-  { key: "reconnecting", title: "重连中", dot: "var(--dsw-alias-state-warn-primary,#e08b1e)" },
-  { key: "stopped", title: "未连接", dot: "var(--dsw-alias-label-tertiary,#9aa1ad)" },
-  { key: "disabled", title: "已停用", dot: "var(--dsw-alias-label-tertiary,#9aa1ad)" },
-  { key: "failed", title: "失败", dot: "var(--dsw-alias-state-error-primary,#e0483e)" },
-];
-
-const STATUS_TEXT: Record<string, string> = {
-  connected: "运行中",
-  connecting: "连接中",
-  reconnecting: "重连中",
-  stopped: "未连接",
-  disabled: "已停用",
-  failed: "失败",
-};
-
-function endpointOf(server: any) {
-  if (server.transport === "streamable-http") return server.url ?? "";
-  const args = Array.isArray(server.args) && server.args.length > 0 ? ` ${server.args.join(" ")}` : "";
-  return `${server.command ?? ""}${args}`;
-}
-
-function renderServer(server: any) {
-  const article = el("article", { class: "dm-server" });
-  const header = el("header");
-  header.appendChild(el("span", { class: "dm-name", text: server.name }));
-  header.appendChild(el("span", {
-    class: `dm-badge ${server.transport === "streamable-http" ? "dm-http" : "dm-stdio"}`,
-    text: server.transport === "streamable-http" ? "HTTP" : "stdio",
-  }));
-  header.appendChild(el("span", { class: "dm-badge", text: server.scope === "project" ? "项目" : "全局" }));
-  const statusBadge = el("span", { class: `dm-badge dm-st-${server.status}`, text: STATUS_TEXT[server.status] ?? server.status });
-  header.appendChild(statusBadge);
-  const toolCount = Array.isArray(server.tools) ? server.tools.length : 0;
-  header.appendChild(el("span", { class: "dm-count", text: `${toolCount} 工具` }));
-  article.appendChild(header);
-
-  article.appendChild(el("div", { class: "dm-endpoint", text: endpointOf(server) }));
-  if (server.error !== undefined && server.error !== "") {
-    article.appendChild(el("div", { class: "dm-err", text: server.error }));
-  }
-
-  if (toolCount > 0) {
-    const details = el("details", { class: "dm-tools" });
-    details.appendChild(el("summary", { text: `工具（${toolCount}）` }));
-    const list = el("ul");
-    for (const tool of server.tools) list.appendChild(el("li", { text: tool }));
-    details.appendChild(list);
-    article.appendChild(details);
-  }
-
-  const actions = el("div", { class: "dm-actions" });
-  const busy = server.status === "connecting" || server.status === "reconnecting";
-  const scopeQuery = `&scope=${server.scope}`;
-  if (server.status === "connected") {
-    actions.appendChild(actionButton("断开", async () => {
-      await api(`${API.disconnect}?name=${encodeURIComponent(server.name)}${scopeQuery}`, { method: "POST" });
-      await refresh();
-    }));
-    actions.appendChild(actionButton("重连", async () => {
-      await api(`${API.reconnect}?name=${encodeURIComponent(server.name)}${scopeQuery}`, { method: "POST" });
-      await refresh();
-    }));
-  } else if (server.status === "disabled") {
-    actions.appendChild(actionButton("启用并连接", async () => {
-      await api(`${API.servers}?name=${encodeURIComponent(server.name)}${scopeQuery}`, {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ enabled: true }),
-      });
-      await api(`${API.connect}?name=${encodeURIComponent(server.name)}${scopeQuery}`, { method: "POST" });
-      await refresh();
-    }, true));
-  } else {
-    actions.appendChild(actionButton("连接", async () => {
-      await api(`${API.connect}?name=${encodeURIComponent(server.name)}${scopeQuery}`, { method: "POST" });
-      await refresh();
-    }, true));
-  }
-  // 禁用开关：非 disabled 状态可一键禁用（宿主断开并注销工具）
-  if (server.status !== "disabled") {
-    actions.appendChild(actionButton("禁用", async () => {
-      await api(`${API.servers}?name=${encodeURIComponent(server.name)}${scopeQuery}`, {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ enabled: false }),
-      });
-      if (editingName === server.name) resetForm();
-      await refresh();
-    }));
-  }
-  actions.appendChild(actionButton("编辑", () => beginEdit(server)));
-  actions.appendChild(actionButton("删除", async () => {
-    if (!window.confirm(`删除 MCP 服务器「${server.name}」？`)) return;
-    await api(`${API.servers}?name=${encodeURIComponent(server.name)}${scopeQuery}`, { method: "DELETE" });
-    if (editingName === server.name) resetForm();
-    await refresh();
-  }, false, true));
-  actions.children[actions.children.length - 1].disabled = busy;
-  article.appendChild(actions);
-  return article;
-}
-
-function actionButton(label: any, onClick: any, primary = false, danger = false) {
-  return el("button", {
-    class: `${primary ? "dm-primary" : ""} ${danger ? "dm-danger" : ""}`.trim(),
-    text: label,
-    onclick: async () => {
-      try {
-        await onClick();
-      } catch (error) {
-        window.alert(`操作失败：${error instanceof Error ? error.message : String(error)}`);
-      }
-    },
-  });
-}
-
-function renderServers() {
-  bodyEl.textContent = "";
-  if (servers.length === 0) {
-    bodyEl.appendChild(el("div", { class: "dm-status", text: "还没有配置 MCP 服务器。切到「快速接入」页添加，或粘贴 mcpServers JSON 导入。" }));
-    return;
-  }
-  for (const group of STATUS_ORDER) {
-    const list = servers.filter((server: any) => server.status === group.key);
-    if (list.length === 0) continue;
-    const section = el("section", { class: "dm-group" });
-    const title = el("h3");
-    title.appendChild(el("span", { class: "dm-dot", style: `background:${group.dot}` }));
-    title.appendChild(document.createTextNode(group.title));
-    title.appendChild(el("span", { class: "dm-count", text: `${list.length}` }));
-    section.appendChild(title);
-    for (const server of list.sort((a: any, b: any) => a.name.localeCompare(b.name))) {
-      section.appendChild(renderServer(server));
-    }
-    bodyEl.appendChild(section);
-  }
-  const others = servers.filter((server: any) => !STATUS_ORDER.some((group) => group.key === server.status));
-  if (others.length > 0) {
-    const section = el("section", { class: "dm-group" });
-    section.appendChild(el("h3", { text: "其他" }));
-    for (const server of others) section.appendChild(renderServer(server));
-    bodyEl.appendChild(section);
-  }
-}
-
-// ------------------------------------------------------- 快速接入页
-
-let formName: any;
-let formScope: any;
-let formTransport: any;
-let formCommand: any;
-let formArgs: any;
-let formEnv: any;
-let formCwd: any;
-let formUrl: any;
-let formHeaders: any;
-let formEnabled: any;
-
-function buildQuickAdd() {
-  const page = el("div");
-
-  // 表单
-  const form = el("section", { class: "dm-section" });
-  form.appendChild(el("h3", { id: "dm-form-title", text: "添加服务器" }));
-  formName = el("input", { id: "dm-f-name", placeholder: "context7", value: editing?.name ?? "" });
-  formScope = el("select", { id: "dm-f-scope" });
-  formScope.appendChild(el("option", { value: "project", text: "项目级（<项目>/.dsh/mcp.json，随会话切换）" }));
-  formScope.appendChild(el("option", { value: "global", text: "全局（~/.dsh/dsh-mcp.json）" }));
-  formScope.value = editing?.scope ?? (projectRoot !== undefined && projectRoot !== "" ? "project" : "global");
-  formTransport = el("select", { id: "dm-f-transport" });
-  formTransport.appendChild(el("option", { value: "stdio", text: "stdio（本地子进程）" }));
-  formTransport.appendChild(el("option", { value: "streamable-http", text: "streamable-http（远程）" }));
-  formCommand = el("input", { id: "dm-f-command", placeholder: "npx" });
-  formArgs = el("input", { id: "dm-f-args", placeholder: "-y, @context7/mcp-server" });
-  formEnv = el("textarea", { id: "dm-f-env", placeholder: "每行 KEY=VALUE，如\nCONTEXT7_API_KEY=${CONTEXT7_API_KEY}" });
-  formCwd = el("input", { id: "dm-f-cwd", placeholder: "可选工作目录" });
-  formUrl = el("input", { id: "dm-f-url", placeholder: "https://mcp.context7.com/mcp" });
-  formHeaders = el("textarea", { id: "dm-f-headers", placeholder: '每行 KEY: VALUE，支持 ${ENV} 引用，如\nAuthorization: Bearer ${CONTEXT7_API_KEY}' });
-  formEnabled = el("input", { id: "dm-f-enabled", type: "checkbox", checked: true });
-
-  const grid = el("div", { class: "dm-form" });
-  grid.appendChild(el("div", { class: "dm-field", children: [el("label", { text: "服务器名称（唯一，作为 mcp__<name>__ 前缀）" }), formName] }));
-  grid.appendChild(el("div", { class: "dm-field", children: [el("label", { text: "归属" }), formScope] }));
-  grid.appendChild(el("div", { class: "dm-field", children: [el("label", { text: "传输类型" }), formTransport] }));
-  grid.appendChild(el("div", { class: "dm-field dm-full", children: [el("label", { text: "命令（stdio）" }), formCommand] }));
-  grid.appendChild(el("div", { class: "dm-field dm-full", children: [el("label", { text: "参数（逗号分隔）" }), formArgs] }));
-  grid.appendChild(el("div", { class: "dm-field dm-full", children: [el("label", { text: "环境变量（每行 KEY=VALUE，支持 ${ENV} 引用，值为空则继承父环境）" }), formEnv] }));
-  grid.appendChild(el("div", { class: "dm-field dm-full", children: [el("label", { text: "工作目录（可选）" }), formCwd] }));
-  grid.appendChild(el("div", { class: "dm-field dm-full", children: [el("label", { text: "URL（streamable-http）" }), formUrl] }));
-  grid.appendChild(el("div", { class: "dm-field dm-full", children: [el("label", { text: "请求头（每行 KEY: VALUE，支持 ${ENV} 引用）" }), formHeaders] }));
-  grid.appendChild(el("div", { class: "dm-check dm-field dm-full", children: [formEnabled, el("label", { text: "启用（保存后立即连接）" })] }));
-  const actions = el("div", { class: "dm-form-actions" });
-  const save = el("button", { class: "dm-primary", text: "保存", onclick: () => void saveForm() });
-  const cancel = el("button", { text: "取消编辑", onclick: () => resetForm(), disabled: true });
-  cancel.dataset.dmCancel = "";
-  actions.appendChild(save);
-  actions.appendChild(cancel);
-  grid.appendChild(actions);
-  form.appendChild(grid);
-  page.appendChild(form);
-
-  // 传输类型切换显示/隐藏
-  const syncTransport = () => {
-    const isHttp = formTransport.value === "streamable-http";
-    for (const field of [formCommand, formArgs, formEnv, formCwd]) {
-      field.closest(".dm-field").style.display = isHttp ? "none" : "flex";
-    }
-    for (const field of [formUrl, formHeaders]) {
-      field.closest(".dm-field").style.display = isHttp ? "flex" : "none";
-    }
-  };
-  formTransport.addEventListener("change", syncTransport);
-
-  // 粘贴 JSON 导入
-  const paste = el("section", { class: "dm-section" });
-  paste.appendChild(el("h3", { text: "粘贴 mcpServers JSON 导入" }));
-  const pasteBox = el("div", { class: "dm-paste-box" });
-  const textarea = el("textarea", {
-    class: "dm-full",
-    placeholder: '{"my-server":{"command":"npx","args":["-y","pkg"],"env":{"KEY":"value"}},"remote":{"url":"https://...","headers":{}}}',
-    style: "width:100%;min-height:90px;border:1px solid #d7dae0;border-radius:6px;padding:6px 8px;font-size:12px;font-family:ui-monospace,Consolas,monospace;box-sizing:border-box",
-  });
-  pasteBox.appendChild(textarea);
-  pasteBox.appendChild(el("div", { class: "dm-actions", children: [
-    el("button", { class: "dm-primary", text: "导入 JSON", onclick: async () => {
-      const result = pasteBox.querySelector(".dm-result");
-      try {
-        const payload = await api(API.importJson, {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ json: textarea.value, scope: formScopeValue(), ...currentCwdBody() }),
-        });
-        result.textContent = `已导入：${payload.imported.join(", ") || "（无）"}`;
-        if (payload.skipped.length > 0) {
-          result.appendChild(el("div", { class: "dm-skip", text: `跳过（已存在）：${payload.skipped.join(", ")}` }));
-        }
-        await refresh();
-      } catch (error) {
-        result.textContent = `导入失败：${error instanceof Error ? error.message : String(error)}`;
-      }
-    } }),
-  ] }));
-  pasteBox.appendChild(el("div", { class: "dm-result" }));
-  paste.appendChild(pasteBox);
-  page.appendChild(paste);
-
-  return page;
-}
-
-/** 表单数据 → 服务器配置对象（scope 由 formScope 决定）。 */
-function readForm() {
-  const server: any = {
-    name: formName.value.trim(),
-    transport: formTransport.value,
-    enabled: formEnabled.checked,
-  };
-  if (server.transport === "stdio") {
-    server.command = formCommand.value.trim();
-    const args = formArgs.value.split(",").map((part: any) => part.trim()).filter(Boolean);
-    if (args.length > 0) server.args = args;
-    const env = parseKV(formEnv.value);
-    if (Object.keys(env).length > 0) server.env = env;
-    if (formCwd.value.trim() !== "") server.cwd = formCwd.value.trim();
-  } else {
-    server.url = formUrl.value.trim();
-    const headers = parseKV(formHeaders.value);
-    if (Object.keys(headers).length > 0) server.headers = headers;
-  }
-  return server;
-}
-
-/** 当前表单选择的归属（project/global）。 */
-function formScopeValue() {
-  if (formScope !== undefined && (formScope.value === "project" || formScope.value === "global")) {
-    return formScope.value;
-  }
-  return projectRoot !== undefined && projectRoot !== "" ? "project" : "global";
-}
-
-/** 当前会话 cwd（POST body 携带，宿主据此切换项目级 MCP）。 */
-function currentCwdBody() {
-  return typeof currentCwd === "string" && currentCwd !== "" ? { cwd: currentCwd } : {};
-}
-
-/** 解析 "KEY: VALUE" / "KEY=VALUE" 多行文本为对象。 */
-function parseKV(text: any) {
-  const out: Record<string, string> = {};
-  for (const raw of text.split(/\r?\n/)) {
-    const line = raw.trim();
-    if (line === "") continue;
-    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*[:=]\s*(.*)$/);
-    if (match === null) continue;
-    const value = match[2].trim();
-    if (value !== "") out[match[1]] = value;
-    else out[match[1]] = "";
-  }
-  return out;
-}
-
-function fillForm(fill: any) {
-  resetForm();
-  if (fill.name !== undefined) formName.value = fill.name;
-  formTransport.value = fill.transport ?? "stdio";
-  if (fill.command !== undefined) formCommand.value = fill.command;
-  if (Array.isArray(fill.args)) formArgs.value = fill.args.join(", ");
-  if (fill.env !== undefined) {
-    formEnv.value = Object.entries(fill.env).map(([key, value]) => `${key}=${value}`).join("\n");
-  }
-  if (fill.cwd !== undefined) formCwd.value = fill.cwd;
-  if (fill.url !== undefined) formUrl.value = fill.url;
-  if (fill.headers !== undefined) {
-    formHeaders.value = Object.entries(fill.headers).map(([key, value]) => `${key}: ${value}`).join("\n");
-  }
-  formTransport.dispatchEvent(new Event("change"));
-}
-
-async function saveForm() {
-  const server = readForm();
-  try {
-    const payload = { ...server, scope: formScopeValue(), ...currentCwdBody() };
-    if (editingName !== undefined) {
-      await api(`${API.servers}?name=${encodeURIComponent(editingName)}&scope=${formScopeValue()}`, {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-    } else {
-      await api(API.servers, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-    }
-    resetForm();
-    await refresh();
-  } catch (error) {
-    window.alert(`保存失败：${error instanceof Error ? error.message : String(error)}`);
-  }
-}
-
-function beginEdit(server: any) {
-  editingName = server.name;
-  editing = server;
-  switchTab("quick");
-  fillForm(server);
-  if (formScope !== undefined && (server.scope === "project" || server.scope === "global")) {
-    formScope.value = server.scope;
-  }
-  const title = document.getElementById("dm-form-title");
-  if (title !== null) title.textContent = `编辑服务器：${server.name}`;
-  const cancel = document.querySelector<HTMLButtonElement>("[data-dm-cancel]");
-  if (cancel !== null) cancel.disabled = false;
-}
-
-function resetForm() {
-  editingName = undefined;
-  editing = undefined;
-  if (formName === undefined) return;
-  formName.value = "";
-  formScope.value = projectRoot !== undefined && projectRoot !== "" ? "project" : "global";
-  formTransport.value = "stdio";
-  formCommand.value = "";
-  formArgs.value = "";
-  formEnv.value = "";
-  formCwd.value = "";
-  formUrl.value = "";
-  formHeaders.value = "";
-  formEnabled.checked = true;
-  formTransport.dispatchEvent(new Event("change"));
-  const title = document.getElementById("dm-form-title");
-  if (title !== null) title.textContent = "添加服务器";
-  const cancel = document.querySelector<HTMLButtonElement>("[data-dm-cancel]");
-  if (cancel !== null) cancel.disabled = true;
-}
-
-// ------------------------------------------------------------- 面板
-
-async function refresh() {
-  try {
-    const suffix = typeof currentCwd === "string" && currentCwd !== ""
-      ? `?cwd=${encodeURIComponent(currentCwd)}`
-      : "";
-    const payload = await api(`${API.servers}${suffix}`);
-    servers = payload.servers ?? [];
-    counts = payload.counts ?? {};
-    projectRoot = payload.projectRoot;
-    renderPill();
-    if (floatOpen) renderFloatPanel();
-    const countsEl = document.querySelector(".dm-counts");
-    if (countsEl !== null) {
-      const parts = [];
-      if (counts.connected > 0) parts.push(`运行中 ${counts.connected}`);
-      if (counts.connecting > 0 || counts.reconnecting > 0) parts.push(`连接中 ${(counts.connecting ?? 0) + (counts.reconnecting ?? 0)}`);
-      if (counts.failed > 0) parts.push(`失败 ${counts.failed}`);
-      countsEl.textContent = parts.length > 0 ? `共 ${servers.length} 台 · ${parts.join(" · ")}` : `共 ${servers.length} 台`;
-    }
-    if (bodyEl !== undefined && activeTab === "servers") renderServers();
-    return true;
-  } catch (error) {
-    if (bodyEl !== undefined && activeTab === "servers") {
-      bodyEl.textContent = "";
-      bodyEl.appendChild(el("div", { class: "dm-status", text: `加载失败：${error instanceof Error ? error.message : String(error)}` }));
-    }
-    return false;
-  }
-}
-
-function switchTab(tab: any) {
-  activeTab = tab;
-  for (const tabEl of document.querySelectorAll<HTMLElement>(".dm-tab")) {
-    tabEl.dataset.active = tabEl.dataset.tab === tab ? "true" : "";
-  }
-  bodyEl.textContent = "";
-  if (tab === "servers") {
-    if (servers.length === 0) void refresh();
-    else renderServers();
-  } else {
-    const page = buildQuickAdd();
-    bodyEl.appendChild(page);
-  }
-}
-
-function close() {
-  if (overlay === undefined) return;
-  open = false;
-  overlay.hidden = true;
-}
-
-function showPanel() {
-  if (overlay === undefined) {
-    overlay = el("div", { class: "dm-overlay", hidden: true });
-    overlay.addEventListener("click", (event: any) => {
-      if (event.target === overlay) close();
-    });
-    card = el("div", { class: "dm-card" });
-
-    const head = el("div", { class: "dm-head" });
-    head.appendChild(el("h2", { text: "MCP 管理器" }));
-    head.appendChild(el("span", { class: "dm-counts", text: "" }));
-    head.appendChild(el("button", { text: "刷新", onclick: () => void refresh() }));
-    head.appendChild(el("button", { text: "关闭", onclick: () => close() }));
-    card.appendChild(head);
-
-    const tabs = el("div", { class: "dm-tabs" });
-    tabs.appendChild(el("button", { class: "dm-tab", dataset: { tab: "servers" }, text: "服务器", onclick: () => switchTab("servers") }));
-    tabs.appendChild(el("button", { class: "dm-tab", dataset: { tab: "quick" }, text: "快速接入", onclick: () => switchTab("quick") }));
-    card.appendChild(tabs);
-
-    bodyEl = el("div", { class: "dm-body" });
-    card.appendChild(bodyEl);
-    overlay.appendChild(card);
-    document.body.appendChild(overlay);
-
-    document.addEventListener("keydown", (event) => {
-      if (event.key === "Escape" && open) close();
-    });
-  }
-  open = true;
-  overlay.hidden = false;
-  switchTab("servers");
-}
-
-// ------------------------------------------------------- 右上角浮窗
-
-let floatPill: any;
-let floatPanel: any;
-let floatOpen = false;
-let currentCwd: any = undefined;
-let projectRoot: any = undefined;
-let updateFloatState: any = undefined;
-let mcpUiConfig: any = { position: "top-right", offsetX: 8, offsetY: 8, blankY: 40 };
-
-/** 状态点的颜色（与 STATUS_ORDER 一致）。 */
-function statusDot(status: any) {
-  const group = STATUS_ORDER.find((entry) => entry.key === status);
-  return group !== undefined ? group.dot : "var(--dsw-alias-label-tertiary,#9aa1ad)";
-}
-
-/** 渲染浮窗胶囊（状态点 + 摘要计数）。 */
-function renderPill() {
-  if (floatPill === undefined) return;
-  const ok = counts.connected ?? 0;
-  const bad = (counts.failed ?? 0) + (counts.reconnecting ?? 0);
-  const dot = bad > 0
-    ? "var(--dsw-alias-state-error-primary,#e0483e)"
-    : ok > 0
-      ? "var(--dsw-alias-state-success-primary,#0f9d6e)"
-      : "var(--dsw-alias-label-tertiary,#9aa1ad)";
-  const label = servers.length > 0 ? `MCP ${ok}/${servers.length}` : "MCP";
-  floatPill.innerHTML = `<span class="dm-dot" style="background:${dot}"></span><span>${label}</span>`;
-}
-
-/** 渲染浮窗下拉面板（项目/全局分组 + 状态 + 快捷操作）。 */
-function renderFloatPanel() {
-  if (floatPanel === undefined) return;
-  floatPanel.textContent = "";
-  const head = el("div", { class: "dm-float-head" });
-  const projectName = typeof projectRoot === "string" && projectRoot !== ""
-    ? (projectRoot.split(/[\\/]/).filter(Boolean).pop() ?? projectRoot)
-    : "全局会话";
-  head.appendChild(el("span", { class: "dm-float-title", text: projectName }));
-  head.appendChild(el("button", { text: "管理", onclick: () => { toggleFloat(false); showPanel(); } }));
-  floatPanel.appendChild(head);
-
-  if (servers.length === 0) {
-    floatPanel.appendChild(el("div", { class: "dm-status", text: "没有 MCP 服务器，点「管理」添加" }));
-    return;
-  }
-  for (const scope of ["project", "global"]) {
-    const list = servers.filter((server: any) => server.scope === scope);
-    if (list.length === 0) continue;
-    const section = el("section", { class: "dm-float-group" });
-    section.appendChild(el("div", { class: "dm-float-group-title", text: scope === "project" ? "项目级" : "全局" }));
-    for (const server of [...list].sort((a: any, b: any) => a.name.localeCompare(b.name))) {
-      section.appendChild(renderFloatRow(server));
-    }
-    floatPanel.appendChild(section);
-  }
-}
-
-/** 浮窗面板里的一行服务器。 */
-function renderFloatRow(server: any) {
-  const row = el("div", { class: "dm-float-row" });
-  row.appendChild(el("span", { class: "dm-dot", style: `background:${statusDot(server.status)}` }));
-  row.appendChild(el("span", { class: "dm-float-name", text: server.name, title: server.name }));
-  const tools = Array.isArray(server.tools) ? server.tools.length : 0;
-  row.appendChild(el("span", { class: "dm-float-meta", text: `${STATUS_TEXT[server.status] ?? server.status} · ${tools} 工具` }));
-  const actions = el("div", { class: "dm-float-actions" });
-  const action = el("button", { class: "dm-float-action" });
-  if (server.status === "connected") {
-    action.textContent = "断开";
-    action.addEventListener("click", () => {
-      void api(`${API.disconnect}?name=${encodeURIComponent(server.name)}&scope=${server.scope}`, { method: "POST" })
-        .then(() => refresh())
-        .catch((error) => console.warn("[dsh-mcp-manager] disconnect failed:", error));
-    });
-  } else if (server.status === "disabled") {
-    action.textContent = "启用";
-    action.addEventListener("click", () => {
-      void api(`${API.servers}?name=${encodeURIComponent(server.name)}&scope=${server.scope}`, {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ enabled: true }),
-      }).then(() => refresh())
-        .catch((error) => console.warn("[dsh-mcp-manager] enable failed:", error));
-    });
-  } else {
-    action.textContent = "连接";
-    action.addEventListener("click", () => {
-      void api(`${API.connect}?name=${encodeURIComponent(server.name)}&scope=${server.scope}`, { method: "POST" })
-        .then(() => refresh())
-        .catch((error) => console.warn("[dsh-mcp-manager] connect failed:", error));
-    });
-  }
-  actions.appendChild(action);
-  // 禁用开关：非 disabled 状态可一键禁用（PATCH enabled:false → 宿主断开并注销工具）
-  if (server.status !== "disabled") {
-    const disable = el("button", { class: "dm-float-action" });
-    disable.textContent = "禁用";
-    disable.addEventListener("click", () => {
-      void api(`${API.servers}?name=${encodeURIComponent(server.name)}&scope=${server.scope}`, {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ enabled: false }),
-      }).then(() => refresh())
-        .catch((error) => console.warn("[dsh-mcp-manager] disable failed:", error));
-    });
-    actions.appendChild(disable);
-  }
-  row.appendChild(actions);
-  return row;
-}
-
-function toggleFloat(force?: any) {
-  if (floatPanel === undefined) return;
-  const next = force !== undefined ? force : !floatOpen;
-  floatOpen = next;
-  floatPanel.hidden = !next;
-  if (next) {
-    placePanel();
-    renderFloatPanel();
-    // 聚焦面板本身，让后续点击外部时能通过 focusout 自动关闭。
-    floatPanel.focus({ preventScroll: true });
-  }
-}
-
-/** 下拉面板定位（fixed 跟随胶囊，避免被滚动容器裁剪）。 */
-function placePanel() {
-  if (floatPill === undefined || floatPanel === undefined) return;
-  const rect = floatPill.getBoundingClientRect();
-  if (rect.width === 0 && rect.height === 0) return;
-  // 翻转逻辑：底部锚点（bottom-right）→ 面板向上弹出（以胶囊上缘为基准，留 6px
-  // 间距并 clamp 到视口上缘，不溢出）；顶部锚点（top-right）→ 向下弹出（历史行为）。
-  const anchorBottom = mcpUiConfig.position === "bottom-right";
-  const gap = 6;
-  floatPanel.style.top = anchorBottom
-    ? `${Math.max(6, rect.top - floatPanel.offsetHeight - gap)}px`
-    : `${Math.max(6, rect.bottom + gap)}px`;
-  floatPanel.style.right = `${Math.max(10, Math.round(window.innerWidth - rect.right))}px`;
-  floatPanel.style.left = "auto";
-}
-
-/** 会话滚动容器：聊天消息实际滚动的区域（shell 的 data-conversation-scroll）。 */
-function conversationHost() {
-  return document.querySelector('[data-conversation-scroll]')
-    ?? document.querySelector('[data-pane="conversation"]')
-    ?? document.querySelector('.pI_x6G_centerCol')
-    ?? document.body;
-}
-
-/** 全局 overlay 层：下拉面板挂这里（fixed 定位，避免被滚动容器裁剪）。 */
-function panelHost() {
-  return document.querySelector('[data-shell-overlay]')
-    ?? document.body;
-}
-
-/** 从 settings.yaml 读取的配置决定新/老会话垂直偏移。 */
-function floatTopOffset(ctx: any) {
-  const snap = ctx?.sessions?.list?.getSnapshot?.();
-  const current = snap?.current;
-  const session = current === undefined ? undefined : snap?.byId?.[current];
-  const blank = session?.blank === true;
-  const cfg = mcpUiConfig || {};
-  const y = typeof cfg.offsetY === "number" ? cfg.offsetY : 8;
-  const blankY = typeof cfg.blankY === "number" ? cfg.blankY : y;
-  return blank ? blankY : y;
-}
-
-/** 挂载浮窗：胶囊继续挂在会话滚动容器（scrollBody）内并钉住右上角，下拉面板 fixed 跟随。 */
-function mountFloat(ctx: any) {
-  const pill = el("button", {
-    type: "button",
-    class: "dm-float",
-    "aria-label": "MCP 管理器",
-    title: "MCP 管理器（点击展开）",
-  });
-  pill.dataset.dshMcpFloat = "";
-  pill.addEventListener("click", () => toggleFloat());
-  const panel = el("div", { class: "dm-float-panel" });
-  panel.hidden = true;
-  panel.tabIndex = -1;
-  floatPill = pill;
-  floatPanel = panel;
-  // 胶囊挂会话滚动容器，下拉面板挂 shell.overlay（fixed 定位，仍与通知同一层）。
-  const panelRoot = panelHost();
-  if (panel.parentElement !== panelRoot) panelRoot.appendChild(panel);
-
-  // 失去焦点后自动关闭：焦点离开胶囊/面板时收起下拉框。
-  // 面板打开时主动聚焦到面板，因此点击外部任意区域都会触发 focusout。
-  const onFocusOut = (event: any) => {
-    if (!floatOpen) return;
-    const next = event.relatedTarget as Node | null;
-    if (next !== null && (floatPanel.contains(next) || floatPill.contains(next))) return;
-    toggleFloat(false);
-  };
-  document.addEventListener("focusout", onFocusOut);
-
-  let host: any;
-  let listeners: any = [];
-
-  /** 按 settings.yaml 配置把胶囊定位到对话容器右上/右下角。 */
-  const updateFloat = () => {
-    const best = conversationHost();
-    if (best === null || best === undefined) return;
-    const rect = best.getBoundingClientRect();
-    const cfg = mcpUiConfig || {};
-    const position = cfg.position === "bottom-right" ? "bottom-right" : "top-right";
-    const offsetX = typeof cfg.offsetX === "number" ? cfg.offsetX : 8;
-    const y = floatTopOffset(ctx);
-    pill.style.position = "fixed";
-    pill.style.left = `${rect.right - pill.offsetWidth - offsetX}px`;
-    pill.style.right = "auto";
-    if (position === "bottom-right") {
-      pill.style.top = `${rect.bottom - pill.offsetHeight - y}px`;
-    } else {
-      pill.style.top = `${rect.top + y}px`;
-    }
-    if (floatOpen) placePanel();
-  };
-  updateFloatState = updateFloat;
-
-  const attachListeners = (target: any) => {
-    for (const detach of listeners.splice(0)) detach();
-    const onScroll = () => updateFloat();
-    const onResize = () => updateFloat();
-    target.addEventListener("scroll", onScroll, { passive: true });
-    window.addEventListener("resize", onResize);
-    listeners.push(() => {
-      target.removeEventListener("scroll", onScroll);
-      window.removeEventListener("resize", onResize);
-    });
-    updateFloat();
-  };
-
-  /**
-   * 放置/迁移：每次调用都重新求最佳宿主（scrollBody 优先），胶囊跟着它走——
-   * 即使初始化时 scrollBody 尚未渲染（退回 body），一旦出现就迁移。
-   */
-  const place = () => {
-    const best = conversationHost();
-    if (best === null || best === undefined) return false;
-    if (host !== best || pill.parentElement !== best) {
-      host = best;
-      if (pill.parentElement !== null) pill.remove();
-      best.appendChild(pill);
-      attachListeners(best);
-    }
-    return true;
-  };
-  const observer = new MutationObserver(() => {
-    place();
-  });
-  if (place()) {
-    observer.observe(document.body, { childList: true, subtree: true });
-  } else {
-    const wait = new MutationObserver(() => {
-      if (place()) {
-        wait.disconnect();
-        observer.observe(document.body, { childList: true, subtree: true });
-      }
-    });
-    wait.observe(document.body, { childList: true, subtree: true });
-  }
-  renderPill();
-  return () => {
-    updateFloatState = undefined;
-    document.removeEventListener("focusout", onFocusOut);
-    observer.disconnect();
-    for (const detach of listeners.splice(0)) detach();
-    pill.remove();
-    panel.remove();
-    floatPill = undefined;
-    floatPanel = undefined;
-    floatOpen = false;
-  };
-}
-
-/** 跟随当前会话：cwd 变化 → 通知宿主切换项目级 MCP + 刷新浮窗。 */
-function bindSession(ctx: any) {
-  const list = ctx.sessions?.list;
-  if (list === undefined || typeof list.getSnapshot !== "function") return () => {};
-  const sync = () => {
-    let cwd: any;
-    try {
-      const snapshot = list.getSnapshot();
-      const sessionId = snapshot?.current;
-      cwd = sessionId === undefined ? undefined : snapshot?.byId?.[sessionId]?.cwd;
-    } catch {
-      cwd = undefined;
-    }
-    const prevCwd = currentCwd;
-    currentCwd = cwd;
-    updateFloatState?.();
-    if (cwd === prevCwd) return;
-    // 无论 cwd 是否为空都通知宿主切换：空 cwd（blank 会话/新会话还没选
-    // 工作区）也要显式清空宿主的项目级 MCP，否则宿主全局单例会残留
-    // 上一个会话的项目级服务器，别的会话就串台显示了。
-    void api(API.session, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ cwd: typeof cwd === "string" ? cwd : "" }),
-    }).then(() => refresh()).catch(() => {});
-  };
-  sync();
-  if (typeof list.subscribe === "function") return list.subscribe(sync);
-  return () => {};
-}
-
-/**
- * 设置页插件卡（settings.plugin.item）：浮窗位置 / 偏移编辑区。
- * 与 provider-usage「胶囊位置」编辑区同构友好度（锚点下拉 + 水平/垂直偏移 + 空白偏移 +
- * 保存），读/写走 /api/dsh-mcp/config（GET 读 / POST 写），保存后经 SSE 热更新。
- */
-function SettingsCard() {
-  const useState = React.useState;
-  const useEffect = React.useEffect;
-  const [cfg, setCfg] = useState(null);
-  const [open, setOpen] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [msg, setMsg] = useState(null);
-
-  useEffect(() => {
-    let live = true;
-    api(API.config).then((c: any) => {
-      if (live && c !== null && typeof c === "object") setCfg(c);
-    }).catch(() => {});
-    return () => {
-      live = false;
-    };
-  }, []);
-
-  if (cfg === null) {
-    return React.createElement("li", { className: "dm-set-card" }, "MCP 管理器：加载中…");
-  }
-
-  const set = (patch: any) => setCfg((c: any) => (c !== null ? Object.assign({}, c, patch) : c));
-  const numInput = (key: string, label: string) =>
-    React.createElement("label", { className: "dm-set-field" },
-      label,
-      React.createElement("input", {
-        className: "dm-set-input",
-        type: "number",
-        min: 0,
-        max: 2000,
-        value: String(cfg[key]),
-        onChange: (e: any) => {
-          const v = Number(e.target.value);
-          set({ [key]: Number.isFinite(v) ? Math.min(2000, Math.max(0, Math.round(v))) : 0 });
-        },
-      }),
-    );
-  const save = async () => {
-    setSaving(true);
-    setMsg(null);
-    try {
-      await api(API.config, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(cfg),
-      });
-      setMsg({ ok: true, text: "已保存——浮窗位置即时生效（无需重启）" });
-      setTimeout(() => setMsg(null), 2400);
-    } catch (e) {
-      setMsg({ ok: false, text: `保存失败：${e instanceof Error ? e.message : String(e)}` });
-    }
-    setSaving(false);
-  };
-
-  return React.createElement("li", { className: "dm-set-card" + (open ? " dm-set-cardOpen" : "") },
-    React.createElement("button", {
-      type: "button",
-      className: "dm-set-head",
-      "aria-expanded": open,
-      onClick: () => setOpen(!open),
-    },
-      React.createElement("span", { className: "dm-set-headText" },
-        React.createElement("span", { className: "dm-set-name" }, "MCP 管理器（dsh-mcp-manager）"),
-        React.createElement("span", { className: "dm-set-description" }, "浮窗位置 / 水平·垂直·空白偏移"),
-      ),
-      React.createElement("span", { className: "dm-set-chevron" + (open ? " dm-set-chevronOpen" : "") }, "▾"),
-    ),
-    open ? React.createElement("div", { className: "dm-set-body" },
-      React.createElement("div", { className: "dm-set-row" },
-        React.createElement("label", { htmlFor: "dm-set-position" }, "锚点"),
-        React.createElement("select", {
-          id: "dm-set-position",
-          className: "dm-set-input",
-          value: cfg.position,
-          onChange: (e: any) => set({ position: e.target.value }),
-        },
-          React.createElement("option", { value: "top-right" }, "右上（top-right）"),
-          React.createElement("option", { value: "bottom-right" }, "右下（bottom-right）"),
-        ),
-      ),
-      React.createElement("div", { className: "dm-set-row" },
-        numInput("offsetX", "水平偏移"),
-        numInput("offsetY", "垂直偏移"),
-        numInput("blankY", "空白偏移"),
-      ),
-      React.createElement("div", { className: "dm-set-hint" },
-        "保存即热更新：宿主经 SSE events 通道广播一变，所有标签页的浮窗即刻原位更新，无需重启 dsh web。"),
-      React.createElement("div", { className: "dm-set-foot" },
-        msg !== null
-          ? React.createElement("span", { className: msg.ok ? "dm-set-saved" : "dm-set-error" }, msg.text)
-          : null,
-        React.createElement("button", {
-          type: "button",
-          className: "dm-set-save",
-          disabled: saving,
-          onClick: () => { void save(); },
-        }, saving ? "保存中…" : "保存"),
-      ),
-    ) : null,
-  );
-}
-
-/**
- * 挂载浏览器端：注入样式 + 右上角浮窗（会话跟随）+ 管理面板。
- * @param {import("@deepseek-ai/dsh-client-runtime/client").ClientContext} ctx
- * @returns {void}
- */
-export function apply(ctx: any) {
-  try {
+    // 注入样式（仅首次；容错：重复 apply 不重复创建）
     if (document.querySelector('style[data-dsh-mcp-manager-style]') === null) {
       const style = document.createElement("style");
       style.dataset.dshMcpManagerStyle = "";
@@ -984,7 +51,7 @@ export function apply(ctx: any) {
 
     // 设置页插件卡（settings.plugin.item）：rc.7 起由 list(id) 改为 keyed(key)，
     // 需 id 与 key 双写且 key = 宿主端 installSettingsNamespace 注册的命名空间
-    // （dsh-mcp-manager），才会被 configurable 面板派发（对照 dsh-lan-proxy）。
+    //（dsh-mcp-manager），才会被 configurable 面板派发（对照 dsh-lan-proxy）。
     const slots = ctx.get("slots");
     if (slots && typeof slots.inject === "function") {
       slots.inject("settings.plugin.item", () => slots.register(
@@ -993,25 +60,24 @@ export function apply(ctx: any) {
       ));
     }
 
-    disposers.push(mountFloat(ctx));
-    disposers.push(bindSession(ctx));
+    disposers.push(mountFloat(ctx, state, actions));
+    disposers.push(bindSession(ctx, state, actions));
 
     // 读取 settings.yaml 中的 UI 配置（右上/右下 + 偏移量），不依赖设置页。
-    api(API.config).then((cfg: any) => {
-      if (cfg !== null && typeof cfg === "object") mcpUiConfig = cfg;
-      updateFloatState?.();
+    api(state.API.config).then((cfg: any) => {
+      if (cfg !== null && typeof cfg === "object") state.mcpUiConfig = cfg;
+      state.updateFloatState?.();
     }).catch(() => {});
-
 
     // 首次刷新：立即执行，失败按 500ms/1s/2s 退避重试（宿主路由可能尚未就绪，
     // 不依赖固定延迟猜测）。
     let retryTimer: any = undefined;
-    const attemptRefresh = (attempt: any) => {
-      refresh().then((ok) => {
+    const attemptRefresh = (attempt: number) => {
+      refresh(state, actions).then((ok) => {
         if (!ok && attempt < 3) {
           retryTimer = setTimeout(() => attemptRefresh(attempt + 1), 500 * 2 ** attempt);
         }
-      }).catch((error) => {
+      }).catch((error: any) => {
         // 防御：refresh 永不 reject（内部 try/catch），但兜底避免 unhandled rejection。
         console.warn("[dsh-mcp-manager] 首刷失败：", error);
       });
@@ -1028,21 +94,21 @@ export function apply(ctx: any) {
       if (refreshTimer !== undefined) return;
       refreshTimer = setTimeout(() => {
         refreshTimer = undefined;
-        void refresh().catch(() => {});
+        void refresh(state, actions).catch(() => {});
       }, 500);
     };
     const startPolling = () => {
       if (pollTimer !== undefined) return;
       const tick = () => {
         pollTimer = setTimeout(() => {
-          void refresh().catch(() => {});
+          void refresh(state, actions).catch(() => {});
           tick();
         }, 10_000);
       };
       tick();
     };
     try {
-      es = new EventSource(API.events);
+      es = new EventSource(state.API.events);
       es.onmessage = (ev: MessageEvent) => {
         let msg: any;
         try {
@@ -1053,9 +119,9 @@ export function apply(ctx: any) {
         if (msg !== undefined && msg.type === "ui-config-changed") {
           // 配置变更（设置页保存 position/offset）→ 重新 GET /config 就地更新浮窗位置，
           // 非仅刷新 /servers；更新 mcpUiConfig 后重新定位胶囊与（若展开的）面板。
-          void api(API.config).then((cfg: any) => {
-            if (cfg !== null && typeof cfg === "object") mcpUiConfig = cfg;
-            updateFloatState?.();
+          void api(state.API.config).then((cfg: any) => {
+            if (cfg !== null && typeof cfg === "object") state.mcpUiConfig = cfg;
+            state.updateFloatState?.();
           }).catch(() => {});
         } else {
           scheduleRefresh();
@@ -1078,10 +144,11 @@ export function apply(ctx: any) {
       // EventSource 不可用：直接轮询兜底。
       startPolling();
     }
+
     // 切回本标签页/窗口时兜底刷新：隐藏期间错过的 SSE 广播不会重放，
     // 恢复可见后主动拉一次，避免 UI 停留在过期状态（如项目级显示未连接）。
     const onVisible = () => {
-      if (!document.hidden) void refresh().catch(() => {});
+      if (!document.hidden) void refresh(state, actions).catch(() => {});
     };
     document.addEventListener("visibilitychange", onVisible);
 
@@ -1092,23 +159,9 @@ export function apply(ctx: any) {
       if (es !== undefined) es.close();
       document.removeEventListener("visibilitychange", onVisible);
       for (const dispose of disposers.splice(0)) dispose();
-      if (overlay !== undefined && overlay.parentElement !== null) overlay.remove();
-      overlay = undefined;
-      open = false;
+      if (state.overlay !== undefined && state.overlay.parentElement !== null) state.overlay.remove();
       // 重置全部模块级状态（HMR / 重复 apply 不残留旧 tab 与编辑态）。
-      card = undefined;
-      bodyEl = undefined;
-      activeTab = "servers";
-      servers = [];
-      counts = {};
-      editingName = undefined;
-      editing = undefined;
-      formName = formScope = formTransport = formCommand = formArgs = formEnv = formCwd = formUrl = formHeaders = formEnabled = undefined;
-      floatPill = undefined;
-      floatPanel = undefined;
-      floatOpen = false;
-      currentCwd = undefined;
-      projectRoot = undefined;
+      Object.assign(state, createState());
     }, "dsh-mcp-manager: ui");
   } catch (error) {
     console.warn("[dsh-mcp-manager] mount failed:", error);

--- a/packages/dsh-mcp-manager/src/client/index.ts
+++ b/packages/dsh-mcp-manager/src/client/index.ts
@@ -160,8 +160,11 @@ export function apply(ctx: any): void {
       document.removeEventListener("visibilitychange", onVisible);
       for (const dispose of disposers.splice(0)) dispose();
       if (state.overlay !== undefined && state.overlay.parentElement !== null) state.overlay.remove();
-      // 重置全部模块级状态（HMR / 重复 apply 不残留旧 tab 与编辑态）。
+      // 重置全部模块级状态，但保留 mcpUiConfig（原始 dispose 不重置它，避免
+      // HMR 重复 apply 期间浮窗位置瞬态跳回默认再被 api(API.config) 拉回）。
+      const savedUiConfig = state.mcpUiConfig;
       Object.assign(state, createState());
+      state.mcpUiConfig = savedUiConfig;
     }, "dsh-mcp-manager: ui");
   } catch (error) {
     console.warn("[dsh-mcp-manager] mount failed:", error);

--- a/packages/dsh-mcp-manager/src/client/panel.ts
+++ b/packages/dsh-mcp-manager/src/client/panel.ts
@@ -1,0 +1,104 @@
+/**
+ * dsh-mcp-manager — 客户端模态面板生命周期。
+ *
+ * 面板的打开/关闭/tab 切换/数据刷新。
+ * 跨模块渲染（renderServers / buildQuickAdd / renderPill / renderFloatPanel）
+ * 直接 import 用到的模块——本模块是 feature 模块的汇聚点，构成单向依赖图：
+ * panel → servers / quick-add / float。
+ */
+
+import { el, api } from "./dom.js";
+import type { McpState, UiActions } from "./state.js";
+import { renderServers } from "./servers.js";
+import { buildQuickAdd } from "./quick-add.js";
+import { renderPill, renderFloatPanel } from "./float.js";
+
+/** 刷新服务器列表与浮窗摘要。 */
+export async function refresh(state: McpState, actions: UiActions): Promise<boolean> {
+  try {
+    const suffix = typeof state.currentCwd === "string" && state.currentCwd !== ""
+      ? `?cwd=${encodeURIComponent(state.currentCwd)}`
+      : "";
+    const payload = await api(`${state.API.servers}${suffix}`);
+    state.servers = payload.servers ?? [];
+    state.counts = payload.counts ?? {};
+    state.projectRoot = payload.projectRoot;
+    renderPill(state);
+    if (state.floatOpen) renderFloatPanel(state, actions);
+    const countsEl = document.querySelector(".dm-counts");
+    if (countsEl !== null) {
+      const parts = [];
+      if (state.counts.connected > 0) parts.push(`运行中 ${state.counts.connected}`);
+      if (state.counts.connecting > 0 || state.counts.reconnecting > 0) parts.push(`连接中 ${(state.counts.connecting ?? 0) + (state.counts.reconnecting ?? 0)}`);
+      if (state.counts.failed > 0) parts.push(`失败 ${state.counts.failed}`);
+      countsEl.textContent = parts.length > 0 ? `共 ${state.servers.length} 台 · ${parts.join(" · ")}` : `共 ${state.servers.length} 台`;
+    }
+    if (state.bodyEl !== undefined && state.activeTab === "servers") renderServers(state, actions);
+    return true;
+  } catch (error) {
+    if (state.bodyEl !== undefined && state.activeTab === "servers") {
+      state.bodyEl.textContent = "";
+      state.bodyEl.appendChild(el("div", { class: "dm-status", text: `加载失败：${error instanceof Error ? error.message : String(error)}` }));
+    }
+    return false;
+  }
+}
+
+/** 切换面板 tab（servers / quick）。 */
+export function switchTab(state: McpState, actions: UiActions, tab: any): void {
+  state.activeTab = tab;
+  for (const tabEl of document.querySelectorAll<HTMLElement>(".dm-tab")) {
+    tabEl.dataset.active = tabEl.dataset.tab === tab ? "true" : "";
+  }
+  if (state.bodyEl === undefined) return;
+  state.bodyEl.textContent = "";
+  if (tab === "servers") {
+    if (state.servers.length === 0) void refresh(state, actions);
+    else renderServers(state, actions);
+  } else {
+    const page = buildQuickAdd(state, actions);
+    state.bodyEl.appendChild(page);
+  }
+}
+
+/** 关闭模态面板。 */
+export function close(state: McpState): void {
+  if (state.overlay === undefined) return;
+  state.open = false;
+  state.overlay.hidden = true;
+}
+
+/** 打开模态面板（首次调用时创建 DOM 结构）。 */
+export function showPanel(state: McpState, actions: UiActions): void {
+  if (state.overlay === undefined) {
+    state.overlay = el("div", { class: "dm-overlay", hidden: true });
+    state.overlay.addEventListener("click", (event: any) => {
+      if (event.target === state.overlay) close(state);
+    });
+    state.card = el("div", { class: "dm-card" });
+
+    const head = el("div", { class: "dm-head" });
+    head.appendChild(el("h2", { text: "MCP 管理器" }));
+    head.appendChild(el("span", { class: "dm-counts", text: "" }));
+    head.appendChild(el("button", { text: "刷新", onclick: () => void refresh(state, actions) }));
+    head.appendChild(el("button", { text: "关闭", onclick: () => close(state) }));
+    state.card.appendChild(head);
+
+    const tabs = el("div", { class: "dm-tabs" });
+    tabs.appendChild(el("button", { class: "dm-tab", dataset: { tab: "servers" }, text: "服务器", onclick: () => switchTab(state, actions, "servers") }));
+    tabs.appendChild(el("button", { class: "dm-tab", dataset: { tab: "quick" }, text: "快速接入", onclick: () => switchTab(state, actions, "quick") }));
+    state.card.appendChild(tabs);
+
+    state.bodyEl = el("div", { class: "dm-body" });
+    state.card.appendChild(state.bodyEl);
+    state.overlay.appendChild(state.card);
+    document.body.appendChild(state.overlay);
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && state.open) close(state);
+    });
+  }
+  state.open = true;
+  state.overlay.hidden = false;
+  switchTab(state, actions, "servers");
+}

--- a/packages/dsh-mcp-manager/src/client/quick-add.ts
+++ b/packages/dsh-mcp-manager/src/client/quick-add.ts
@@ -1,0 +1,231 @@
+/**
+ * dsh-mcp-manager — 客户端「快速接入」页：表单与 mcpServers JSON 导入。
+ *
+ * 表单构建、读写、编辑、保存、重置；跨模块动作（refresh / switchTab）经
+ * actions 注入，不直接引用 panel 模块，避免循环依赖。
+ */
+
+import { el, api } from "./dom.js";
+import type { McpState, UiActions } from "./state.js";
+
+/** 解析 "KEY: VALUE" / "KEY=VALUE" 多行文本为对象。 */
+export function parseKV(text: any): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line === "") continue;
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*[:=]\s*(.*)$/);
+    if (match === null) continue;
+    const value = match[2].trim();
+    if (value !== "") out[match[1]] = value;
+    else out[match[1]] = "";
+  }
+  return out;
+}
+
+/** 当前表单选择的归属（project/global）。 */
+export function formScopeValue(state: McpState): string {
+  if (state.formScope !== undefined && (state.formScope.value === "project" || state.formScope.value === "global")) {
+    return state.formScope.value;
+  }
+  return state.projectRoot !== undefined && state.projectRoot !== "" ? "project" : "global";
+}
+
+/** 当前会话 cwd（POST body 携带，宿主据此切换项目级 MCP）。 */
+export function currentCwdBody(state: McpState): Record<string, string> {
+  return typeof state.currentCwd === "string" && state.currentCwd !== "" ? { cwd: state.currentCwd } : {};
+}
+
+/** 表单数据 → 服务器配置对象（scope 由 formScope 决定）。 */
+export function readForm(state: McpState): any {
+  const server: any = {
+    name: state.formName?.value.trim() ?? "",
+    transport: state.formTransport?.value ?? "stdio",
+    enabled: state.formEnabled?.checked ?? true,
+  };
+  if (server.transport === "stdio") {
+    server.command = state.formCommand?.value.trim() ?? "";
+    const args = (state.formArgs?.value ?? "").split(",").map((part: any) => part.trim()).filter(Boolean);
+    if (args.length > 0) server.args = args;
+    const env = parseKV(state.formEnv?.value ?? "");
+    if (Object.keys(env).length > 0) server.env = env;
+    if ((state.formCwd?.value ?? "").trim() !== "") server.cwd = state.formCwd?.value.trim();
+  } else {
+    server.url = state.formUrl?.value.trim() ?? "";
+    const headers = parseKV(state.formHeaders?.value ?? "");
+    if (Object.keys(headers).length > 0) server.headers = headers;
+  }
+  return server;
+}
+
+/** 重置表单为默认值。 */
+export function resetForm(state: McpState): void {
+  state.editingName = undefined;
+  state.editing = undefined;
+  if (state.formName === undefined) return;
+  state.formName.value = "";
+  state.formScope.value = state.projectRoot !== undefined && state.projectRoot !== "" ? "project" : "global";
+  state.formTransport.value = "stdio";
+  state.formCommand.value = "";
+  state.formArgs.value = "";
+  state.formEnv.value = "";
+  state.formCwd.value = "";
+  state.formUrl.value = "";
+  state.formHeaders.value = "";
+  state.formEnabled.checked = true;
+  state.formTransport.dispatchEvent(new Event("change"));
+  const title = document.getElementById("dm-form-title");
+  if (title !== null) title.textContent = "添加服务器";
+  const cancel = document.querySelector<HTMLButtonElement>("[data-dm-cancel]");
+  if (cancel !== null) cancel.disabled = true;
+}
+
+/** 用服务器数据填充表单（编辑模式）。 */
+export function fillForm(state: McpState, fill: any): void {
+  resetForm(state);
+  if (fill.name !== undefined) state.formName.value = fill.name;
+  state.formTransport.value = fill.transport ?? "stdio";
+  if (fill.command !== undefined) state.formCommand.value = fill.command;
+  if (Array.isArray(fill.args)) state.formArgs.value = fill.args.join(", ");
+  if (fill.env !== undefined) {
+    state.formEnv.value = Object.entries(fill.env).map(([key, value]) => `${key}=${value}`).join("\n");
+  }
+  if (fill.cwd !== undefined) state.formCwd.value = fill.cwd;
+  if (fill.url !== undefined) state.formUrl.value = fill.url;
+  if (fill.headers !== undefined) {
+    state.formHeaders.value = Object.entries(fill.headers).map(([key, value]) => `${key}: ${value}`).join("\n");
+  }
+  state.formTransport.dispatchEvent(new Event("change"));
+}
+
+/** 保存表单（新增或更新）。 */
+export async function saveForm(state: McpState, actions: UiActions): Promise<void> {
+  const server = readForm(state);
+  try {
+    const payload = { ...server, scope: formScopeValue(state), ...currentCwdBody(state) };
+    if (state.editingName !== undefined) {
+      await api(`${state.API.servers}?name=${encodeURIComponent(state.editingName)}&scope=${formScopeValue(state)}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+    } else {
+      await api(state.API.servers, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+    }
+    resetForm(state);
+    await actions.refresh();
+  } catch (error) {
+    window.alert(`保存失败：${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+/** 进入编辑模式：填充表单，切换到快速接入 tab。 */
+export function beginEdit(state: McpState, actions: UiActions, server: any): void {
+  state.editingName = server.name;
+  state.editing = server;
+  actions.switchTab("quick");
+  fillForm(state, server);
+  if (state.formScope !== undefined && (server.scope === "project" || server.scope === "global")) {
+    state.formScope.value = server.scope;
+  }
+  const title = document.getElementById("dm-form-title");
+  if (title !== null) title.textContent = `编辑服务器：${server.name}`;
+  const cancel = document.querySelector<HTMLButtonElement>("[data-dm-cancel]");
+  if (cancel !== null) cancel.disabled = false;
+}
+
+/** 构建「快速接入」页面（表单 + JSON 导入）。 */
+export function buildQuickAdd(state: McpState, actions: UiActions): any {
+  const page = el("div");
+
+  // 表单
+  const form = el("section", { class: "dm-section" });
+  form.appendChild(el("h3", { id: "dm-form-title", text: "添加服务器" }));
+  state.formName = el("input", { id: "dm-f-name", placeholder: "context7", value: state.editing?.name ?? "" });
+  state.formScope = el("select", { id: "dm-f-scope" });
+  state.formScope.appendChild(el("option", { value: "project", text: "项目级（<项目>/.dsh/mcp.json，随会话切换）" }));
+  state.formScope.appendChild(el("option", { value: "global", text: "全局（~/.dsh/dsh-mcp.json）" }));
+  state.formScope.value = state.editing?.scope ?? (state.projectRoot !== undefined && state.projectRoot !== "" ? "project" : "global");
+  state.formTransport = el("select", { id: "dm-f-transport" });
+  state.formTransport.appendChild(el("option", { value: "stdio", text: "stdio（本地子进程）" }));
+  state.formTransport.appendChild(el("option", { value: "streamable-http", text: "streamable-http（远程）" }));
+  state.formCommand = el("input", { id: "dm-f-command", placeholder: "npx" });
+  state.formArgs = el("input", { id: "dm-f-args", placeholder: "-y, @context7/mcp-server" });
+  state.formEnv = el("textarea", { id: "dm-f-env", placeholder: "每行 KEY=VALUE，如\nCONTEXT7_API_KEY=${CONTEXT7_API_KEY}" });
+  state.formCwd = el("input", { id: "dm-f-cwd", placeholder: "可选工作目录" });
+  state.formUrl = el("input", { id: "dm-f-url", placeholder: "https://mcp.context7.com/mcp" });
+  state.formHeaders = el("textarea", { id: "dm-f-headers", placeholder: '每行 KEY: VALUE，支持 ${ENV} 引用，如\nAuthorization: Bearer ${CONTEXT7_API_KEY}' });
+  state.formEnabled = el("input", { id: "dm-f-enabled", type: "checkbox", checked: true });
+
+  const grid = el("div", { class: "dm-form" });
+  grid.appendChild(el("div", { class: "dm-field", children: [el("label", { text: "服务器名称（唯一，作为 mcp__<name>__ 前缀）" }), state.formName] }));
+  grid.appendChild(el("div", { class: "dm-field", children: [el("label", { text: "归属" }), state.formScope] }));
+  grid.appendChild(el("div", { class: "dm-field", children: [el("label", { text: "传输类型" }), state.formTransport] }));
+  grid.appendChild(el("div", { class: "dm-field dm-full", children: [el("label", { text: "命令（stdio）" }), state.formCommand] }));
+  grid.appendChild(el("div", { class: "dm-field dm-full", children: [el("label", { text: "参数（逗号分隔）" }), state.formArgs] }));
+  grid.appendChild(el("div", { class: "dm-field dm-full", children: [el("label", { text: "环境变量（每行 KEY=VALUE，支持 ${ENV} 引用，值为空则继承父环境）" }), state.formEnv] }));
+  grid.appendChild(el("div", { class: "dm-field dm-full", children: [el("label", { text: "工作目录（可选）" }), state.formCwd] }));
+  grid.appendChild(el("div", { class: "dm-field dm-full", children: [el("label", { text: "URL（streamable-http）" }), state.formUrl] }));
+  grid.appendChild(el("div", { class: "dm-field dm-full", children: [el("label", { text: "请求头（每行 KEY: VALUE，支持 ${ENV} 引用）" }), state.formHeaders] }));
+  grid.appendChild(el("div", { class: "dm-check dm-field dm-full", children: [state.formEnabled, el("label", { text: "启用（保存后立即连接）" })] }));
+  const actionsEl = el("div", { class: "dm-form-actions" });
+  const save = el("button", { class: "dm-primary", text: "保存", onclick: () => void saveForm(state, actions) });
+  const cancel = el("button", { text: "取消编辑", onclick: () => resetForm(state), disabled: true });
+  cancel.dataset.dmCancel = "";
+  actionsEl.appendChild(save);
+  actionsEl.appendChild(cancel);
+  grid.appendChild(actionsEl);
+  form.appendChild(grid);
+  page.appendChild(form);
+
+  // 传输类型切换显示/隐藏
+  const syncTransport = () => {
+    const isHttp = state.formTransport.value === "streamable-http";
+    for (const field of [state.formCommand, state.formArgs, state.formEnv, state.formCwd]) {
+      (field as any).closest(".dm-field").style.display = isHttp ? "none" : "flex";
+    }
+    for (const field of [state.formUrl, state.formHeaders]) {
+      (field as any).closest(".dm-field").style.display = isHttp ? "flex" : "none";
+    }
+  };
+  state.formTransport.addEventListener("change", syncTransport);
+
+  // 粘贴 JSON 导入
+  const paste = el("section", { class: "dm-section" });
+  paste.appendChild(el("h3", { text: "粘贴 mcpServers JSON 导入" }));
+  const pasteBox = el("div", { class: "dm-paste-box" });
+  const textarea = el("textarea", {
+    class: "dm-full",
+    placeholder: '{"my-server":{"command":"npx","args":["-y","pkg"],"env":{"KEY":"value"}},"remote":{"url":"https://...","headers":{}}}',
+    style: "width:100%;min-height:90px;border:1px solid #d7dae0;border-radius:6px;padding:6px 8px;font-size:12px;font-family:ui-monospace,Consolas,monospace;box-sizing:border-box",
+  });
+  pasteBox.appendChild(textarea);
+  pasteBox.appendChild(el("div", { class: "dm-actions", children: [
+    el("button", { class: "dm-primary", text: "导入 JSON", onclick: async () => {
+      const result = pasteBox.querySelector(".dm-result");
+      try {
+        const payload = await api(state.API.importJson, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ json: textarea.value, scope: formScopeValue(state), ...currentCwdBody(state) }),
+        });
+        result.textContent = `已导入：${payload.imported.join(", ") || "（无）"}`;
+        if (payload.skipped.length > 0) {
+          result.appendChild(el("div", { class: "dm-skip", text: `跳过（已存在）：${payload.skipped.join(", ")}` }));
+        }
+        await actions.refresh();
+      } catch (error) {
+        result.textContent = `导入失败：${error instanceof Error ? error.message : String(error)}`;
+      }
+    } }),
+  ] }));
+  pasteBox.appendChild(el("div", { class: "dm-result" }));
+  paste.appendChild(pasteBox);
+  page.appendChild(paste);
+
+  return page;
+}

--- a/packages/dsh-mcp-manager/src/client/servers.ts
+++ b/packages/dsh-mcp-manager/src/client/servers.ts
@@ -1,0 +1,146 @@
+/**
+ * dsh-mcp-manager — 客户端「服务器列表页」渲染。
+ *
+ * 按状态分级展示服务器卡片（端点 / 错误 / 工具列表 / 操作按钮）。
+ * 跨模块动作（refresh / resetForm / beginEdit）经 actions 注入，不直接引用
+ * panel/quick-add 模块，避免循环依赖。
+ */
+
+import { el, api } from "./dom.js";
+import { STATUS_ORDER, STATUS_TEXT } from "./constants.js";
+import type { McpState, UiActions } from "./state.js";
+
+/** 服务器端点摘要：streamable-http 显示 URL，stdio 显示 command + args。 */
+export function endpointOf(server: any): string {
+  if (server.transport === "streamable-http") return server.url ?? "";
+  const args = Array.isArray(server.args) && server.args.length > 0 ? ` ${server.args.join(" ")}` : "";
+  return `${server.command ?? ""}${args}`;
+}
+
+/** 操作按钮（统一失败提示）。 */
+export function actionButton(label: any, onClick: any, primary = false, danger = false): any {
+  return el("button", {
+    class: `${primary ? "dm-primary" : ""} ${danger ? "dm-danger" : ""}`.trim(),
+    text: label,
+    onclick: async () => {
+      try {
+        await onClick();
+      } catch (error) {
+        window.alert(`操作失败：${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  });
+}
+
+/** 渲染单台服务器卡片。 */
+export function renderServer(server: any, state: McpState, actions: UiActions): any {
+  const article = el("article", { class: "dm-server" });
+  const header = el("header");
+  header.appendChild(el("span", { class: "dm-name", text: server.name }));
+  header.appendChild(el("span", {
+    class: `dm-badge ${server.transport === "streamable-http" ? "dm-http" : "dm-stdio"}`,
+    text: server.transport === "streamable-http" ? "HTTP" : "stdio",
+  }));
+  header.appendChild(el("span", { class: "dm-badge", text: server.scope === "project" ? "项目" : "全局" }));
+  const statusBadge = el("span", { class: `dm-badge dm-st-${server.status}`, text: STATUS_TEXT[server.status] ?? server.status });
+  header.appendChild(statusBadge);
+  const toolCount = Array.isArray(server.tools) ? server.tools.length : 0;
+  header.appendChild(el("span", { class: "dm-count", text: `${toolCount} 工具` }));
+  article.appendChild(header);
+
+  article.appendChild(el("div", { class: "dm-endpoint", text: endpointOf(server) }));
+  if (server.error !== undefined && server.error !== "") {
+    article.appendChild(el("div", { class: "dm-err", text: server.error }));
+  }
+
+  if (toolCount > 0) {
+    const details = el("details", { class: "dm-tools" });
+    details.appendChild(el("summary", { text: `工具（${toolCount}）` }));
+    const list = el("ul");
+    for (const tool of server.tools) list.appendChild(el("li", { text: tool }));
+    details.appendChild(list);
+    article.appendChild(details);
+  }
+
+  const actionsEl = el("div", { class: "dm-actions" });
+  const busy = server.status === "connecting" || server.status === "reconnecting";
+  const scopeQuery = `&scope=${server.scope}`;
+  if (server.status === "connected") {
+    actionsEl.appendChild(actionButton("断开", async () => {
+      await api(`${state.API.disconnect}?name=${encodeURIComponent(server.name)}${scopeQuery}`, { method: "POST" });
+      await actions.refresh();
+    }));
+    actionsEl.appendChild(actionButton("重连", async () => {
+      await api(`${state.API.reconnect}?name=${encodeURIComponent(server.name)}${scopeQuery}`, { method: "POST" });
+      await actions.refresh();
+    }));
+  } else if (server.status === "disabled") {
+    actionsEl.appendChild(actionButton("启用并连接", async () => {
+      await api(`${state.API.servers}?name=${encodeURIComponent(server.name)}${scopeQuery}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      });
+      await api(`${state.API.connect}?name=${encodeURIComponent(server.name)}${scopeQuery}`, { method: "POST" });
+      await actions.refresh();
+    }, true));
+  } else {
+    actionsEl.appendChild(actionButton("连接", async () => {
+      await api(`${state.API.connect}?name=${encodeURIComponent(server.name)}${scopeQuery}`, { method: "POST" });
+      await actions.refresh();
+    }, true));
+  }
+  // 禁用开关：非 disabled 状态可一键禁用（宿主断开并注销工具）
+  if (server.status !== "disabled") {
+    actionsEl.appendChild(actionButton("禁用", async () => {
+      await api(`${state.API.servers}?name=${encodeURIComponent(server.name)}${scopeQuery}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: false }),
+      });
+      if (state.editingName === server.name) actions.resetForm();
+      await actions.refresh();
+    }));
+  }
+  actionsEl.appendChild(actionButton("编辑", () => actions.beginEdit(server)));
+  actionsEl.appendChild(actionButton("删除", async () => {
+    if (!window.confirm(`删除 MCP 服务器「${server.name}」？`)) return;
+    await api(`${state.API.servers}?name=${encodeURIComponent(server.name)}${scopeQuery}`, { method: "DELETE" });
+    if (state.editingName === server.name) actions.resetForm();
+    await actions.refresh();
+  }, false, true));
+  actionsEl.children[actionsEl.children.length - 1].disabled = busy;
+  article.appendChild(actionsEl);
+  return article;
+}
+
+/** 渲染服务器列表页（按状态分组）。 */
+export function renderServers(state: McpState, actions: UiActions): void {
+  if (state.bodyEl === undefined) return;
+  state.bodyEl.textContent = "";
+  if (state.servers.length === 0) {
+    state.bodyEl.appendChild(el("div", { class: "dm-status", text: "还没有配置 MCP 服务器。切到「快速接入」页添加，或粘贴 mcpServers JSON 导入。" }));
+    return;
+  }
+  for (const group of STATUS_ORDER) {
+    const list = state.servers.filter((server: any) => server.status === group.key);
+    if (list.length === 0) continue;
+    const section = el("section", { class: "dm-group" });
+    const title = el("h3");
+    title.appendChild(el("span", { class: "dm-dot", style: `background:${group.dot}` }));
+    title.appendChild(document.createTextNode(group.title));
+    title.appendChild(el("span", { class: "dm-count", text: `${list.length}` }));
+    section.appendChild(title);
+    for (const server of list.sort((a: any, b: any) => a.name.localeCompare(b.name))) {
+      section.appendChild(renderServer(server, state, actions));
+    }
+    state.bodyEl.appendChild(section);
+  }
+  const others = state.servers.filter((server: any) => !STATUS_ORDER.some((group) => group.key === server.status));
+  if (others.length > 0) {
+    const section = el("section", { class: "dm-group" });
+    section.appendChild(el("h3", { text: "其他" }));
+    for (const server of others) section.appendChild(renderServer(server, state, actions));
+    state.bodyEl.appendChild(section);
+  }
+}

--- a/packages/dsh-mcp-manager/src/client/session.ts
+++ b/packages/dsh-mcp-manager/src/client/session.ts
@@ -1,0 +1,40 @@
+/**
+ * dsh-mcp-manager — 客户端会话跟随。
+ *
+ * 监听当前会话变化（cwd），通知宿主切换项目级 MCP 并刷新 UI。
+ * 跨模块动作（refresh）经 actions 注入，不直接引用 panel 模块。
+ */
+
+import { api } from "./dom.js";
+import type { McpState, UiActions } from "./state.js";
+
+/** 跟随当前会话：cwd 变化 → 通知宿主切换项目级 MCP + 刷新浮窗。 */
+export function bindSession(ctx: any, state: McpState, actions: UiActions): () => void {
+  const list = ctx.sessions?.list;
+  if (list === undefined || typeof list.getSnapshot !== "function") return () => {};
+  const sync = () => {
+    let cwd: any;
+    try {
+      const snapshot = list.getSnapshot();
+      const sessionId = snapshot?.current;
+      cwd = sessionId === undefined ? undefined : snapshot?.byId?.[sessionId]?.cwd;
+    } catch {
+      cwd = undefined;
+    }
+    const prevCwd = state.currentCwd;
+    state.currentCwd = cwd;
+    state.updateFloatState?.();
+    if (cwd === prevCwd) return;
+    // 无论 cwd 是否为空都通知宿主切换：空 cwd（blank 会话/新会话还没选
+    // 工作区）也要显式清空宿主的项目级 MCP，否则宿主全局单例会残留
+    // 上一个会话的项目级服务器，别的会话就串台显示了。
+    void api(state.API.session, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ cwd: typeof cwd === "string" ? cwd : "" }),
+    }).then(() => actions.refresh()).catch(() => {});
+  };
+  sync();
+  if (typeof list.subscribe === "function") return list.subscribe(sync);
+  return () => {};
+}

--- a/packages/dsh-mcp-manager/src/client/settings-card.ts
+++ b/packages/dsh-mcp-manager/src/client/settings-card.ts
@@ -1,0 +1,120 @@
+/**
+ * dsh-mcp-manager — 设置页插件卡（SettingsCard）。
+ *
+ * 浮窗位置 / 偏移编辑区，React 组件（经 build-client externals 注入）。
+ * 读/写走 /api/dsh-mcp/config（GET 读 / POST 写），保存后经 SSE 热更新。
+ * 注册面：slots.inject("settings.plugin.item")，由 index.ts 装配。
+ */
+
+import * as React from "react";
+import { API } from "./constants.js";
+import { api } from "./dom.js";
+
+/**
+ * 设置页插件卡（settings.plugin.item）：浮窗位置 / 偏移编辑区。
+ * 与 provider-usage「胶囊位置」编辑区同构友好度（锚点下拉 + 水平/垂直偏移 +
+ * 空白偏移 + 保存），读/写走 /api/dsh-mcp/config（GET 读 / POST 写），
+ * 保存后经 SSE 热更新。
+ */
+export function SettingsCard() {
+  const useState = React.useState;
+  const useEffect = React.useEffect;
+  const [cfg, setCfg] = useState(null) as any;
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState(null) as any;
+
+  useEffect(() => {
+    let live = true;
+    api(API.config).then((c: any) => {
+      if (live && c !== null && typeof c === "object") setCfg(c);
+    }).catch(() => {});
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  if (cfg === null) {
+    return React.createElement("li", { className: "dm-set-card" }, "MCP 管理器：加载中…");
+  }
+
+  const set = (patch: any) => setCfg((c: any) => (c !== null ? Object.assign({}, c, patch) : c));
+  const numInput = (key: string, label: string) =>
+    React.createElement("label", { className: "dm-set-field" },
+      label,
+      React.createElement("input", {
+        className: "dm-set-input",
+        type: "number",
+        min: 0,
+        max: 2000,
+        value: String(cfg[key]),
+        onChange: (e: any) => {
+          const v = Number(e.target.value);
+          set({ [key]: Number.isFinite(v) ? Math.min(2000, Math.max(0, Math.round(v))) : 0 });
+        },
+      }),
+    );
+  const save = async () => {
+    setSaving(true);
+    setMsg(null);
+    try {
+      await api(API.config, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(cfg),
+      });
+      setMsg({ ok: true, text: "已保存——浮窗位置即时生效（无需重启）" });
+      setTimeout(() => setMsg(null), 2400);
+    } catch (e) {
+      setMsg({ ok: false, text: `保存失败：${e instanceof Error ? e.message : String(e)}` });
+    }
+    setSaving(false);
+  };
+
+  return React.createElement("li", { className: "dm-set-card" + (open ? " dm-set-cardOpen" : "") },
+    React.createElement("button", {
+      type: "button",
+      className: "dm-set-head",
+      "aria-expanded": open,
+      onClick: () => setOpen(!open),
+    },
+      React.createElement("span", { className: "dm-set-headText" },
+        React.createElement("span", { className: "dm-set-name" }, "MCP 管理器（dsh-mcp-manager）"),
+        React.createElement("span", { className: "dm-set-description" }, "浮窗位置 / 水平·垂直·空白偏移"),
+      ),
+      React.createElement("span", { className: "dm-set-chevron" + (open ? " dm-set-chevronOpen" : "") }, "▾"),
+    ),
+    open ? React.createElement("div", { className: "dm-set-body" },
+      React.createElement("div", { className: "dm-set-row" },
+        React.createElement("label", { htmlFor: "dm-set-position" }, "锚点"),
+        React.createElement("select", {
+          id: "dm-set-position",
+          className: "dm-set-input",
+          value: cfg.position,
+          onChange: (e: any) => set({ position: e.target.value }),
+        },
+          React.createElement("option", { value: "top-right" }, "右上（top-right）"),
+          React.createElement("option", { value: "bottom-right" }, "右下（bottom-right）"),
+        ),
+      ),
+      React.createElement("div", { className: "dm-set-row" },
+        numInput("offsetX", "水平偏移"),
+        numInput("offsetY", "垂直偏移"),
+        numInput("blankY", "空白偏移"),
+      ),
+      React.createElement("div", { className: "dm-set-hint" },
+        "保存即热更新：宿主经 SSE events 通道广播一变，所有标签页的浮窗即刻原位更新，无需重启 dsh web。"),
+      React.createElement("div", { className: "dm-set-foot" },
+        msg !== null
+          ? React.createElement("span", { className: msg.ok ? "dm-set-saved" : "dm-set-error" }, msg.text)
+          : null,
+        React.createElement("button", {
+          type: "button",
+          className: "dm-set-save",
+          disabled: saving,
+          onClick: () => { void save(); },
+        }, saving ? "保存中…" : "保存"),
+      ),
+    ) : null,
+  );
+}

--- a/packages/dsh-mcp-manager/src/client/state.ts
+++ b/packages/dsh-mcp-manager/src/client/state.ts
@@ -1,0 +1,139 @@
+/**
+ * dsh-mcp-manager — 客户端状态类型与工厂。
+ *
+ * 所有可变状态收进单一 McpState 对象，在 apply() 内创建，经参数传递到各模块。
+ * 禁止模块级全局变量，确保连续挂载/卸载无残留。
+ */
+
+import { API } from "./constants.js";
+
+/** 单台 MCP 服务器面向 UI 的摘要形态。 */
+export interface McpServerSummary {
+  name: string;
+  transport: string;
+  status: string;
+  scope: string;
+  enabled: boolean;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  error?: string;
+  tools?: string[];
+  toolCallTimeoutMs?: number;
+  description?: string;
+}
+
+/** 各状态计数。 */
+export interface McpCounts {
+  connected?: number;
+  connecting?: number;
+  reconnecting?: number;
+  stopped?: number;
+  disabled?: number;
+  failed?: number;
+}
+
+/** 浮窗 UI 配置（客户端扁平形态，与 host normalizeUiConfig 兼容）。 */
+export interface McpUiConfig {
+  position: string;
+  offsetX: number;
+  offsetY: number;
+  blankY: number;
+}
+
+/** MCP 管理器客户端全部可变状态。 */
+export interface McpState {
+  /** 模态面板遮罩层根元素。 */
+  overlay: any;
+  /** 模态面板卡片根元素。 */
+  card: any;
+  /** 模态面板 body 容器。 */
+  bodyEl: any;
+  /** 模态面板是否打开。 */
+  open: boolean;
+  /** 当前激活的 tab（servers / quick）。 */
+  activeTab: string;
+  /** 服务器列表。 */
+  servers: any[];
+  /** 各状态计数。 */
+  counts: any;
+  /** 正在编辑的服务器名称（undefined 表示新建）。 */
+  editingName: any;
+  /** 正在编辑的服务器原始数据。 */
+  editing: any;
+
+  // 表单 DOM 引用
+  formName: any;
+  formScope: any;
+  formTransport: any;
+  formCommand: any;
+  formArgs: any;
+  formEnv: any;
+  formCwd: any;
+  formUrl: any;
+  formHeaders: any;
+  formEnabled: any;
+
+  // 浮窗状态
+  floatPill: any;
+  floatPanel: any;
+  floatOpen: boolean;
+  currentCwd: any;
+  projectRoot: any;
+  updateFloatState: any;
+  mcpUiConfig: McpUiConfig;
+
+  // 与宿主 ROUTES 一致的路径（单一来源见 src/client/constants.ts）。
+  API: typeof API;
+}
+
+/** 创建初始状态对象。 */
+export function createState(): McpState {
+  return {
+    overlay: undefined,
+    card: undefined,
+    bodyEl: undefined,
+    open: false,
+    activeTab: "servers",
+    servers: [],
+    counts: {},
+    editingName: undefined,
+    editing: undefined,
+    formName: undefined,
+    formScope: undefined,
+    formTransport: undefined,
+    formCommand: undefined,
+    formArgs: undefined,
+    formEnv: undefined,
+    formCwd: undefined,
+    formUrl: undefined,
+    formHeaders: undefined,
+    formEnabled: undefined,
+    floatPill: undefined,
+    floatPanel: undefined,
+    floatOpen: false,
+    currentCwd: undefined,
+    projectRoot: undefined,
+    updateFloatState: undefined,
+    mcpUiConfig: { position: "top-right", offsetX: 8, offsetY: 8, blankY: 40 },
+    API: { ...API },
+  };
+}
+
+/**
+ * 跨模块动作回调集合。
+ * index.ts 装配，避免 feature 模块间循环依赖——各模块通过 actions 调用
+ * 其他模块的功能（如 servers.ts 调用 actions.refresh / actions.resetForm）。
+ */
+export interface UiActions {
+  refresh: () => Promise<boolean>;
+  resetForm: () => void;
+  beginEdit: (server: any) => void;
+  switchTab: (tab: string) => void;
+  close: () => void;
+  showPanel: () => void;
+  toggleFloat: (force?: boolean) => void;
+}


### PR DESCRIPTION
## 背景

issue #18 方案 B3：拆分 `dsh-mcp-manager/src/client/index.ts`（1121 行）为多个 ≤400 行模块。前置 B2（web-file-preview 拆分，PR #137）已合并，本 PR 沿用其手法。

## 改动

按 issue 最后评论的 B3 职责表拆分，并做一处微调（已在说明中标注）：

| 新文件 | 职责 | 行数 |
|---|---|---|
| `constants.ts` | API 路径、STATUS_ORDER/STATUS_TEXT、statusDot | 44 |
| `dom.ts` | `el()`/`api()` 通用工具 | 47 |
| `state.ts` | `McpState` 状态接口 + `createState()` 工厂 + `UiActions` 动作回调接口 | 139 |
| `servers.ts` | `renderServers()`/`renderServer()`/`actionButton()`/`endpointOf()` | 146 |
| `quick-add.ts` | `buildQuickAdd()`/`readForm()`/`formScopeValue()`/`currentCwdBody()`/`parseKV()`/`fillForm()`/`saveForm()`/`beginEdit()`/`resetForm()` | 231 |
| `panel.ts` | `showPanel()`/`close()`/`switchTab()`/`refresh()` + counts 渲染 | 104 |
| `float.ts` | `mountFloat()`/`toggleFloat()`/`placePanel()`/`renderFloatPanel()`/`renderFloatRow()`/`renderPill()` + `conversationHost()`/`panelHost()`/`floatTopOffset()` | 271 |
| `session.ts` | `bindSession()` | 40 |
| `settings-card.ts` | `SettingsCard` React 组件（原计划 .tsx，实际无 JSX 语法，用 .ts） | 120 |
| `index.ts` | `apply()` 装配 + SSE/重试/visibilitychange + `inject`/`export` | 173 |

### 与职责表的出入（说明）

1. **`statusDot()` 归入 `constants.ts`**（与 STATUS_ORDER 配色同源，避免 split 后重复定义）。
2. **API 常量定义在 `constants.ts`**，`state.ts` 以 `{ ...API }` 引用——保证构建产物中 `/api/...` 字面量唯一（smoke 有「client bundle 的 /api/ 路径与 host ROUTES 完全一致」断言，重复字面量会失败）。
3. **`settings-card.tsx` 改为 `settings-card.ts`**：原组件全部用 `React.createElement`、无 JSX 语法，`.tsx` 不在 tsconfig `include`（`src/**/*.ts`）中会导致 tsc 无法解析 import；改 `.ts` 后 tsc/build 均绿。
4. **跨模块动作经 `UiActions` 回调注入**（index.ts 装配）：servers/quick-add/float/session 不直接 import panel/彼此，模块依赖图为单向 `panel → servers/quick-add/float`，无循环依赖。

## 状态管理要点（落实）

- 全部可变状态收进 `apply()` 内创建的单一 `McpState` 对象，经参数传递；`index.ts` 卸载清理用 `Object.assign(state, createState())` 全量重置，HMR/重复 apply 不残留。
- 无任何模块级 `let`/`var`（仅 const 函数与常量）。

## 验证

- `pnpm build && pnpm test && pnpm contract && pnpm pack:check` 全绿（另跑 `pnpm typecheck` 也绿）
- mcp-manager smoke：403/405 围栏、settings 注入（`slots.inject("settings.plugin.item")`）、config 写路由（回归 #125）全过
- 行为零变化：纯搬移 + 防御性 guard（原代码在不可达路径会 TypeError 处加 `?.`/早退，可达路径行为不变）

关联 issue：Refs #18
