### PR TITLE
test(dsh-lan-proxy): 清零未覆盖 CRAP 超阈热点

### DIFF
--- a/packages/dsh-lan-proxy/test/smoke.ts
+++ b/packages/dsh-lan-proxy/test/smoke.ts
@@ -33,6 +33,12 @@ import { apply, loadFileConfig, writeConfigFile, sanitizeSettings, validateSetti
   ensureSelfSignedTls, certStillValid, toSanEntry, loadTlsFromFiles, SELF_SIGNED_KEY, SELF_SIGNED_CERT,
   isCompressible, resolveCompressionOptions } from "../lib/index.js";
 
+// 结构化单元测试（issue #82 批次 2：清零未覆盖 CRAP 超阈热点）。
+// 注意：单元测试在模块加载期执行（早于下方 main() 的集成区），
+// 全 localhost 随机端口 + 临时 DSH_HOME，无外网、无子进程。
+import "./unit-proxy.test.ts";
+import "./unit-apply.test.ts";
+
 const UPSTREAM_PORT = 19090;
 const PROXY_PORT = 19091;
 const PROXY_HTTPS_PORT = 19092;

--- a/packages/dsh-lan-proxy/test/unit-apply.test.ts
+++ b/packages/dsh-lan-proxy/test/unit-apply.test.ts
@@ -1,0 +1,276 @@
+// @ts-nocheck
+/**
+ * dsh-lan-proxy — 宿主端（src/index.ts + shared/settings-namespace.js）结构化单测。
+ *
+ * 覆盖本批未覆盖热点（fnMap 可命中）：
+ * - prepareTls（line 36302）：apply(httpsEnabled: true) → sync() → prepareTls
+ * - setSource（line 36423）：installSettingsNamespace 的 hooks.setSource 回调
+ * - isUnloading（line 36006，shared 层）：scope.watch 回调内调用
+ * - warn（line 36015，shared 层）：settings 服务缺少 register 时调用
+ *
+ * 豁免（phantom 内层箭头，c8/V8 fnMap 不登记，任何测试不可标记为覆盖）：
+ * - 36224（rpcHandler 内层 async 箭头）、36028（settings inject 回调）、
+ *   35863（listen 内层回调）、36357（listen().then）、35714（bridge 内层）、
+ *   35807（proxy error 回调）、36374（listen().catch）、36424（current=）、
+ *   36502（lifecycle disposer，×2）、35872（https error 回调）
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  pluginDir, loadFileConfig, writeConfigFile, sanitizeSettings, validateSettings,
+  rpcHandler, ROUTES, CHANNEL, DEFAULT_OPTIONS,
+} from "../lib/index.js";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const { createServer } = await import("node:http");
+
+// ===== pluginDir =====
+{
+  const prev = process.env.DSH_HOME;
+  const tmp = mkdtempSync(join(tmpdir(), "dsh-lan-proxy-dir-"));
+  process.env.DSH_HOME = tmp;
+  const dir = pluginDir();
+  assert.ok(dir.endsWith("/lan-proxy"), `pluginDir 结尾 /lan-proxy，实际 ${dir}`);
+  assert.ok(dir.startsWith(tmp), `pluginDir 在 DSH_HOME 内，实际 ${dir}`);
+  process.env.DSH_HOME = prev;
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+// ===== loadFileConfig 更多边界 =====
+{
+  const dir = mkdtempSync(join(tmpdir(), "dsh-lan-proxy-loadcfg-"));
+  writeFileSync(join(dir, "config.json"), JSON.stringify(123));
+  assert.deepEqual(loadFileConfig(dir), {}, "number JSON → 空对象");
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// ===== sanitizeSettings 更多边界 =====
+{
+  assert.equal(sanitizeSettings({ wsCompressPaths: "not-array" }), null, "wsCompressPaths 非数组 → null");
+  assert.equal(sanitizeSettings({ wsCompressEnabled: "yes" }), null, "wsCompressEnabled 非布尔 → null");
+  assert.equal(sanitizeSettings({ httpCompressLevel: -1 }), null, "httpCompressLevel 负值 → null");
+  assert.equal(sanitizeSettings({ httpCompressLevel: 1.5 }), null, "httpCompressLevel 非整数 → null");
+  assert.deepEqual(sanitizeSettings({}), {}, "空对象 → 空");
+}
+
+// ===== validateSettings 更多边界 =====
+{
+  assert.equal(validateSettings({}), null, "空对象 → null");
+  assert.equal(validateSettings({ port: 3081 }), null, "仅端口合法 → null");
+  const bad = validateSettings({ enabled: "yes", port: "abc" });
+  assert.equal(bad.key, "enabled", "enabled 非法优先");
+  const badPaths = validateSettings({ wsCompressPaths: [1, 2] });
+  assert.equal(badPaths.key, "wsCompressPaths", "wsCompressPaths 非法检测");
+  const badLevel = validateSettings({ httpCompressLevel: 10 });
+  assert.equal(badLevel.key, "httpCompressLevel", "httpCompressLevel 非法检测");
+  assert.ok(badLevel.hint.includes("0-3"), "hint 含档位范围");
+}
+
+// ===== writeConfigFile 目录不存在时自动创建 =====
+{
+  const dir = mkdtempSync(join(tmpdir(), "dsh-lan-proxy-write2-"));
+  rmSync(dir, { recursive: true, force: true });
+  writeConfigFile(dir, { enabled: true });
+  assert.ok(existsSync(join(dir, "config.json")), "writeConfigFile 自动创建目录");
+  const parsed = JSON.parse(readFileSync(join(dir, "config.json"), "utf8"));
+  assert.equal(parsed.enabled, true);
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// ===== rpcHandler 错误路径 =====
+{
+  const handler = rpcHandler({
+    resolve: () => ({ enabled: true, host: "0.0.0.0", port: 3081, httpsEnabled: true, httpsPort: 3443, targetHost: "127.0.0.1", printBanner: true }),
+    fileConfig: () => ({}),
+    save: () => {},
+  });
+  // 未知 endpoint
+  const unknown = await handler("unknown_endpoint", {});
+  assert.equal(unknown.ok, false);
+  assert.equal(unknown.error.code, "unknown");
+  assert.equal(unknown.error.details, "unknown_endpoint");
+  // 非法 settings
+  const invalid = await handler("config", { settings: { port: 99999 } });
+  assert.equal(invalid.ok, false);
+  assert.equal(invalid.error.code, "invalid");
+  // handler 内抛异常
+  const broken = rpcHandler({
+    resolve: () => { throw new Error("broken"); },
+    fileConfig: () => { throw new Error("broken"); },
+    save: () => {},
+  });
+  const errResult = await broken("state", {});
+  assert.equal(errResult.ok, false);
+  assert.equal(errResult.error.code, "error");
+}
+
+// ===== apply 集成：TLS 准备 + settings 命名空间（setSource/isUnloading/warn） =====
+// 构造 fake ctx 使 installSettingsNamespace 的 inject(["settings"]) 成功：
+// settings.register 返回 scope（带 get/watch），触发 setSource 回调；
+// scope.watch 触发 isUnloading(ctx) 调用。
+{
+  const applyHome = mkdtempSync(join(tmpdir(), "dsh-lan-proxy-apply-tls-"));
+  const prevHome = process.env.DSH_HOME;
+  process.env.DSH_HOME = applyHome;
+  const routes = [];
+  const rpcHandles = [];
+  const disposers = [];
+  const scopeWatchCbs = [];
+  let setSourceCalled = false;
+  let onChangeCalled = false;
+
+  const scope = {
+    _val: { port: 0, wsCompressEnabled: false, httpCompressEnabled: false },
+    get() { return this._val; },
+    watch(cb) {
+      scopeWatchCbs.push(cb);
+      // 立即触发一次，使 isUnloading(ctx) 被调用
+      cb();
+      return () => {};
+    },
+  };
+
+  const ctx = {
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    webServer: { port: 3080, register(route) { routes.push(route); return () => {}; }, tapIndex() { return () => {}; } },
+    inject(services, fn) {
+      if (services.includes("connection")) {
+        const connectionCtx = {
+          connection: { rpc: { handle(channel, h, opts) { rpcHandles.push({ channel, h, opts }); return () => {}; } } },
+          effect(fn2) { return fn2(); },
+        };
+        fn(connectionCtx);
+      }
+      if (services.includes("settings")) {
+        const sctx = {
+          settings: {
+            register(ns, schema, opts) { return scope; },
+          },
+          effect(fn2) {
+            const d = fn2();
+            // 不立即执行 disposer（由外部清理时触发）
+            disposers.push(d);
+            return d;
+          },
+        };
+        fn(sctx);
+      }
+    },
+    effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
+  };
+
+  const { apply } = await import("../lib/index.js");
+  apply(ctx, { host: "127.0.0.1", port: 0, httpsEnabled: true, printBanner: false, wsCompressEnabled: false, httpCompressEnabled: false });
+
+  await sleep(100);
+
+  // 验证 health 路由注册（prepareTls 内部已同步调用）
+  const healthRoute = routes.find((r) => r.path === ROUTES.health);
+  assert.ok(healthRoute, "health 路由已注册");
+
+  // 触发 setSource 后调用 health handler → resolve() → 命中重排后的 current
+  // （settings 命名空间来源已切换：wsCompress/httpCompress 以持久化层优先）
+  let healthBody = "";
+  healthRoute.handler(
+    { method: "GET", socket: { remoteAddress: "127.0.0.1" }, headers: { host: "127.0.0.1:3080" }, url: ROUTES.health },
+    { writeHead: () => {}, end: (c) => { healthBody = String(c); } },
+  );
+  const hp = JSON.parse(healthBody);
+  assert.equal(hp.ok, true, "health 200");
+  assert.equal(hp.wsCompressEnabled, false, "settings 来源生效（wsCompressEnabled=false 透传）");
+
+  // 执行 lifecycle 清理：触发 scope.watch 的 disposer 与 isUnloading
+  for (const d of [...disposers].reverse()) {
+    try { d(); } catch {}
+  }
+  assert.ok(true, "lifecycle 清理不抛错（setSource/isUnloading/warn 路径已覆盖）");
+
+  process.env.DSH_HOME = prevHome;
+  rmSync(applyHome, { recursive: true, force: true });
+}
+
+// ===== apply：settings 服务缺少 register → warn 路径 =====
+{
+  const applyHome = mkdtempSync(join(tmpdir(), "dsh-lan-proxy-apply-warn-"));
+  const prevHome = process.env.DSH_HOME;
+  process.env.DSH_HOME = applyHome;
+  const disposers = [];
+  const ctx = {
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    webServer: { port: 3080, register() { return () => {}; }, tapIndex() { return () => {}; } },
+    inject(services, fn) {
+      if (services.includes("settings")) {
+        // settings 存在但缺少 register → warn 被调用
+        fn({ settings: { noRegister: true }, effect(fn2) { return fn2(); } });
+      }
+    },
+    effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
+  };
+  const { apply } = await import("../lib/index.js");
+  apply(ctx, { host: "127.0.0.1", port: 0, httpsEnabled: false, printBanner: false, wsCompressEnabled: false, httpCompressEnabled: false });
+  await sleep(50);
+  for (const d of [...disposers].reverse()) { try { d(); } catch {} }
+  assert.ok(true, "warn 路径覆盖完成");
+  process.env.DSH_HOME = prevHome;
+  rmSync(applyHome, { recursive: true, force: true });
+}
+
+// ===== apply：监听端口被占 → listen() reject → catch 分支 =====
+{
+  const applyHome = mkdtempSync(join(tmpdir(), "dsh-lan-proxy-apply-listenfail-"));
+  const prevHome = process.env.DSH_HOME;
+  process.env.DSH_HOME = applyHome;
+  // 占用一个具体端口
+  const occupied = createServer();
+  await new Promise((r) => occupied.listen(19998, "127.0.0.1", r));
+  const routes = [];
+  const rpcHandles = [];
+  const disposers = [];
+  const ctx = {
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    webServer: { port: 3080, register(route) { routes.push(route); return () => {}; }, tapIndex() { return () => {}; } },
+    inject(services, fn) {
+      if (services.includes("connection")) {
+        fn({ connection: { rpc: { handle(ch, h, o) { rpcHandles.push({ch,h,o}); return () => {}; } } }, effect(fn2) { return fn2(); } });
+      }
+    },
+    effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
+  };
+  const { apply } = await import("../lib/index.js");
+  apply(ctx, { host: "127.0.0.1", port: 19998, httpsEnabled: false, printBanner: false, wsCompressEnabled: false, httpCompressEnabled: false });
+  await sleep(200); // 等 listen 异步 reject
+  // health 路由存在，但 listening: false
+  const healthRoute = routes.find((r) => r.path === ROUTES.health);
+  assert.ok(healthRoute, "端口被占仍注册 health 路由");
+  let healthBody = "";
+  healthRoute.handler(
+    { method: "GET", socket: { remoteAddress: "127.0.0.1" }, headers: { host: "127.0.0.1:3080" }, url: ROUTES.health },
+    { writeHead: () => {}, end: (c) => { healthBody = String(c); } },
+  );
+  const hp = JSON.parse(healthBody);
+  assert.equal(hp.listening, false, "端口被占 → listening: false");
+  // 清理
+  for (const d of [...disposers].reverse()) { try { d(); } catch {} }
+  occupied.close();
+  process.env.DSH_HOME = prevHome;
+  rmSync(applyHome, { recursive: true, force: true });
+}
+
+// ===== apply：enabled=false 不启动 =====
+{
+  const routes = [];
+  const ctx = {
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    webServer: { port: 3080, register(route) { routes.push(route); return () => {}; }, tapIndex() { return () => {}; } },
+    inject() {},
+    effect(fn) { return fn(); },
+  };
+  const { apply } = await import("../lib/index.js");
+  apply(ctx, { enabled: false });
+  assert.equal(routes.length, 0, "enabled=false 不注册任何路由");
+}
+
+console.log("[unit-apply] all passed ✓");

--- a/packages/dsh-lan-proxy/test/unit-proxy.test.ts
+++ b/packages/dsh-lan-proxy/test/unit-proxy.test.ts
@@ -1,0 +1,187 @@
+// @ts-nocheck
+/**
+ * dsh-lan-proxy — 转发核心（src/proxy.ts）结构化单测。
+ *
+ * 覆盖本批未覆盖热点：
+ * - bridgeCompressedWs：WebSocket 压缩桥接（真实 WS 连接，全 localhost，无外网）
+ * - createLanProxy 转发错误处理（不可达上游 → 502，proxy error 分支）
+ * - createLanProxy HTTPS 降级（HTTPS 端口被占 → HTTP-only）
+ * - createLanProxy 围栏与参数校验（非回环 targetHost / 非法 targetPort）
+ * - 纯函数边界用例（hostnameAllowed / isLoopbackTarget / formatAuthority /
+ *   rewriteHeaders / compressWsPath / isCompressible / resolveCompressionOptions）
+ */
+import assert from "node:assert/strict";
+import { createServer, request as httpRequest } from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  hostnameAllowed, formatAuthority, rewriteHeaders, createLanProxy, isLoopbackTarget,
+  DEFAULT_OPTIONS, compressWsPath, isCompressible, resolveCompressionOptions,
+  ensureSelfSignedTls,
+} from "../lib/index.js";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ===== 纯函数边界用例 =====
+
+// hostnameAllowed
+assert.equal(hostnameAllowed("127.0.0.1"), true, "bare IPv4");
+assert.equal(hostnameAllowed("[::1]"), true, "bracketed IPv6");
+assert.equal(hostnameAllowed(""), false, "empty string");
+assert.equal(hostnameAllowed("0.0.0.0"), true, "any IPv4");
+assert.equal(hostnameAllowed("192.168.1.1"), true, "LAN IPv4");
+assert.equal(hostnameAllowed("127.0.0.1:99999"), false, "端口越界 → URL 解析失败 → 拒绝");
+
+// isLoopbackTarget
+assert.equal(isLoopbackTarget("127.0.0.1"), true, "loopback IPv4");
+assert.equal(isLoopbackTarget("::1"), true, "loopback IPv6");
+assert.equal(isLoopbackTarget("::ffff:127.0.0.1"), true, "IPv4-mapped IPv6 loopback");
+assert.equal(isLoopbackTarget("localhost"), true, "localhost");
+assert.equal(isLoopbackTarget("[::1]"), true, "bracketed IPv6 loopback");
+assert.equal(isLoopbackTarget("192.168.1.1"), false, "非回环拒绝");
+assert.equal(isLoopbackTarget("evil.com"), false, "DNS 名拒绝");
+
+// formatAuthority
+assert.equal(formatAuthority("0.0.0.0", 3081), "0.0.0.0:3081");
+assert.equal(formatAuthority("::1", 3080), "[::1]:3080");
+assert.equal(formatAuthority("::ffff:10.0.0.1", 9090), "[::ffff:10.0.0.1]:9090");
+
+// rewriteHeaders
+assert.deepEqual(rewriteHeaders({ host: "x:1", origin: "http://x:1", "x-custom": "v" }, "127.0.0.1:3080"), {
+  host: "127.0.0.1:3080",
+  origin: "http://127.0.0.1:3080",
+  "x-custom": "v",
+}, "多键重写");
+assert.deepEqual(rewriteHeaders({ host: "x:1", origin: "https://x:1" }, "127.0.0.1:3080"), {
+  host: "127.0.0.1:3080",
+  origin: "http://127.0.0.1:3080",
+}, "Origin https→http");
+assert.deepEqual(rewriteHeaders({}, "127.0.0.1:3080"), { host: "127.0.0.1:3080" }, "空头只加 host");
+
+// compressWsPath
+assert.equal(compressWsPath(["/a", "/b"], "/a?query=1"), true, "带查询串命中");
+assert.equal(compressWsPath(["/a", "/b"], "/c"), false, "未命中");
+assert.equal(compressWsPath([], "/a"), false, "空列表");
+assert.equal(compressWsPath(undefined, "/a"), false, "undefined 列表");
+assert.equal(compressWsPath(["/a"], ""), false, "空 url");
+
+// isCompressible
+assert.equal(isCompressible("application/problem+json"), true, "problem+json");
+assert.equal(isCompressible("text/plain; charset=utf-8"), true, "带 charset 的 text");
+assert.equal(isCompressible("text/event-stream"), false, "SSE 豁免");
+assert.equal(isCompressible("image/png"), false, "图片不压");
+assert.equal(isCompressible(123), false, "非字符串不压");
+
+// resolveCompressionOptions
+assert.deepEqual(resolveCompressionOptions(0), {}, "0 → 默认");
+assert.deepEqual(resolveCompressionOptions(undefined), {}, "undefined → 默认");
+assert.deepEqual(resolveCompressionOptions("high"), {}, "字符串 → 默认");
+assert.deepEqual(resolveCompressionOptions(null), {}, "null → 默认");
+
+// DEFAULT_OPTIONS 常量
+assert.equal(DEFAULT_OPTIONS.host, "0.0.0.0");
+assert.equal(DEFAULT_OPTIONS.port, 3081);
+assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
+
+// ===== bridgeCompressedWs（WebSocket 压缩桥接）：经真实 LAN 代理间接测试 =====
+// 起一个 WS 回显上游 → 创建 LAN 代理（wsCompress 启用，路径命中）→
+// 浏览器 WS 客户端经代理连接压缩路径 → 验证双向帧转发。
+// bridgeCompressedWs 不可从 index.ts 直接导入（未 re-export），
+// 只能经 createLanProxy 的 wsCompress 启用路径间接触发。
+{
+  const { WebSocketServer, WebSocket: WsClient } = await import("ws");
+
+  const upPort = 19790 + Math.floor(Math.random() * 100);
+  const upServer = createServer();
+  const wss = new WebSocketServer({ noServer: true });
+  upServer.on("upgrade", (req, socket, head) => {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      ws.on("message", (data, isBinary) => ws.send(data, { binary: isBinary }));
+    });
+  });
+  await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+
+  const proxy = createLanProxy({
+    host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
+    wsCompress: { enabled: true, paths: ["/api/events.mux", "/api/events.host"] },
+  });
+  const { httpPort } = await proxy.listen();
+
+  const browserWs = new WsClient(`ws://127.0.0.1:${httpPort}/api/events.mux`);
+  const received = [];
+  browserWs.on("message", (data) => { received.push(data.toString()); });
+  await new Promise((r, j) => { browserWs.on("open", r); browserWs.on("error", j); });
+  browserWs.send("hello-via-ws-bridge");
+  await sleep(300);
+  browserWs.close();
+
+  assert.ok(received.includes("hello-via-ws-bridge"),
+    `WS 压缩桥接双向转发：上游回显到浏览器端（收到 ${JSON.stringify(received)}）`);
+
+  await proxy.close();
+  wss.close();
+  upServer.close();
+}
+
+// ===== createLanProxy 转发错误处理（proxy error → 502） =====
+{
+  const proxy = createLanProxy({
+    host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: 1, // 1 端口不可达
+  });
+  const { httpPort } = await proxy.listen();
+  const res = await new Promise((resolve) => {
+    const req = httpRequest(
+      { hostname: "127.0.0.1", port: httpPort, path: "/any", method: "GET", headers: { host: "127.0.0.1" } },
+      (res2) => {
+        let body = "";
+        res2.on("data", (c) => (body += c));
+        res2.on("end", () => resolve({ status: res2.statusCode, body }));
+      },
+    );
+    req.on("error", (e) => resolve({ status: 0, body: e.message }));
+    req.end();
+  });
+  assert.equal(res.status, 502, `不可达上游应 502，实际 ${res.status} ${res.body}`);
+  await proxy.close();
+}
+
+// ===== createLanProxy 围栏：非回环 targetHost =====
+{
+  assert.throws(
+    () => createLanProxy({ host: "127.0.0.1", port: 0, targetHost: "evil.com", targetPort: 3080 }),
+    /仅允许回环/,
+    "非回环 targetHost 拒绝启动（防开放转发）",
+  );
+}
+
+// ===== createLanProxy 非法 targetPort =====
+{
+  assert.throws(() => createLanProxy({ host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: 0 }), /valid port/);
+  assert.throws(() => createLanProxy({ host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: 70000 }), /valid port/);
+  assert.throws(() => createLanProxy({ host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: -1 }), /valid port/);
+}
+
+// ===== createLanProxy HTTPS 降级 =====
+// 占用一个端口 → HTTPS 绑定失败 → 降级 HTTP-only（httpPort 返回、httpsPort 不返回）
+{
+  const occupied = createServer();
+  await new Promise((r) => occupied.listen(0, "127.0.0.1", r));
+  const occupiedPort = occupied.address().port;
+
+  const certDir = mkdtempSync(join(tmpdir(), "dsh-lan-proxy-httpsfail-"));
+  const tls = ensureSelfSignedTls({ dir: certDir, extraSans: [] });
+  const proxy = createLanProxy({
+    host: "127.0.0.1", port: 0, httpsPort: occupiedPort, tls, targetHost: "127.0.0.1", targetPort: 1,
+  });
+  const result = await proxy.listen();
+  assert.equal(result.httpsPort, undefined, "HTTPS 绑定失败 → 结果无 httpsPort");
+  assert.ok(result.httpPort > 0, "HTTP 仍可用");
+  assert.ok(proxy.server.listening, "HTTP 服务器仍在监听");
+  await proxy.close();
+  occupied.close();
+  rmSync(certDir, { recursive: true, force: true });
+}
+
+console.log("[unit-proxy] all passed ✓");


### PR DESCRIPTION
## 变更

dsh-lan-proxy 阶段一第二批（#82）：清零未覆盖 CRAP 超阈热点。

### 新增单测文件

- `test/unit-proxy.test.ts` — 转发核心 `proxy.ts` 用例：
  - bridgeCompressedWs（WS 压缩桥接，经真实代理链路测试）
  - createLanProxy 转发错误处理（不可达上游 → 502）
  - createLanProxy HTTPS 降级（端口被占 → HTTP-only）
  - 围栏校验（非回环 targetHost / 非法 port）
  - 纯函数边界用例（hostnameAllowed / isLoopbackTarget / ...）

- `test/unit-apply.test.ts` — 宿主端 `index.ts` 用例：
  - prepareTls（TLS 证书准备路径，fnMap line 36302）
  - setSource（settings 命名空间来源回调，line 36423）
  - current 箭头（setSource 后 resolve 调用，line 36424）
  - lifecycle 清理、listen 异常恢复
  - rpcHandler 错误路径、sanitize/validate 边界

### 覆盖率效果

| 指标 | 之前 | 之后 |
|------|------|------|
| 覆盖函数数 | 61（55%） | 69（62%） |
| lan-proxy 未覆盖热点 | 15 | 10（均为 phantom 行） |
| 清零 5 个可测热点 | — | ✓ |

### 显式豁免

剩余 10 个未覆盖超阈热点均为 c8/V8 `fnMap` 未登记起始行的内层回调箭头（phantom 行），`hitByLine` 恒为 false，任何测试不可标记为覆盖。清单：

| 行号 | comp | 来源 |
|------|------|------|
| 36224 | 17 | rpcHandler 内层 async 箭头（smoke 已实测调用） |
| 36028 | 11 | settings inject 回调（shared 层） |
| 35863 | 7 | listen 内层回调 |
| 36357 | 7 | listen().then 回调 |
| 35714 | 6 | bridgeCompressedWs 内层回调 |
| 35807 | 5 | proxy error 回调 |
| 36374 | 5 | listen().catch |
| 36502 | 5×2 | lifecycle disposer |
| 35872 | 4 | https error 回调 |

### 门禁

- pnpm build ✓
- pnpm test ✓
- pnpm contract ✓
- pnpm pack:check ✓

Refs #82