### PR TITLE
test(meta): Stryker 接入 dsh-web-file-preview（#152）

### DIFF
--- a/scripts/data/gauntlet.config.json
+++ b/scripts/data/gauntlet.config.json
@@ -42,6 +42,18 @@
         "baselineDuration": "12.7s",
         "baselineScope": "packages/dsh-idle-archive/lib/index.js:1055-1060+1146-1375（self-written 段；排除 esbuild 垫片、cosmokit/schemastery 内联 vendor、shared 契约层内联副本）",
         "config": "stryker.conf.d/dsh-idle-archive.json"
+      },
+      "dsh-web-file-preview": {
+        "baselineScore": 42.6,
+        "baselineCovered": 72.27,
+        "baselineKilled": 330,
+        "baselineTotal": 777,
+        "baselineNoCoverage": 319,
+        "baselineErrors": 0,
+        "baselineDate": "2026-08-24",
+        "baselineDuration": "15s",
+        "baselineScope": "packages/dsh-web-file-preview/lib/index.js:1255-1924（self-written 段；排除 untildify/mime 内联 vendor、shared 契约层内联副本与 routes import 提升段；client/link-resolver 内联进 index.js 本体故纳入）",
+        "config": "stryker.conf.d/dsh-web-file-preview.json"
       }
     }
   }

--- a/stryker.conf.d/dsh-web-file-preview.json
+++ b/stryker.conf.d/dsh-web-file-preview.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "mutate": [
+    "packages/dsh-web-file-preview/lib/index.js:1255-1924"
+  ],
+  "testRunner": "tap",
+  "tap": {
+    "nodeArgs": ["-r", "./scripts/test/mutation-tap-bridge.cjs"],
+    "testFiles": [
+      "packages/dsh-web-file-preview/test/unit-grouping.test.ts",
+      "packages/dsh-web-file-preview/test/unit-link-resolver.test.ts",
+      "packages/dsh-web-file-preview/test/unit-relpath.test.ts",
+      "packages/dsh-web-file-preview/test/unit-routes.test.ts"
+    ]
+  },
+  "mutator": {
+    "excludedMutations": [
+      "StringLiteral",
+      "ArrayLiteral",
+      "ObjectLiteral",
+      "TemplateLiteral"
+    ]
+  },
+  "plugins": ["@stryker-mutator/tap-runner"],
+  "concurrency": 4,
+  "timeoutMS": 60000,
+  "dryRunTimeoutMinutes": 5,
+  "reporters": [
+    "progress",
+    "clear-text",
+    "json"
+  ],
+  "jsonReporter": {
+    "fileName": "coverage/mutation/dsh-web-file-preview.json"
+  },
+  "coverageAnalysis": "perTest",
+  "tempDirName": ".stryker-tmp",
+  "cleanTempDir": true,
+  "_comment": "#152 接入：mutate 限定 lib/index.js 的 self-written 连续段 1255-1924（grouping/mime/git/basename-fallback/routes/relpath/client/link-resolver/index 八段，esbuild 路径注释 // lib/* 分界），排除头部 untildify 与 mime 库内联 vendor 段（1-30、75-1254，含 var __classPrivateFieldGet 垫片）、shared/loopback+host-utils 内联契约层副本（35-74，shared 由仓库级禁改规则保护且多包重复计账会使 score 横向不可比）、31-34 的 routes import 提升段（纯 ESM import 无可变异面）。client/link-resolver 为本仓自写代码且内联进 index.js 本体（wrapper 模式），有 unit-link-resolver.test.ts 直测故纳入——区别于 idle-archive 的独立 lib/client.js 不在 mutate 面。tap.nodeArgs 注入 mutation-tap-bridge.cjs（#151 全局生效）将未捕获异常转写 TAP not ok，RuntimeError 计 Killed。"
+}


### PR DESCRIPTION
Refs #152

## 改动内容（模板 = #162 idle-archive 形态）

- 新增 `stryker.conf.d/dsh-web-file-preview.json`：
  - `mutate` 限定 `lib/index.js:1255-1924` self-written 连续段
    （grouping / mime / git / basename-fallback / routes / relpath /
    client/link-resolver / index 八段，esbuild 路径注释分界）；
    排除 untildify + mime 库内联 vendor 段（1-30、75-1254，含
    `var __classPrivateFieldGet` 垫片）、shared 内联契约层副本
    （35-74）、31-34 routes import 提升段（纯 import 无可变异面）
  - client/link-resolver 为本仓自写代码且内联进 index.js 本体
    （wrapper 模式），有 unit-link-resolver.test.ts 直测故纳入
  - `testFiles`：本包四个 unit-*.test.ts 逐个列出（不扫全仓）
- `scripts/data/gauntlet.config.json` mutation.packages 增加
  `dsh-web-file-preview` 基线条目（字段对齐 idle-archive）

根配置 `stryker.config.json` 与 `scripts/test/mutation-tap-bridge.cjs`
未动；bridge 经 tap.nodeArgs 全局生效。

## 实测数据（npx stryker run stryker.conf.d/dsh-web-file-preview.json）

| 指标 | 值 |
|---|---|
| score（报告口径，分母含 noCoverage） | **42.60%**（331/777） |
| covered（官方 mutationScore 口径） | **72.27%**（331/458） |
| killed / timeout / survived / noCoverage | 330 / 1 / 127 / 319 |
| errors | **0**（bridge 生效，无 RuntimeError 分类） |
| 时长 | 15s（远低于 10 分钟上限） |

mutator 排除项与既有包一致（StringLiteral/ArrayLiteral/ObjectLiteral/
TemplateLiteral）；concurrency 4、perTest coverage。

## 门禁结论

本地五连门禁全绿（exit 0）：`pnpm build && pnpm test && pnpm contract
&& pnpm pack:check && pnpm typecheck`。notifier scope 回归不必重跑
（根配置未变）。