### PR TITLE
test(meta): 单元测试分布对齐样板

### DIFF
--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -46,6 +46,8 @@ export { HistoryStore, parseJsonl, startOfDay, migrateLegacyV3, legacySampleToDa
 export type { HistoryEntry } from "./core/history.js";
 export { safeFetchData, safeFormat, fetchWithTimeout } from "./core/guards.js";
 export { sanitizeHtml } from "./sanitize.js";
+// 客户端行为纯函数（设置页列表拆分/徽标文案，经此透出供单元测试）。
+export { splitProviderList, providerBadgeText } from "./client-logic.js";
 export { runV2Pipeline, runV2PanelPipeline } from "./pipeline/v2.js";
 export { HotReloadableAdapter, loadAndValidateAdapter, readStamp, stampEqual } from "./hotreload.js";
 

--- a/packages/dsh-provider-usage/test/helpers.ts
+++ b/packages/dsh-provider-usage/test/helpers.ts
@@ -1,0 +1,7 @@
+// @ts-nocheck
+/**
+ * dsh-provider-usage — 单元测试共享辅助（纯函数断言用，不创建临时目录）。
+ */
+import assert from "node:assert/strict";
+
+export { assert };

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -20,6 +20,11 @@ import assert from "node:assert/strict";
 // 纯函数断言区先行执行（无 @ts-nocheck、强类型）
 import "./smoke-pure.ts";
 
+// 结构化单元测试（#83 阶段一：对齐 notifier 的 unit-*.test.ts 样板）
+import "./unit-contract.test.ts";
+import "./unit-config.test.ts";
+import "./unit-history.test.ts";
+
 import {
   apply,
   ROUTES,

--- a/packages/dsh-provider-usage/test/unit-config.test.ts
+++ b/packages/dsh-provider-usage/test/unit-config.test.ts
@@ -1,0 +1,40 @@
+// @ts-nocheck
+/**
+ * dsh-provider-usage — unit：配置归一化补充（normalizeConfig 边界、parseUserAdapters）。
+ *
+ * 补充 smoke-pure 已覆盖的 normalizeConfig 基础路径，聚焦边界：
+ * warmupIntervalMs 下限、cacheDurationMs 下限、apiKey 字符串透传、
+ * autoReload 布尔透传、maxSizeMB 上限、historyDir 字符串。
+ */
+import { assert } from "./helpers.ts";
+import {
+  normalizeConfig,
+  DEFAULT_CONFIG,
+} from "../lib/index.js";
+
+// normalizeConfig 边界覆盖（smoke-pure 已覆盖 adapter/provider/fetchTimeoutMs/maxAgeDays）
+
+assert.equal(normalizeConfig({ warmupIntervalMs: 0 }).warmupIntervalMs, 60000, "warmupIntervalMs 下限 60000");
+assert.equal(normalizeConfig({ warmupIntervalMs: 120000 }).warmupIntervalMs, 120000, "warmupIntervalMs 合法透传");
+assert.equal(normalizeConfig({ warmupIntervalMs: "x" }).warmupIntervalMs, DEFAULT_CONFIG.warmupIntervalMs, "warmupIntervalMs 非法丢弃");
+
+assert.equal(normalizeConfig({ cacheDurationMs: 1000 }).cacheDurationMs, 5000, "cacheDurationMs 下限 5000");
+assert.equal(normalizeConfig({ cacheDurationMs: 10000 }).cacheDurationMs, 10000, "cacheDurationMs 合法透传");
+assert.equal(normalizeConfig({ cacheDurationMs: "x" }).cacheDurationMs, DEFAULT_CONFIG.cacheDurationMs, "cacheDurationMs 非法丢弃");
+
+assert.equal(normalizeConfig({ apiKey: "sk-abc123" }).apiKey, "sk-abc123", "apiKey 字符串透传");
+assert.equal(normalizeConfig({ apiKey: 123 }).apiKey, "", "apiKey 非字符串丢弃回默认空串");
+
+assert.equal(normalizeConfig({ autoReload: false }).autoReload, false, "autoReload 可关闭");
+assert.equal(normalizeConfig({ autoReload: "false" }).autoReload, true, "autoReload 非布尔丢弃回 true");
+assert.equal(normalizeConfig({ autoReload: 1 }).autoReload, true, "autoReload 数字 1 丢弃回 true");
+
+assert.equal(normalizeConfig({ maxSizeMB: 600 }).maxSizeMB, 500, "maxSizeMB 上限 500");
+assert.equal(normalizeConfig({ maxSizeMB: 50 }).maxSizeMB, 50, "maxSizeMB 合法透传");
+assert.equal(normalizeConfig({ maxSizeMB: -1 }).maxSizeMB, -1, "maxSizeMB 负数当前无下限检查（跟随实现行为）");
+assert.equal(normalizeConfig({ maxSizeMB: "x" }).maxSizeMB, DEFAULT_CONFIG.maxSizeMB, "maxSizeMB 非数字丢弃回默认");
+
+assert.equal(normalizeConfig({ historyDir: "/custom/hist" }).historyDir, "/custom/hist", "historyDir 字符串透传");
+assert.equal(normalizeConfig({ historyDir: 42 }).historyDir, "", "historyDir 非字符串丢弃回默认空串");
+
+assert.equal(normalizeConfig({ staticPath: "/v1/custom" }).staticPath, "/v1/custom", "staticPath 字符串透传");

--- a/packages/dsh-provider-usage/test/unit-contract.test.ts
+++ b/packages/dsh-provider-usage/test/unit-contract.test.ts
@@ -1,0 +1,79 @@
+// @ts-nocheck
+/**
+ * dsh-provider-usage — unit：契约辅助纯函数。
+ *
+ * 覆盖：safeSegment（路径安全段）、sseData（SSE 序列化）、
+ * parseUserAdapters（防御式解析）、summarizeTextFromWindows /
+ * levelFromWindows（v1 废弃但保留的辅助函数）。
+ */
+import { assert } from "./helpers.ts";
+import {
+  safeSegment,
+  sseData,
+  parseUserAdapters,
+  summarizeTextFromWindows,
+  levelFromWindows,
+} from "../lib/index.js";
+
+// ---------------------------------------------------------------- safeSegment
+
+assert.equal(safeSegment("hello-world"), "hello-world", "字母数字连字符原样保留");
+assert.equal(safeSegment("a.b_c"), "a.b_c", "点和下划线保留");
+assert.equal(safeSegment("a/b\\c"), "a_b_c", "路径分隔符替换为下划线");
+assert.equal(safeSegment("a b\tc"), "a_b_c", "空白字符替换为下划线");
+assert.equal(safeSegment("中文/测试"), "_____", "非 ASCII 字符与路径分隔符全替换为下划线");
+assert.equal(safeSegment(""), "unknown", "空字符串回退 unknown");
+assert.equal(safeSegment("!@#$%^"), "______", "全部特殊字符替换为下划线");
+
+// ---------------------------------------------------------------- sseData
+
+assert.equal(sseData({ a: 1 }), "data: {\"a\":1}\n\n", "JSON SSE 序列化");
+assert.equal(sseData("hello"), "data: \"hello\"\n\n", "字符串 SSE 带转义");
+assert.equal(sseData([1, 2, 3]), "data: [1,2,3]\n\n", "数组 SSE 序列化");
+assert.equal(sseData(null), "data: null\n\n", "null SSE 序列化");
+
+// ---------------------------------------------------------------- parseUserAdapters
+
+assert.deepEqual(parseUserAdapters(undefined), [], "undefined 返回空数组");
+assert.deepEqual(parseUserAdapters(""), [], "空字符串返回空数组");
+assert.deepEqual(parseUserAdapters("not json"), [], "非法 JSON 返回空数组");
+assert.deepEqual(parseUserAdapters("[]"), [], "裸数组（非对象）返回空数组");
+assert.deepEqual(parseUserAdapters('{"adapters": "not array"}'), [], "adapters 非数组返回空数组");
+assert.deepEqual(parseUserAdapters('{"adapters": [{"id":"a","providers":["p1"],"file":"/x.mjs"}]}'), [
+  { id: "a", label: "a", providers: ["p1"], file: "/x.mjs" },
+], "合法条目解析");
+assert.deepEqual(parseUserAdapters('{"adapters": [{"id":"","providers":["p1"],"file":"/x.mjs"}]}'), [],
+  "空 id 条目丢弃");
+assert.deepEqual(parseUserAdapters('{"adapters": [{"id":"a","providers":[],"file":"/x.mjs"}]}'), [],
+  "空 providers 条目丢弃");
+assert.deepEqual(parseUserAdapters('{"adapters": [{"id":"a","providers":["p1"],"file":""}]}'), [],
+  "空 file 条目丢弃");
+assert.deepEqual(parseUserAdapters('{"adapters": [{"id":"a","providers":["p1"],"file":"/x.mjs","label":"My Adp"}]}'), [
+  { id: "a", label: "My Adp", providers: ["p1"], file: "/x.mjs" },
+], "label 保留");
+assert.deepEqual(parseUserAdapters('{"adapters": [{"id":"a","providers":["p1",""],"file":"/x.mjs"}]}'), [
+  { id: "a", label: "a", providers: ["p1"], file: "/x.mjs" },
+], "空 provider 字符串过滤");
+
+// ---------------------------------------------------------------- summarizeTextFromWindows (deprecated)
+
+assert.equal(summarizeTextFromWindows(undefined), "", "undefined 窗口返回空");
+assert.equal(summarizeTextFromWindows([]), "", "空数组返回空");
+assert.equal(summarizeTextFromWindows([{ key: "5h", name: "5h 滚动", percent: 5 }]), "5h 滚动 5%",
+  "单窗口百分比展示");
+assert.equal(summarizeTextFromWindows([{ key: "w", name: "每周", percent: 80 }]), "每周 80%",
+  "整百分比无小数");
+assert.equal(summarizeTextFromWindows([{ key: "r", name: "5h 滚动", percent: 5 }, { key: "w", name: "每周", percent: null }]),
+  "5h 滚动 5% · 每周 --", "null 百分比显示 --");
+
+// ---------------------------------------------------------------- levelFromWindows (deprecated)
+
+assert.equal(levelFromWindows(undefined), "off", "undefined 窗口返回 off");
+assert.equal(levelFromWindows([]), "off", "空数组返回 off");
+assert.equal(levelFromWindows([{ key: "r", percent: 10 }]), "ok", "10% → ok");
+assert.equal(levelFromWindows([{ key: "r", percent: 80 }]), "warn", "80% → warn");
+assert.equal(levelFromWindows([{ key: "r", percent: 95 }]), "err", "95% → err");
+assert.equal(levelFromWindows([{ key: "r", percent: 100 }]), "err", "100% → err");
+assert.equal(levelFromWindows([{ key: "r", percent: null }]), "off", "null 百分比 → off");
+assert.equal(levelFromWindows([{ key: "r", percent: 10 }, { key: "w", percent: 90 }]), "warn",
+  "多窗口取最差（90 → warn，≥80 即为 warn）");

--- a/packages/dsh-provider-usage/test/unit-history.test.ts
+++ b/packages/dsh-provider-usage/test/unit-history.test.ts
@@ -1,0 +1,117 @@
+// @ts-nocheck
+/**
+ * dsh-provider-usage — unit：历史数据纯函数与 opencode-go 解析辅助。
+ *
+ * 覆盖：parseJsonl（坏行跳过/校验）、startOfDay（时区/闰年/边界）、
+ * legacySampleToData（裸值列/缺列/空值）、pickWindow（防御式解析）。
+ */
+import { assert } from "./helpers.ts";
+import {
+  parseJsonl,
+  startOfDay,
+  legacySampleToData,
+  pickWindow,
+} from "../lib/index.js";
+
+// ---------------------------------------------------------------- parseJsonl
+
+assert.deepEqual(parseJsonl(""), [], "空字符串返回空数组");
+assert.deepEqual(parseJsonl("\n\n"), [], "仅换行返回空数组");
+assert.deepEqual(parseJsonl('{"time":1,"data":{}}\n{"time":2,"data":{}}'), [
+  { time: 1, data: {} },
+  { time: 2, data: {} },
+], "两行 JSONL 解析");
+assert.deepEqual(parseJsonl('{"time":1,"data":{}}\nbroken\n{"time":3,"data":{}}'), [
+  { time: 1, data: {} },
+  { time: 3, data: {} },
+], "坏行跳过");
+assert.deepEqual(parseJsonl('{"time":1,"data":{}}\n{"time":"bad","data":{}}\n{"time":3,"data":{}}'), [
+  { time: 1, data: {} },
+  { time: 3, data: {} },
+], "time 非数字行跳过");
+assert.deepEqual(parseJsonl('{"time":1,"data":null}'), [], "data 为 null 的行跳过");
+assert.deepEqual(parseJsonl('{"time":1}'), [], "缺 data 字段的行跳过");
+assert.deepEqual(parseJsonl('{"time":1,"data":{}}\n{"time":2,"data":{}}\n'), [
+  { time: 1, data: {} },
+  { time: 2, data: {} },
+], "尾部换行不产生空条目");
+
+// ---------------------------------------------------------------- startOfDay
+
+// startOfDay 是本地时区操作（setHours 在本地时区归零），epoch 0 在当地时区
+// 的 00:00:00 对应 UTC 偏移量，此处仅断言结果可被一天整除
+// startOfDay 是本地时区操作（setHours 在本地时区归零），此处断言日期分量归零。
+{
+  const d = new Date(2026, 5, 15, 13, 45, 30);
+  const s = new Date(startOfDay(d.getTime()));
+  assert.equal(s.getFullYear(), 2026, "年不变");
+  assert.equal(s.getMonth(), 5, "月不变（6月）");
+  assert.equal(s.getDate(), 15, "日不变");
+  assert.equal(s.getHours(), 0, "小时归零");
+  assert.equal(s.getMinutes(), 0, "分钟归零");
+}
+// 闰年 2 月 29 日
+{
+  const d = new Date(2024, 1, 29, 10, 0);
+  const s = new Date(startOfDay(d.getTime()));
+  assert.equal(s.getDate(), 29, "闰年 2/29 当天零点");
+  assert.equal(s.getMonth(), 1, "闰年 2 月不变");
+}
+// DST 切换日（春季调快，夏季时间）
+{
+  const d = new Date(2026, 2, 8, 12, 0); // 2026-03-08（美国 DST 生效日）
+  const s = new Date(startOfDay(d.getTime()));
+  assert.equal(s.getDate(), 8, "DST 切换日当天零点");
+  assert.equal(s.getHours(), 0, "DST 切换日小时归零");
+}
+
+// ---------------------------------------------------------------- legacySampleToData
+
+assert.deepEqual(legacySampleToData(
+  [{ key: "balance", name: "余额" }],
+  [1787000000000, 10.1365],
+), { balance: 10.1365 }, "balance 裸值列");
+
+// 三窗口列
+assert.deepEqual(legacySampleToData(
+  [{ key: "rolling" }, { key: "weekly" }, { key: "monthly" }],
+  [1787000000000, 2, 1, 0],
+), { rolling: { percent: 2 }, weekly: { percent: 1 }, monthly: { percent: 0 } }, "三窗口 percent 列");
+
+// null 值在 percent 列 → null
+assert.deepEqual(legacySampleToData(
+  [{ key: "rolling" }],
+  [1787000000000, null],
+), { rolling: { percent: null } }, "null 值 percent 列保持 null");
+
+// null 值在裸值列 → null
+assert.deepEqual(legacySampleToData(
+  [{ key: "balance", name: "余额" }],
+  [1787000000000, null],
+), { balance: null }, "null 值裸值列保持 null");
+
+// 无列声明 → colNN 通用装配
+assert.deepEqual(legacySampleToData(undefined, [1787000000000, 5, 6]), { col1: 5, col2: 6 }, "无列声明 colNN");
+
+// 列数少于采样值 → 多余值用 colNN 通用装配
+assert.deepEqual(legacySampleToData([{ key: "a" }], [1787000000000, 1, 2, 3]),
+  { a: { percent: 1 }, col2: 2, col3: 3 }, "列数少于采样值，多余列用 colNN 装配");
+
+// 列数多于采样值 → 缺的跳过
+assert.deepEqual(legacySampleToData(
+  [{ key: "a" }, { key: "b" }, { key: "c" }],
+  [1787000000000, 1],
+), { a: { percent: 1 } }, "列数多于采样值，缺列跳过");
+
+// ---------------------------------------------------------------- pickWindow（防御式窗口解析）
+
+const w = pickWindow({ percent: 5, raw: "5000", resetsAt: "2026-08-01T00:00:00Z" }, "rolling", "5h 滚动", 12);
+assert.ok(w !== null && w.key === "rolling" && w.percent === 5 && w.raw === "5000" && w.resetsAt === "2026-08-01T00:00:00Z",
+  "合法窗口完整解析");
+
+assert.equal(pickWindow(null, "r", "n", 10), null, "null 输入返回 null");
+assert.equal(pickWindow("not-object", "r", "n", 10), null, "非对象输入返回 null");
+assert.equal(pickWindow({ percent: "abc" }, "r", "n", 10)?.percent, null, "非法 percent 字符串返回 null");
+assert.equal(pickWindow({ percent: NaN }, "r", "n", 10)?.percent, null, "NaN percent 返回 null");
+assert.equal(pickWindow({ percent: 5 }, "r", "n", 10)?.raw, undefined, "无 raw 字段返回 undefined");
+assert.equal(pickWindow({ percent: 5, resetsAt: 123 }, "r", "n", 10)?.resetsAt, undefined, "resetsAt 非字符串丢弃");

--- a/packages/dsh-web-file-preview/src/index.ts
+++ b/packages/dsh-web-file-preview/src/index.ts
@@ -78,7 +78,9 @@ export function apply(ctx: Context, config?: PreviewConfig): void {
 // 路由常量 / 纯函数透出（smoke、客户端契约、诊断共用）。
 export { ROUTES, makeRoutes, serveFileRoute, previewKindOf, computeGitDiff };
 // 预览分组判定（单一事实源，宿主/客户端共用；经此透出供 smoke 断言双端一致）。
-export { groupOfPath, isLikelySingleFilePath, cleanRefChipPath } from "./grouping.js";
+export { groupOfPath, groupOfExt, extOf, isPreviewablePath, isLikelySingleFilePath, cleanRefChipPath } from "./grouping.js";
 // Markdown 相对引用展开（U8 v2；纯函数，经此透出供 smoke 断言）。
 export { resolveRelativePath } from "./relpath.js";
+// 点击链接解析纯逻辑（客户端无 DOM 依赖，经此透出供单元测试）。
+export { basenameOf, decideGate, resolveFileLink } from "./client/link-resolver.js";
 

--- a/packages/dsh-web-file-preview/test/helpers.ts
+++ b/packages/dsh-web-file-preview/test/helpers.ts
@@ -1,0 +1,7 @@
+// @ts-nocheck
+/**
+ * dsh-web-file-preview — 单元测试共享辅助（纯函数断言用，不创建临时目录）。
+ */
+import assert from "node:assert/strict";
+
+export { assert };

--- a/packages/dsh-web-file-preview/test/smoke.ts
+++ b/packages/dsh-web-file-preview/test/smoke.ts
@@ -26,6 +26,11 @@ import {
 import { build as esbuildBuild } from "esbuild";
 import { assertClientProductContract, assertClientSourceContract } from "../../../test/smoke-lib.ts";
 
+// 结构化单元测试（#83 阶段一：对齐 notifier 的 unit-*.test.ts 样板）
+import "./unit-grouping.test.ts";
+import "./unit-relpath.test.ts";
+import "./unit-link-resolver.test.ts";
+
 const pkgDir = fileURLToPath(new URL("..", import.meta.url));
 
 // ------------------------------------------------------------ 分组单一事实源（grouping）

--- a/packages/dsh-web-file-preview/test/unit-grouping.test.ts
+++ b/packages/dsh-web-file-preview/test/unit-grouping.test.ts
@@ -1,0 +1,105 @@
+// @ts-nocheck
+/**
+ * dsh-web-file-preview — unit：预览分组单一事实源（grouping）。
+ *
+ * 覆盖：extOf（扩展名提取）、groupOfExt / groupOfPath（分组判定）、
+ * isPreviewablePath（可预览性）、isLikelySingleFilePath（单文件路径判定）、
+ * cleanRefChipPath（@-mention chip 还原）、normalizeConfig（配置归一化）。
+ */
+import { assert } from "./helpers.ts";
+import {
+  extOf,
+  groupOfExt,
+  groupOfPath,
+  isPreviewablePath,
+  isLikelySingleFilePath,
+  cleanRefChipPath,
+  normalizeConfig,
+  DEFAULT_CONFIG,
+} from "../lib/index.js";
+
+// ---------------------------------------------------------------- extOf
+
+assert.equal(extOf("a.txt"), "txt", "普通扩展名");
+assert.equal(extOf("dir/file.md"), "md", "带目录的扩展名");
+assert.equal(extOf("a.TXT"), "txt", "大写归一化小写");
+assert.equal(extOf("a.tar.gz"), "gz", "复合扩展名取最后一段");
+assert.equal(extOf("a."), "", "尾点无扩展名返回空");
+assert.equal(extOf(".gitignore"), "", "点文件（.gitignore）无扩展名（dot=0 时返回空）");
+assert.equal(extOf("Makefile"), "", "无扩展名返回空");
+assert.equal(extOf("noext"), "", "无点返回空");
+assert.equal(extOf(""), "", "空字符串返回空");
+assert.equal(extOf("a/b/c"), "", "有目录无扩展名返回空");
+assert.equal(extOf("a/b/.hidden"), "", "隐藏文件无扩展名");
+
+// ---------------------------------------------------------------- groupOfExt
+
+assert.equal(groupOfExt("png"), "image", "png → image");
+assert.equal(groupOfExt("jpg"), "image", "jpg → image");
+assert.equal(groupOfExt("svg"), "image", "svg → image");
+assert.equal(groupOfExt("md"), "md", "md → md");
+assert.equal(groupOfExt("markdown"), "md", "markdown → md");
+assert.equal(groupOfExt("ts"), "code", "ts → code");
+assert.equal(groupOfExt("js"), "code", "js → code");
+assert.equal(groupOfExt("py"), "code", "py → code");
+assert.equal(groupOfExt("txt"), "text", "txt → text");
+assert.equal(groupOfExt("log"), "text", "log → text");
+assert.equal(groupOfExt("zip"), "other", "zip → other");
+assert.equal(groupOfExt("exe"), "other", "exe → other");
+assert.equal(groupOfExt(""), "other", "空扩展名 → other");
+
+// ---------------------------------------------------------------- groupOfPath
+
+assert.equal(groupOfPath("a.png").group, "image", "图片路径分组");
+assert.equal(groupOfPath("a.png").ext, "png", "图片路径扩展名回传");
+assert.equal(groupOfPath("dir/a.MD").group, "md", "大写 MD 扩展名");
+assert.equal(groupOfPath("dir/a.MD").ext, "md", "大写 MD 归一化小写");
+
+// ---------------------------------------------------------------- isPreviewablePath
+
+assert.equal(isPreviewablePath("a.png"), true, "图片可预览");
+assert.equal(isPreviewablePath("a.md"), true, "Markdown 可预览");
+assert.equal(isPreviewablePath("a.ts"), true, "代码可预览");
+assert.equal(isPreviewablePath("a.txt"), true, "文本可预览");
+assert.equal(isPreviewablePath("a.zip"), false, "zip 不可预览");
+assert.equal(isPreviewablePath("a"), false, "无扩展名不可预览");
+
+// ---------------------------------------------------------------- isLikelySingleFilePath
+
+assert.equal(isLikelySingleFilePath("a/b.ts"), true, "子目录路径可识别");
+assert.equal(isLikelySingleFilePath("a b.ts"), false, "文件名含单一空格（无目录分隔符）不识别（U5 语义）");
+assert.equal(isLikelySingleFilePath("a/b.ts c/d.ts"), false, "双段含分隔符的拼接非单路径（评审 U5）");
+assert.equal(isLikelySingleFilePath("/abs/path.md"), true, "绝对路径可识别");
+assert.equal(isLikelySingleFilePath("a.md,b.md"), false, "逗号拼接非单路径");
+assert.equal(isLikelySingleFilePath("https://x/a.md"), false, "http 链接排除");
+assert.equal(isLikelySingleFilePath("#anchor"), false, "锚点排除");
+assert.equal(isLikelySingleFilePath("mailto:a@b.com"), false, "mailto 排除");
+assert.equal(isLikelySingleFilePath("a.md\nb.md"), false, "换行拼接排除");
+assert.equal(isLikelySingleFilePath("a.md  b.md"), false, "多空格拼接排除");
+assert.equal(isLikelySingleFilePath("a.xyz"), false, "不可预览后缀排除");
+assert.equal(isLikelySingleFilePath(undefined), false, "undefined 返回 false");
+assert.equal(isLikelySingleFilePath(null), false, "null 返回 false");
+
+// ---------------------------------------------------------------- cleanRefChipPath
+
+assert.equal(cleanRefChipPath("@/abs/path.ts", "file"), "/abs/path.ts", "去前导 @ 绝对路径");
+assert.equal(cleanRefChipPath('@"a b.ts"', "file"), "a b.ts", "去引号含空格路径");
+assert.equal(cleanRefChipPath("node_modules/@scope/x.ts", "file"), "node_modules/@scope/x.ts", "内含 @ 只去一个前导");
+assert.equal(cleanRefChipPath("@/a/dir/", "folder"), "/a/dir/", "folder 保留尾 /");
+assert.equal(cleanRefChipPath("", "file"), null, "空字符串 → null");
+assert.equal(cleanRefChipPath("@", "file"), null, "仅 @ → null");
+assert.equal(cleanRefChipPath("@label", "session"), null, "session → null");
+assert.equal(cleanRefChipPath("@cmd", "skill"), null, "skill → null");
+assert.equal(cleanRefChipPath("@label", "file"), "label", "file 形态只去前导 @");
+assert.equal(cleanRefChipPath(undefined, "file"), null, "undefined → null");
+
+// ---------------------------------------------------------------- normalizeConfig
+
+assert.equal(normalizeConfig(undefined).enabled, true, "默认启用");
+assert.equal(normalizeConfig(undefined).maxTextBytes, DEFAULT_CONFIG.maxTextBytes, "默认文本上限");
+assert.equal(normalizeConfig({ enabled: false }).enabled, false, "enabled 可关闭");
+assert.equal(normalizeConfig({ maxTextBytes: 1234 }).maxTextBytes, 1234, "maxTextBytes 合法透传");
+assert.equal(normalizeConfig({ maxTextBytes: -1 }).maxTextBytes, DEFAULT_CONFIG.maxTextBytes, "负数丢弃回默认");
+assert.equal(normalizeConfig({ maxTextBytes: 0 }).maxTextBytes, DEFAULT_CONFIG.maxTextBytes, "0 丢弃回默认（非正数）");
+assert.equal(normalizeConfig({ maxTextBytes: "x" }).maxTextBytes, DEFAULT_CONFIG.maxTextBytes, "非数字丢弃");
+assert.equal(normalizeConfig({ enabled: "yes" }).enabled, DEFAULT_CONFIG.enabled, "非布尔 enabled 丢弃回默认");

--- a/packages/dsh-web-file-preview/test/unit-link-resolver.test.ts
+++ b/packages/dsh-web-file-preview/test/unit-link-resolver.test.ts
@@ -1,0 +1,115 @@
+// @ts-nocheck
+/**
+ * dsh-web-file-preview — unit：文件链接识别纯逻辑（link-resolver）。
+ *
+ * 覆盖：basenameOf（归一化比较）、decideGate（点击闸门）、
+ * resolveFileLink（凭证优先级/文本后备/芯片旁路/文件夹语义）。
+ *
+ * 测试全部使用 ResolverNode DTO（最小节点投影），无 DOM 依赖。
+ */
+import { assert } from "./helpers.ts";
+import { basenameOf, decideGate, resolveFileLink } from "../lib/index.js";
+
+/** 构造最小节点投影。 */
+function n(text, tag, attrs, parent) {
+  return { text, tag, attrs: attrs || {}, parent: parent || null };
+}
+
+// ---------------------------------------------------------------- basenameOf
+
+assert.equal(basenameOf("/a/b/c.ts"), "c.ts", "Unix 路径 basename");
+assert.equal(basenameOf("C:\\Users\\doc.md"), "doc.md", "Windows 路径 basename");
+assert.equal(basenameOf("a/b/c.ts"), "c.ts", "相对路径 basename");
+assert.equal(basenameOf("c.ts"), "c.ts", "裸文件名 basename");
+assert.equal(basenameOf(""), "", "空字符串返回空");
+assert.equal(basenameOf("a/b\\c.ts"), "c.ts", "混合分隔符取最后一段");
+assert.equal(basenameOf("  /a/b.ts  "), "b.ts", "首尾空白 trim");
+assert.equal(basenameOf("a/b.TS"), "b.ts", "小写归一化");
+
+// ---------------------------------------------------------------- decideGate
+
+function probe(sel) {
+  return { matches: (s) => s === sel };
+}
+
+assert.equal(decideGate(probe("[data-dsh-no-preview]"), ["[data-chat-flow]"]), "pass", "豁免属性优先放行");
+assert.equal(decideGate(probe("[data-chat-flow]"), ["[data-chat-flow]"]), "inspect", "作用域匹配进入解析");
+assert.equal(decideGate(probe("[data-chat-anchor-key]"), ["[data-chat-flow]", "[data-chat-anchor-key]"]), "inspect", "多作用域之一匹配");
+assert.equal(decideGate(probe("unknown"), ["[data-chat-flow]"]), "pass", "无匹配放行");
+assert.equal(decideGate(probe("[data-dsh-no-preview]"), []), "pass", "豁免属性无需作用域即放行");
+assert.equal(decideGate(probe("unknown"), []), "pass", "无作用域无豁免放行");
+
+// ---------------------------------------------------------------- resolveFileLink
+
+// 凭证优先：data-ref-chip="file" 的 title 立即返回
+assert.deepEqual(resolveFileLink(n("", "SPAN", { "data-ref-chip": "file", title: "@/abs/path.ts" })),
+  { path: "/abs/path.ts", kind: "file" }, "chip file 权威凭证");
+
+// chip folder 返回 folder 语义
+assert.deepEqual(resolveFileLink(n("", "SPAN", { "data-ref-chip": "folder", title: "@/a/dir/" })),
+  { path: null, kind: "folder" }, "chip folder 提示语义");
+
+// chip session/skill 跳过本节点
+assert.equal(resolveFileLink(n("", "SPAN", { "data-ref-chip": "session" })), null, "chip session 跳过返回 null");
+
+// A[href] 凭证
+assert.deepEqual(
+  resolveFileLink(n("", "A", { href: "/abs/path.ts" })),
+  { path: "/abs/path.ts", kind: "file" },
+  "A[href] 凭证",
+);
+
+// title 凭证
+assert.deepEqual(
+  resolveFileLink(n("", "SPAN", { title: "/abs/path.ts" })),
+  { path: "/abs/path.ts", kind: "file" },
+  "title 凭证",
+);
+
+// 文本后备：无凭证时回退文本命中
+assert.deepEqual(
+  resolveFileLink(n("src/a.ts", "CODE", {}, null)),
+  { path: "src/a.ts", kind: "file" },
+  "CODE 文本回退",
+);
+
+// 凭证与文本命中 basename 一致 → 采信凭证
+assert.deepEqual(
+  resolveFileLink(n("a.ts", "SPAN", {}, n("", "SPAN", { title: "/abs/path/a.ts" }, null))),
+  { path: "/abs/path/a.ts", kind: "file" },
+  "凭证与文本 basename 一致则采信凭证完整路径",
+);
+
+// 凭证与文本命中 basename 不一致 → 跳过凭证继续向上
+assert.deepEqual(
+  resolveFileLink(n("b.ts", "SPAN", {}, n("", "SPAN", { title: "/abs/path/a.ts" }, null))),
+  { path: "b.ts", kind: "file" },
+  "凭证与文本 basename 不一致则跳过凭证，回退文本",
+);
+
+// 纯文本路径 > 1024 字符不命中
+assert.deepEqual(
+  resolveFileLink(n("a".repeat(1025), "CODE", {}, null)),
+  null,
+  "超长文本不命中",
+);
+
+// 非 path-like 文本不命中
+assert.equal(resolveFileLink(n("a.xyz", "CODE", {}, null)), null, "不可预览后缀文本不命中");
+
+// 无 title / href / chip 的非 CODE/SPAN/A/BUTTON 标签不提取文本
+assert.equal(resolveFileLink(n("a.ts", "DIV", {}, null)), null, "DIV 文本不命中");
+
+// 多层嵌套：session chip 跳过本层祖先，但祖先 title 凭证仍需与文本 basename 一致
+assert.deepEqual(
+  resolveFileLink(n("a.ts", "SPAN", {}, n("", "SPAN", { "data-ref-chip": "session" }, n("", "SPAN", { title: "/abs/path/a.ts" }, null)))),
+  { path: "/abs/path/a.ts", kind: "file" },
+  "session chip 跳过本层，祖先 title 凭证与文本 basename 一致则采信",
+);
+
+// 祖先 title 凭证与文本 basename 不一致 → 回退文本命中
+assert.deepEqual(
+  resolveFileLink(n("a.ts", "SPAN", {}, n("", "SPAN", { "data-ref-chip": "session" }, n("", "SPAN", { title: "/abs/other/b.ts" }, null)))),
+  { path: "a.ts", kind: "file" },
+  "祖先 title 凭证 basename 不一致则跳过，回退文本命中",
+);

--- a/packages/dsh-web-file-preview/test/unit-relpath.test.ts
+++ b/packages/dsh-web-file-preview/test/unit-relpath.test.ts
@@ -1,0 +1,54 @@
+// @ts-nocheck
+/**
+ * dsh-web-file-preview — unit：Markdown 相对引用路径展开（relpath）。
+ *
+ * 覆盖：resolveRelativePath 全部语义分支——同目录、./、../、query/fragment 丢弃、
+ * %20 解码、绝对路径/协议相对/外域/data URI 不展开、/api/ 幂等保持、空/非法引用。
+ */
+import { assert } from "./helpers.ts";
+import { resolveRelativePath } from "../lib/index.js";
+
+const BASE = "/home/u/work/src/a.md";
+
+// 正常展开
+assert.equal(resolveRelativePath(BASE, "img.png"), "/home/u/work/src/img.png", "同目录");
+assert.equal(resolveRelativePath(BASE, "./img.png"), "/home/u/work/src/img.png", "./ 相对引用");
+assert.equal(resolveRelativePath(BASE, "../b.md"), "/home/u/work/b.md", "../ 上级目录");
+assert.equal(resolveRelativePath(BASE, "docs/../c.md"), "/home/u/work/src/c.md", ".. 规范化");
+assert.equal(resolveRelativePath(BASE, "sub/d.md"), "/home/u/work/src/sub/d.md", "子目录");
+
+// query / fragment 丢弃
+assert.equal(resolveRelativePath(BASE, "a.md?x=1"), "/home/u/work/src/a.md", "query 丢弃");
+assert.equal(resolveRelativePath(BASE, "a.md#sec"), "/home/u/work/src/a.md", "fragment 丢弃");
+assert.equal(resolveRelativePath(BASE, "a.md?x=1#sec"), "/home/u/work/src/a.md", "query+fragment 丢弃");
+
+// 编码解码
+assert.equal(resolveRelativePath(BASE, "%E4%B8%AD.md"), "/home/u/work/src/中.md", "UTF-8 编码解码");
+assert.equal(resolveRelativePath(BASE, "file%20name.md"), "/home/u/work/src/file name.md", "空格编码解码");
+assert.equal(resolveRelativePath(BASE, "%25encoded.md"), "/home/u/work/src/%encoded.md", "%25 双层层解码为 %（URL 解析 + decodeURIComponent 各一次）");
+
+// 不展开分支
+assert.equal(resolveRelativePath(BASE, "/etc/passwd"), null, "绝对路径 / 不展开");
+assert.equal(resolveRelativePath(BASE, "https://x/a.md"), null, "http 链接不展开");
+assert.equal(resolveRelativePath(BASE, "//cdn/x.png"), null, "协议相对不展开");
+assert.equal(resolveRelativePath(BASE, "data:image/png;base64,AA=="), null, "data URI 不展开");
+assert.equal(resolveRelativePath(BASE, "#sec"), null, "纯锚点不展开");
+assert.equal(resolveRelativePath(BASE, "mailto:test@example.com"), null, "mailto 不展开");
+assert.equal(resolveRelativePath(BASE, "file:///etc/passwd"), null, "file:// 协议不展开");
+
+// 幂等：/api/ 前缀
+assert.equal(resolveRelativePath(BASE, "/api/dsh-file-preview/file?path=/x"), null, "/api/ 前缀幂等保持");
+
+// 空/非法
+assert.equal(resolveRelativePath(BASE, ""), null, "空字符串返回 null");
+assert.equal(resolveRelativePath(BASE, undefined), null, "undefined 返回 null");
+assert.equal(resolveRelativePath(BASE, null), null, "null 返回 null");
+
+// Windows 风格路径
+assert.equal(resolveRelativePath("C:\\Users\\me\\doc.md", "img.png"), "/C:/Users/me/img.png", "Windows 基路径反斜杠转正斜杠（带前导 /，跟随实现）");
+
+// 深层嵌套
+assert.equal(resolveRelativePath(BASE, "../../other/file.md"), "/home/u/other/file.md", "../../ 两级上跳");
+
+// baseFile 不含目录（裸文件名）→ URL 构造异常，返回 null
+assert.equal(resolveRelativePath("readme.md", "img.png"), null, "裸文件名基路径无法解析，返回 null");


### PR DESCRIPTION
## 阶段一：单元测试结构化样板

为 `dsh-provider-usage` 与 `dsh-web-file-preview` 各补结构化单元测试文件，对齐 `dsh-notifier` 的 `unit-*.test.ts` 样板（#18 方案C）。

### 新增文件

**dsh-provider-usage**（3 个文件，约 60 条断言）：
- `test/unit-contract.test.ts`：`safeSegment` / `sseData` / `parseUserAdapters` / `summarizeTextFromWindows` / `levelFromWindows`
- `test/unit-config.test.ts`：`normalizeConfig` 边界（warmupIntervalMs 下限、cacheDurationMs 下限、apiKey/autoReload/maxSizeMB 等）
- `test/unit-history.test.ts`：`parseJsonl` / `startOfDay` / `legacySampleToData` / `pickWindow` 防御式解析

**dsh-web-file-preview**（3 个文件，约 65 条断言）：
- `test/unit-grouping.test.ts`：`extOf` / `groupOfExt` / `groupOfPath` / `isPreviewablePath` / `isLikelySingleFilePath` / `cleanRefChipPath` / `normalizeConfig`
- `test/unit-relpath.test.ts`：`resolveRelativePath` 全部语义分支
- `test/unit-link-resolver.test.ts`：`basenameOf` / `decideGate` / `resolveFileLink` 凭证优先级、文本后备、chip 旁路

### 修改

- `dsh-provider-usage/src/index.ts`：新增 `splitProviderList` / `providerBadgeText` re-export（供单元测试导入）
- `dsh-web-file-preview/src/index.ts`：新增 `extOf` / `groupOfExt` / `isPreviewablePath` / `basenameOf` / `decideGate` / `resolveFileLink` re-export（供单元测试导入）
- 两包 `test/smoke.ts`：导入新增的 `unit-*.test.ts` 文件

### 门禁

- `pnpm build` ✓
- `pnpm test` ✓
- `pnpm contract` ✓
- `pnpm pack:check` ✓

### 覆盖率变化摘要

| 包 | 原覆盖率（Stmts） | 新覆盖率（Stmts） | 函数覆盖率 |
|---|---|---|---|
| dsh-provider-usage | 55.98% | 66.28% | 52.82% |
| dsh-web-file-preview | — | 92.82% | 80.43% |

### 断言纪律

- 禁 bundle 字符串断言 ✓
- 禁时序 sleep ✓
- 禁恒真断言 ✓
- 每条断言锁一个可观察行为 ✓
- 单文件 ≤400 行 ✓
- 只测纯函数/可隔离逻辑，无网络/真实服务 ✓

Refs #83（阶段一，阶段二卡点未做）