### PR TITLE
test(meta): Stryker 接入 dsh-mcp-manager（#148）

### DIFF
--- a/scripts/data/gauntlet.config.json
+++ b/scripts/data/gauntlet.config.json
@@ -54,6 +54,18 @@
         "baselineDuration": "15s",
         "baselineScope": "packages/dsh-web-file-preview/lib/index.js:1255-1924（self-written 段；排除 untildify/mime 内联 vendor、shared 契约层内联副本与 routes import 提升段；client/link-resolver 内联进 index.js 本体故纳入）",
         "config": "stryker.conf.d/dsh-web-file-preview.json"
+      },
+      "dsh-mcp-manager": {
+        "baselineScore": 10.51,
+        "baselineCovered": 29.37,
+        "baselineKilled": 204,
+        "baselineTotal": 1951,
+        "baselineNoCoverage": 1253,
+        "baselineErrors": 0,
+        "baselineDate": "2026-08-24",
+        "baselineDuration": "1m17s",
+        "baselineScope": "packages/dsh-mcp-manager/lib/index.js:8610-8696+17322-17456+19271-19915+19964-21027（self-written 四段：store、transport+scope、protocol/supervisor/catalog、import/routes/index；排除 esbuild 垫片、zod/@modelcontextprotocol/sdk/ajv 等大段内联 vendor、shared 契约层内联副本与纯 import 提升段）",
+        "config": "stryker.conf.d/dsh-mcp-manager.json"
       }
     }
   }

--- a/stryker.conf.d/dsh-mcp-manager.json
+++ b/stryker.conf.d/dsh-mcp-manager.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "mutate": [
+    "packages/dsh-mcp-manager/lib/index.js:8610-8696",
+    "packages/dsh-mcp-manager/lib/index.js:17322-17456",
+    "packages/dsh-mcp-manager/lib/index.js:19271-19915",
+    "packages/dsh-mcp-manager/lib/index.js:19964-21027"
+  ],
+  "testRunner": "tap",
+  "tap": {
+    "nodeArgs": ["-r", "./scripts/test/mutation-tap-bridge.cjs"],
+    "testFiles": [
+      "packages/dsh-mcp-manager/test/unit-apply.test.ts",
+      "packages/dsh-mcp-manager/test/unit-hotspot.test.ts",
+      "packages/dsh-mcp-manager/test/unit-manager.test.ts",
+      "packages/dsh-mcp-manager/test/unit-shared.test.ts"
+    ]
+  },
+  "mutator": {
+    "excludedMutations": [
+      "StringLiteral",
+      "ArrayLiteral",
+      "ObjectLiteral",
+      "TemplateLiteral"
+    ]
+  },
+  "plugins": ["@stryker-mutator/tap-runner"],
+  "concurrency": 4,
+  "timeoutMS": 60000,
+  "dryRunTimeoutMinutes": 5,
+  "reporters": [
+    "progress",
+    "clear-text",
+    "json"
+  ],
+  "jsonReporter": {
+    "fileName": "coverage/mutation/dsh-mcp-manager.json"
+  },
+  "coverageAnalysis": "perTest",
+  "tempDirName": ".stryker-tmp",
+  "cleanTempDir": true,
+  "_comment": "#148 接入：mutate 限定 lib/index.js 的 self-written 四段（esbuild 路径注释 // lib/* 分界）：8610-8696 store、17322-17456 transport+scope、19271-19915 protocol/supervisor/catalog、19964-21027 import/routes/index。排除头部 var __* 垫片（1-42）、cosmokit/schemastery/which/cross-spawn/ajv/fast-uri/zod/@modelcontextprotocol/sdk 等 node_modules 内联 vendor 大段（43-8549、8700-17321、17457-19270）、shared/settings-namespace+loopback+host-utils 内联契约层副本（8557-8609、19916-19963，shared 由仓库级禁改规则保护且多包重复计账会使 score 横向不可比）、8550-8556 与 8697-8699 的纯 ESM import 提升段（无可变异面）。tap.nodeArgs 注入 mutation-tap-bridge.cjs（#151 全局生效）将未捕获异常转写 TAP not ok，RuntimeError 计 Killed。"
+}


### PR DESCRIPTION
Refs #148, #80

## 内容
- 新增 `stryker.conf.d/dsh-mcp-manager.json`：mutate 限定 `lib/index.js` self-written 四段（esbuild 路径注释分界）：8610-8696 store、17322-17456 transport+scope、19271-19915 protocol/supervisor/catalog、19964-21027 import/routes/index；排除头部垫片、zod/@modelcontextprotocol/sdk/ajv 等内联 vendor 大段、shared 契约层内联副本与纯 import 提升段
- testFiles：本包 4 个 unit-*.test.ts，经 mutation-tap-bridge.cjs 注入（RuntimeError 计 Killed）
- `scripts/data/gauntlet.config.json` mutation.packages 落盘 baseline（只记录不判红）

## Baseline（2026-08-24，耗时 1m17s，errors=0）
| 口径 | 值 |
|---|---|
| score（Stryker total 口径，分母含 noCoverage） | 10.51% |
| covered（官方口径 (killed+timeout)/(total-noCoverage)） | 29.37% |
| killed / timeout / survived / noCoverage / total | 204 / 1 / 493 / 1253 / 1951 |

noCoverage 占比高：supervisor 进程管理与 transport 流处理段单测触达有限，观察期仅记录，待 #42 二期校准。

## 门禁
五连门禁本地全绿：build / test / contract / pack:check / typecheck。