### PR TITLE
fix(dsh-provider-usage): maxAgeDays 非正整数回落默认 + readAdapterState 拒绝非对象输入（#184）

### DIFF
--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -227,7 +227,11 @@ export function normalizeConfig(input: unknown): NormalizedConfig {
   if (Number.isFinite(cfg.cacheDurationMs)) base.cacheDurationMs = Math.max(5000, cfg.cacheDurationMs as number);
   if (Number.isFinite(cfg.fetchTimeoutMs)) base.fetchTimeoutMs = Math.min(Math.max(500, cfg.fetchTimeoutMs as number), 30000);
   if (typeof cfg.autoReload === "boolean") base.autoReload = cfg.autoReload;
-  if (Number.isFinite(cfg.maxAgeDays)) base.maxAgeDays = Math.min(365, cfg.maxAgeDays as number);
+  // #184：maxAgeDays 仅接受正整数——<=0 会令 maybePrune 下界落在未来（历史被全量清理）、
+  // 面板查询区间 start>end 永空；非正整数一律视为非法回落默认值，上界 365 维持既有 clamp
+  if (Number.isInteger(cfg.maxAgeDays) && (cfg.maxAgeDays as number) > 0) {
+    base.maxAgeDays = Math.min(365, cfg.maxAgeDays as number);
+  }
   if (Number.isFinite(cfg.maxSizeMB)) base.maxSizeMB = Math.min(500, cfg.maxSizeMB as number);
   return base;
 }
@@ -299,7 +303,11 @@ export async function readUserAdapters(root: string): Promise<UserAdapterRecord[
 export async function readAdapterState(root: string): Promise<Record<string, string | null>> {
   try {
     if (!existsSync(adapterStateFile(root))) return {};
-    const data = JSON.parse(await readFile(adapterStateFile(root), "utf8")) as Record<string, unknown>;
+    const parsed: unknown = JSON.parse(await readFile(adapterStateFile(root), "utf8"));
+    // #184：顶层必须是 plain object——null / 数组 / 字符串等类数组输入一律拒绝，
+    // 返回与「无有效状态」一致的空对象（调用方遍历空对象即无任何恢复动作）
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {};
+    const data = parsed as Record<string, unknown>;
     const out: Record<string, string | null> = {};
     for (const [provider, id] of Object.entries(data)) {
       if (typeof provider !== "string" || provider.length === 0) continue;

--- a/packages/dsh-provider-usage/test/unit-config.test.ts
+++ b/packages/dsh-provider-usage/test/unit-config.test.ts
@@ -288,11 +288,14 @@ assert.equal(normalizeConfig({ fetchTimeoutMs: 30000 }).fetchTimeoutMs, 30000, "
 assert.equal(normalizeConfig({ fetchTimeoutMs: 30001 }).fetchTimeoutMs, 30000, "fetchTimeoutMs 上限 30000");
 assert.equal(normalizeConfig({ fetchTimeoutMs: "x" }).fetchTimeoutMs, DEFAULT_CONFIG.fetchTimeoutMs, "fetchTimeoutMs 非法丢弃");
 
-// maxAgeDays 上限 365（无下限）
+// maxAgeDays 上限 365、下限正整数（#184：<=0 或非整数回落默认，避免 maybePrune 下界落在未来全量清史）
+assert.equal(normalizeConfig({ maxAgeDays: 1 }).maxAgeDays, 1, "maxAgeDays 合法边界 1 保留");
 assert.equal(normalizeConfig({ maxAgeDays: 365 }).maxAgeDays, 365, "maxAgeDays 边界 365 透传");
 assert.equal(normalizeConfig({ maxAgeDays: 366 }).maxAgeDays, 365, "maxAgeDays 上限 365");
-assert.equal(normalizeConfig({ maxAgeDays: -5 }).maxAgeDays, -5, "maxAgeDays 负数无下限（跟随实现）");
-assert.equal(normalizeConfig({ maxAgeDays: [] }).maxAgeDays, DEFAULT_CONFIG.maxAgeDays, "maxAgeDays 数组（Number.isFinite false）丢弃");
+assert.equal(normalizeConfig({ maxAgeDays: -5 }).maxAgeDays, DEFAULT_CONFIG.maxAgeDays, "maxAgeDays 负数回落默认");
+assert.equal(normalizeConfig({ maxAgeDays: 0 }).maxAgeDays, DEFAULT_CONFIG.maxAgeDays, "maxAgeDays 0 回落默认");
+assert.equal(normalizeConfig({ maxAgeDays: 1.5 }).maxAgeDays, DEFAULT_CONFIG.maxAgeDays, "maxAgeDays 非整数回落默认");
+assert.equal(normalizeConfig({ maxAgeDays: [] }).maxAgeDays, DEFAULT_CONFIG.maxAgeDays, "maxAgeDays 数组丢弃");
 
 // warmupIntervalMs 下限
 assert.equal(normalizeConfig({ warmupIntervalMs: 59999 }).warmupIntervalMs, 60000, "warmupIntervalMs 下限 60000（59999 抬升）");
@@ -372,10 +375,19 @@ assert.deepEqual(parseUserAdapters('"str"'), [], "JSON 字符串返回空数组"
   assert.deepEqual(state, { p1: "a", p2: null },
     "仅保留非空字符串 id 与显式 null；空 key/空串/数字/数组/对象全部剔除");
 
-  // 顶层 JSON 标量字符串 → 实现按 Record 读，Object.entries 按字符索引展开（跟随实现行为）
+  // #184：顶层非 plain object（字符串/数字/null/数组）一律拒绝 → 空对象（与「无有效状态」同形态）
   writeFileSync(join(root, "adapter-state.json"), '"ab"', "utf8");
-  const fromStr = await readAdapterState(root);
-  assert.deepEqual(fromStr, { 0: "a", 1: "b" }, "顶层字符串按字符索引展开（跟随实现行为）");
+  assert.deepEqual(await readAdapterState(root), {}, "顶层字符串拒绝（不再按字符索引展开）");
+  writeFileSync(join(root, "adapter-state.json"), "42", "utf8");
+  assert.deepEqual(await readAdapterState(root), {}, "顶层数字拒绝");
+  writeFileSync(join(root, "adapter-state.json"), "null", "utf8");
+  assert.deepEqual(await readAdapterState(root), {}, "顶层 null 拒绝");
+  writeFileSync(join(root, "adapter-state.json"), '["a","b"]', "utf8");
+  assert.deepEqual(await readAdapterState(root), {}, "顶层数组拒绝");
+
+  // plain object 正常解析（拒绝路径不误伤合法映射）
+  writeFileSync(join(root, "adapter-state.json"), '{"p9":"x"}', "utf8");
+  assert.deepEqual(await readAdapterState(root), { p9: "x" }, "plain object 正常解析");
 }
 
 // ================================================================ #150 二阶段：UI 配置与面板锚点纯函数矩阵


### PR DESCRIPTION
## 概述

实施 #184（维护者 approved，按「修实现」方向）：修复两处被 #183 测试钉死的可疑行为。

## 行为变更（各一行核心逻辑）

1. **maxAgeDays**：仅接受正整数；`<=0` / 小数 / 非数值回落默认 30（原：负值透传 → maybePrune 下界落在未来全量清史、面板 start>end 永空）。上界 Math.min(365) 不变。
2. **readAdapterState**：解析结果非 plain object（null/数组/字符串等）一律返回 `{}`，与「文件缺失/坏 JSON」同形态；调用方 apply() 零改动（原：字符串被按索引展开为 `{0:"a",1:"b"}`）。

## 断言表

| 条目 | 级别 | 证据 |
|---|---|---|
| 五连门禁 | 硬性 | build/test/contract/pack:check/typecheck = 0/0/0/0/0 |
| 变异 covered 无回退 | 硬性 | 实测 67.44%（killed 1517 + timeout 20），较 #183 口径 66.98% +0.46pp |
| 测试矩阵更新 | 硬性 | maxAgeDays -5/0/1.5→默认、1→保留；readAdapterState "ab"/42/null/数组→{}、plain object→正常解析 |
| 主控 diff 复核 | 硬性 | src 核心改动各 1 处条件分支，注释含根因，无夹带 |

Closes #184
