### PR TITLE
ci(meta): 报告 self-written 覆盖率口径

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,16 @@ jobs:
         run: pnpm cov
         continue-on-error: true   # 观察期：采集自身异常不得阻断门禁
 
+      - name: Self-written coverage summary
+        run: |
+          {
+            echo "### Self-written 覆盖率口径"
+            echo ""
+            echo '```'
+            node scripts/gate/self-cov.mjs
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: CRAP check（复杂度×覆盖率，观察期只记录）
         run: pnpm crap
         continue-on-error: true   # 观察期：同上；基线校准后移除并启用 --strict

--- a/scripts/data/gauntlet.config.json
+++ b/scripts/data/gauntlet.config.json
@@ -12,7 +12,9 @@
       "pct": 55.26,
       "total": 722,
       "covered": 399,
-      "note": "观察期基线（self-cov 口径，去内联垫片后仅计自写函数），只记录不判红"
+      "threshold": 60,
+      "strict": false,
+      "note": "观察期基线（self-cov 口径，去内联垫片后仅计自写函数），threshold 为阶段二目标值，当前只记录不判红"
     }
   },
   "mutation": {


### PR DESCRIPTION
## 改动

### 阶段二：ci.yml 报告改为自写覆盖率口径（#79）

**红线已豁免**：维护者已打 `approved` 标签

1. **`.github/workflows/ci.yml`**：在 c8 覆盖率步骤后新增 `Self-written coverage summary` 步骤，执行 `node scripts/gate/self-cov.mjs` 并输出到 `$GITHUB_STEP_SUMMARY`
2. **`scripts/data/gauntlet.config.json`**：`coverage.selfWrittenFunctions` 添加 `threshold: 60` 与 `strict: false` 字段，保持观察期只记录不判红

### 不做
- 阶段二硬卡点（`strict: true`）——关联 #42 二期校准，本轮不动

Refs #79