### PR TITLE
test(dsh-lan-proxy): 变异驱动断言加固——covered 49.75%→62.52%，60% 第一阶达标（#147）

### DIFF
--- a/packages/dsh-lan-proxy/test/unit-apply.test.ts
+++ b/packages/dsh-lan-proxy/test/unit-apply.test.ts
@@ -273,4 +273,98 @@ const { createServer } = await import("node:http");
   assert.equal(routes.length, 0, "enabled=false 不注册任何路由");
 }
 
+// ===== rpcHandler 成功路径与 config 合并语义（#147 变异加固） =====
+{
+  let saved = null;
+  const handler = rpcHandler({
+    resolve: () => ({ enabled: true, host: "0.0.0.0", port: 3081, httpCompressLevel: 2 }),
+    fileConfig: () => ({ host: "127.0.0.1", port: 3081 }),
+    save: (s) => { saved = s; },
+    compress: () => ({ compressed: 3, passthrough: 4 }),
+  });
+  // state：settings=文件层、effective=resolve()、compress 快照透传
+  const st = await handler("state", {});
+  assert.equal(st.ok, true, "state 成功");
+  assert.equal(st.value.settings.host, "127.0.0.1", "state.settings 来自 fileConfig");
+  assert.equal(st.value.effective.httpCompressLevel, 2, "state.effective 来自 resolve");
+  assert.deepEqual(st.value.compress, { compressed: 3, passthrough: 4 }, "state.compress 快照透传");
+  // deps.compress 缺省 → null
+  const handlerNoCompress = rpcHandler({
+    resolve: () => ({ enabled: true }), fileConfig: () => ({}), save: () => {},
+  });
+  const st2 = await handlerNoCompress("state", {});
+  assert.equal(st2.value.compress, null, "无 compress deps 时快照为 null");
+
+  // config 成功：merged = 文件层 ⊕ 提交项；save 落盘
+  const ok = await handler("config", { settings: { port: 4000 } });
+  assert.equal(ok.ok, true, "config 合法提交成功");
+  assert.equal(ok.value.settings.port, 4000, "merged 含新 port");
+  assert.equal(ok.value.settings.host, "127.0.0.1", "merged 保留旧 host");
+  assert.deepEqual(saved, ok.value.settings, "save 收到 merged");
+
+  // tls 空串清空语义：raw 显式 "" → merged 删除该键（回落自签名）
+  const clearTls = await handler("config", { settings: { tlsCertFile: "", tlsKeyFile: "", printBanner: false } });
+  assert.equal(clearTls.ok, true, "tls 双空串成对合法");
+  assert.ok(!("tlsCertFile" in saved) && !("tlsKeyFile" in saved), "空串提交从 merged 剔除两个 tls 键");
+
+  // tls-pair 校验：只给证书不给私钥
+  const halfPair = await handler("config", { settings: { tlsCertFile: "/tmp/a.pem" } });
+  assert.equal(halfPair.ok, false, "单边 tls 被拒");
+  assert.equal(halfPair.error.code, "tls-pair", "tls-pair 错误码");
+}
+
+// ===== validateSettings 字段级边界矩阵（#147 变异加固） =====
+{
+  // 非 object payload（数组按 object 形态处理、无字段可校验故通过——锁定现状）
+  for (const bad of [null, 42, "x"]) {
+    const r = validateSettings(bad);
+    assert.equal(r?.key, "(payload)", `非对象 ${JSON.stringify(bad)} 报 payload 错`);
+  }
+  assert.equal(validateSettings([]), null, "空数组无字段可校验、按现状通过");
+  // 数组也是 object——但仍是合法载体形态，逐字段校验通过后返回 null
+  // 端口类边界：0 / 负数 / 小数 / 超 65535
+  for (const p of [0, -1, 3.5, 65536, "80"]) {
+    const r = validateSettings({ port: p });
+    assert.equal(r?.key, "port", `port=${JSON.stringify(p)} 非法`);
+  }
+  assert.equal(validateSettings({ port: 65535 }), null, "port 上界 65535 合法");
+  assert.equal(validateSettings({ port: 1 }), null, "port 下界 1 合法");
+  // targetHost 回环约束
+  assert.equal(validateSettings({ targetHost: "8.8.8.8" })?.key, "targetHost", "非回环 targetHost 非法");
+  assert.equal(validateSettings({ targetHost: "localhost" }), null, "localhost 合法");
+  // httpCompressLevel 档位与迁移窗口
+  assert.equal(validateSettings({ httpCompressLevel: -1 })?.key, "httpCompressLevel", "-1 非法");
+  assert.equal(validateSettings({ httpCompressLevel: 10 })?.key, "httpCompressLevel", "10 超迁移窗非法");
+  assert.equal(validateSettings({ httpCompressLevel: 3.5 })?.key, "httpCompressLevel", "小数档位非法");
+  for (const lv of [0, 1, 2, 3]) {
+    assert.equal(validateSettings({ httpCompressLevel: lv }), null, `档位 ${lv} 合法`);
+  }
+  // wsCompressPaths 元素类型
+  assert.equal(validateSettings({ wsCompressPaths: [42] })?.key, "wsCompressPaths", "非字符串元素非法");
+  assert.equal(validateSettings({ wsCompressPaths: [] }), null, "空数组合法");
+  // undefined/null 字段跳过
+  assert.equal(validateSettings({ port: undefined, host: null }), null, "undefined/null 字段跳过校验");
+}
+
+// ===== sanitizeSettings 清洗语义（#147 变异加固） =====
+{
+  // 非 object → null
+  assert.equal(sanitizeSettings(null), null, "null → null");
+  assert.equal(sanitizeSettings("x"), null, "字符串 → null");
+  // 未知键被剔除、合法键保留
+  const cleaned = sanitizeSettings({ port: 3000, evilKey: "x" });
+  assert.equal(cleaned.port, 3000, "合法键保留");
+  assert.ok(!("evilKey" in cleaned), "未知键剔除");
+  // level 迁移 4-9 → 3
+  assert.equal(sanitizeSettings({ httpCompressLevel: 7 }).httpCompressLevel, 3, "level 7 迁移为高档 3");
+  assert.equal(sanitizeSettings({ httpCompressLevel: 4 }).httpCompressLevel, 3, "level 4 迁移为高档 3");
+  assert.equal(sanitizeSettings({ httpCompressLevel: 9 }).httpCompressLevel, 3, "level 9 迁移为高档 3");
+  // tls 空串剔除
+  const noTls = sanitizeSettings({ tlsCertFile: "", tlsKeyFile: "", httpsEnabled: true });
+  assert.ok(!("tlsCertFile" in noTls) && !("tlsKeyFile" in noTls), "tls 空串被剔除");
+  assert.equal(noTls.httpsEnabled, true, "其余键不受影响");
+  // 非法值整体拒绝
+  assert.equal(sanitizeSettings({ port: 99999 }), null, "非法值整体返回 null");
+}
+
 console.log("[unit-apply] all passed ✓");

--- a/packages/dsh-lan-proxy/test/unit-apply.test.ts
+++ b/packages/dsh-lan-proxy/test/unit-apply.test.ts
@@ -367,4 +367,58 @@ const { createServer } = await import("node:http");
   assert.equal(sanitizeSettings({ port: 99999 }), null, "非法值整体返回 null");
 }
 
+// ===== validateSettings 全字段类型矩阵（#147 变异加固接续：布尔/字符串/数组类逐字段） =====
+{
+  // 布尔类字段：字符串/数字形态一律非法
+  for (const key of ["enabled", "httpsEnabled", "printBanner", "wsCompressEnabled", "httpCompressEnabled"]) {
+    for (const bad of ["true", 1, 0]) {
+      assert.equal(validateSettings({ [key]: bad })?.key, key, `${key}=${JSON.stringify(bad)} 非法`);
+      assert.equal(validateSettings({ [key]: true }), null, `${key}=true 合法`);
+    }
+  }
+  // 字符串类字段：数字形态非法；空串除 targetHost（回环约束）外合法
+  for (const key of ["host", "tlsCertFile", "tlsKeyFile"]) {
+    assert.equal(validateSettings({ [key]: 42 })?.key, key, `${key} 数字形态非法`);
+    assert.equal(validateSettings({ [key]: "" }), null, `${key} 空串合法（留空语义）`);
+  }
+  assert.equal(validateSettings({ targetHost: 42 })?.key, "targetHost", "targetHost 数字形态非法");
+  assert.equal(validateSettings({ targetHost: "" })?.key, "targetHost", "targetHost 空串非回环非法");
+  // httpsPort 与 targetPort 共用端口校验器
+  assert.equal(validateSettings({ httpsPort: 0 })?.key, "httpsPort", "httpsPort 下界外非法");
+  assert.equal(validateSettings({ targetPort: 65536 })?.key, "targetPort", "targetPort 上界外非法");
+  assert.equal(validateSettings({ httpsPort: 3443, targetPort: 3080 }), null, "两端口合法值通过");
+  // level 迁移窗口内（4-9）经归一化后合法——validate 与 sanitize 同窗
+  assert.equal(validateSettings({ httpCompressLevel: 5 }), null, "level 5 迁移后合法");
+  assert.equal(validateSettings({ httpCompressLevel: 9 }), null, "level 9 迁移后合法");
+}
+
+// ===== Config schema 直测：schemastery 默认值与上界（#147 变异加固接续） =====
+{
+  const { Config } = await import("../lib/index.js");
+  // 空对象 → 全默认值（BooleanLiteral default true / 数值默认）
+  const defaults = Config({});
+  assert.equal(defaults.enabled, true, "enabled 默认 true");
+  assert.equal(defaults.httpsEnabled, true, "httpsEnabled 默认 true");
+  assert.equal(defaults.printBanner, true, "printBanner 默认 true");
+  assert.equal(defaults.wsCompressEnabled, true, "wsCompressEnabled 默认 true");
+  assert.equal(defaults.httpCompressEnabled, true, "httpCompressEnabled 默认 true");
+  assert.equal(defaults.httpCompressLevel, 1, "httpCompressLevel 默认低档 1");
+  assert.deepEqual(defaults.wsCompressPaths, ["/api/events.mux", "/api/events.host"], "ws 压缩路径默认两会话端点");
+  // 端口上界 65535 由 schema max 强制
+  assert.throws(() => Config({ port: 65536 }), "port 超 schema 上界抛错");
+  assert.throws(() => Config({ httpsPort: -1 }), "httpsPort 负数抛错");
+  assert.throws(() => Config({ httpCompressLevel: 4 }), "压缩档位超 3 抛错");
+}
+
+// ===== loadFileConfig 坏 JSON 与非 object JSON（#147 变异加固接续） =====
+{
+  const dir = mkdtempSync(join(tmpdir(), "dsh-lan-proxy-loadcfg2-"));
+  writeFileSync(join(dir, "config.json"), "{not-json", "utf8");
+  assert.deepEqual(loadFileConfig(dir), {}, "语法坏 JSON → 空对象（catch 分支）");
+  writeFileSync(join(dir, "config.json"), "[1,2]", "utf8");
+  assert.deepEqual(loadFileConfig(dir), {}, "数组 JSON 无合法配置键 → 空对象");
+  process.env.DSH_HOME;
+  rmSync(dir, { recursive: true, force: true });
+}
+
 console.log("[unit-apply] all passed ✓");

--- a/packages/dsh-lan-proxy/test/unit-proxy.test.ts
+++ b/packages/dsh-lan-proxy/test/unit-proxy.test.ts
@@ -12,14 +12,19 @@
  */
 import assert from "node:assert/strict";
 import { createServer, request as httpRequest } from "node:http";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { X509Certificate } from "node:crypto";
+import { constants as zlibConstants } from "node:zlib";
 
 import {
   hostnameAllowed, formatAuthority, rewriteHeaders, createLanProxy, isLoopbackTarget,
   DEFAULT_OPTIONS, compressWsPath, isCompressible, resolveCompressionOptions,
   ensureSelfSignedTls,
+} from "../lib/index.js";
+import {
+  toSanEntry, certStillValid, loadTlsFromFiles, SELF_SIGNED_KEY, SELF_SIGNED_CERT,
 } from "../lib/index.js";
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -30,9 +35,16 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 assert.equal(hostnameAllowed("127.0.0.1"), true, "bare IPv4");
 assert.equal(hostnameAllowed("[::1]"), true, "bracketed IPv6");
 assert.equal(hostnameAllowed(""), false, "empty string");
+assert.equal(hostnameAllowed(undefined), false, "非字符串（undefined）→ 拒绝");
 assert.equal(hostnameAllowed("0.0.0.0"), true, "any IPv4");
 assert.equal(hostnameAllowed("192.168.1.1"), true, "LAN IPv4");
 assert.equal(hostnameAllowed("127.0.0.1:99999"), false, "端口越界 → URL 解析失败 → 拒绝");
+assert.equal(hostnameAllowed("localhost"), true, "localhost 字面量放行");
+assert.equal(hostnameAllowed("localhost:3080"), true, "localhost 带端口放行");
+assert.equal(hostnameAllowed("[::1]:443"), true, "bracketed IPv6 带端口放行");
+assert.equal(hostnameAllowed("example.com"), false, "DNS 域名拒绝（重绑定防护核心语义）");
+assert.equal(hostnameAllowed("sub.example.org"), false, "多级 DNS 域名拒绝");
+assert.equal(hostnameAllowed("::1"), false, "裸 IPv6 冒号 authority → URL 解析失败 → 拒绝");
 
 // isLoopbackTarget
 assert.equal(isLoopbackTarget("127.0.0.1"), true, "loopback IPv4");
@@ -40,8 +52,12 @@ assert.equal(isLoopbackTarget("::1"), true, "loopback IPv6");
 assert.equal(isLoopbackTarget("::ffff:127.0.0.1"), true, "IPv4-mapped IPv6 loopback");
 assert.equal(isLoopbackTarget("localhost"), true, "localhost");
 assert.equal(isLoopbackTarget("[::1]"), true, "bracketed IPv6 loopback");
+assert.equal(isLoopbackTarget("[127.0.0.1]"), true, "bracketed IPv4 loopback");
+assert.equal(isLoopbackTarget("[::ffff:127.0.0.1]"), true, "bracketed mapped loopback");
 assert.equal(isLoopbackTarget("192.168.1.1"), false, "非回环拒绝");
 assert.equal(isLoopbackTarget("evil.com"), false, "DNS 名拒绝");
+assert.equal(isLoopbackTarget(""), false, "空串拒绝");
+assert.equal(isLoopbackTarget("127.0.0.2"), false, "非 .1 回环段仍按字面匹配语义拒绝");
 
 // formatAuthority
 assert.equal(formatAuthority("0.0.0.0", 3081), "0.0.0.0:3081");
@@ -59,6 +75,16 @@ assert.deepEqual(rewriteHeaders({ host: "x:1", origin: "https://x:1" }, "127.0.0
   origin: "http://127.0.0.1:3080",
 }, "Origin https→http");
 assert.deepEqual(rewriteHeaders({}, "127.0.0.1:3080"), { host: "127.0.0.1:3080" }, "空头只加 host");
+assert.deepEqual(rewriteHeaders({ host: ["a", "b"], origin: ["http://a"] }, "127.0.0.1:9"), {
+  host: "127.0.0.1:9",
+  origin: "http://127.0.0.1:9",
+}, "多值头（string[]）同样整体覆盖为单值 authority");
+// 原对象不被修改（浅拷贝语义）
+{
+  const src = { host: "old:1" };
+  rewriteHeaders(src, "127.0.0.1:2");
+  assert.equal(src.host, "old:1", "入参 headers 不被就地修改");
+}
 
 // compressWsPath
 assert.equal(compressWsPath(["/a", "/b"], "/a?query=1"), true, "带查询串命中");

--- a/scripts/data/gauntlet.config.json
+++ b/scripts/data/gauntlet.config.json
@@ -58,45 +58,46 @@
       "dsh-mcp-manager": {
         "baselineScore": 58.74,
         "baselineCovered": 74.66,
-        "baselineKilled": 1142,
-        "baselineTimeout": 4,
+        "baselineKilled": 1141,
+        "baselineTimeout": 5,
         "baselineSurvived": 389,
         "baselineTotal": 1951,
         "baselineNoCoverage": 416,
         "baselineErrors": 0,
         "baselineDate": "2026-08-24",
-        "baselineDuration": "3m52s",
+        "baselineDuration": "3m0s",
         "baselineScope": "packages/dsh-mcp-manager/lib/index.js:8610-8696+17322-17456+19271-19915+19964-21027（self-written 四段：store、transport+scope、protocol/supervisor/catalog、import/routes/index；排除 esbuild 垫片、zod/@modelcontextprotocol/sdk/ajv 等大段内联 vendor、shared 契约层内联副本与纯 import 提升段）",
         "config": "stryker.conf.d/dsh-mcp-manager.json",
-        "hardeningNote": "#148 变异加固轮：6 个单测 commit 将 covered 由 29.37% 提升至 74.66%"
+        "hardeningNote": "#148 变异加固轮：6 个单测 commit 将 covered 由 29.37% 提升至 74.66%；耗时优化（#173）零杀伤 testFiles 移除 + conc8，3m52s→3m0s"
       },
       "dsh-provider-usage": {
-        "baselineScore": 26.21,
-        "baselineCovered": 39.46,
-        "baselineKilled": 661,
+        "baselineScore": 39.1,
+        "baselineCovered": 52.87,
+        "baselineKilled": 976,
         "baselineTotal": 2556,
-        "baselineNoCoverage": 858,
+        "baselineNoCoverage": 662,
         "baselineErrors": 0,
-        "baselineDate": "2026-08-24",
-        "baselineDuration": "1m55s",
+        "baselineDate": "2026-08-25",
+        "baselineDuration": "4m30s",
         "baselineScope": "packages/dsh-provider-usage/lib/index.js:1372-2769+2805-3696（self-written 两段：contracts/registry/adapters-opencode-go/core-guards/sanitize/pipeline-v2/history/provider-config/hotreload 与 path-resolve/client-logic/index；排除 esbuild 垫片、cosmokit/schemastery/async-mutex/untildify 内联 vendor、shared 契约层内联副本与纯 import 提升段）",
         "config": "stryker.conf.d/dsh-provider-usage.json",
-        "baselineTimeout": 9,
-        "hardeningNote": "#150 变异加固轮（分片1+2 部分）：covered 由 31.80% 提升至 39.46%，60% 达标缺口单列跟进"
+        "baselineTimeout": 18,
+        "hardeningNote": "#150 变异加固轮一阶段（PR #169）：covered 由 31.80% 提升至 52.87%（图表分档矩阵/sanitizeHtml 全正则/guards 边界），60% 达标缺口二阶段跟进"
       },
       "dsh-lan-proxy": {
-        "baselineScore": 35.11,
-        "baselineCovered": 49.75,
-        "baselineKilled": 259,
-        "baselineTimeout": 37,
-        "baselineSurvived": 299,
+        "baselineScore": 52.43,
+        "baselineCovered": 62.52,
+        "baselineKilled": 400,
+        "baselineTimeout": 42,
+        "baselineSurvived": 265,
         "baselineTotal": 843,
-        "baselineNoCoverage": 248,
+        "baselineNoCoverage": 136,
         "baselineErrors": 0,
-        "baselineDate": "2026-08-24",
-        "baselineDuration": "7m36s",
+        "baselineDate": "2026-08-25",
+        "baselineDuration": "7m50s",
         "baselineScope": "packages/dsh-lan-proxy/lib/index.js:35657-35911+35912-35972+36058-36643（self-written 三段，对应 src/proxy.ts+cert.ts+index.ts 尾段；排除 esbuild 垫片、cosmokit/schemastery/ws/http-proxy/node-forge/selfsigned 内联 vendor、shared 契约层内联副本）",
-        "config": "stryker.conf.d/dsh-lan-proxy.json"
+        "config": "stryker.conf.d/dsh-lan-proxy.json",
+        "hardeningNote": "#147 变异加固轮：covered 由 49.75% 提升至 62.52%，60% 第一阶达标"
       }
     }
   }


### PR DESCRIPTION
## 关联 issue
- #147（Stryker 接入 dsh-lan-proxy，阶段二加固达标）

## 改动内容（4 commits）
1. hostname 重绑定防护 / cert 校验 / TLS 加载边界断言（接续上轮 agent 现场）
2. **rpcHandler 全路径**：state 双 deps 形态、config merged 落盘语义、tls 空串清空回落自签名、tls-pair 成对校验拒绝
3. **validateSettings/sanitizeSettings 字段级边界矩阵**：布尔五字段非法形态、端口上下界、回环约束、档位迁移窗 4-9→3、未知键剔除、null/undefined 跳过
4. **Config schema 直测**：全默认值锁定、schema 上界抛错（port/httpsPort/httpCompressLevel）；loadFileConfig 坏 JSON catch 分支
5. chore：三包变异基线刷新落账

## 实测效果

| 指标 | 改前 | 改后 |
|---|---|---|
| covered score | 49.75% | **62.52%（60% 达标）** |
| total score | 35.11% | 52.43% |
| killed+timeout | 296 | 442 |
| noCoverage | 248 | 136 |

耗时 7m50s 持平（41-42 个 WS 挂起 mutant 的 timeoutMS=15000 固定开销主导，testFiles 仅 2 个无可移除；压缩方案另立 issue）。

## 验证
- [x] 本地五连门禁全绿（build/test/contract/pack:check/typecheck）
- [x] 变异报告核对：survived/noCoverage 分布与断言目标一致