### PR TITLE
fix(dsh-provider-usage): 子代理会话 provider 检测沿 parentId 上溯并保持上次检测结果

### DIFF
--- a/packages/dsh-provider-usage/src/client/core.ts
+++ b/packages/dsh-provider-usage/src/client/core.ts
@@ -73,10 +73,35 @@ export interface ConnectionHandleLike {
   api?: {
     sessions?: {
       models?(req: { sessionId: string }): Promise<{
-        result?: { ok?: boolean; value?: { current?: { provider?: string; model?: string } } };
+        result?: {
+          ok?: boolean;
+          value?: { current?: { provider?: string; model?: string } };
+          /** RPC 业务错误形态（{ok:false,error:{code,...}}；agent-busy 即此形态或抛错携带 code）。 */
+          error?: { code?: string; message?: string } | unknown;
+        };
       }>;
     };
   };
+}
+
+/** sessions.list 快照中的单行（客户端 store 形态，防御式可选字段）。 */
+export interface SessionListRowLike {
+  id?: string;
+  /** 子代理行标记（spawn/fork 两类子代理均由宿主 store 写入）。 */
+  origin?: string;
+  /**
+   * 父会话 id：客户端 store 归一字段（线上 wire 字段 parentSessionId 由
+   * dsh-client-runtime 归一为 parentId）；防御兼容两种命名。
+   */
+  parentId?: string;
+  parentSessionId?: string;
+}
+
+/** sessions.list 快照形态（{current, ids, byId}，与宿主 client-runtime 一致）。 */
+export interface SessionListSnapshotLike {
+  current?: string;
+  ids?: string[];
+  byId?: Record<string, SessionListRowLike>;
 }
 
 export interface SessionsServiceLike {
@@ -84,7 +109,7 @@ export interface SessionsServiceLike {
     getSnapshot(): SessionMaybeProvide;
     subscribe?(fn: () => void): () => void;
   };
-  list?: { getSnapshot?(): { current?: string }; subscribe?(fn: () => void): () => void };
+  list?: { getSnapshot?(): SessionListSnapshotLike; subscribe?(fn: () => void): () => void };
 }
 
 export function currentSessionId(sessions: SessionsServiceLike | undefined): string | undefined {
@@ -98,6 +123,63 @@ export function currentSessionId(sessions: SessionsServiceLike | undefined): str
   return undefined;
 }
 
+// ---------------------------------------------------------------- 会话祖先链上溯（issue #69 方案 A）
+
+/** 上溯链深度封顶：链上最多探测的会话数（自身 + 至多 N-1 代祖先），防环与异常长链。 */
+export const MAX_ANCESTRY_DEPTH = 3;
+
+/** 行内父 id 读取：优先归一字段 parentId，防御兼容 wire 原名 parentSessionId。 */
+function parentSessionIdOf(row: SessionListRowLike | undefined): string | undefined {
+  const p = row?.parentId ?? row?.parentSessionId;
+  return typeof p === "string" && p.length > 0 ? p : undefined;
+}
+
+/**
+ * 从 startId 沿 sessions.list 快照 byId 行的 parentId 逐级上溯，产出待探测会话 id 链。
+ * 封顶 MAX_ANCESTRY_DEPTH（可调），visited 集合防环；快照缺失/断链即停。
+ * 设计原则（#69）：不做「是不是子代理」的正向分类——ordinary 会话无 parentId，链长即为 1。
+ */
+export function sessionAncestryChain(
+  sessions: SessionsServiceLike | undefined,
+  startId: string,
+  maxDepth: number = MAX_ANCESTRY_DEPTH,
+): string[] {
+  if (!(maxDepth >= 1)) return [];
+  const chain = [startId];
+  const seen = new Set<string>([startId]);
+  const byId = sessions?.list?.getSnapshot?.()?.byId;
+  let cur = startId;
+  while (chain.length < maxDepth) {
+    const parent = byId === undefined ? undefined : parentSessionIdOf(byId[cur]);
+    if (parent === undefined || seen.has(parent)) break; // 断链 / 环 → 停
+    chain.push(parent);
+    seen.add(parent);
+    cur = parent;
+  }
+  return chain;
+}
+
+/** agent-busy 错误识别：抛错携带 code/message，或 RPC 错误分支对象。 */
+export function isAgentBusyError(error: unknown): boolean {
+  if (error === null || typeof error !== "object") return false;
+  if ((error as { code?: unknown }).code === "agent-busy") return true;
+  const msg = (error as { message?: unknown }).message;
+  return typeof msg === "string" && msg.includes("agent-busy");
+}
+
+/** agent-busy 诊断日志（排障信号，不影响返回值语义）。 */
+function logAgentBusyDiagnosis(sessionId: string): void {
+  console.warn(
+    `[dsh-provider-usage] 会话 ${sessionId} 为忙着的子代理会话（agent-busy），provider 检测沿父会话上溯`,
+  );
+}
+
+/**
+ * 解析当前展示会话的 provider（issue #69 方案 A+B 的检测半区）：
+ * 从当前会话沿 parentId 上溯（封顶深度 3、防环），首个 models() 解析成功者胜；
+ * 子代理会话 models() 抛/返 agent-busy 时记一条诊断日志。全链失败返回 undefined，
+ * 兜底语义（保持上次检测 / 回落默认）由调用方 decideProviderAfterDetect 决定。
+ */
 export async function resolveProviderFromSession(
   sessions: SessionsServiceLike | undefined,
   connection: ConnectionHandleLike | undefined,
@@ -106,14 +188,59 @@ export async function resolveProviderFromSession(
   if (sessionId === undefined) return undefined;
   const models = connection?.api?.sessions?.models;
   if (typeof models !== "function") return undefined;
-  try {
-    const res = await models({ sessionId });
-    const value = res?.result?.value;
-    if (res?.result?.ok !== true || !value || typeof value.current?.provider !== "string") return undefined;
-    return value.current.provider;
-  } catch {
-    return undefined;
+  for (const sid of sessionAncestryChain(sessions, sessionId)) {
+    try {
+      const res = await models({ sessionId: sid });
+      const result = res?.result;
+      const value = result?.value;
+      if (result?.ok === true && value && typeof value.current?.provider === "string") {
+        return value.current.provider;
+      }
+      // RPC 业务错误形态（不抛错）：agent-busy 同样记诊断后继续上溯
+      if (isAgentBusyError((result as { error?: unknown } | undefined)?.error)) logAgentBusyDiagnosis(sid);
+    } catch (error) {
+      if (isAgentBusyError(error)) logAgentBusyDiagnosis(sid);
+    }
   }
+  return undefined;
+}
+
+// ---------------------------------------------------------------- 检测兜底决策（issue #69 方案 B）
+
+/** 无任何成功检测时的回落 provider（内置默认；仅在「从未检测成功」时使用）。 */
+export const FALLBACK_PROVIDER = "opencode-go";
+
+/** 胶囊 title 未识别标注文案。 */
+export const UNKNOWN_PROVIDER_HINT = "提供商未识别";
+
+/** detect 一轮结果决策入参。 */
+export interface DetectDecisionInput {
+  /** 本轮 resolveProviderFromSession 的解析结果（undefined = 全链失败或无会话）。 */
+  resolved: string | undefined;
+  /** 本轮检测时是否存在当前会话（区分「无会话回落」与「有会话但不可解析」）。 */
+  hadSession: boolean;
+  /** 历史上最近一次成功检测的 provider（从未成功则为 undefined）。 */
+  previousDetected: string | undefined;
+}
+
+/** detect 一轮结果决策出参。 */
+export interface DetectDecision {
+  /** 本轮应生效的 provider。 */
+  provider: string;
+  /** true = 有会话但 provider 未能确认（胶囊 title 标注「提供商未识别」）。 */
+  unknown: boolean;
+}
+
+/**
+ * 检测结果决策（纯函数，issue #69 方案 B）：
+ * - 解析成功 → 采用；
+ * - 无任何会话 → 维持原回落行为（回归防护，不算未知态）；
+ * - 有会话但全链失败 → 保持上次检测结果并标注未识别；仅当从未成功检测过才回落默认。
+ */
+export function decideProviderAfterDetect(input: DetectDecisionInput): DetectDecision {
+  if (input.resolved !== undefined) return { provider: input.resolved, unknown: false };
+  if (!input.hadSession) return { provider: FALLBACK_PROVIDER, unknown: false };
+  return { provider: input.previousDetected ?? FALLBACK_PROVIDER, unknown: true };
 }
 
 // ---------------------------------------------------------------- 数据拉取（v2）

--- a/packages/dsh-provider-usage/src/client/index.ts
+++ b/packages/dsh-provider-usage/src/client/index.ts
@@ -11,9 +11,13 @@
  */
 import {
   resolveProviderFromSession,
+  decideProviderAfterDetect,
+  currentSessionId,
   fetchStats,
   fetchHistory,
   fetchUiConfig,
+  FALLBACK_PROVIDER,
+  UNKNOWN_PROVIDER_HINT,
   EVENTS_URL,
 } from "./core.js";
 import type { SessionsServiceLike, ConnectionHandleLike, StatsResponseV2, HistoryResponseV2, UiPlacementConfig } from "./core.js";
@@ -21,9 +25,6 @@ import { SettingsPage } from "./settings.js";
 // React externals 路径：运行时由 dsh web factory require("react") 注入
 import * as React from "react";
 import STYLE from "./style.css";
-
-/** 无会话时回落 provider（内置 opencode-go）。 */
-const FALLBACK_PROVIDER = "opencode-go";
 
 const REFRESH_MS = 60000; // 轮询间隔
 const PILL_PREFIX = "dou-"; // 样式类名前缀
@@ -87,6 +88,10 @@ let connection: ConnectionHandleLike | undefined;
 
 /** 当前生效 provider。 */
 let currentProvider: string = FALLBACK_PROVIDER;
+/** 最近一次成功检测的 provider（issue #69 方案 B：全链失败时的保持值；undefined = 从未成功）。 */
+let detectedProvider: string | undefined;
+/** true = 有会话但 provider 未能确认（胶囊 title 标注「提供商未识别」）。 */
+let providerUnknown = false;
 /** 最近一次 /stats 响应。 */
 let lastStats: StatsResponseV2 | null = null;
 /** 最近一次 /history 响应。 */
@@ -166,15 +171,19 @@ function renderPill(): void {
   const hide = stats === null;
   floatPill.hidden = hide;
   if (stats !== null) {
+    let title: string;
     if (!stats.configured) {
-      floatPill.title = `${currentProvider} · 未配置适配器，点击查看接入引导`;
+      title = `${currentProvider} · 未配置适配器，点击查看接入引导`;
     } else if (stats.error !== null && stats.error !== undefined) {
-      floatPill.title = `用量获取失败：${stats.error}`;
+      title = `用量获取失败：${stats.error}`;
     } else if ((stats as { reason?: string | null }).reason === "busy") {
-      floatPill.title = `${stats.adapterName} · 取数进行中，稍候自动刷新`;
+      title = `${stats.adapterName} · 取数进行中，稍候自动刷新`;
     } else {
-      floatPill.title = `${stats.adapterName} · ${stats.status === "stale" ? "数据陈旧" : stats.status === "cached" ? "缓存" : "实时"} · 更新于 ${fmtAge(stats.fetchedAt)}`;
+      title = `${stats.adapterName} · ${stats.status === "stale" ? "数据陈旧" : stats.status === "cached" ? "缓存" : "实时"} · 更新于 ${fmtAge(stats.fetchedAt)}`;
     }
+    // issue #69 方案 B：有会话但 provider 未确认 → title 显式标注（不再静默展示可能不对的数据）
+    if (providerUnknown) title += ` · ${UNKNOWN_PROVIDER_HINT}`;
+    floatPill.title = title;
   }
   if (labelEl !== null) {
     if (stats?.capsuleHtml) labelEl.innerHTML = stats.capsuleHtml;
@@ -517,14 +526,26 @@ export function apply(ctx: any): void {
     const disposeFloat = mountFloat();
 
     // provider 检测：会话变化 → 重新解析 provider → 重渲染
+    // （issue #69：子代理会话 models() 必拒（agent-busy），检测沿 parentId 上溯父会话；
+    //   全链失败保持上次检测结果并标注未识别，仅「从未成功」才回落默认——不再无条件回落）
     let unsubSessions: (() => void) | undefined;
     const detect = (): void => {
       void (async () => {
-        const detected = await resolveProviderFromSession(sessions, connection);
-        const next = detected ?? FALLBACK_PROVIDER;
-        if (next !== currentProvider) {
-          currentProvider = next;
+        // 先同步取会话在场快照（区分「无任何会话」与「有会话但不可解析」，await 前读取防竞态）
+        const hadSession = currentSessionId(sessions) !== undefined;
+        const resolved = await resolveProviderFromSession(sessions, connection);
+        const decision = decideProviderAfterDetect({
+          resolved,
+          hadSession,
+          previousDetected: detectedProvider,
+        });
+        if (resolved !== undefined) detectedProvider = resolved;
+        providerUnknown = decision.unknown;
+        if (decision.provider !== currentProvider) {
+          currentProvider = decision.provider;
           onProviderChanged();
+        } else {
+          renderPill(); // provider 未变但未知标注可能变化 → 刷胶囊 title
         }
       })();
     };
@@ -544,6 +565,8 @@ export function apply(ctx: any): void {
       if (unsubSessions !== undefined) unsubSessions();
       disposeFloat();
       renderGeneration += 1;
+      detectedProvider = undefined;
+      providerUnknown = false;
       sessions = undefined;
       connection = undefined;
     }, "dsh-provider-usage: float");

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -26,6 +26,7 @@ import "./unit-config.test.ts";
 import "./unit-history.test.ts";
 import "./unit-v1.test.ts";
 import "./unit-apply.test.ts";
+import "./unit-detect.test.ts";
 
 import {
   apply,

--- a/packages/dsh-provider-usage/test/unit-detect.test.ts
+++ b/packages/dsh-provider-usage/test/unit-detect.test.ts
@@ -1,0 +1,283 @@
+// @ts-nocheck
+/**
+ * dsh-provider-usage — unit：provider 检测链（issue #69）。
+ *
+ * 覆盖：子代理会话 models() 拒绝（agent-busy 抛错 / RPC 错误分支两种形态）时沿
+ * parentId 上溯取父会话 provider、上溯深度封顶与环防御、全链失败保持上次检测 +
+ * 「提供商未识别」标注决策、无任何会话维持原回落行为（回归防护）、
+ * ordinary 会话直连解析回归。
+ *
+ * 被测对象为 src/client/core.ts 真实源码：lib/client/*.js 由 bundle-host 按
+ * 发布物边界清理（仅留顶层 index.js/client.js 与 .d.ts），故沿用 web-file-preview
+ * 先例——用仓库 devDependency esbuild 把源码即时打成内存 ESM、经 data-URI 导入。
+ * 无网络、无真实凭据、无 DOM。
+ */
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build as esbuildBuild } from "esbuild";
+import { assert } from "./helpers.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(here, "..");
+
+// ---- 即时打包 src/client/core.ts（真实源码直测）----
+// __DSH_ROUTES__ 为宿主构建期 define 注入：测试环境定义为 undefined，
+// 与生产「注入缺失走默认 URL」的回落语义一致（core.ts 顶部 ?? 兜底）。
+const coreBundle = await esbuildBuild({
+  entryPoints: [join(pkgDir, "src/client/core.ts")],
+  bundle: true,
+  format: "esm",
+  write: false,
+  logLevel: "silent",
+  define: { __DSH_ROUTES__: "undefined" },
+});
+const core = await import(
+  `data:text/javascript;base64,${Buffer.from(coreBundle.outputFiles[0].text).toString("base64")}`
+);
+const {
+  currentSessionId,
+  sessionAncestryChain,
+  MAX_ANCESTRY_DEPTH,
+  resolveProviderFromSession,
+  decideProviderAfterDetect,
+  isAgentBusyError,
+  FALLBACK_PROVIDER,
+  UNKNOWN_PROVIDER_HINT,
+} = core;
+
+// ---------------------------------------------------------------- 构造工具
+
+/** fake sessions：list 快照 {current, byId}（currentProvideInfo 缺席 → 走 list.current）。 */
+function makeSessions(byId, current) {
+  return { list: { getSnapshot: () => ({ current, byId }) } };
+}
+
+/** fake connection：models 按会话 id 分派；record 收集调用序。 */
+function makeConnection(providerBySession, record, rejectSessions = []) {
+  return {
+    api: {
+      sessions: {
+        models: async (req) => {
+          if (record) record.push(req.sessionId);
+          if (rejectSessions.includes(req.sessionId)) {
+            throw Object.assign(new Error(`session ${req.sessionId} rejects models: subagent busy`), { code: "agent-busy" });
+          }
+          return {
+            result: { ok: true, value: { current: { provider: providerBySession[req.sessionId] ?? "prov-x" } } },
+          };
+        },
+      },
+    },
+  };
+}
+
+/** 捕获 console.warn（返回恢复函数 + 记录数组）。 */
+function captureWarn() {
+  const lines = [];
+  const orig = console.warn;
+  console.warn = (...args) => { lines.push(args.map(String).join(" ")); };
+  return { lines, restore: () => { console.warn = orig; } };
+}
+
+// ---------------------------------------------------------------- 1) 子代理会话（models 拒绝）+ 父可解析 → 取父 provider
+
+{
+  // spawn 型：byId 行带 parentId（客户端 store 归一字段）
+  const sessions = makeSessions(
+    {
+      "child-1": { origin: "subagent", parentId: "root-1" },
+      "root-1": {},
+    },
+    "child-1",
+  );
+  const calls = [];
+  const conn = makeConnection({ "root-1": "deepseek" }, calls, ["child-1"]);
+  const warn = captureWarn();
+  let got;
+  try {
+    got = await resolveProviderFromSession(sessions, conn);
+  } finally {
+    warn.restore();
+  }
+  assert.equal(got, "deepseek", "子代理 models 拒绝 → 上溯父会话取 provider");
+  assert.deepEqual(calls, ["child-1", "root-1"], "先试自身再上溯父会话");
+  assert.ok(
+    warn.lines.some((l) => l.includes("agent-busy") && l.includes("child-1")),
+    "agent-busy 抛错应记诊断日志",
+  );
+}
+
+{
+  // RPC 错误分支形态（{ok:false,error:{code:"agent-busy"}}，不抛错）同样诊断并上溯
+  const sessions = makeSessions({ c: { parentId: "p" }, p: {} }, "c");
+  const calls = [];
+  const conn = {
+    api: {
+      sessions: {
+        models: async (req) => {
+          calls.push(req.sessionId);
+          if (req.sessionId === "c") {
+            return { result: { ok: false, error: { code: "agent-busy", message: "busy", details: { reason: "x" } } } };
+          }
+          return { result: { ok: true, value: { current: { provider: "openai" } } } };
+        },
+      },
+    },
+  };
+  const warn = captureWarn();
+  let got;
+  try {
+    got = await resolveProviderFromSession(sessions, conn);
+  } finally {
+    warn.restore();
+  }
+  assert.equal(got, "openai", "RPC 错误分支 agent-busy 同样继续上溯");
+  assert.deepEqual(calls, ["c", "p"], "错误分支不中断上溯链");
+  assert.ok(warn.lines.some((l) => l.includes("agent-busy")), "RPC 错误分支也应记诊断");
+}
+
+{
+  // fork / wire 原名防御：行只带 parentSessionId（旧命名）→ 兼容上溯
+  const sessions = makeSessions({ f: { origin: "subagent", parentSessionId: "main" }, main: {} }, "f");
+  const conn = makeConnection({ main: "kimi" }, [], ["f"]);
+  const got = await resolveProviderFromSession(sessions, conn);
+  assert.equal(got, "kimi", "parentSessionId 命名兼容上溯");
+}
+
+// ---------------------------------------------------------------- 2) 全链失败：保持上次检测 + 未识别标注
+
+{
+  // 全链（自身 + 祖先）均拒绝 → undefined（兜底交给 decideProviderAfterDetect）
+  const sessions = makeSessions(
+    { s: { parentId: "m" }, m: { parentId: "g" }, g: {} },
+    "s",
+  );
+  const conn = makeConnection({}, [], ["s", "m", "g"]);
+  const got = await resolveProviderFromSession(sessions, conn);
+  assert.equal(got, undefined, "全链失败返回 undefined");
+
+  // 有历史检测 → 保持上次值且标注未识别
+  const d1 = decideProviderAfterDetect({ resolved: undefined, hadSession: true, previousDetected: "deepseek" });
+  assert.equal(d1.provider, "deepseek", "全链失败且有历史检测 → 保持上次检测值");
+  assert.equal(d1.unknown, true, "有会话但不可解析 → 标注未知态");
+  assert.ok(UNKNOWN_PROVIDER_HINT.includes("未识别"), "标注文案含「未识别」");
+
+  // 从未成功检测过 → 才回落默认
+  const d2 = decideProviderAfterDetect({ resolved: undefined, hadSession: true, previousDetected: undefined });
+  assert.equal(d2.provider, FALLBACK_PROVIDER, "从未成功检测 → 回落默认 provider");
+  assert.equal(FALLBACK_PROVIDER, "opencode-go", "回落值即内置 opencode-go");
+  assert.equal(d2.unknown, true, "从未成功且会话在场 → 仍属未知态");
+}
+
+{
+  // 客户端源码契约：title 标注接线真实存在（unknown 态追加「提供商未识别」）
+  const src = readFileSync(join(here, "..", "src", "client", "index.ts"), "utf8");
+  assert.ok(src.includes("UNKNOWN_PROVIDER_HINT"), "index.ts 应引用未识别标注常量");
+  assert.ok(src.includes("if (providerUnknown)"), "胶囊 title 渲染应按 providerUnknown 追加标注");
+  assert.ok(src.includes("decideProviderAfterDetect"), "detect() 应经纯函数决策兜底");
+  assert.ok(!src.includes("detected ?? FALLBACK_PROVIDER"), "已移除对 FALLBACK 的无条件回落写法");
+}
+
+// ---------------------------------------------------------------- 3) 无任何会话 → 维持原回落行为（回归防护）
+
+{
+  // 无 sessions 服务 / 无当前会话 → 解析器直接 undefined，且不发起任何 models 调用
+  const calls = [];
+  const conn = makeConnection({}, calls);
+  assert.equal(await resolveProviderFromSession(undefined, conn), undefined, "无 sessions → undefined");
+  assert.equal(await resolveProviderFromSession(makeSessions({}, undefined), conn), undefined, "无 current → undefined");
+  assert.equal(await resolveProviderFromSession(makeSessions({ a: {} }, ""), conn), undefined, "空串 current 视为无会话");
+  assert.deepEqual(calls, [], "无会话场景不得调用 models");
+
+  // 决策层：无任何会话一律回落默认（即使有历史检测也不沿用——维持原行为）
+  const d1 = decideProviderAfterDetect({ resolved: undefined, hadSession: false, previousDetected: "deepseek" });
+  assert.equal(d1.provider, FALLBACK_PROVIDER, "无会话 + 有历史 → 维持原回落（不用历史值）");
+  assert.equal(d1.unknown, false, "无会话回落不算未知态（原行为无标注）");
+  const d2 = decideProviderAfterDetect({ resolved: undefined, hadSession: false, previousDetected: undefined });
+  assert.equal(d2.provider, FALLBACK_PROVIDER, "无会话 + 无历史 → 回落默认");
+  assert.equal(d2.unknown, false, "无会话回落无标注");
+}
+
+// ---------------------------------------------------------------- 4) 上溯深度封顶 / 环防御
+
+{
+  // 环：a → b → a（visited 防环，链终止于 [a, b]）
+  const cyc = makeSessions({ a: { parentId: "b" }, b: { parentId: "a" } }, "a");
+  assert.deepEqual(sessionAncestryChain(cyc, "a"), ["a", "b"], "环链在 visited 处截断");
+  // 自环：a → a
+  const self = makeSessions({ a: { parentId: "a" } }, "a");
+  assert.deepEqual(sessionAncestryChain(self, "a"), ["a"], "自环不重复探测");
+  // 深链封顶：d → c → b → a，默认深度 3 只取三代
+  const deep = makeSessions({ d: { parentId: "c" }, c: { parentId: "b" }, b: { parentId: "a" }, a: {} }, "d");
+  assert.deepEqual(sessionAncestryChain(deep, "d"), ["d", "c", "b"], "默认封顶 MAX_ANCESTRY_DEPTH=3");
+  assert.equal(MAX_ANCESTRY_DEPTH, 3, "封顶常量为 3（issue 方案 A）");
+  assert.deepEqual(sessionAncestryChain(deep, "d", 1), ["d"], "自定义深度生效");
+  assert.deepEqual(sessionAncestryChain(deep, "d", 0), [], "非法深度（<1）返回空链");
+  // 快照缺失 / 断链 / 非字符串父 id → 单节点链
+  assert.deepEqual(sessionAncestryChain(undefined, "x"), ["x"], "无 sessions → 仅自身");
+  assert.deepEqual(sessionAncestryChain({}, "x"), ["x"], "无 list 快照 → 仅自身");
+  assert.deepEqual(sessionAncestryChain(makeSessions({ x: {} }, "x"), "x"), ["x"], "断链 → 仅自身");
+  assert.deepEqual(sessionAncestryChain(makeSessions({ x: { parentId: "" }, "": {} }, "x"), "x"), ["x"], "空串父 id 忽略");
+
+  // 环链下解析器有限次调用后终止
+  const calls = [];
+  const conn = makeConnection({}, calls, ["a", "b"]);
+  const got = await resolveProviderFromSession(cyc, conn);
+  assert.equal(got, undefined, "环链全失败 → undefined");
+  assert.ok(calls.length <= MAX_ANCESTRY_DEPTH, `环链探测次数被封顶（实际 ${calls.length}）`);
+}
+
+// ---------------------------------------------------------------- 5) ordinary 会话直连回归 + 边界
+
+{
+  // ordinary 会话（无 parentId）→ 直接解析成功，仅一次调用
+  const sessions = makeSessions({ only: { origin: "user" } }, "only");
+  const calls = [];
+  const conn = makeConnection({ only: "opencode-go" }, calls);
+  const got = await resolveProviderFromSession(sessions, conn);
+  assert.equal(got, "opencode-go", "ordinary 会话直接解析");
+  assert.deepEqual(calls, ["only"], "ordinary 不触发上溯（单次调用）");
+
+  // currentProvideInfo 优先路径照旧生效
+  const viaInfo = {
+    currentProvideInfo: { getSnapshot: () => ({ sessionId: "info-sid" }) },
+    list: { getSnapshot: () => ({ current: "list-sid", byId: {} }) },
+  };
+  assert.equal(currentSessionId(viaInfo), "info-sid", "currentProvideInfo 优先级不变");
+
+  // models 缺失 / 非 ok 且非 agent-busy 错误码：不上溯报错、静默 undefined
+  assert.equal(await resolveProviderFromSession(sessions, {} as never), undefined, "connection 无 models → undefined");
+  const otherErr = {
+    api: { sessions: { models: async () => { throw Object.assign(new Error("boom"), { code: "no-api-key" }); } } },
+  };
+  const warn = captureWarn();
+  try {
+    assert.equal(await resolveProviderFromSession(sessions, otherErr), undefined, "非 agent-busy 抛错 → undefined");
+    assert.ok(!warn.lines.some((l) => l.includes("agent-busy")), "非 agent-busy 不记忙会话诊断");
+  } finally {
+    warn.restore();
+  }
+
+  // isAgentBusyError 形状覆盖
+  assert.equal(isAgentBusyError(Object.assign(new Error("x"), { code: "agent-busy" })), true, "code 形态命中");
+  assert.equal(isAgentBusyError(new Error("rejected: agent-busy here")), true, "message 内嵌命中");
+  assert.equal(isAgentBusyError({ code: "agent-busy" }), true, "裸对象 code 命中");
+  assert.equal(isAgentBusyError(new Error("other")), false, "普通错误不命中");
+  assert.equal(isAgentBusyError(null), false, "null 不命中");
+  assert.equal(isAgentBusyError("agent-busy"), false, "字符串不命中");
+}
+
+// ---------------------------------------------------------------- 6) 成功解析优先于上溯（首个成功者胜）
+
+{
+  // 自身即可解析（ordinary）→ 不再向上多打一次 models
+  const sessions = makeSessions({ k: { parentId: "up" }, up: {} }, "k");
+  const calls = [];
+  const conn = makeConnection({ k: "prov-k" }, calls);
+  const got = await resolveProviderFromSession(sessions, conn);
+  assert.equal(got, "prov-k", "首个解析成功者胜");
+  assert.deepEqual(calls, ["k"], "自身成功后不再上溯");
+}
+
+console.log("[unit-detect] 全部断言通过 ✓ (#69 provider 检测链)");


### PR DESCRIPTION
Closes #69

## 问题与根因

GUI 切到子代理会话视图时，provider 检测必败（DSH 官方契约：`sessions.models` 仅对 ordinary session 有效，subagent 会话拒并抛 `agent-busy`），原链路 catch 后静默回落内置默认 `opencode-go`，展示看似正常但完全不对的数据且无任何用户可见信号。

## 修复（issue 推荐方案 C = A + B，不做「是不是子代理」正向分类）

- **A 上溯解析**：`resolveProviderFromSession` 经 `sessionAncestryChain` 沿 `sessions.list` 快照 `byId` 行的 `parentId` 逐级上溯（封顶 `MAX_ANCESTRY_DEPTH=3`、visited 防环），首个解析成功者胜；兼容 wire 原名 `parentSessionId`；agent-busy（抛错 `code`/`message` 与 RPC `{ok:false,error:{code}}` 两种形态）记 console 诊断。
- **B 兜底改语义**：新增纯函数 `decideProviderAfterDetect`——解析成功采用；无任何会话维持原回落（回归防护）；有会话但全链失败时保持上次检测值并在胶囊 title 追加「提供商未识别」，仅从未成功检测过才回落默认。移除 `detect()` 对 `FALLBACK_PROVIDER` 的无条件回落。
- dispose 同步清理 `detectedProvider` / `providerUnknown` 新状态。

## 验收断言表（issue 落地清单 ↔ 测试）

| issue 条目 | 断言 | 结果 |
|---|---|---|
| 类型面扩到 byId 行（parentId） | `SessionListRowLike.parentId`/`parentSessionId` 防御双命名 | PASS |
| 子代理会话（models 拒绝）+ 父可解析 → 取父 provider | unit-detect §1（抛错/RPC 错误分支/parentSessionId 命名三形态） | PASS |
| 全链失败且有历史检测 → 保持上次值 + title 含「未识别」 | unit-detect §2（`unknown=true` + `UNKNOWN_PROVIDER_HINT`） | PASS |
| 无任何会话 → 维持原回落行为 | unit-detect §3 回归防护（含无 sessions/current 缺失/空串） | PASS |
| 上溯深度封顶 + 环防御 | unit-detect §4（封顶常量=3、环链有界终止） | PASS |
| ordinary 直连回归 / agent-busy 判定边界 | unit-detect §5/§6（首个成功者胜、非 busy 错误不命中） | PASS |

本地复跑凭据：`[unit-detect] 全部断言通过 ✓ (#69 provider 检测链)`

## 门禁

五连门禁本地全绿：`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck`（exit 0，6/6 客户端包契约 PASS，tarball 完整性 PASS）。CI 全量门禁以本 PR checks 为准。

## 复核说明（流程留痕）

- 改动面：仅 `src/client/core.ts`、`src/client/index.ts`、`test/`（+454/-20），未触及红线文件与宿主端路由/注册表/适配器。
- 本任务实施过程中委派通道出现实例楔死异常，主控按接管协议留痕处置：最终实现由恢复后的执行实例提交（e79d0d3），主控对全量 diff 做了逐行预审；另派上下文独立实例按上表逐条复核中，复核判回后开启 auto-merge。