### PR TITLE
test(dsh-notifier): 免打扰用例改动态时钟窗口——消除 23:59 边界分钟 flake（#181）

### DIFF
--- a/packages/dsh-notifier/test/e2e-approval.test.ts
+++ b/packages/dsh-notifier/test/e2e-approval.test.ts
@@ -70,7 +70,14 @@ try {
 
   // M4 免打扰紧急例外：allowKinds 中的 kind 在免打扰时段仍通知
   {
-    const qhOn = { enabled: true, start: "00:00", end: "23:59" };
+    // 窗口围绕当前时间动态构造（±2 分钟）：#181 —— 写死 "00:00"/"23:59" 假设
+    // 全天覆盖，但实现是半开区间 [start, end)，23:59 这一分钟不命中，UTC 边缘必炸；
+    // now 邻近 00:00 时 start > end，天然走实现的跨午夜分支（quiet-hours.ts）。
+    const hhmm = (offsetMinutes) => {
+      const t = new Date(Date.now() + offsetMinutes * 60_000);
+      return `${String(t.getHours()).padStart(2, "0")}:${String(t.getMinutes()).padStart(2, "0")}`;
+    };
+    const qhOn = { enabled: true, start: hhmm(-2), end: hhmm(2) };
     const cfgAsk = join(work, "qh-ask.json");
     writeFileSync(cfgAsk, JSON.stringify({ quietHours: { ...qhOn, allowKinds: ["ask"] } }));
     const infos = [];


### PR DESCRIPTION
## 概述

修复 #181：e2e-approval 免打扰用例写死 `{ start: "00:00", end: "23:59" }`，实现为半开区间 `[start, end)`，UTC 23:59 这一分钟不在窗口内 → 每天存在 1 分钟必现失败窗口（PR #180 远端 CI 于 23:59:02~29 实证三 job 同炸）。

## 改动

- 窗口改为围绕当前时间动态构造（±2 分钟 HH:MM 补零），任意时刻确定性通过；
- now 邻近 00:00 时 `start > end` 天然走实现的跨午夜分支（注释留痕 #181 根因与设计意图）；
- 两处子断言语义不变；仅 1 文件 +8/-1。

## 断言表

| 条目 | 级别 | 证据 |
|---|---|---|
| diff <30 行且仅测试文件 | 硬性 | +8/-1 |
| 五连门禁 | 硬性 | 0/0/0/0/0（worktree 实跑） |
| 主控独立复核：diff 审查 + notifier 测试实跑 OK | 硬性 | 本 PR 描述留痕 |

Closes #181
