### PR TITLE
test(dsh-idle-archive): 补结构化单测——纯函数覆盖缺口闭合（#83）

### DIFF
--- a/packages/dsh-idle-archive/test/helpers.ts
+++ b/packages/dsh-idle-archive/test/helpers.ts
@@ -1,0 +1,32 @@
+// @ts-nocheck
+/**
+ * dsh-idle-archive — 单元测试共享辅助（#83 剩余缺口：结构化单测）。
+ *
+ * - assert：断言统一出口（对齐 web-file-preview 样板）；
+ * - withTempHome(fn)：DSH_HOME 隔离辅助——凡触及 readState/writeState/stateFile
+ *   的用例必须走隔离临时路径（防 flake 纪律，见 docs/DEVELOPMENT.md §5）：
+ *   临时目录 + 环境变量注入，finally 中清理目录并还原环境，全程无网络、无固定 sleep。
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+export { assert };
+
+/**
+ * 在隔离临时 DSH_HOME 下执行异步用例。
+ * @param fn - 用例体（DSH_HOME 已指向新临时目录）。
+ * @returns - fn 的返回值（透传）。
+ */
+export async function withTempHome<T>(fn: () => Promise<T>): Promise<T> {
+  const home = mkdtempSync(join(tmpdir(), "dia-unit-"));
+  const saved = process.env.DSH_HOME;
+  process.env.DSH_HOME = home;
+  try {
+    return await fn();
+  } finally {
+    process.env.DSH_HOME = saved;
+    rmSync(home, { recursive: true, force: true });
+  }
+}

--- a/packages/dsh-idle-archive/test/smoke.ts
+++ b/packages/dsh-idle-archive/test/smoke.ts
@@ -36,7 +36,12 @@ import {
 // 结构化单元测试（#82 批次 6：settings 命名空间路径 / isUnloading / warn /
 // persistSettingsFromStore / sanitizeSettings 边界），对齐 notifier/provider-usage
 // 样板：smoke.ts 作为入口同步加载（package.json test 命令只跑 smoke.ts）。
+// #83 剩余缺口：三纯函数（settings/state/title）结构化单测同批挂载，
+// unit 断言只写在 unit-*.test.ts 内，本文件不混入。
 import "./unit-apply.test.ts";
+import "./unit-settings.test.ts";
+import "./unit-state.test.ts";
+import "./unit-title.test.ts";
 
 // 隔离 DSH_HOME：全部落盘到临时目录，不碰真实 ~/.dsh。
 const HOME = mkdtempSync(join(tmpdir(), "dia-"));

--- a/packages/dsh-idle-archive/test/unit-settings.test.ts
+++ b/packages/dsh-idle-archive/test/unit-settings.test.ts
@@ -1,0 +1,109 @@
+// @ts-nocheck
+/**
+ * dsh-idle-archive — unit：设置纯函数（sanitizeSettings / defaultSettings）。
+ *
+ * #83 剩余缺口结构化单测。覆盖：
+ * - defaultSettings：五键结构与默认值、每次调用返回新对象；
+ * - sanitizeSettings 正例：全键合法提交、部分键提交（缺省回落默认）、
+ *   小数四舍五入、边界值钳制（各键 min/max）；
+ * - sanitizeSettings 反例：null/undefined/原始类型/数组整体回落默认、
+ *   非有限数值（NaN/Infinity/-Infinity）与类型错值（字符串/布尔）单键回落默认、
+ *   enabled 非 boolean 回落 true、未知键丢弃、返回对象不含原型链杂质。
+ */
+import { assert } from "./helpers.ts";
+import { sanitizeSettings, defaultSettings } from "../lib/index.js";
+
+// ---------------------------------------------------------------- defaultSettings
+
+const def = defaultSettings();
+
+assert.deepEqual(
+  def,
+  { idleHours: 72, snoozeHours: 24, scanMinutes: 60, enabled: true, maxRows: 50 },
+  "defaultSettings 五键结构与默认值",
+);
+assert.deepEqual(Object.keys(def).sort(), ["enabled", "idleHours", "maxRows", "scanMinutes", "snoozeHours"], "键集合固定");
+assert.notEqual(defaultSettings(), def, "每次调用返回新对象（调用方改动不串扰）");
+assert.equal(typeof def.idleHours, "number", "数值字段为 number 类型");
+
+// ---------------------------------------------------------------- sanitizeSettings：正例
+
+// 全键合法提交
+{
+  const s = sanitizeSettings({ idleHours: 12, snoozeHours: 6, scanMinutes: 30, enabled: false, maxRows: 10 });
+  assert.deepEqual(s, { idleHours: 12, snoozeHours: 6, scanMinutes: 30, enabled: false, maxRows: 10 }, "全键合法提交原样保留");
+}
+
+// 部分键提交：只覆盖给定键，其余保持默认
+{
+  const s = sanitizeSettings({ scanMinutes: 15 });
+  assert.equal(s.scanMinutes, 15, "部分提交：给定键生效");
+  assert.equal(s.idleHours, 72, "部分提交：缺省键回落默认 idleHours");
+  assert.equal(s.snoozeHours, 24, "部分提交：缺省键回落默认 snoozeHours");
+  assert.equal(s.maxRows, 50, "部分提交：缺省键回落默认 maxRows");
+  assert.equal(s.enabled, true, "部分提交：缺省键回落默认 enabled");
+}
+
+// 各键边界值钳制（min/max 与 LIMITS 一致）
+assert.equal(sanitizeSettings({ idleHours: 1 }).idleHours, 1, "idleHours min=1 保持");
+assert.equal(sanitizeSettings({ idleHours: 24 * 365 }).idleHours, 24 * 365, "idleHours max=8760 保持");
+assert.equal(sanitizeSettings({ snoozeHours: 1 }).snoozeHours, 1, "snoozeHours min=1 保持");
+assert.equal(sanitizeSettings({ snoozeHours: 24 * 30 }).snoozeHours, 24 * 30, "snoozeHours max=720 保持");
+assert.equal(sanitizeSettings({ scanMinutes: 5 }).scanMinutes, 5, "scanMinutes min=5 保持");
+assert.equal(sanitizeSettings({ scanMinutes: 24 * 60 }).scanMinutes, 24 * 60, "scanMinutes max=1440 保持");
+assert.equal(sanitizeSettings({ maxRows: 1 }).maxRows, 1, "maxRows min=1 保持");
+assert.equal(sanitizeSettings({ maxRows: 200 }).maxRows, 200, "maxRows max=200 保持");
+
+// 越界钳制与四舍五入
+assert.equal(sanitizeSettings({ idleHours: 0 }).idleHours, 1, "idleHours=0 下越界钳到 min");
+assert.equal(sanitizeSettings({ maxRows: 999 }).maxRows, 200, "maxRows=999 上越界钳到 max");
+assert.equal(sanitizeSettings({ scanMinutes: 4.4 }).scanMinutes, 5, "4.4 四舍五入为 4 再钳到 min=5");
+assert.equal(sanitizeSettings({ snoozeHours: 6.5 }).snoozeHours, 7, "6.5 四舍五入为 7");
+assert.equal(sanitizeSettings({ maxRows: 10.2 }).maxRows, 10, "10.2 四舍五入为 10");
+
+// enabled 合法布尔
+assert.equal(sanitizeSettings({ enabled: false }).enabled, false, "enabled=false 接受");
+assert.equal(sanitizeSettings({ enabled: true }).enabled, true, "enabled=true 接受");
+
+// ---------------------------------------------------------------- sanitizeSettings：反例（整体非法）
+
+assert.deepEqual(sanitizeSettings(null), def, "null 回落默认");
+assert.deepEqual(sanitizeSettings(undefined), def, "undefined 回落默认");
+assert.deepEqual(sanitizeSettings(42), def, "数字整体回落默认");
+assert.deepEqual(sanitizeSettings("x"), def, "字符串整体回落默认");
+assert.deepEqual(sanitizeSettings(true), def, "布尔整体回落默认");
+assert.deepEqual(sanitizeSettings([]), def, "数组（typeof object 但无已知键）回落默认");
+assert.deepEqual(sanitizeSettings(() => {}), def, "函数整体回落默认");
+
+// ---------------------------------------------------------------- sanitizeSettings：反例（单键非法）
+
+assert.equal(sanitizeSettings({ idleHours: NaN }).idleHours, 72, "NaN 忽略回落默认");
+assert.equal(sanitizeSettings({ idleHours: Infinity }).idleHours, 72, "Infinity 忽略回落默认");
+assert.equal(sanitizeSettings({ idleHours: -Infinity }).idleHours, 72, "-Infinity 忽略回落默认");
+assert.equal(sanitizeSettings({ idleHours: "48" }).idleHours, 72, "字符串数值不接受回落默认");
+assert.equal(sanitizeSettings({ idleHours: null }).idleHours, 72, "null 值不接受回落默认");
+assert.equal(sanitizeSettings({ snoozeHours: "x" }).snoozeHours, 24, "snoozeHours 类型错值回落默认");
+assert.equal(sanitizeSettings({ scanMinutes: true }).scanMinutes, 60, "scanMinutes 类型错值回落默认");
+assert.equal(sanitizeSettings({ maxRows: {} }).maxRows, 50, "maxRows 对象值回落默认");
+assert.equal(sanitizeSettings({ enabled: "yes" }).enabled, true, "enabled 非 boolean 回落默认 true");
+assert.equal(sanitizeSettings({ enabled: 0 }).enabled, true, "enabled 数字 0 回落默认 true");
+
+// ---------------------------------------------------------------- 其他语义
+
+// 未知键丢弃：输出只含五个已知键
+{
+  const s = sanitizeSettings({ idleHours: 10, unknown: "v", another: 1 });
+  assert.equal("unknown" in s, false, "未知键丢弃");
+  assert.equal("another" in s, false, "第二个未知键丢弃");
+  assert.deepEqual(Object.keys(s).sort(), ["enabled", "idleHours", "maxRows", "scanMinutes", "snoozeHours"], "输出键集合与 Settings 同构");
+}
+
+// 输出为全新对象：不改写输入
+{
+  const input = Object.freeze({ idleHours: 3 });
+  const s = sanitizeSettings(input);
+  assert.equal(s.idleHours, 3, "冻结输入可正常读取");
+  assert.notEqual(s, input, "返回新对象不回写输入");
+}
+
+console.log("PASS: dsh-idle-archive unit-settings（sanitizeSettings 正反例 / defaultSettings 结构与默认值）");

--- a/packages/dsh-idle-archive/test/unit-state.test.ts
+++ b/packages/dsh-idle-archive/test/unit-state.test.ts
@@ -1,0 +1,145 @@
+// @ts-nocheck
+/**
+ * dsh-idle-archive — unit：状态文件纯读写（readState / writeState / stateFile）。
+ *
+ * #83 剩余缺口结构化单测。覆盖：
+ * - stateFile：DSH_HOME 注入优先、未注入回落 ~/.dsh；
+ * - readState：缺文件回落默认、BOM 剥离、settings 净化合并、snoozed 过期清理、
+ *   snoozed 数组/原始类型拒绝、坏 JSON 回落且不覆盖写；
+ * - writeState：深层目录自动创建、tmp+rename 原子写后无残留 tmp、写后读回一致。
+ *
+ * 防 flake 纪律：全部用例经 withTempHome 走隔离临时 DSH_HOME，无网络、
+ * 无真实用户路径字面量、轮询替代固定 sleep（本组用例纯异步 IO，无等待）。
+ */
+import { existsSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { assert, withTempHome } from "./helpers.ts";
+import { defaultSettings, sanitizeSettings, stateFile, readState, writeState } from "../lib/index.js";
+
+const def = defaultSettings();
+
+// ---------------------------------------------------------------- stateFile
+
+{
+  const saved = process.env.DSH_HOME;
+  process.env.DSH_HOME = "/tmp/dia-fake-home";
+  assert.equal(stateFile(), join("/tmp/dia-fake-home", "dsh-idle-archive.json"), "DSH_HOME 注入时状态文件指向其下");
+  delete process.env.DSH_HOME;
+  assert.equal(stateFile(), join(homedir(), ".dsh", "dsh-idle-archive.json"), "未注入时回落 ~/.dsh");
+  if (saved === undefined) delete process.env.DSH_HOME; else process.env.DSH_HOME = saved;
+}
+
+// ---------------------------------------------------------------- readState：缺文件回落默认
+
+await withTempHome(async () => {
+  const st = await readState();
+  assert.deepEqual(st.settings, def, "缺文件 settings 回落默认");
+  assert.deepEqual(st.snoozed, {}, "缺文件 snoozed 为空映射");
+});
+
+// ---------------------------------------------------------------- writeState + readState：写后读回
+
+await withTempHome(async () => {
+  const st = await writeState({
+    settings: sanitizeSettings({ idleHours: 8, enabled: false }),
+    snoozed: { s1: Date.now() + 60_000 },
+  }).then(readState);
+  assert.equal(st.settings.idleHours, 8, "写后读回 idleHours");
+  assert.equal(st.settings.enabled, false, "写后读回 enabled");
+  assert.ok(typeof st.snoozed.s1 === "number" && st.snoozed.s1 > Date.now(), "未过期 snooze 读回保留");
+
+  // 落盘格式：JSON、两空格缩进、单一最终文件
+  const raw = JSON.parse(readFileSync(stateFile(), "utf8"));
+  assert.equal(raw.settings.idleHours, 8, "落盘内容为合法 JSON 且含 settings");
+  assert.ok(raw.snoozed && typeof raw.snoozed === "object" && !Array.isArray(raw.snoozed), "落盘含 snoozed 映射");
+  assert.ok(!existsSync(stateFile() + ".tmp") && !/\.tmp$/.test(readStateTmpProbe()), "原子写完成后无 .tmp 残留");
+});
+
+/** 探测状态目录中是否残留 tmp 文件（配合上一用例）。 */
+function readStateTmpProbe(): string {
+  const dir = stateFile().slice(0, stateFile().lastIndexOf("/"));
+  const names = existsSync(dir) ? readdirSync(dir) : [];
+  return names.find((n) => n.endsWith(".tmp")) ?? "";
+}
+
+// ---------------------------------------------------------------- writeState：深层目录自动创建
+
+await withTempHome(async () => {
+  process.env.DSH_HOME = join(process.env.DSH_HOME, "nested", "deeper");
+  await writeState({ settings: def, snoozed: {} });
+  assert.ok(existsSync(stateFile()), "DSH_HOME 子路径不存在时自动递归创建并写入");
+});
+
+// ---------------------------------------------------------------- readState：净化与容错
+
+// BOM 剥离：\uFEFF 开头的 UTF-8 文件可正常解析
+await withTempHome(async () => {
+  writeFileSync(stateFile(), "\uFEFF" + JSON.stringify({ settings: { idleHours: 5 }, snoozed: {} }), "utf8");
+  const st = await readState();
+  assert.equal(st.settings.idleHours, 5, "BOM 头剥离后正常解析 settings");
+});
+
+// settings 字段缺失 → sanitize(undefined) 回落默认；非法值单键净化
+await withTempHome(async () => {
+  writeFileSync(stateFile(), JSON.stringify({ snoozed: {} }), "utf8");
+  let st = await readState();
+  assert.deepEqual(st.settings, def, "settings 字段缺失回落默认");
+  writeFileSync(stateFile(), JSON.stringify({ settings: { idleHours: 99999, scanMinutes: "bad" }, snoozed: {} }), "utf8");
+  st = await readState();
+  assert.equal(st.settings.idleHours, 24 * 365, "越界 idleHours 读入时钳制");
+  assert.equal(st.settings.scanMinutes, 60, "类型错值 scanMinutes 读入时回落默认");
+});
+
+// snoozed 过期清理 + 非法条目过滤
+await withTempHome(async () => {
+  writeFileSync(
+    stateFile(),
+    JSON.stringify({
+      settings: {},
+      snoozed: {
+        expired: Date.now() - 1000,
+        fresh: Date.now() + 60_000,
+        "": Date.now() + 60_000, // 空 id 过滤
+        badnum: "not-a-number", // 非 number until 过滤
+        [String(123)]: Date.now() + 60_000, // 数字型键名（JSON 键恒字符串，保留）
+      },
+    }),
+    "utf8",
+  );
+  const st = await readState();
+  assert.ok(!("expired" in st.snoozed), "已过期 snooze 清理");
+  assert.ok("fresh" in st.snoozed, "未过期 snooze 保留");
+  assert.ok(!("" in st.snoozed), "空 id 条目过滤");
+  assert.ok(!("badnum" in st.snoozed), "非数值 until 条目过滤");
+});
+
+// snoozed 为数组 / 原始类型 → 整体拒绝为空
+await withTempHome(async () => {
+  writeFileSync(stateFile(), JSON.stringify({ settings: {}, snoozed: ["a", "b"] }), "utf8");
+  let st = await readState();
+  assert.deepEqual(st.snoozed, {}, "snoozed 数组整体拒绝");
+  writeFileSync(stateFile(), JSON.stringify({ settings: {}, snoozed: "x" }), "utf8");
+  st = await readState();
+  assert.deepEqual(st.snoozed, {}, "snoozed 字符串整体拒绝");
+});
+
+// 整个文件顶层为数组/原始类型 → 回落默认
+await withTempHome(async () => {
+  writeFileSync(stateFile(), "[1,2]", "utf8");
+  let st = await readState();
+  assert.deepEqual(st.settings, def, "顶层数组回落默认 settings");
+  writeFileSync(stateFile(), '"str"', "utf8");
+  st = await readState();
+  assert.deepEqual(st.snoozed, {}, "顶层字符串回落默认 snoozed");
+});
+
+// 坏 JSON → 回落默认且不覆盖写坏文件（等下次写入再修复）
+await withTempHome(async () => {
+  writeFileSync(stateFile(), "{broken", "utf8");
+  const st = await readState();
+  assert.deepEqual(st.settings, def, "坏 JSON 回落默认 settings");
+  assert.equal(readFileSync(stateFile(), "utf8"), "{broken", "坏文件原样保留不被覆盖");
+});
+
+console.log("PASS: dsh-idle-archive unit-state（stateFile / readState 容错 / writeState 原子写，DSH_HOME 全程隔离）");

--- a/packages/dsh-idle-archive/test/unit-title.test.ts
+++ b/packages/dsh-idle-archive/test/unit-title.test.ts
@@ -1,0 +1,110 @@
+// @ts-nocheck
+/**
+ * dsh-idle-archive — unit：标题提取纯函数（titleOfAgent）。
+ *
+ * #83 剩余缺口结构化单测。覆盖两分支正反例：
+ * - 无事件分支：agent undefined/null、无 session、events 缺失/非数组/空数组、
+ *   无 session/title 事件；
+ * - 有事件分支：正常提取并 trim、倒序取最新一条、data.title 非 string 跳过继续
+ *   向前找、空白标题视为无标题、event 元素 null 容错。
+ */
+import { assert } from "./helpers.ts";
+import { titleOfAgent } from "../lib/index.js";
+
+// ---------------------------------------------------------------- 无事件分支
+
+assert.equal(titleOfAgent(undefined), undefined, "agent undefined → undefined");
+assert.equal(titleOfAgent(null), undefined, "agent null → undefined");
+assert.equal(titleOfAgent({}), undefined, "无 session → undefined");
+assert.equal(titleOfAgent({ session: {} }), undefined, "session 无 events → undefined");
+assert.equal(titleOfAgent({ session: { events: "not-array" } }), undefined, "events 非数组 → undefined");
+assert.equal(titleOfAgent({ session: { events: [] } }), undefined, "events 空数组 → undefined");
+assert.equal(
+  titleOfAgent({ session: { events: [{ type: "chat/complete", data: {} }, { type: "session/message", data: {} }] } }),
+  undefined,
+  "有事件但无 session/title → undefined",
+);
+
+// ---------------------------------------------------------------- 有事件分支
+
+// 正常提取：取最后一条 session/title 并 trim
+assert.equal(
+  titleOfAgent({ session: { events: [{ type: "session/title", data: { title: "修复 gzip 压缩" } }] } }),
+  "修复 gzip 压缩",
+  "单条 title 提取",
+);
+assert.equal(
+  titleOfAgent({
+    session: {
+      events: [
+        { type: "chat/complete", data: {} },
+        { type: "session/title", data: { title: "  两侧空白应去除  " } },
+      ],
+    },
+  }),
+  "两侧空白应去除",
+  "提取时 trim 首尾空白",
+);
+
+// 倒序扫描：多条 title 取最新（数组尾部优先）
+assert.equal(
+  titleOfAgent({
+    session: {
+      events: [
+        { type: "session/title", data: { title: "旧标题" } },
+        { type: "chat/complete", data: {} },
+        { type: "session/title", data: { title: "新标题" } },
+      ],
+    },
+  }),
+  "新标题",
+  "多条 title 取最新（倒序扫描）",
+);
+
+// data.title 非 string：跳过该条继续向前找更早的合法 title
+assert.equal(
+  titleOfAgent({
+    session: {
+      events: [
+        { type: "session/title", data: { title: "合法旧标题" } },
+        { type: "session/title", data: { title: 42 } },
+      ],
+    },
+  }),
+  "合法旧标题",
+  "非 string title 跳过后回落更早的合法 title",
+);
+
+// 纯空白标题：trim 后为空视为无标题 → undefined
+assert.equal(
+  titleOfAgent({ session: { events: [{ type: "session/title", data: { title: "   " } }] } }),
+  undefined,
+  "空白标题视为无",
+);
+
+// 最新条为空白标题：不回吞更早的非空标题（trim 后为空即返回 undefined）
+assert.equal(
+  titleOfAgent({
+    session: {
+      events: [
+        { type: "session/title", data: { title: "旧标题" } },
+        { type: "session/title", data: { title: "  " } },
+      ],
+    },
+  }),
+  undefined,
+  "最新 title 为空白时不向前回吞（跟随实现语义）",
+);
+
+// event 元素 null / 缺 data：容错跳过不抛错
+assert.equal(
+  titleOfAgent({
+    session: {
+      events: [null, { type: "session/title" }, { type: "session/title", data: {} }, { type: "session/title", data: { title: "兜底标题" } }],
+    },
+  }),
+  "兜底标题",
+  "null 事件与缺 data 事件容错跳过",
+);
+
+console.log("PASS: dsh-idle-archive unit-title（titleOfAgent 无事件/有事件两分支正反例）");


### PR DESCRIPTION
# test(dsh-idle-archive): 补结构化单测——纯函数覆盖缺口闭合（#83）

Refs #83（meta issue 尚有其他包事项，不用 Closes）。

为 issue #83「单元测试分布对齐」的剩余缺口（dsh-idle-archive）补齐结构化单测，
样板对齐 packages/dsh-web-file-preview/test/ 形态。新增 3 个 unit 文件 + 共享
helpers + smoke 入口挂载，共 86 条新断言、401 行纯增、零删除。

## 改动清单

| 文件 | 说明 |
|---|---|
| `packages/dsh-idle-archive/test/helpers.ts` | 新增：assert 统一出口 + withTempHome 隔离辅助 |
| `packages/dsh-idle-archive/test/unit-settings.test.ts` | 新增：sanitizeSettings 正反例 + defaultSettings 结构与默认值（47 断言） |
| `packages/dsh-idle-archive/test/unit-state.test.ts` | 新增：readState/writeState/stateFile 容错与原子写（25 断言） |
| `packages/dsh-idle-archive/test/unit-title.test.ts` | 新增：titleOfAgent 有/无事件两分支正反例（14 断言） |
| `packages/dsh-idle-archive/test/smoke.ts` | 仅 +5 行：import 挂载三份新 unit（断言不混入 smoke 主体） |

## 全量断言表（验收标准 = issue #83 评论「[spec] 剩余缺口验收标准 v1」）

| 条目 | 结论 | 证据或漂移解释 |
|---|---|---|
| 1. [硬性] 缺口闭合：unit-*.test.ts 从 0 增至 ≥1 | PASS | `ls packages/dsh-idle-archive/test/unit-*.test.ts \| wc -l` = 4（unit-apply + 本 PR 新增 settings/state/title）。漂移说明：spec 基线时点为 0，取数后 main 已由 #146 引入 unit-apply.test.ts，本 PR 前实际起点 1 → 完成后 4，方向只增不减，不影响验收语义 |
| 2. [硬性] 三导出纯函数正反例覆盖；handler/apply 不强制 | PASS | sanitizeSettings：整体非法回落默认 7 例（null/undefined/数字/字符串/布尔/数组/函数）+ 单键非法 10 例 + 边界钳制/四舍五入/未知键丢弃等共 47 断言组；defaultSettings：五键结构与默认值 deepEqual、键集合固定、调用返回新对象；titleOfAgent：无事件分支 7 反例 + 有事件分支 7 正反例（提取/trim/倒序取最新/非 string 跳过/空白标题/null 事件容错）；`pnpm -C packages/dsh-idle-archive test` 绿（exit=0） |
| 3. [硬性] 目录拆分对齐 #18 方案 C 与 web-file-preview 样板 | PASS | 文件置于 test/ 且命名 `unit-<主题>.test.ts`；assert 复用 `./helpers.ts`；被测对象自 `../lib/index.js`（构建产物）导入；每个文件头部注释块声明覆盖面；unit 与 e2e(smoke.ts) 分离——smoke.ts 仅加 import 挂载行，未混入任何 unit 断言；smoke.ts 原有断言未改动 |
| 4. [硬性] 单文件 < 400 行 | PASS | wc -l：unit-settings 109 / unit-state 145 / unit-title 110，全部远低于 400 |
| 5. [硬性] 隔离与防 flake 纪律 | PASS | 凡触及 stateFile 的用例全部经 helpers.withTempHome：mkdtemp 临时目录注入 DSH_HOME，finally 还原环境并清理；grep 测试代码无 sleep/setTimeout 实际调用（仅纪律注释字样）、无 /home/tangyi 等真实用户路径字面量；全程无网络无凭据；同链连跑 3 次 exit=0 且 PASS 输出逐行一致（run1 与 run3 diff 为空） |
| 6. [硬性] 既有分布不回退 | PASS | 逐包 glob 计数：provider-usage 5≥5、web-file-preview 4≥3、mcp-manager 4≥4、notifier 3≥3、lan-proxy 2≥2；git diff 对既有 unit/smoke 断言零删除零放宽（smoke.ts 仅 +5 行挂载注释与 import），401 insertions 0 deletions |
| 7. [硬性] 门禁全绿且改动边界干净 | PASS | 独立 worktree ../wt-83 内实跑退出码全 0：build=0 / test=0 / contract=0 / pack:check=0 / typecheck=0；`git diff origin/main --stat` 仅涉 packages/dsh-idle-archive/test/ 下 5 个文件，不触碰 src/ 被测逻辑与其他包；主 checkout 零改动（git status 干净） |
| 8. [量级] 总覆盖不降 + cov 留痕（观察期） | PASS | smoke+unit 断言总量纯增（+86 条断言 / +401 行，无删改）；cov 取数留痕见下节 |

## cov 覆盖率留痕（第 8 条，观察期仅记录不判红）

- 取数时点：2026-08-24 12:29 CST；命令：`pnpm cov`（c8 --reporter=json,text 包 pnpm -r test）
- dsh-idle-archive `lib/index.js`：**行 50.35% / 分支 79.36% / 函数 26.35% / 语句 50.35%**
- 说明：数值供 gauntlet.config.json 基线校准（issue #42 二期）输入；client.js 由
  client-shim.mjs 独立进程执行，不在本次 c8 汇总口径内

## 门禁结论

worktree 内五连门禁全绿（本地实测退出码全 0）：

```text
pnpm build       exit=0
pnpm test        exit=0   （7 workspace 包全 PASS；lan-proxy 两行 EADDRINUSE 为既有容错分支日志）
pnpm contract    exit=0
pnpm pack:check  exit=0
pnpm typecheck   exit=0
```
