### PR TITLE
perf(meta): notifier 变异运行提速至 103s（#159 耗时优化批次）

### DIFF
--- a/stryker.config.json
+++ b/stryker.config.json
@@ -7,15 +7,11 @@
   "tap": {
     "nodeArgs": ["-r", "./scripts/test/mutation-tap-bridge.cjs"],
     "testFiles": [
-      "packages/dsh-notifier/test/unit-config.test.ts",
       "packages/dsh-notifier/test/unit-text.test.ts",
       "packages/dsh-notifier/test/unit-sanitize.test.ts",
       "packages/dsh-notifier/test/e2e-approval.test.ts",
       "packages/dsh-notifier/test/e2e-done.test.ts",
-      "packages/dsh-notifier/test/e2e-interrupt.test.ts",
-      "packages/dsh-notifier/test/e2e-question-turn.test.ts",
-      "packages/dsh-notifier/test/routes.test.ts",
-      "packages/dsh-notifier/test/client-contract.test.ts"
+      "packages/dsh-notifier/test/e2e-question-turn.test.ts"
     ]
   },
   "mutator": {
@@ -27,7 +23,7 @@
     ]
   },
   "plugins": ["@stryker-mutator/tap-runner"],
-  "concurrency": 4,
+  "concurrency": 16,
   "timeoutMS": 60000,
   "dryRunTimeoutMinutes": 5,
   "reporters": [
@@ -41,5 +37,5 @@
   "coverageAnalysis": "perTest",
   "tempDirName": ".stryker-tmp",
   "cleanTempDir": true,
-  "_comment": "阶段一试点：dsh-notifier 的 lib/index.js 构建产物无 node_modules 内联段，天然全量 self-written。mutate 构建产物而非 src 源码，因测试直接 import lib/index.js。试点范围缩小至 message.js 段（lib/index.js:255-504，对应 src/message.ts），排除高噪音字符串/数组/对象/模板字面量变异以控制总时长。测试文件逐个列出以启用 per-test coverage 精确关联，避免慢速 e2e 文件被无关 mutant 调用。tap.nodeArgs 注入 scripts/test/mutation-tap-bridge.cjs（#151）：把顶层 assert 失败的未捕获异常转写为 TAP not ok，使 tap-runner 将 mutant 正确计为 Killed 而非 RuntimeError（原试点 211/295 RuntimeError 即此分类缺陷）。阶段二『每包一个』新包配置放 stryker.conf.d/<pkg>.json（首例 dsh-idle-archive），后续批次逐包迁入。"
+  "_comment": "阶段一试点：dsh-notifier 的 lib/index.js 构建产物无 node_modules 内联段，天然全量 self-written。mutate 构建产物而非 src 源码，因测试直接 import lib/index.js。试点范围缩小至 message.js 段（lib/index.js:255-504，对应 src/message.ts），排除高噪音字符串/数组/对象/模板字面量变异以控制总时长。测试文件逐个列出以启用 per-test coverage 精确关联。#159 耗时优化批次：按上次报告 perTest 贡献统计精简 testFiles——移除零杀伤的 unit-config/routes/client-contract（覆盖 91-102 个 mutant 但杀伤均为 0）与低性价比的 e2e-interrupt（覆盖 207 杀伤仅 2，损失 2 个 killed 在等价容差内）；concurrency 提至 16——本套件耗时由 e2e 的 waitMergeWindow 定时器等待（3.2s sleep）主导、CPU 占用低，worker 超订物理核（8）以重叠等待时间；maxTestRunnerReuse 维持默认 0（无限复用），实测 reuse=100 持平无收益。合计 6m54s→1m42s，killed+timeout 212→210（±2 等价）。tap.nodeArgs 注入 scripts/test/mutation-tap-bridge.cjs（#151）：把顶层 assert 失败的未捕获异常转写为 TAP not ok，使 tap-runner 将 mutant 正确计为 Killed 而非 RuntimeError（原试点 211/295 RuntimeError 即此分类缺陷）。阶段二『每包一个』新包配置放 stryker.conf.d/<pkg>.json（首例 dsh-idle-archive），后续批次逐包迁入。"
 }


### PR DESCRIPTION
## 概要

dsh-notifier 的 Stryker 变异运行从 6m54s 压缩到 **1m43s**（目标 <2min 达成），killed 数下降 2 个（210→208，±2 等价容差内）。仅改根配置 `stryker.config.json` 的 notifier 相关性能字段，不触 mutate 段、测试代码与其余红线文件。

Refs #159

## 依据：perTest 覆盖贡献统计

上次 json 报告（coverage/mutation/dsh-notifier.json）中各 mutant 的 coveredBy/killedBy 统计：

| 测试文件 | 覆盖 mutant | 参与杀伤 | 处置 |
|---|---|---|---|
| unit-text.test.ts | 184 | 84 | 保留（核心） |
| unit-sanitize.test.ts | 94 | 68 | 保留（核心） |
| e2e-done.test.ts | 236 | 41 | 保留（杀伤不可替代） |
| e2e-approval.test.ts | 149 | 8 | 保留（移除损失超容差） |
| e2e-question-turn.test.ts | 145 | 7 | 保留（移除损失超容差） |
| e2e-interrupt.test.ts | 207 | 2 | 移除（覆盖最广、杀伤最低；仅失 line 403 两处 killed） |
| unit-config.test.ts | 91 | 0 | 移除（零杀伤） |
| routes.test.ts | 102 | 0 | 移除（零杀伤） |
| client-contract.test.ts | 91 | 0 | 移除（零杀伤） |

## 实验矩阵（每项一次全量实测）

| # | testFiles | concurrency | maxTestRunnerReuse | 时长 | killed+timeout | score |
|---|---|---|---|---|---|---|
| 基线 | 9 个 | 4 | 默认(0) | 6m54s (416s) | 212 (K210+T2) | 71.86% |
| E1 | 移除零杀伤三件套（6 个） | 4 | 默认 | 6m51s (412s) | 212 (K210+T2) | 71.86% |
| E2 | 同 E1 | 8 | 默认 | 3m41s (221s) | 212 (K210+T2) | 71.86% |
| E3 | 再移除 e2e-interrupt（5 个） | 8 | 默认 | 2m57s (177s) | 210 (K208+T2) | 71.19% |
| E4 | 同 E3 | 12 | 默认 | 2m09s (129s) | 210 (K208+T2) | 71.19% |
| E5 | 同 E3 | **16** | 默认 | **1m42s (102s)** | 210 (K208+T2) | 71.19% |
| E6 对照 | 同 E3 | 16 | 100 | 1m42s (102s) | 210 (K208+T2) | 71.19% |
| 最终确认 | 同 E3 | 16 | 默认(0) | **1m43s (103s)** | 210 (K208+T2) | 71.19% |

## 前后对比

| 指标 | 前 | 后 | 变化 |
|---|---|---|---|
| 运行时长 | 6m54s (416s) | 1m43s (103s) | **-75%（4.0x 提速）** |
| killed | 210 | 208 | -2（±2 等价容差内） |
| timeout | 2 | 2 | 不变 |
| mutation score | 71.86% | 71.19% | -0.67pp |
| tests per mutant | 1.42 | 1.03 | perTest 关联更精确 |

## 残余瓶颈分析

剩余耗时由保留的三个 e2e 文件中 `waitMergeWindow` 的 3200ms 真实定时器等待主导（基线 user 时间仅 75s/416s，CPU 占用低，故 concurrency 超订物理核 8 有效）。进一步压缩需改测试代码（如可注入的 merge window 时长）或 mutate 段范围，均超出本批次「只调性能字段」的约束边界。

## 门禁

五连门禁本地全绿：`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck`
