### PR TITLE
fix(dsh-provider-usage): warmup 改串行 await——多 provider 采样被 mutex busy 短路（#156）

### DIFF
--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -871,15 +871,24 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
   // 8. 后台预热定时器（保持历史连续；无客户端访问时兜底）
   let warmupTimer: ReturnType<typeof setInterval> | null = null;
   if (config.warmupIntervalMs > 0) {
-    const warmupFn = () => {
+    // #156：必须串行 await——并发发起时全部 getStats 的同步段（cacheFresh →
+    // isLocked → runExclusive）在事件循环同一轮内执行，注册序第一个 provider
+    // 拿到全局互斥锁后其余全部 busy 短路，多 provider 场景下永远只有第一个
+    // 能采样（夜间无 GUI 轮询时段其余 provider 断采数小时）。串行化后每个
+    // provider 依次持锁取数，busy 短路语义仅保留给并发的 /stats 客户端请求。
+    const warmupFn = async () => {
       for (const provider of registry.enabledProviders()) {
-        void getStats(provider).catch(() => {});
+        try {
+          await getStats(provider);
+        } catch {
+          // 单个 provider 失败不阻断后续 provider 的采样
+        }
       }
     };
     warmupTimer = setInterval(warmupFn, config.warmupIntervalMs);
     (warmupTimer as { unref?: () => void }).unref?.();
     // 启动时立即预热一次（所有启用 provider）
-    warmupFn();
+    void warmupFn();
   }
 
   // 9. 设置面板命名空间（只读镜像；apiKey 不进 schema 避免回显）

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -33,6 +33,7 @@ import {
   ADAPTER_CONTRACT_VERSION,
   OPENCODE_GO_PROVIDER,
   OPENCODE_GO_ADAPTER_ID,
+  userAdaptersFile,
 } from "../lib/index.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -489,6 +490,79 @@ export function formatPanel() { return "<p>p</p>"; }
 }
 
 console.log("[smoke] 全部断言通过 ✓ (v2 集成)");
+
+// ---------------------------------------------------------------- #156 warmup 串行采样回归
+
+/**
+ * 回归：warmup 并发发起 + getStats 全局 mutex busy 短路 → 多 provider 只有
+ * 注册序第一个能采样，其余零采样数小时。修复后 warmupFn 串行 await，
+ * 全部 enabled provider 依次持锁取数。
+ */
+{
+  // 构造两个用户适配器（providers 互不相同），注册表指向绝对路径 mjs
+  const adapterDir = mkdtempSync(join(tmpdir(), "dou-warmup-adapters-"));
+  const mkAdapter = (name, provider) => {
+    const file = join(adapterDir, `${name}.mjs`);
+    writeFileSync(file, `
+export const version = 2;
+export const name = "${name}";
+export const label = "${name}";
+export const providers = ["${provider}"];
+export async function fetchData() {
+  // 模拟真实远端 IO 延迟：让持锁窗口覆盖后续 provider 的同步检查段，
+  // 否则 mock 同步完成过快、两请求都排进 mutex 队列，无法复现 busy 短路
+  await new Promise((r) => setTimeout(r, 40));
+  return { visits: 7 };
+}
+export function formatCapsule(input) { return "<span>" + input.data.visits + "</span>"; }
+export function formatPanel() { return "<p>ok</p>"; }
+`, "utf8");
+    return file;
+  };
+  const fileA = mkAdapter("warm-a", "prov-a");
+  const fileB = mkAdapter("warm-b", "prov-b");
+  writeFileSync(userAdaptersFile(join(process.env.DSH_HOME, "dsh-provider-usage")), JSON.stringify({
+    adapters: [
+      { id: "warm-a", label: "Warm A", providers: ["prov-a"], file: fileA },
+      { id: "warm-b", label: "Warm B", providers: ["prov-b"], file: fileB },
+    ],
+  }), "utf8");
+
+  const disposers = [];
+  const { ctx, routes } = makeFakeCtx({
+    effect(fn) {
+      const d = fn();
+      if (typeof d === "function") disposers.push(d);
+      return typeof d === "function" ? d : () => {};
+    },
+  });
+  await apply(ctx, { ...ISOLATED_CONFIG, warmupIntervalMs: 60000 });
+  // 启动即预热一次（串行 await）：给足两个 provider 依次取数的时间
+  await new Promise((r) => setTimeout(r, 400));
+
+  const statsRoute = routes.find((r) => r.path === ROUTES.stats);
+  const queryProvider = async (provider) => {
+    let payload;
+    statsRoute.handler(
+      fakeReq({ url: `${ROUTES.stats}?provider=${provider}` }),
+      { writeHead: () => {}, end: (chunk) => { payload = JSON.parse(chunk); } },
+    );
+    await new Promise((r) => setTimeout(r, 30));
+    return payload;
+  };
+  const pa = await queryProvider("prov-a");
+  const pb = await queryProvider("prov-b");
+
+  assert.equal(pa.adapterName, "warm-a", "provider A 经 warmup 完成采样（适配器生效）");
+  assert.notEqual(pa.status, "stale", `provider A 非 stale 短路（实际 ${pa.status}）`);
+  assert.equal(pb.adapterName, "warm-b", "provider B 经 warmup 完成采样——旧实现下 B 因 mutex busy 零采样（#156 主回归点）");
+  assert.notEqual(pb.status, "stale", `provider B 非 stale 短路（实际 ${pb.status}）`);
+
+  for (const d of [...disposers].reverse()) {
+    try { d(); } catch {}
+  }
+  console.log("[smoke] #156 warmup 串行采样回归 ✓");
+}
 
 // 恢复真实环境变量（测试收尾）
 for (const k of SAVED_ENV_KEYS) {

--- a/packages/dsh-provider-usage/test/unit-v1.test.ts
+++ b/packages/dsh-provider-usage/test/unit-v1.test.ts
@@ -827,16 +827,18 @@ assert.equal(openCodeGoAdapter.formatPanel({
     assert.equal(fast.aborted, false, "未超时时 signal 未被 abort");
     assert.equal(fast.url, "https://gw.test/x", "url 原样透传");
     assert.deepEqual(fast.headers, { "x-k": "v" }, "init.headers 透传");
-    const sigFast = calls[calls.length - 1].opts.signal;
+    // 同理按 url 过滤取 fast 的调用记录：calls 尾部在负载下可能被外部污染
+    const sigFast = calls.find((c) => c.url === "https://gw.test/x")?.opts.signal;
     assert.ok(sigFast instanceof AbortSignal, "signal 覆盖为真 AbortSignal（展开序 {...init, signal}）");
 
     // 慢路径：超过 timeoutMs 的延迟 -> 返回时已观察到 abort
-    // （增量计数：前置测试可能遗留异步操作在本 await 窗口内触发 mock fetch，
-    //   绝对计数会造成时序 flake——CI 实证，改用差值锁定本调用恰一次）
-    const beforeSlow = calls.length;
+    // （按 url 过滤计数：await 窗口内前置测试遗留异步操作可能触发本 mock fetch，
+    //   绝对计数与差值计数均会时序 flake——CI 两次实证；只有按调用特征过滤
+    //   才能彻底与外部污染解耦）
     const slow = await fetchWithTimeout("https://gw.test/y", 20, { delayMs: 80 });
     assert.equal(slow.aborted, true, "超过 timeoutMs 后 controller.abort 已触发");
-    assert.equal(calls.length - beforeSlow, 1, "慢路径恰一次到达注入 fetch");
+    assert.equal(calls.filter((c) => c.url === "https://gw.test/y").length, 1,
+      "慢路径恰一次到达注入 fetch");
 
     // 默认参数形态：省略 timeoutMs 与 init 仍可完成快调用
     globalThis.fetch = async (url, opts) => ({ marker: "def", aborted: opts.signal.aborted });


### PR DESCRIPTION
## 关联 issue

Closes #156

## 根因（issue 实证）

warmup 每 5 分钟对全部 enabled provider **并发发起** `void getStats(provider)`；getStats 同步段（cacheFresh → isLocked → runExclusive）在同一轮事件循环内执行，注册序第一个 provider 持锁后其余全部命中 busy 短路返回 stale——夜间无 GUI 轮询时段非首位 provider 断采数小时（实测 6h 零采样）。

## 修复

warmupFn 改串行 await：各 provider 依次持锁取数，单 provider 失败不阻断后续。/stats 客户端请求的 busy 短路语义不变（验收条目 3）。

## 回归断言设计要点

- 双用户适配器（providers 互不相同）+ **fetchData 40ms IO 延迟**——延迟是断言有效性的关键：mock 同步完成过快时两个请求都排进 async-mutex 队列、无法复现 busy 竞争窗口
- 已实证：旧实现下回归断言变红（provider B 零采样），新实现全绿

## 附带修复

unit-v1 fetchWithTimeout mock 的两处残余时序 flake（绝对/差值计数与取尾记录均会被 await 窗口内外部遗留异步污染，全仓 test 高负载下实证复发），统一改按 url 过滤定位调用记录。

## 验收对照（#156 spec 评论）

1. [x] warmup 并发场景全部 provider 依次完成采样落盘（回归段主断言）
2. [x] /stats 单请求 cached/fresh 路径行为不变（既有 smoke 全绿）
3. [x] 锁占用期 /stats 快速短路语义保留（isLocked 检查未动）
4. [x] smoke 三态断言入库
5. [x] 多 provider 夜间断采根因消除

- [x] 本地五连门禁全绿