### PR TITLE
feat(ci): Stryker 增量模式接入——夜间全量落基线缓存与 PR 增量变异门禁（#178）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,8 +225,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build package（变异对象 = lib 编译产物，与夜间口径一致）
-        run: pnpm --filter ./packages/${{ matrix.package }} build
+      # 必须全量构建（run #32790425132 教训）：后续 pnpm cov = c8 包裹全仓 smoke，
+      # 任一包 lib/index.js 缺失即 ERR_MODULE_NOT_FOUND；且 selfWritten.functions.pct
+      # 为全仓口径，单包 cov 会让覆盖率分母与夜间口径漂移
+      - name: Build all packages（变异对象与覆盖率口径均依赖全集 lib 产物）
+        run: pnpm build
 
       - name: Restore nightly incremental baseline（只读，无 save 后置步骤）
         # 精确 key 永不命中（PR 的 run_id 与夜间不同）→ 必走 restore-keys 前缀，

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,9 @@ jobs:
       matrix:
         package: ${{ fromJSON(needs.changes.outputs.mutationPackages) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 45 分钟悬崖余量：缓存 miss 首夜 = 天然降级全量变异（lan-proxy 全量实测 7m36s，
+    # 再叠加 install + 全量 build + cov 全仓 smoke），30 分钟存在被误杀风险
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
@@ -235,12 +237,23 @@ jobs:
         # 精确 key 永不命中（PR 的 run_id 与夜间不同）→ 必走 restore-keys 前缀，
         # 命中最近一夜 observe-incremental-<run_id>；save 归档根 = coverage/mutation/
         #（六份 incremental-*.json 同目录 glob），此处以同目录 path 解压还原。
+        id: baseline
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: coverage/mutation
           key: observe-incremental-${{ github.run_id }}
           restore-keys: |
             observe-incremental-
+
+      - name: Baseline cache verdict（hit/miss 审计标注）
+        env:
+          MATCHED_KEY: ${{ steps.baseline.outputs.cache-matched-key }}
+        run: |
+          if [ -n "$MATCHED_KEY" ]; then
+            echo "incremental 基线命中：$MATCHED_KEY"
+          else
+            echo '::notice::incremental 基线缓存 miss —— 本次降级为全量变异（首夜无基线或 LRU 淘汰均属预期，非缺陷）'
+          fi
 
       - name: Incremental mutation（incremental 生效跳过未变 mutant）
         run: npx stryker run stryker.conf.d/${{ matrix.package }}.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     outputs:
       # 命中"需跑 smoke/typecheck 切片"的包清单（json 数组，可为 []）
       hitPackages: ${{ steps.pkgs.outputs.hitPackages }}
+      # 增量变异切片清单（#178）：hitPackages 剔除聚合包 dsh-plugins-all（无变异配置）
+      mutationPackages: ${{ steps.pkgs.outputs.mutationPackages }}
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
@@ -86,15 +88,20 @@ jobs:
           BASE_SET: ${{ steps.base.outputs.base }}
         run: |
           set -e
+          # mutationPackages：hitPackages 剔除聚合包后的增量变异切片（#178）
+          emit_outputs() {
+            echo "hitPackages=$1" >> "$GITHUB_OUTPUT"
+            echo "mutationPackages=$(printf '%s' "$1" | jq -c '[.[] | select(. != "dsh-plugins-all")]')" >> "$GITHUB_OUTPUT"
+          }
           # fail-closed 双闸：diff 基准不可用 或 filter 步骤失败 → 一律全量切片
           if [ -z "$BASE_SET" ] || [ "$FILTER_OUTCOME" = "failure" ]; then
             echo '::notice::fallback 全量切片（fail-closed）'
-            echo 'hitPackages=["dsh-notifier","dsh-idle-archive","dsh-web-file-preview","dsh-mcp-manager","dsh-provider-usage","dsh-lan-proxy","dsh-plugins-all"]' >> "$GITHUB_OUTPUT"
+            emit_outputs '["dsh-notifier","dsh-idle-archive","dsh-web-file-preview","dsh-mcp-manager","dsh-provider-usage","dsh-lan-proxy","dsh-plugins-all"]'
             exit 0
           fi
           if [ "$GLOBAL_HIT" = "true" ]; then
             echo '::notice::全局路径命中 → 全量切片'
-            echo 'hitPackages=["dsh-notifier","dsh-idle-archive","dsh-web-file-preview","dsh-mcp-manager","dsh-provider-usage","dsh-lan-proxy","dsh-plugins-all"]' >> "$GITHUB_OUTPUT"
+            emit_outputs '["dsh-notifier","dsh-idle-archive","dsh-web-file-preview","dsh-mcp-manager","dsh-provider-usage","dsh-lan-proxy","dsh-plugins-all"]'
             exit 0
           fi
           HITS='['
@@ -116,7 +123,7 @@ jobs:
             fi
           done
           HITS="$HITS]"
-          echo "hitPackages=$HITS" >> "$GITHUB_OUTPUT"
+          emit_outputs "$HITS"
           echo "命中包（跑 smoke/typecheck 切片）: $HITS"
 
   # ── 第 2 段：全包并行 build + lib artifact；smoke/typecheck 只对命中包切片 ──
@@ -183,10 +190,71 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  # ── 第 3 段：聚合闸（job 名保持分支保护 required check 名不变，无缝切换）──
+  # ── 第 3 段：增量变异门禁（#178 v2：paths-filter 切片 + 夜间基线增量复用）──
+  # - 仅对命中包实例化（动态 matrix ← changes.mutationPackages；空清单时整体 skipped）
+  # - restore-only：只读夜间全量落下的 incremental 基线，绝不回写（防 PR 结果污染夜间基线源）
+  # - 缓存未命中（首夜前 / LRU 淘汰）天然降级为全量变异，门禁语义不变仅变慢
+  # - 双指标判分（scripts/gate/mutation-gate.mjs）：测试覆盖率（self-written 函数，
+  #   恒硬）+ 变异测试率（covered ≥ threshold，受 mutation.strict 开关约束）
+  # - 成败并入 repo-gate 聚合闸，不新增分支保护 required check 名
+  # 已知约束：GitHub Actions 的 matrix 不允许引用 env context，但可引用 needs outputs
+  mutation-gate:
+    name: Mutation gate (${{ matrix.package }})
+    needs: changes
+    if: always() && needs.changes.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.changes.outputs.mutationPackages) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+        # 版本以根 package.json 的 packageManager 字段为单一事实源（勿同时指定 version）
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package（变异对象 = lib 编译产物，与夜间口径一致）
+        run: pnpm --filter ./packages/${{ matrix.package }} build
+
+      - name: Restore nightly incremental baseline（只读，无 save 后置步骤）
+        # 精确 key 永不命中（PR 的 run_id 与夜间不同）→ 必走 restore-keys 前缀，
+        # 命中最近一夜 observe-incremental-<run_id>；save 归档根 = coverage/mutation/
+        #（六份 incremental-*.json 同目录 glob），此处以同目录 path 解压还原。
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: coverage/mutation
+          key: observe-incremental-${{ github.run_id }}
+          restore-keys: |
+            observe-incremental-
+
+      - name: Incremental mutation（incremental 生效跳过未变 mutant）
+        run: npx stryker run stryker.conf.d/${{ matrix.package }}.json
+
+      - name: Coverage collection（self-written 口径数据源：c8 包裹全仓 smoke）
+        run: pnpm cov
+
+      - name: Self-written coverage report（落盘 coverage/self-coverage.json）
+        run: node scripts/gate/self-cov.mjs
+
+      - name: Mutation gate verdict（双指标判分：覆盖率恒硬 + 变异率受 strict 开关）
+        run: node scripts/gate/mutation-gate.mjs ${{ matrix.package }}
+
+  # ── 第 4 段：聚合闸（job 名保持分支保护 required check 名不变，无缝切换）──
   repo-gate:
     name: Build / Contract / Smoke / Pack
-    needs: [changes, build-test]
+    needs: [changes, build-test, mutation-gate]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -194,13 +262,20 @@ jobs:
       - name: Fail-closed gate assertion（F2：任何上游非 success 即红）
         run: |
           set -e
-          echo "changes=${{ needs.changes.result }}  build-test=${{ needs.build-test.result }}"
+          echo "changes=${{ needs.changes.result }}  build-test=${{ needs.build-test.result }}  mutation-gate=${{ needs.mutation-gate.result }}"
           if [ "${{ needs.changes.result }}" != "success" ]; then
             echo "::error::changes 作业未成功（${{ needs.changes.result }}）—— fail-closed"
             exit 1
           fi
           if [ "${{ needs.build-test.result }}" != "success" ]; then
             echo "::error::build-test 存在失败/skipped 实例（${{ needs.build-test.result }}）—— fail-closed"
+            exit 1
+          fi
+          # mutation-gate（#178）：success 放行；skipped 仅当无命中包（空矩阵）或
+          # changes 未成功——后者已被上方断言拦截，此处放行不构成旁路；
+          # failure/cancelled 一律判红
+          if [ "${{ needs.mutation-gate.result }}" != "success" ] && [ "${{ needs.mutation-gate.result }}" != "skipped" ]; then
+            echo "::error::mutation-gate 存在失败实例（${{ needs.mutation-gate.result }}）—— fail-closed"
             exit 1
           fi
 

--- a/.github/workflows/observe.yml
+++ b/.github/workflows/observe.yml
@@ -5,6 +5,12 @@ name: Observe (nightly)
 # - 六包全量变异（串行）+ mutate 面守卫（F5）
 # - 报告落 issue（幂等：同日不重开）；回落 >1pp 自动追评（隔夜必有工单）
 # 变异硬门禁在本 workflow 生效：任一包 covered < threshold 且 strict 开启 → 运行失败。
+# #178 v2 增量链路：
+# - 本 workflow 刻意不做 actions/cache restore —— 无增量基线即天然全量，无需 --force；
+#   请勿"好心"补 restore 步骤（会破坏全量基线语义）。
+# - 全量运行末尾将六份 incremental 基线写入 actions/cache（save 用 if: always()
+#   保证部分失败夜也落盘已产出文件），key = observe-incremental-<run_id> 单条目；
+#   PR 侧 ci.yml 以 observe-incremental- 前缀 restore-only 读取。
 
 on:
   schedule:
@@ -59,13 +65,37 @@ jobs:
       - name: Mutation scope guard（F5：mutate 区间须落在 // lib/*.js 分段边界内）
         run: node scripts/gate/mutate-scope-guard.mjs
 
-      - name: Mutation suites（六包串行全量）
+      - name: Mutation suites（六包串行全量；单包失败记账继续跑完，结尾统一判红）
+        # #178 逐包容错：strict 判红路径下 incremental 基线已先落盘（StrykerJS 源码核实），
+        # 记账继续可让后续包照常产出报告与基线，避免单包连锁丢弃整夜数据
         run: |
+          FAILED=0
+          FAILED_PKGS=''
           for pkg in notifier idle-archive web-file-preview mcp-manager provider-usage lan-proxy; do
             echo "::group::stryker dsh-$pkg"
-            npx stryker run "stryker.conf.d/dsh-$pkg.json"
-            echo "::endgroup::"
+            if npx stryker run "stryker.conf.d/dsh-$pkg.json"; then
+              echo "::endgroup::"
+            else
+              echo "::endgroup::"
+              echo "::error::变异套件失败：dsh-$pkg（记账后继续执行其余包）"
+              FAILED=1
+              FAILED_PKGS="$FAILED_PKGS $pkg"
+            fi
           done
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::以下包变异套件失败，统一判红:$FAILED_PKGS"
+            exit 1
+          fi
+
+      - name: Save incremental baseline cache（夜间新鲜基线 → PR 增量门禁读取）
+        # #178 v2：save 用 glob 使归档根 = coverage/mutation/（六文件同目录），
+        # PR 侧 restore 以同目录 path 解压。if: always() —— 部分失败夜已产出的
+        # 基线文件照常落缓存；key 带 run_id 单条目，旧夜靠 PR 侧 restore-keys 前缀兜底。
+        if: always()
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          key: observe-incremental-${{ github.run_id }}
+          path: coverage/mutation/incremental-*.json
 
       - name: Threshold check & report body（阈值校验 + 回落检测 + 报告产出）
         id: report

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -37,6 +37,25 @@ pnpm typecheck    # 全仓类型检查
 > （只记录不判红），`threshold` 为阶段二目标值，待基线校准（issue #42 二期）后再
 > 接入 CI 硬卡点。
 
+### 变异测试与增量链路（#178）
+
+六包变异配置集中在 `stryker.conf.d/dsh-<pkg>.json`（mutate 区间、testFiles、
+阈值口径与 `gauntlet.config.json` 三方一致，由 workflow-assert 自测锚定）。增量链路：
+
+- **夜间全量落基线**（observe.yml）：刻意不 restore 任何缓存——无 incremental
+  基线即天然全量；运行末尾把六份 `coverage/mutation/incremental-*.json` 写入
+  actions/cache（key = `observe-incremental-<run_id>`）。逐包容错记账：单包失败
+  记账继续跑完其余包，结尾统一非零退出。
+- **PR 增量门禁**（ci.yml `mutation-gate` job）：按 paths-filter 命中包切片，
+  restore-only 读最近一夜基线（绝不回写）后对该包跑 Stryker——incremental 模式
+  跳过未变 mutant，报告仍为全量口径（复用 mutant 继承原状态）。双指标判分
+  （scripts/gate/mutation-gate.mjs）：测试覆盖率 self-written 函数 ≥ threshold
+  恒硬；变异测试率 covered ≥ per-package threshold 受全局 `mutation.strict`
+  约束（false 期间仅标注，#150 达标翻转后自动变硬）。成败并入 repo-gate
+  聚合闸，不新增分支保护 required check 名。缓存未命中时天然降级为全量变异。
+- 本地手动入口：`npx stryker run stryker.conf.d/dsh-<pkg>.json`（临时强制全量用
+  官方 `--force` 参数，勿改配置文件）。
+
 目录结构：
 
 ```text

--- a/scripts/gate/mutation-gate.mjs
+++ b/scripts/gate/mutation-gate.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * mutation-gate — PR 增量变异门禁双指标判分（#178 v2）
+ *
+ * 输入（ci.yml mutation-gate job 内按序产出）：
+ *   - coverage/mutation/<pkg>.json     Stryker JSON 报告（incremental 运行产物，
+ *                                      复用 mutant 继承原状态，报告恒为全量口径）
+ *   - coverage/self-coverage.json      self-written 覆盖率明细（self-cov.mjs 先行产出）
+ *   - scripts/data/gauntlet.config.json（阈值唯一事实源）
+ *
+ * 用法：node scripts/gate/mutation-gate.mjs <pkg>   # pkg 形如 dsh-mcp-manager
+ *
+ * 判分（两项指标）：
+ *   1) 测试覆盖率：self-written functions pct ≥ coverage.selfWrittenFunctions.threshold
+ *      —— 恒硬（PR 门禁不随观察期开关放松，防止低覆盖改动借道合入）；
+ *   2) 变异测试率：covered score ≥ mutation.packages[pkg].threshold
+ *      —— 受全局 mutation.strict 开关约束：false 期间仅标注不拦截
+ *      （provider-usage 在 #150 达标翻转 strict 后自动变硬，避免达标前卡死触该包的 PR）。
+ *
+ * 退出码：0 = 通过；1 = 门禁违约；2 = 环境/数据缺失错误（fail-closed）
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { readMutationReport } from '../lib/mutation-report-lib.mjs';
+
+const repoRoot = process.cwd();
+const pkg = process.argv[2];
+if (!pkg || !/^dsh-[a-z0-9-]+$/.test(pkg)) {
+  console.error('mutation-gate: 用法：node scripts/gate/mutation-gate.mjs <dsh-<name>>');
+  process.exit(2);
+}
+
+// ── gauntlet 配置 ─────────────────────────────────────────────
+let gauntlet;
+try {
+  gauntlet = JSON.parse(readFileSync(join(repoRoot, 'scripts', 'data', 'gauntlet.config.json'), 'utf8'));
+} catch (err) {
+  console.error(`mutation-gate: gauntlet.config.json 解析失败：${err.message}`);
+  process.exit(2);
+}
+const mutCfg = gauntlet?.mutation?.packages?.[pkg];
+if (!mutCfg) {
+  console.error(`mutation-gate: ${pkg} 不在 gauntlet mutation.packages 内——聚合包无变异配置，不应进入本门禁`);
+  process.exit(2);
+}
+const threshold = typeof mutCfg.threshold === 'number' ? mutCfg.threshold : null;
+if (threshold === null) {
+  console.error(`mutation-gate: ${pkg}.threshold 未配置 —— 视为配置错误（fail-closed）`);
+  process.exit(2);
+}
+const mutationStrict = Boolean(gauntlet?.mutation?.strict);
+const covCfg = gauntlet?.coverage?.selfWrittenFunctions ?? {};
+const covThreshold = typeof covCfg.threshold === 'number' ? covCfg.threshold : null;
+if (covThreshold === null) {
+  console.error('mutation-gate: coverage.selfWrittenFunctions.threshold 未配置 —— 视为配置错误（fail-closed）');
+  process.exit(2);
+}
+
+let failed = false;
+
+// ── 指标一：测试覆盖率（self-written 函数口径，恒硬） ──────────
+const selfCovPath = join(repoRoot, 'coverage', 'self-coverage.json');
+if (!existsSync(selfCovPath)) {
+  console.error('mutation-gate: coverage/self-coverage.json 不存在（须先运行 self-cov.mjs）—— fail-closed');
+  process.exit(2);
+}
+let fnPct = null;
+try {
+  fnPct = JSON.parse(readFileSync(selfCovPath, 'utf8'))?.selfWritten?.functions?.pct ?? null;
+} catch (err) {
+  console.error(`mutation-gate: self-coverage.json 解析失败：${err.message}`);
+  process.exit(2);
+}
+if (fnPct === null) {
+  console.error('mutation-gate: self-coverage.json 缺少 selfWritten.functions.pct —— fail-closed');
+  process.exit(2);
+}
+console.log(`mutation-gate [${pkg}] 测试覆盖率: functions ${fnPct}% vs threshold ${covThreshold}%（恒硬）`);
+if (fnPct < covThreshold) {
+  console.error(`mutation-gate: FAIL —— self-written 函数覆盖 ${fnPct}% 低于下限 ${covThreshold}%`);
+  failed = true;
+}
+
+// ── 指标二：变异测试率（covered 口径，受 mutation.strict 约束）──
+const reportPath = join(repoRoot, 'coverage', 'mutation', `${pkg}.json`);
+const r = readMutationReport(reportPath);
+if (!r) {
+  // stryker 步骤成功后报告必然存在；缺失 = 链路异常而非门禁语义，一律判红
+  console.error(`mutation-gate: ${pkg} 变异报告缺失或不可解析（${reportPath}）—— fail-closed`);
+  process.exit(2);
+}
+console.log(
+  `mutation-gate [${pkg}] 变异测试率: covered ${r.coveredScore}% vs threshold ${threshold}%`
+  + ` (killed ${r.killed} + timeout ${r.timeout} / covered ${r.killed + r.timeout + r.survived})`,
+);
+if (r.coveredScore < threshold) {
+  if (mutationStrict) {
+    console.error(`mutation-gate: FAIL —— 变异 covered ${r.coveredScore}% 低于 threshold ${threshold}%（strict=${mutationStrict}）`);
+    failed = true;
+  } else {
+    console.warn(`mutation-gate: WARN —— 变异 covered ${r.coveredScore}% 低于 threshold ${threshold}%，strict=false 观察态不拦截（#150 达标后自动变硬）`);
+  }
+}
+
+if (failed) process.exit(1);
+console.log(`mutation-gate: ${pkg} 双指标通过`);

--- a/scripts/gate/observe-check.mjs
+++ b/scripts/gate/observe-check.mjs
@@ -20,6 +20,7 @@
  */
 import { readFileSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { readMutationReport } from '../lib/mutation-report-lib.mjs';
 
 const repoRoot = process.cwd();
 const argv = process.argv.slice(2);
@@ -41,30 +42,6 @@ try {
 const packages = gauntlet?.mutation?.packages ?? {};
 const mutationStrict = Boolean(gauntlet?.mutation?.strict);
 
-/** 从 Stryker 报告提取 covered 口径指标 */
-function readMutationReport(path) {
-  if (!existsSync(path)) return null;
-  let report;
-  try {
-    report = JSON.parse(readFileSync(path, 'utf8'));
-  } catch {
-    return null;
-  }
-  let killed = 0, timeout = 0, survived = 0, noCoverage = 0;
-  for (const f of Object.values(report.files ?? {})) {
-    for (const m of f.mutants ?? []) {
-      if (m.status === 'Killed') killed += 1;
-      else if (m.status === 'Timeout') timeout += 1;
-      else if (m.status === 'Survived') survived += 1;
-      else if (m.status === 'NoCoverage') noCoverage += 1;
-    }
-  }
-  const covered = killed + timeout + survived;
-  // covered 口径与仓库既有基线一致：分母不含 noCoverage
-  const coveredScore = covered > 0 ? Math.round(((killed + timeout) / covered) * 10000) / 100 : 0;
-  return { killed, timeout, survived, noCoverage, total: covered + noCoverage, coveredScore };
-}
-
 const rows = [];
 const violations = [];
 const regressions = [];
@@ -80,11 +57,18 @@ if (existsSync(selfCovPath)) {
 
 for (const [pkg, cfg] of Object.entries(packages)) {
   const reportPath = join(repoRoot, 'coverage', 'mutation', `${pkg}.json`);
+  // 缺失与损坏分开标注（#178）：逐包容错记账后单包失败不再中断整夜，
+  // 「文件不存在」= 该包本次未执行（非崩溃），「存在但解析失败」= 报告损坏
+  if (!existsSync(reportPath)) {
+    rows.push({ pkg, missing: true, missingLabel: '未执行' });
+    // F4 fail-closed：strict 开启后报告缺失 = 门禁被静默跳过，必须判红
+    if (mutationStrict) violations.push(`${pkg}: 变异报告缺失（${pkg}.json 不存在——该包未执行）`);
+    continue;
+  }
   const r = readMutationReport(reportPath);
   if (!r) {
-    rows.push({ pkg, missing: true });
-    // F4 fail-closed：strict 开启后报告缺失 = 门禁被静默跳过，必须判红
-    if (mutationStrict) violations.push(`${pkg}: 变异报告缺失（${pkg}.json 不存在或不可解析）`);
+    rows.push({ pkg, missing: true, missingLabel: '报告损坏' });
+    if (mutationStrict) violations.push(`${pkg}: 变异报告损坏（${pkg}.json 存在但不可解析）`);
     continue;
   }
   const threshold = typeof cfg.threshold === 'number' ? cfg.threshold : null;
@@ -123,7 +107,7 @@ lines.push('| 包 | covered | threshold | 基线 | Δ vs 基线 | killed | survi
 lines.push('|---|---|---|---|---|---|---|---|');
 for (const r of rows) {
   if (r.missing) {
-    lines.push(`| ${r.pkg} | ⚠️ 报告缺失 | — | — | — | — | — | — |`);
+    lines.push(`| ${r.pkg} | ⚠️ ${r.missingLabel} | — | — | — | — | — | — |`);
     continue;
   }
   const delta = r.baseline === null ? '—' : (r.coveredScore - r.baseline).toFixed(2);

--- a/scripts/lib/mutation-report-lib.mjs
+++ b/scripts/lib/mutation-report-lib.mjs
@@ -1,0 +1,47 @@
+/**
+ * mutation-report-lib — Stryker JSON 报告统计（单一事实源）
+ *
+ * 自 observe-check.mjs 提出（#178）：observe 夜间报告与 ci PR 增量门禁
+ * （mutation-gate.mjs）共用同一 covered 口径统计，防两处口径漂移。
+ */
+import { readFileSync } from 'node:fs';
+
+/**
+ * 从 Stryker JSON 报告提取 covered 口径指标。
+ *
+ * 口径约定（#178 v2 固化）：
+ *   - StrykerJS 10 无 Skipped 状态——incremental 模式复用的 mutant 继承上次
+ *     的原状态（Killed/Survived/Timeout/NoCoverage），报告恒为全量口径，
+ *     分母不因增量复用而缩水；
+ *   - 未捕获异常经 scripts/test/mutation-tap-bridge.cjs 转写 TAP not ok 计
+ *     Killed（error=0 前提，#151），RuntimeError 不会以冻结形式逃过计杀；
+ *   - covered 口径与仓库既有基线一致：分母不含 noCoverage。
+ *
+ * 返回 null = 报告不存在或不可解析（调用方自行区分文案）。
+ */
+export function readMutationReport(path) {
+  let raw;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+  let report;
+  try {
+    report = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  let killed = 0, timeout = 0, survived = 0, noCoverage = 0;
+  for (const f of Object.values(report.files ?? {})) {
+    for (const m of f.mutants ?? []) {
+      if (m.status === 'Killed') killed += 1;
+      else if (m.status === 'Timeout') timeout += 1;
+      else if (m.status === 'Survived') survived += 1;
+      else if (m.status === 'NoCoverage') noCoverage += 1;
+    }
+  }
+  const covered = killed + timeout + survived;
+  const coveredScore = covered > 0 ? Math.round(((killed + timeout) / covered) * 10000) / 100 : 0;
+  return { killed, timeout, survived, noCoverage, total: covered + noCoverage, coveredScore };
+}

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -19,7 +19,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync, readdirSync, existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, basename } from 'node:path'
 
 const ROOT = join(import.meta.dirname, '../..')
 const CI = readFileSync(join(ROOT, '.github/workflows/ci.yml'), 'utf8')
@@ -93,7 +93,8 @@ test('ci.yml/observe.yml: 第三方与官方 action 一律 pin commit SHA', () =
     const lines = text.split('\n').filter((l) => l.trim().startsWith('uses:'))
     assert.ok(lines.length > 0, `${name} 存在 uses 步骤`)
     for (const line of lines) {
-      const m = /^uses:\s*([\w.-]+\/[\w.-]+)(?:@(\S+))?\s*(?:#.*)?$/.exec(line.trim())
+      // owner/repo 及其子 action 路径（如 actions/cache/restore，#178 引入）
+      const m = /^uses:\s*([\w.-]+(?:\/[\w.-]+)+)(?:@(\S+))?\s*(?:#.*)?$/.exec(line.trim())
       assert.ok(m, `${name}: 无法解析的 uses 行："${line.trim()}"`)
       assert.match(m[2] ?? '', /^[0-9a-f]{40}/, `${name}: ${m[1]} 未 pin 到 40 位 commit SHA`)
     }
@@ -146,5 +147,65 @@ test('gauntlet: mutation.packages 全部带 threshold 字段且 ≥60（阶段�
   for (const [pkg, cfg] of Object.entries(pkgs)) {
     assert.equal(typeof cfg.threshold, 'number', `${pkg}.threshold 已落盘`)
     assert.ok(cfg.threshold >= 60, `${pkg}.threshold=${cfg.threshold} 不低于阶段一基线 60`)
+  }
+})
+
+// ── #178 v2：Stryker 增量模式接入（夜间全量落缓存 + PR 增量切片门禁）──
+
+test('#178: observe.yml 夜间保持全量——只落缓存不读缓存', () => {
+  assert.ok(OBSERVE.includes('actions/cache/save@'), '夜间全量运行末尾须保存 incremental 基线缓存')
+  assert.ok(
+    !OBSERVE.includes('actions/cache/restore'),
+    'observe.yml 严禁出现 restore 缓存步骤——无基线即天然全量（v2 架构定案，勿"好心"补 restore）',
+  )
+  const idx = OBSERVE.indexOf('Save incremental baseline cache')
+  assert.ok(idx > 0, 'save 步骤在位')
+  const block = OBSERVE.slice(idx, OBSERVE.indexOf('- name:', idx + 10))
+  assert.ok(block.includes('if: always()'), 'save 步骤必须 if: always()（部分失败夜已产出的基线照常落盘，评审 P1#3）')
+  assert.ok(block.includes('observe-incremental-${{ github.run_id }}'), '缓存 key = 单条目 observe-incremental-<run_id>（v2 P2#2 偏离定案）')
+  assert.ok(block.includes('coverage/mutation/incremental-*.json'), 'save path 用 glob 收六份基线文件')
+})
+
+test('#178: ci.yml PR 增量门禁——restore-only + 按命中包切片 + 并入 repo-gate', () => {
+  // 只读不回写：允许 cache/restore，禁止 cache/save（防 PR 结果污染夜间基线源）
+  assert.ok(CI.includes('actions/cache/restore@'), 'PR 侧 restore-only 读缓存')
+  assert.ok(!CI.includes('actions/cache/save@'), 'ci.yml 禁止 save 缓存（PR 结果绝不回写夜间基线）')
+
+  const gateIdx = CI.indexOf('\n  mutation-gate:')
+  assert.ok(gateIdx > 0, 'mutation-gate job 在位')
+  const mg = CI.slice(gateIdx, CI.indexOf('\n  repo-gate:'))
+  assert.ok(mg.includes('package: ${{ fromJSON(needs.changes.outputs.mutationPackages) }}'),
+    '动态 matrix ← changes.mutationPackages（命中包天然切片，未触包不实例化）')
+  assert.ok(mg.includes('restore-keys:'), '精确 key 必 miss 后走前缀兜底（命中最近一夜基线）')
+  assert.ok(mg.includes('observe-incremental-'), 'restore-keys 前缀与夜间 save key 同源')
+  assert.ok(!mg.includes("'use-cache'") && !mg.includes('cache: true'), '不得用主 action 形态（自带 save 后置步骤即回写）')
+  assert.ok(mg.includes('scripts/gate/mutation-gate.mjs'), '双指标判分脚本执行点在位')
+  assert.ok(mg.includes('scripts/gate/self-cov.mjs'), '覆盖率指标数据源执行点在位')
+
+  // 成败并入既有聚合闸，不新增分支保护 required check 名
+  assert.ok(/needs: \[changes, build-test, mutation-gate\]/.test(CI), 'repo-gate needs 纳入 mutation-gate')
+})
+
+test('#178: 六份 stryker 配置开增量且 incrementalFile 无点前缀', () => {
+  const confDir = join(ROOT, 'stryker.conf.d')
+  const confFiles = readdirSync(confDir).filter((f) => f.endsWith('.json')).sort()
+  assert.ok(confFiles.length > 0, 'stryker.conf.d 非空')
+  for (const f of confFiles) {
+    const conf = JSON.parse(readFileSync(join(confDir, f), 'utf8'))
+    assert.equal(conf.incremental, true, `${f} 未开启 incremental`)
+    const inc = typeof conf.incrementalFile === 'string' ? conf.incrementalFile : ''
+    assert.match(inc, /^coverage\/mutation\/incremental-[a-z0-9-]+\.json$/,
+      `${f} incrementalFile 必须落在 coverage/mutation/ 下且命名 incremental-<pkg>.json`)
+    assert.ok(!basename(inc).startsWith('.'), `${f} incrementalFile 不得为 dotfile（upload-artifact v4 默认排除 hidden files，评审 P2#1）`)
+    const pkgShort = f.replace(/^dsh-/, '').replace(/\.json$/, '')
+    assert.ok(inc.endsWith(`incremental-${pkgShort}.json`), `${f} incrementalFile 包名段与配置文件名一致`)
+  }
+})
+
+test('#178: 变异统计口径单一事实源——observe-check 与 mutation-gate 共用 lib', () => {
+  for (const f of ['scripts/gate/observe-check.mjs', 'scripts/gate/mutation-gate.mjs']) {
+    const src = readFileSync(join(ROOT, f), 'utf8')
+    assert.ok(src.includes("from '../lib/mutation-report-lib.mjs'"),
+      `${f} 须 import scripts/lib/mutation-report-lib.mjs 共享统计函数（防两处 covered 口径漂移）`)
   }
 })

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -178,7 +178,12 @@ test('#178: ci.yml PR 增量门禁——restore-only + 按命中包切片 + 并�
     '动态 matrix ← changes.mutationPackages（命中包天然切片，未触包不实例化）')
   assert.ok(mg.includes('restore-keys:'), '精确 key 必 miss 后走前缀兜底（命中最近一夜基线）')
   assert.ok(mg.includes('observe-incremental-'), 'restore-keys 前缀与夜间 save key 同源')
-  assert.ok(!mg.includes("'use-cache'") && !mg.includes('cache: true'), '不得用主 action 形态（自带 save 后置步骤即回写）')
+  // 主 action 形态自带 save 后置步骤即回写，一律禁用（只允许 restore/save 子 action）
+  assert.ok(!CI.includes('actions/cache/@'), 'ci.yml 禁用 actions/cache@ 主 action 形态（自带回写）')
+  assert.ok(!CI.includes('actions/cache/save@'), 'ci.yml 禁止 save 缓存（PR 结果绝不回写夜间基线）')
+  assert.ok(/timeout-minutes: 45/.test(mg), 'mutation-gate timeout ≥45 分钟（miss 首夜全量变异 + cov 全仓 smoke 的悬崖余量）')
+  assert.ok(mg.includes('cache-matched-key'), 'restore 步骤须暴露 cache-matched-key 供 hit/miss 审计')
+  assert.ok(mg.includes('::notice::'), '缓存 miss 时须打 notice 标注全量降级（首夜属预期，防误判缺陷）')
   assert.ok(mg.includes('scripts/gate/mutation-gate.mjs'), '双指标判分脚本执行点在位')
   assert.ok(mg.includes('scripts/gate/self-cov.mjs'), '覆盖率指标数据源执行点在位')
   // build 必须全量（run #32790425132 教训）：pnpm cov = c8 包裹全仓 smoke，
@@ -191,6 +196,21 @@ test('#178: ci.yml PR 增量门禁——restore-only + 按命中包切片 + 并�
 
   // 成败并入既有聚合闸，不新增分支保护 required check 名
   assert.ok(/needs: \[changes, build-test, mutation-gate\]/.test(CI), 'repo-gate needs 纳入 mutation-gate')
+  // 聚合闸 fail-closed 判定脚本必须显式引用 mutation-gate 结果（防聚合闸旁路）
+  const rg = CI.slice(CI.indexOf('\n  repo-gate:'))
+  assert.ok(rg.includes('needs.mutation-gate.result'),
+    'repo-gate fail-closed 判定脚本必须检查 needs.mutation-gate.result')
+})
+
+test('#178: ci.yml 包名全集 ≡ gauntlet 变异六包 ∪ {dsh-plugins-all}（防清单漂移）', () => {
+  const mentioned = [...new Set(CI.match(/dsh-[a-z0-9-]+/g) ?? [])].sort()
+  const expected = [...new Set([
+    ...Object.keys(GAUNTLET?.mutation?.packages ?? {}),
+    'dsh-plugins-all',
+  ])].sort()
+  assert.deepEqual(mentioned, expected,
+    `ci.yml 出现的包名集合与 gauntlet mutation.packages ∪ {dsh-plugins-all} 不一致：`
+    + `ci=${mentioned.join(',')} gauntlet+all=${expected.join(',')}——新增包须同步全部清单`)
 })
 
 test('#178: 六份 stryker 配置开增量且 incrementalFile 无点前缀', () => {

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -181,6 +181,13 @@ test('#178: ci.yml PR 增量门禁——restore-only + 按命中包切片 + 并�
   assert.ok(!mg.includes("'use-cache'") && !mg.includes('cache: true'), '不得用主 action 形态（自带 save 后置步骤即回写）')
   assert.ok(mg.includes('scripts/gate/mutation-gate.mjs'), '双指标判分脚本执行点在位')
   assert.ok(mg.includes('scripts/gate/self-cov.mjs'), '覆盖率指标数据源执行点在位')
+  // build 必须全量（run #32790425132 教训）：pnpm cov = c8 包裹全仓 smoke，
+  // 单包构建会让其余包 lib/index.js 缺失而 ERR_MODULE_NOT_FOUND
+  const mgBuildIdx = mg.indexOf('Build all packages')
+  assert.ok(mgBuildIdx > 0, 'mutation-gate 全量构建步骤在位')
+  const mgBuildBlock = mg.slice(mgBuildIdx, mg.indexOf('- name:', mgBuildIdx + 10))
+  assert.ok(/run: pnpm build\s*$/.test(mgBuildBlock), 'mutation-gate 构建步骤必须为全量 pnpm build')
+  assert.ok(!mgBuildBlock.includes('--filter'), 'mutation-gate 构建步骤禁止 --filter 单包切片')
 
   // 成败并入既有聚合闸，不新增分支保护 required check 名
   assert.ok(/needs: \[changes, build-test, mutation-gate\]/.test(CI), 'repo-gate needs 纳入 mutation-gate')

--- a/stryker.conf.d/dsh-idle-archive.json
+++ b/stryker.conf.d/dsh-idle-archive.json
@@ -36,5 +36,7 @@
   "coverageAnalysis": "perTest",
   "tempDirName": ".stryker-tmp",
   "cleanTempDir": true,
+  "incremental": true,
+  "incrementalFile": "coverage/mutation/incremental-idle-archive.json",
   "_comment": "#151 打样结论：tap-runner 将「进程非零退出且 TAP 流无 not ok 行」分类为 RuntimeError（captureTapResult 抛错分支）而非 Killed，顶层 assert 直跑型测试下 score 恒为 0%。tap.nodeArgs 注入 scripts/test/mutation-tap-bridge.cjs 把未捕获异常转写为一行 TAP not ok 后退出，RuntimeError 即全部转化为 Killed（实验矩阵见 PR）。结构说明：阶段二『每包一个』采用 stryker.conf.d/<pkg>.json 独立完整配置（Stryker 无继承机制）；根 stryker.config.json 暂保留 dsh-notifier 试点入口（package.json mutation script 绑定），后续批次逐包迁入后再退役。mutate 限定本包 self-written 两段（esbuild 分段注释 // lib/index.js），排除头部 var __* 垫片、cosmokit/schemastery 内联 vendor（// node_modules 段）与 shared/* 内联契约层副本（shared 由仓库级禁改规则与共享测试批次保护，多包内联重复计账会使各包 score 横向不可比）。client-shim.mjs 测 lib/client.js 不在 mutate 面，纳入仅为 dryRun 全绿完整性。"
 }

--- a/stryker.conf.d/dsh-lan-proxy.json
+++ b/stryker.conf.d/dsh-lan-proxy.json
@@ -36,5 +36,7 @@
   "coverageAnalysis": "perTest",
   "tempDirName": ".stryker-tmp",
   "cleanTempDir": true,
+  "incremental": true,
+  "incrementalFile": "coverage/mutation/incremental-lan-proxy.json",
   "_comment": "#147 阶段二『每包一个』：mutate 限定 lib/index.js 三段 self-written（esbuild 分段注释 // lib/*.js）：35657-35911（src/proxy.ts 转发核心，comp17/CRAP306 一带）、35912-35972（src/cert.ts 自签证书）、36058-36643（src/index.ts 尾段 Config/apply/路由）；35635-35646 为纯 import 头无可变异语句不列。排除头部 var __* 垫片、cosmokit/schemastery/ws/http-proxy/node-forge/selfsigned 内联 vendor（// node_modules 段，约 3.5 万行）与 shared/* 内联契约层副本（同 dsh-idle-archive 口径：shared 由仓库级禁改规则保护，多包内联重复计账使各包 score 横向不可比）。testFiles 仅列 2 个 unit 文件逐个启用 per-test 关联；smoke.ts 绑定固定端口不可并行故不入。timeoutMS 必须保持 15000：unit-proxy 的 WS 桥接类 mutant 注入后挂起而非抛错，60s 兜底会使总时长冲到 15 分钟以上（#147 实测），15s 下全量三段 7m36s 达标。已知风险备注：unit-apply.test.ts 固定占用 19998 构造端口被占场景，多 worker 同时进入该用例理论上会 EADDRINUSE 互踩造成假阳性 Killed；#147 实测两轮 total 均为 843 且 error=0、score 与 dryRun 覆盖关联面吻合，未观察到互踩迹象，维持 concurrency=4。"
 }

--- a/stryker.conf.d/dsh-mcp-manager.json
+++ b/stryker.conf.d/dsh-mcp-manager.json
@@ -43,5 +43,7 @@
   "coverageAnalysis": "perTest",
   "tempDirName": ".stryker-tmp",
   "cleanTempDir": true,
+  "incremental": true,
+  "incrementalFile": "coverage/mutation/incremental-mcp-manager.json",
   "_comment": "#148 接入：mutate 限定 lib/index.js 的 self-written 四段（esbuild 路径注释 // lib/* 分界）：8610-8696 store、17322-17456 transport+scope、19271-19915 protocol/supervisor/catalog、19964-21027 import/routes/index。排除头部 var __* 垫片（1-42）、cosmokit/schemastery/which/cross-spawn/ajv/fast-uri/zod/@modelcontextprotocol/sdk 等 node_modules 内联 vendor 大段（43-8549、8700-17321、17457-19270）、shared/settings-namespace+loopback+host-utils 内联契约层副本（8557-8609、19916-19963，shared 由仓库级禁改规则保护且多包重复计账会使 score 横向不可比）、8550-8556 与 8697-8699 的纯 ESM import 提升段（无可变异面）。tap.nodeArgs 注入 mutation-tap-bridge.cjs（#151 全局生效）将未捕获异常转写 TAP not ok，RuntimeError 计 Killed。"
 }

--- a/stryker.conf.d/dsh-notifier.json
+++ b/stryker.conf.d/dsh-notifier.json
@@ -37,5 +37,7 @@
   "coverageAnalysis": "perTest",
   "tempDirName": ".stryker-tmp",
   "cleanTempDir": true,
+  "incremental": true,
+  "incrementalFile": "coverage/mutation/incremental-notifier.json",
   "_comment": "#85 observe.yml 六包夜间串行调度的 notifier 入口：内容与根 stryker.config.json 的试点配置一致（根配置保留作 pnpm mutation 手动入口，两者勿单侧漂移——workflow-assert 自测断言 conf.d 文件集与 gauntlet 包集一致）。阶段一试点：dsh-notifier 的 lib/index.js 构建产物无 node_modules 内联段，天然全量 self-written。mutate 构建产物而非 src 源码，因测试直接 import lib/index.js。试点范围缩小至 message.js 段（lib/index.js:255-504，对应 src/message.ts），排除高噪音字符串/数组/对象/模板字面量变异以控制总时长。#159 耗时优化批次：perTest 贡献精简 testFiles + concurrency 16 超订（e2e 定时器等待主导、CPU 占用低），6m54s→1m42s。"
 }

--- a/stryker.conf.d/dsh-provider-usage.json
+++ b/stryker.conf.d/dsh-provider-usage.json
@@ -38,5 +38,7 @@
   "coverageAnalysis": "perTest",
   "tempDirName": ".stryker-tmp",
   "cleanTempDir": true,
+  "incremental": true,
+  "incrementalFile": "coverage/mutation/incremental-provider-usage.json",
   "_comment": "#150 接入：mutate 限定 lib/index.js 的 self-written 两段（esbuild 路径注释 // lib/* 分界）：1372-2769 contracts/registry/adapters-opencode-go/core-guards/sanitize/pipeline-v2/history/provider-config/hotreload 九段连续自写模块、2805-3696 path-resolve/client-logic/index 主体。排除头部 var __* 垫片（1-30）、cosmokit/schemastery/async-mutex/untildify 等 node_modules 内联 vendor 大段（31-1054、1163-1368、2775-2804）、shared/loopback+host-utils+settings-namespace 内联契约层副本（1062-1162，shared 由仓库级禁改规则保护且多包重复计账会使 score 横向不可比）、1055-1061 与 1369-1371 与 2770-2774 的纯 ESM import 提升段（无可变异面）。tap.nodeArgs 注入 mutation-tap-bridge.cjs（#151 全局生效）将未捕获异常转写 TAP not ok，RuntimeError 计 Killed。"
 }

--- a/stryker.conf.d/dsh-web-file-preview.json
+++ b/stryker.conf.d/dsh-web-file-preview.json
@@ -36,5 +36,7 @@
   "coverageAnalysis": "perTest",
   "tempDirName": ".stryker-tmp",
   "cleanTempDir": true,
+  "incremental": true,
+  "incrementalFile": "coverage/mutation/incremental-web-file-preview.json",
   "_comment": "#152 接入：mutate 限定 lib/index.js 的 self-written 连续段 1255-1924（grouping/mime/git/basename-fallback/routes/relpath/client/link-resolver/index 八段，esbuild 路径注释 // lib/* 分界），排除头部 untildify 与 mime 库内联 vendor 段（1-30、75-1254，含 var __classPrivateFieldGet 垫片）、shared/loopback+host-utils 内联契约层副本（35-74，shared 由仓库级禁改规则保护且多包重复计账会使 score 横向不可比）、31-34 的 routes import 提升段（纯 ESM import 无可变异面）。client/link-resolver 为本仓自写代码且内联进 index.js 本体（wrapper 模式），有 unit-link-resolver.test.ts 直测故纳入——区别于 idle-archive 的独立 lib/client.js 不在 mutate 面。tap.nodeArgs 注入 mutation-tap-bridge.cjs（#151 全局生效）将未捕获异常转写 TAP not ok，RuntimeError 计 Killed。"
 }


### PR DESCRIPTION
## 概述

实施 #178 方案 v2（已获维护者 approved + 转向修订）：夜间链路保持全量、每次全量后落增量基线缓存；PR CI 新增按包切片的**增量变异门禁**，同时纳入测试覆盖率与变异测试率双指标。

Refs #178（合并后仍保持 open：远端「故意红」负例验证与缓存不回写实证待合并后补录，补录完成再关闭）

## 实施要点

- **六份 stryker.conf.d 配置**：`incremental: true` + `incrementalFile: coverage/mutation/incremental-<pkg>.json`（无点前缀，规避 upload-artifact v4 hidden files 过滤）
- **observe.yml 夜间**：刻意不 restore 缓存保持全量口径；六包循环逐包容错记账（单包失败记账继续、结尾统一非零退出）；末尾 `actions/cache/save@0057852… # v4.3.0`（SHA 经 git ls-remote 实解析）`if: always()` 落基线，key 单条目
- **ci.yml PR 门禁**：mutation-gate job 动态 matrix 按 paths-filter 命中包切片；restore-only 读最近一夜基线（绝不回写）；双指标判分——测试覆盖率恒硬、变异测试率受既有 `mutation.strict` 开关约束（false 仅 WARN，provider-usage 达标翻转后自动变硬）；成败并入既有 repo-gate 聚合闸「Build / Contract / Smoke / Pack」，分支保护零手工切换
- **口径单一事实源**：统计函数提取 `scripts/lib/mutation-report-lib.mjs`，observe-check 与 mutation-gate 共用；报告缺失区分「未执行 / 报告损坏」，strict 开启时均判红

## 对方案 v2 的偏离点

1. 缓存 key 由按包拆 key 改为单条目 `observe-incremental-<run_id>`：六文件合计约 300KB 同存同取，restore 前缀语义由 PR 侧 restore-keys 承担
2. incrementalFile 取短包名（不带 dsh- 前缀），与 observe.yml 循环变量一致、save glob 直接收齐
3. hit/miss 显式 output 未自建：actions/cache/restore 自带 cache-matched-key output 与日志承载
4. Actions 缓存 save-glob / restore-dir 行为无法本地实证，依赖本 PR 自身远端 CI 验证（workflow 改动以真实运行为准的铁律）

## 断言表（coder 产出）

| 条目 | 级别 | 证据 |
|---|---|---|
| 五连门禁 build/test/contract/pack:check/typecheck | 硬性 | 退出码 0/0/0/0/0（worktree 实跑） |
| test:scripts 结构断言（含 4 条新增防回归锚） | 硬性 | 35 项全绿 |
| 本地冒烟：全量 13.66s → 增量 2.61s（5.2x），reused 273/369 | 硬性 | stryker info 日志留痕 |
| strict=false 低变异率 → WARN + exit 0 | 硬性 | 沙盒负例实证 |
| strict=true 低变异率 → FAIL + exit 1 | 硬性 | 沙盒负例实证 |
| observe-check 对缺失 json 标注「⚠️ 未执行」且不崩溃 | 硬性 | 沙盒负例实证（五包缺 json exit 0） |
| 夜间缓存不被 PR 回写污染 | 硬性 | 待远端 CI 实证（本 PR 运行 + 合并后 dispatch 补录） |
| 故意红一次验证硬门禁拦截 | 硬性 | 待合并后负例补录 |

> 改动类型 = 纯 CI/scripts：qa 实测豁免；硬性条目由主控独立复核 + 复核闸对抗评审（触 .github 必触发）。

## 验证计划

1. 本 PR 自身 CI 即新管线的首次真实验证（pull_request 使用 PR 分支 workflow 版本）
2. 合并后手动 dispatch 一次 Observe (nightly) 验证落缓存路径
3. 负例补录后在 #178 关单收尾
