### PR TITLE
test(meta): Stryker 接入 dsh-provider-usage（#150）

### DIFF
--- a/scripts/data/gauntlet.config.json
+++ b/scripts/data/gauntlet.config.json
@@ -66,6 +66,18 @@
         "baselineDuration": "1m17s",
         "baselineScope": "packages/dsh-mcp-manager/lib/index.js:8610-8696+17322-17456+19271-19915+19964-21027（self-written 四段：store、transport+scope、protocol/supervisor/catalog、import/routes/index；排除 esbuild 垫片、zod/@modelcontextprotocol/sdk/ajv 等大段内联 vendor、shared 契约层内联副本与纯 import 提升段）",
         "config": "stryker.conf.d/dsh-mcp-manager.json"
+      },
+      "dsh-provider-usage": {
+        "baselineScore": 21.05,
+        "baselineCovered": 31.8,
+        "baselineKilled": 529,
+        "baselineTotal": 2556,
+        "baselineNoCoverage": 864,
+        "baselineErrors": 0,
+        "baselineDate": "2026-08-24",
+        "baselineDuration": "1m51s",
+        "baselineScope": "packages/dsh-provider-usage/lib/index.js:1372-2769+2805-3696（self-written 两段：contracts/registry/adapters-opencode-go/core-guards/sanitize/pipeline-v2/history/provider-config/hotreload 与 path-resolve/client-logic/index；排除 esbuild 垫片、cosmokit/schemastery/async-mutex/untildify 内联 vendor、shared 契约层内联副本与纯 import 提升段）",
+        "config": "stryker.conf.d/dsh-provider-usage.json"
       }
     }
   }

--- a/stryker.conf.d/dsh-provider-usage.json
+++ b/stryker.conf.d/dsh-provider-usage.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "mutate": [
+    "packages/dsh-provider-usage/lib/index.js:1372-2769",
+    "packages/dsh-provider-usage/lib/index.js:2805-3696"
+  ],
+  "testRunner": "tap",
+  "tap": {
+    "nodeArgs": ["-r", "./scripts/test/mutation-tap-bridge.cjs"],
+    "testFiles": [
+      "packages/dsh-provider-usage/test/unit-apply.test.ts",
+      "packages/dsh-provider-usage/test/unit-contract.test.ts",
+      "packages/dsh-provider-usage/test/unit-config.test.ts",
+      "packages/dsh-provider-usage/test/unit-history.test.ts",
+      "packages/dsh-provider-usage/test/unit-v1.test.ts"
+    ]
+  },
+  "mutator": {
+    "excludedMutations": [
+      "StringLiteral",
+      "ArrayLiteral",
+      "ObjectLiteral",
+      "TemplateLiteral"
+    ]
+  },
+  "plugins": ["@stryker-mutator/tap-runner"],
+  "concurrency": 4,
+  "timeoutMS": 60000,
+  "dryRunTimeoutMinutes": 5,
+  "reporters": [
+    "progress",
+    "clear-text",
+    "json"
+  ],
+  "jsonReporter": {
+    "fileName": "coverage/mutation/dsh-provider-usage.json"
+  },
+  "coverageAnalysis": "perTest",
+  "tempDirName": ".stryker-tmp",
+  "cleanTempDir": true,
+  "_comment": "#150 接入：mutate 限定 lib/index.js 的 self-written 两段（esbuild 路径注释 // lib/* 分界）：1372-2769 contracts/registry/adapters-opencode-go/core-guards/sanitize/pipeline-v2/history/provider-config/hotreload 九段连续自写模块、2805-3696 path-resolve/client-logic/index 主体。排除头部 var __* 垫片（1-30）、cosmokit/schemastery/async-mutex/untildify 等 node_modules 内联 vendor 大段（31-1054、1163-1368、2775-2804）、shared/loopback+host-utils+settings-namespace 内联契约层副本（1062-1162，shared 由仓库级禁改规则保护且多包重复计账会使 score 横向不可比）、1055-1061 与 1369-1371 与 2770-2774 的纯 ESM import 提升段（无可变异面）。tap.nodeArgs 注入 mutation-tap-bridge.cjs（#151 全局生效）将未捕获异常转写 TAP not ok，RuntimeError 计 Killed。"
+}


### PR DESCRIPTION
Refs #150（不关闭；父 issue #80 阶段二 P1 落地，模板同 #163/#164）

## 改动
- 新增 `stryker.conf.d/dsh-provider-usage.json`：mutate 限定 `lib/index.js` self-written 两段 **1372-2769**（contracts/registry/adapters-opencode-go/core-guards/sanitize/pipeline-v2/history/provider-config/hotreload）与 **2805-3696**（path-resolve/client-logic/index 主体）；排除头部 var __* 垫片、cosmokit/schemastery/async-mutex/untildify 内联 vendor、shared 三段契约层副本与纯 import 提升段
- `scripts/data/gauntlet.config.json` mutation.packages 增 dsh-provider-usage 条目（观察期只记录不判红）

## baseline（双口径）
| 口径 | 值 |
|---|---|
| score（报告口径，分母含 noCoverage） | **21.05%** |
| covered（官方 mutationScore：(killed+timeout)/(total-noCoverage)） | **31.80%** |
| killed / timeout / survived / noCoverage | 529 / 9 / 1154 / 864（total 2556） |
| errors | 0（mutation-tap-bridge.cjs 生效） |
| 时长 | 1m51s（<10 分钟，未缩 scope） |

## 门禁结论
本地五连门禁全绿：`pnpm build` ✓ `pnpm test` ✓ `pnpm contract` ✓ `pnpm pack:check` ✓ `pnpm typecheck` ✓

## 备注
- 运行命令用位置参数：`npx stryker run stryker.conf.d/dsh-provider-usage.json`（Stryker 10 无 --config）
- 根配置与 mutation-tap-bridge.cjs 未动；notifier 回归未重跑