### PR TITLE
test(meta): Stryker 接入 dsh-lan-proxy（#147）

### DIFF
--- a/scripts/data/gauntlet.config.json
+++ b/scripts/data/gauntlet.config.json
@@ -78,6 +78,20 @@
         "baselineDuration": "1m51s",
         "baselineScope": "packages/dsh-provider-usage/lib/index.js:1372-2769+2805-3696（self-written 两段：contracts/registry/adapters-opencode-go/core-guards/sanitize/pipeline-v2/history/provider-config/hotreload 与 path-resolve/client-logic/index；排除 esbuild 垫片、cosmokit/schemastery/async-mutex/untildify 内联 vendor、shared 契约层内联副本与纯 import 提升段）",
         "config": "stryker.conf.d/dsh-provider-usage.json"
+      },
+      "dsh-lan-proxy": {
+        "baselineScore": 35.11,
+        "baselineCovered": 49.75,
+        "baselineKilled": 259,
+        "baselineTimeout": 37,
+        "baselineSurvived": 299,
+        "baselineTotal": 843,
+        "baselineNoCoverage": 248,
+        "baselineErrors": 0,
+        "baselineDate": "2026-08-24",
+        "baselineDuration": "7m36s",
+        "baselineScope": "packages/dsh-lan-proxy/lib/index.js:35657-35911+35912-35972+36058-36643（self-written 三段，对应 src/proxy.ts+cert.ts+index.ts 尾段；排除 esbuild 垫片、cosmokit/schemastery/ws/http-proxy/node-forge/selfsigned 内联 vendor、shared 契约层内联副本）",
+        "config": "stryker.conf.d/dsh-lan-proxy.json"
       }
     }
   }

--- a/stryker.conf.d/dsh-lan-proxy.json
+++ b/stryker.conf.d/dsh-lan-proxy.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "mutate": [
+    "packages/dsh-lan-proxy/lib/index.js:35657-35911",
+    "packages/dsh-lan-proxy/lib/index.js:35912-35972",
+    "packages/dsh-lan-proxy/lib/index.js:36058-36643"
+  ],
+  "testRunner": "tap",
+  "tap": {
+    "nodeArgs": ["-r", "./scripts/test/mutation-tap-bridge.cjs"],
+    "testFiles": [
+      "packages/dsh-lan-proxy/test/unit-apply.test.ts",
+      "packages/dsh-lan-proxy/test/unit-proxy.test.ts"
+    ]
+  },
+  "mutator": {
+    "excludedMutations": [
+      "StringLiteral",
+      "ArrayLiteral",
+      "ObjectLiteral",
+      "TemplateLiteral"
+    ]
+  },
+  "plugins": ["@stryker-mutator/tap-runner"],
+  "concurrency": 4,
+  "timeoutMS": 15000,
+  "dryRunTimeoutMinutes": 5,
+  "reporters": [
+    "progress",
+    "clear-text",
+    "json"
+  ],
+  "jsonReporter": {
+    "fileName": "coverage/mutation/dsh-lan-proxy.json"
+  },
+  "coverageAnalysis": "perTest",
+  "tempDirName": ".stryker-tmp",
+  "cleanTempDir": true,
+  "_comment": "#147 阶段二『每包一个』：mutate 限定 lib/index.js 三段 self-written（esbuild 分段注释 // lib/*.js）：35657-35911（src/proxy.ts 转发核心，comp17/CRAP306 一带）、35912-35972（src/cert.ts 自签证书）、36058-36643（src/index.ts 尾段 Config/apply/路由）；35635-35646 为纯 import 头无可变异语句不列。排除头部 var __* 垫片、cosmokit/schemastery/ws/http-proxy/node-forge/selfsigned 内联 vendor（// node_modules 段，约 3.5 万行）与 shared/* 内联契约层副本（同 dsh-idle-archive 口径：shared 由仓库级禁改规则保护，多包内联重复计账使各包 score 横向不可比）。testFiles 仅列 2 个 unit 文件逐个启用 per-test 关联；smoke.ts 绑定固定端口不可并行故不入。timeoutMS 必须保持 15000：unit-proxy 的 WS 桥接类 mutant 注入后挂起而非抛错，60s 兜底会使总时长冲到 15 分钟以上（#147 实测），15s 下全量三段 7m36s 达标。已知风险备注：unit-apply.test.ts 固定占用 19998 构造端口被占场景，多 worker 同时进入该用例理论上会 EADDRINUSE 互踩造成假阳性 Killed；#147 实测两轮 total 均为 843 且 error=0、score 与 dryRun 覆盖关联面吻合，未观察到互踩迹象，维持 concurrency=4。"
+}


### PR DESCRIPTION
Refs #147 Refs #80

## 改动

- 新增 `stryker.conf.d/dsh-lan-proxy.json`（形态对齐 #162 的 dsh-idle-archive 条目）
- `scripts/data/gauntlet.config.json` mutation.packages 增 dsh-lan-proxy 条目（实测数字）

根配置 stryker.config.json 与 scripts/test/mutation-tap-bridge.cjs 沿用 #162 产物，未改动。

## mutate 口径（self-written 三段）

esbuild 分段注释定位，排除约 3.5 万行内联 vendor：

| 行范围 | 对应源码 | 说明 |
|---|---|---|
| 35657-35911 | src/proxy.ts 转发核心 | comp17/CRAP306 一带，issue P0 排序依据 |
| 35912-35972 | src/cert.ts 自签证书 | |
| 36058-36643 | src/index.ts 尾段 | Config/apply/路由 |

排除：头部 var __* 垫片、cosmokit/schemastery/ws/http-proxy/node-forge/selfsigned 内联 vendor（// node_modules 段）、shared/* 契约层内联副本（同 idle-archive 口径：多包内联重复计账使 score 横向不可比）。35635-35646 纯 import 头无可变异语句不列。

testFiles 仅列 unit-apply / unit-proxy 两个 unit 文件启用 per-test 关联；smoke.ts 绑定固定端口不入面。

## baseline 实测（双口径）

- mutants：843 = killed 259 + timeout 37 + survived 299 + noCoverage 248 + **errors 0**
- 报告口径 score（分母含 noCoverage）：**35.11%**
- 官方 covered 口径 ((killed+timeout)/(total-noCoverage) = 296/595)：**49.75%**
- 时长：**7m36s**（<10 分钟达标），concurrency=4
- bridge（#151）生效：RuntimeError 清零，error=0

## 调参备注（不缩 scope 的依据）

首轮 timeoutMS=60000 实测 15m21s 超限——unit-proxy 的 WS 桥接类 mutant 注入后挂起而非抛错，每个白等到 60s 兜底；降为 timeoutMS=15000 后全量三段 7m36s 达标，两轮 total 均为 843（mutant 面稳定），无需缩 scope。该约束已写入 config _comment 防回归。

已知风险备注：unit-apply.test.ts 固定占用 19998 构造端口被占场景，多 worker 并发理论上可能互踩造成假阳性 Killed；实测两轮 error=0 且 score 与 dryRun 覆盖关联面吻合，未见互踩迹象。

## 门禁结论

五连门禁本地全绿：pnpm build / test / contract / pack:check / typecheck 均 OK。
notifier scope 回归不在本次改动面（仅增配置与数据条目），未重跑。