### PR TITLE
feat(ci): mutation-gate 收敛至 pull_request 触发——main 变异覆盖归夜间全量（#187）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,9 +279,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0   # 阈值单调性校验需读 origin/main 的 config（F3）
+
       - name: Fail-closed gate assertion（F2：任何上游非 success 即红）
         # #187：判定逻辑收敛到 scripts/gate/repo-gate-assert.mjs（事件 × 切片清单
-        # × job 结果三维判定表，可被单元测试全组合锁死），env 注入避免内联 bash 漂移
+        # × job 结果三维判定表，可被单元测试全组合锁死），env 注入避免内联 bash 漂移。
+        # 必须排在 Checkout 之后（run #32800733630 教训：脚本版需要工作区文件，
+        # 旧内联 bash 无文件依赖掩盖了这一时序约束）；仅依赖 Node 内置模块，
+        # 无需等 pnpm/setup-node，紧随 checkout 尽早判红
         env:
           GATE_EVENT: ${{ github.event_name }}
           GATE_CHANGES: ${{ needs.changes.result }}
@@ -289,11 +297,6 @@ jobs:
           GATE_MUTATION: ${{ needs.mutation-gate.result }}
           GATE_MUTATION_PKGS: ${{ needs.changes.outputs.mutationPackages }}
         run: node scripts/gate/repo-gate-assert.mjs
-
-      - name: Checkout
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-        with:
-          fetch-depth: 0   # 阈值单调性校验需读 origin/main 的 config（F3）
 
       - name: Setup pnpm
         uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,8 +190,12 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  # ── 第 3 段：增量变异门禁（#178 v2：paths-filter 切片 + 夜间基线增量复用）──
+  # ── 第 3 段：增量变异门禁（#178 v2 切片 + #187 触发面收敛至 pull_request）──
   # - 仅对命中包实例化（动态 matrix ← changes.mutationPackages；空清单时整体 skipped）
+  # - 仅限 pull_request 触发（#187）：main push 场景 before 基线不可用时 paths-filter
+  #   走 fail-closed 全量 fallback，变异会退化全量且与 observe.yml 夜间全量完全重复；
+  #   主干变异覆盖归夜间、发版归 release.yml tag 管线——全量只在这两处真实执行。
+  #   非 PR 事件下整体 skipped，由 repo-gate 判定脚本按事件语义显式放行
   # - restore-only：只读夜间全量落下的 incremental 基线，绝不回写（防 PR 结果污染夜间基线源）
   # - 缓存未命中（首夜前 / LRU 淘汰）天然降级为全量变异，门禁语义不变仅变慢
   # - 双指标判分（scripts/gate/mutation-gate.mjs）：测试覆盖率（self-written 函数，
@@ -201,7 +205,7 @@ jobs:
   mutation-gate:
     name: Mutation gate (${{ matrix.package }})
     needs: changes
-    if: always() && needs.changes.result == 'success'
+    if: github.event_name == 'pull_request' && needs.changes.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -276,24 +280,15 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Fail-closed gate assertion（F2：任何上游非 success 即红）
-        run: |
-          set -e
-          echo "changes=${{ needs.changes.result }}  build-test=${{ needs.build-test.result }}  mutation-gate=${{ needs.mutation-gate.result }}"
-          if [ "${{ needs.changes.result }}" != "success" ]; then
-            echo "::error::changes 作业未成功（${{ needs.changes.result }}）—— fail-closed"
-            exit 1
-          fi
-          if [ "${{ needs.build-test.result }}" != "success" ]; then
-            echo "::error::build-test 存在失败/skipped 实例（${{ needs.build-test.result }}）—— fail-closed"
-            exit 1
-          fi
-          # mutation-gate（#178）：success 放行；skipped 仅当无命中包（空矩阵）或
-          # changes 未成功——后者已被上方断言拦截，此处放行不构成旁路；
-          # failure/cancelled 一律判红
-          if [ "${{ needs.mutation-gate.result }}" != "success" ] && [ "${{ needs.mutation-gate.result }}" != "skipped" ]; then
-            echo "::error::mutation-gate 存在失败实例（${{ needs.mutation-gate.result }}）—— fail-closed"
-            exit 1
-          fi
+        # #187：判定逻辑收敛到 scripts/gate/repo-gate-assert.mjs（事件 × 切片清单
+        # × job 结果三维判定表，可被单元测试全组合锁死），env 注入避免内联 bash 漂移
+        env:
+          GATE_EVENT: ${{ github.event_name }}
+          GATE_CHANGES: ${{ needs.changes.result }}
+          GATE_BUILD_TEST: ${{ needs.build-test.result }}
+          GATE_MUTATION: ${{ needs.mutation-gate.result }}
+          GATE_MUTATION_PKGS: ${{ needs.changes.outputs.mutationPackages }}
+        run: node scripts/gate/repo-gate-assert.mjs
 
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -37,10 +37,13 @@ pnpm typecheck    # 全仓类型检查
 > （只记录不判红），`threshold` 为阶段二目标值，待基线校准（issue #42 二期）后再
 > 接入 CI 硬卡点。
 
-### 变异测试与增量链路（#178）
+### 变异测试与增量链路（#178 / #187）
 
 六包变异配置集中在 `stryker.conf.d/dsh-<pkg>.json`（mutate 区间、testFiles、
 阈值口径与 `gauntlet.config.json` 三方一致，由 workflow-assert 自测锚定）。增量链路：
+
+**全量分工总述**：PR 门管变更切片；夜间 observe 门管主干全量；发版前
+release.yml tag 管线跑全量门禁——全量只在这三处语义中的后两处真实执行。
 
 - **夜间全量落基线**（observe.yml）：刻意不 restore 任何缓存——无 incremental
   基线即天然全量；运行末尾把六份 `coverage/mutation/incremental-*.json` 写入
@@ -52,7 +55,12 @@ pnpm typecheck    # 全仓类型检查
   （scripts/gate/mutation-gate.mjs）：测试覆盖率 self-written 函数 ≥ threshold
   恒硬；变异测试率 covered ≥ per-package threshold 受全局 `mutation.strict`
   约束（false 期间仅标注，#150 达标翻转后自动变硬）。成败并入 repo-gate
-  聚合闸，不新增分支保护 required check 名。缓存未命中时天然降级为全量变异。
+  聚合闸（判定逻辑见 scripts/gate/repo-gate-assert.mjs），不新增分支保护
+  required check 名。缓存未命中时天然降级为全量变异。
+- **触发面收敛**（#187）：`mutation-gate` 仅限 pull_request 触发——push 到 main
+  时 diff 基准 `before` 不可用会使 paths-filter 走 fail-closed 全量 fallback，
+  变异随之退化全量且与当晚夜间全量完全重复；主干变异覆盖由 observe.yml 夜间
+  全量承接、发版前由 release.yml tag 管线承接，非 PR 事件下该 job 整体 skipped。
 - 本地手动入口：`npx stryker run stryker.conf.d/dsh-<pkg>.json`（临时强制全量用
   官方 `--force` 参数，勿改配置文件）。
 

--- a/scripts/gate/repo-gate-assert.mjs
+++ b/scripts/gate/repo-gate-assert.mjs
@@ -18,10 +18,11 @@
  *   3) mutationPackages 解析失败 / 非数组 → 环境数据违约（exit 2，fail-closed）；
  *   4) pull_request 事件：
  *      - 切片非空 → mutation-gate 必须 success。skipped 视同「该跑没跑」的
- *        门禁静默绕过（与空矩阵合法 skip 在 job result 上无法区分，故按清单
+ *        门禁静默绕过（与空矩阵合法缺席在 job result 上无法区分，故按清单
  *        维度区分——这是 #187 收敛前旧判定存在的语义漏洞，此处堵死）；
- *      - 切片为空 → mutation-gate 必须 skipped（动态空矩阵整体不实例化的唯一
- *        合法形态；出现其他结果说明矩阵契约被破坏）；
+ *      - 切片为空 → skipped 或 failure 均属合法缺席（GitHub 对零实例动态矩阵
+ *        实测回报 failure 而非官方口径 skipped，实证 run 32802575298；
+ *        success/cancelled 说明矩阵契约被破坏）；
  *   5) 非 pull_request 事件（push / workflow_dispatch / 未来新增触发器）→
  *      mutation-gate 必须 skipped。这是 #187 的触发面收敛不变量：主干变异覆盖
  *      归 observe.yml 夜间全量、发版归 release.yml tag 管线全量；若非 skipped，
@@ -79,12 +80,19 @@ export function evaluateGate(input) {
         };
       }
     } else {
-      // 空矩阵 → 整体 skipped 是唯一合法形态
-      if (mutation !== 'skipped') {
+      // 空切片（合法缺席）：GitHub 对零实例动态矩阵实测回报 'failure' 而非官方
+      // 口径 'skipped'——实证 run 32802575298（commit 3012980，PR 仅改
+      // stryker.conf.d/<pkg>.json 不被任何包 filter 命中 → mutationPackages=[] →
+      // 矩阵零实例化：check-runs 无该 job 记录、jobs API total_count=9 无变异实例，
+      // needs.mutation-gate.result 却为 'failure'）。两种形态均放行；
+      // success/cancelled 仍属契约异常照旧判红。
+      // 注意与 job 级 if 整体跳过（非 PR 分支，result='skipped'）是不同机制，
+      // 该分支语义不受本实证影响、维持只收 skipped。
+      if (mutation !== 'skipped' && mutation !== 'failure') {
         return {
           ok: false,
           code: 1,
-          reason: `mutation-gate 空切片却得到结果 ${mutation}（期望 skipped）—— 动态矩阵契约破坏`,
+          reason: `mutation-gate 空切片却得到结果 ${mutation}（期望 skipped/failure）—— 动态矩阵契约破坏`,
         };
       }
     }

--- a/scripts/gate/repo-gate-assert.mjs
+++ b/scripts/gate/repo-gate-assert.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * repo-gate-assert — repo-gate 聚合闸 fail-closed 判定脚本（#187 触发面收敛版）
+ *
+ * 取代原先内联在 ci.yml 的 bash 断言：判定逻辑收敛为纯函数后可被单元测试
+ * 全组合锁死，避免内联 bash 只能靠 workflow 静态文本锚间接覆盖。
+ *
+ * 输入（由 ci.yml repo-gate 首步以 env 注入）：
+ *   GATE_EVENT          github.event_name（pull_request / push / workflow_dispatch / …）
+ *   GATE_CHANGES        needs.changes.result
+ *   GATE_BUILD_TEST     needs.build-test.result
+ *   GATE_MUTATION       needs.mutation-gate.result
+ *   GATE_MUTATION_PKGS  needs.changes.outputs.mutationPackages（JSON 数组文本，恒为合法数组）
+ *
+ * 判定表（fail-closed：任何未显式放行的组合一律红）：
+ *   1) changes != success → 红（一切切片判定的前提，#85 F2）；
+ *   2) build-test != success → 红（全集构建是全局门禁的产物前提，评审 F1）；
+ *   3) mutationPackages 解析失败 / 非数组 → 环境数据违约（exit 2，fail-closed）；
+ *   4) pull_request 事件：
+ *      - 切片非空 → mutation-gate 必须 success。skipped 视同「该跑没跑」的
+ *        门禁静默绕过（与空矩阵合法 skip 在 job result 上无法区分，故按清单
+ *        维度区分——这是 #187 收敛前旧判定存在的语义漏洞，此处堵死）；
+ *      - 切片为空 → mutation-gate 必须 skipped（动态空矩阵整体不实例化的唯一
+ *        合法形态；出现其他结果说明矩阵契约被破坏）；
+ *   5) 非 pull_request 事件（push / workflow_dispatch / 未来新增触发器）→
+ *      mutation-gate 必须 skipped。这是 #187 的触发面收敛不变量：主干变异覆盖
+ *      归 observe.yml 夜间全量、发版归 release.yml tag 管线全量；若非 skipped，
+ *      说明 ci.yml 中 if 的事件限制已被破坏，宁可显性红也不静默退化全量。
+ *
+ * 用法：node scripts/gate/repo-gate-assert.mjs   （无命令行参数，全部走 env）
+ * 退出码：0 = 通过；1 = 门禁违约；2 = 环境/数据缺失错误（fail-closed）
+ */
+import { pathToFileURL } from 'node:url';
+
+/**
+ * 判定核心（纯函数，供单元测试全组合覆盖）。
+ * @param {{
+ *   event: string,
+ *   changes: string,
+ *   buildTest: string,
+ *   mutation: string,
+ *   mutationPkgsJson: string,
+ * }} input
+ * @returns {{ ok: boolean, code: 0 | 1 | 2, reason: string }}
+ */
+export function evaluateGate(input) {
+  const { event, changes, buildTest, mutation } = input;
+
+  // 前提闸：changes 是所有切片判定的事实源，非 success 即红
+  if (changes !== 'success') {
+    return { ok: false, code: 1, reason: `changes 作业未成功（${changes}）—— fail-closed` };
+  }
+  // build-test 恒全集构建（不受触发面收敛影响），任何实例失败/skipped 即红
+  if (buildTest !== 'success') {
+    return { ok: false, code: 1, reason: `build-test 存在失败/skipped 实例（${buildTest}）—— fail-closed` };
+  }
+
+  // 变异切片清单：changes 已成功仍解析失败 = 数据契约破坏，按环境错误处理
+  let pkgs;
+  try {
+    pkgs = JSON.parse(input.mutationPkgsJson);
+  } catch (err) {
+    return { ok: false, code: 2, reason: `mutationPackages 不是合法 JSON（${err.message}）—— 数据契约破坏` };
+  }
+  if (!Array.isArray(pkgs)) {
+    return { ok: false, code: 2, reason: 'mutationPackages 不是 JSON 数组 —— 数据契约破坏' };
+  }
+
+  if (event === 'pull_request') {
+    // PR 事件：变异门禁必须真实执行或合法缺席，二选一精确锁定
+    if (pkgs.length > 0) {
+      // 切片非空 → 必须 success。skipped 在 job result 上与「if 被改坏导致
+      // 该跑没跑」不可区分，一律按门禁绕过判红（#187 堵旧判定语义漏洞）
+      if (mutation !== 'success') {
+        return {
+          ok: false,
+          code: 1,
+          reason: `mutation-gate 切片 [${pkgs.join(', ')}] 结果为 ${mutation}（期望 success）—— PR 下该跑没跑视为门禁绕过`,
+        };
+      }
+    } else {
+      // 空矩阵 → 整体 skipped 是唯一合法形态
+      if (mutation !== 'skipped') {
+        return {
+          ok: false,
+          code: 1,
+          reason: `mutation-gate 空切片却得到结果 ${mutation}（期望 skipped）—— 动态矩阵契约破坏`,
+        };
+      }
+    }
+    return { ok: true, code: 0, reason: 'PR 门禁：变更切片 + 增量变异全部通过' };
+  }
+
+  // 非 PR 事件：触发面收敛不变量——变异只允许 skipped（main 归夜间、发版归 release）
+  if (mutation !== 'skipped') {
+    return {
+      ok: false,
+      code: 1,
+      reason: `${event} 事件下 mutation-gate 结果为 ${mutation}（期望 skipped）—— #187 触发面收敛不变量被破坏（ci.yml if 事件限制疑似失效）`,
+    };
+  }
+  return { ok: true, code: 0, reason: '主干/手动触发：变异门禁已收敛至夜间与发版管线（skipped 符合预期）' };
+}
+
+// ── CLI 入口（仅直跑时执行；被测试 import 时只暴露 evaluateGate 不产生副作用）──
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  const env = process.env;
+  const verdict = evaluateGate({
+    event: env.GATE_EVENT ?? '',
+    changes: env.GATE_CHANGES ?? '',
+    buildTest: env.GATE_BUILD_TEST ?? '',
+    mutation: env.GATE_MUTATION ?? '',
+    mutationPkgsJson: env.GATE_MUTATION_PKGS ?? '',
+  });
+  console.log(`event=${env.GATE_EVENT}  changes=${env.GATE_CHANGES}  `
+    + `build-test=${env.GATE_BUILD_TEST}  mutation-gate=${env.GATE_MUTATION}`);
+  // 违约/环境错误走 ::error:: 注解（GitHub PR 页面可见，与旧内联断言同款）
+  if (verdict.code === 0) {
+    console.log(`判定：${verdict.reason}`);
+  } else {
+    console.error(`::error::${verdict.reason}`);
+  }
+  process.exit(verdict.code);
+}

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -13,6 +13,8 @@
  *   - observe.yml：夜间调度、self-cov --check 与 mutate-scope-guard 执行点在位；
  *     六包串行清单 ↔ stryker.conf.d 文件集 ↔ gauntlet mutation.packages 三方一致
  *   - changes 的 case 映射覆盖全部包（防新增包静默漏检，评审 F7）
+ *   - #187 触发面收敛：mutation-gate 仅限 pull_request；repo-gate 判定走
+ *     scripts/gate/repo-gate-assert.mjs 并以判定表全组合单测锁死
  *
  * 运行：node --test scripts/test/workflow-assert.test.ts（或 pnpm test:scripts）
  */
@@ -20,6 +22,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync, readdirSync, existsSync } from 'node:fs'
 import { join, basename } from 'node:path'
+import { spawnSync } from 'node:child_process'
 
 const ROOT = join(import.meta.dirname, '../..')
 const CI = readFileSync(join(ROOT, '.github/workflows/ci.yml'), 'utf8')
@@ -43,12 +46,16 @@ test('ci.yml: repo-gate 保持分支保护 required check 名', () => {
     'required check 名必须与旧单作业名一致（维护者分支保护无缝切换）')
 })
 
-test('ci.yml: repo-gate if always() 且首步 fail-closed 断言双上游', () => {
+test('ci.yml: repo-gate if always() 且首步 fail-closed 断言经判定脚本执行', () => {
   const gate = CI.slice(CI.indexOf('\n  repo-gate:'))
   assert.ok(/if: always\(\)/.test(gate), 'repo-gate 必须 always() 运行（上游失败时仍执行判红）')
-  assert.ok(gate.includes('needs.changes.result'), '断言 changes 结果')
-  assert.ok(gate.includes('needs.build-test.result'), '断言 build-test 结果')
   assert.ok(/Fail-closed gate assertion/.test(gate), 'fail-closed 断言步骤在位')
+  // #187：内联 bash 收敛为可单测的判定脚本，env 三维注入（事件 × 切片 × 结果）
+  assert.ok(gate.includes('run: node scripts/gate/repo-gate-assert.mjs'),
+    'repo-gate fail-closed 判定必须调用 scripts/gate/repo-gate-assert.mjs')
+  for (const env of ['GATE_EVENT', 'GATE_CHANGES', 'GATE_BUILD_TEST', 'GATE_MUTATION', 'GATE_MUTATION_PKGS']) {
+    assert.ok(new RegExp(`${env}: \\$\\{\\{`).test(gate), `判定脚本 env ${env} 注入缺失`)
+  }
 })
 
 test('ci.yml: filter 失败 fallback 全量切片（fail-closed 双闸）', () => {
@@ -200,6 +207,107 @@ test('#178: ci.yml PR 增量门禁——restore-only + 按命中包切片 + 并�
   const rg = CI.slice(CI.indexOf('\n  repo-gate:'))
   assert.ok(rg.includes('needs.mutation-gate.result'),
     'repo-gate fail-closed 判定脚本必须检查 needs.mutation-gate.result')
+})
+
+// ── #187 触发面收敛：mutation-gate 仅限 pull_request，主干变异归夜间全量 ──
+
+test('#187: ci.yml mutation-gate if 收敛至 pull_request（删除或改坏必红）', () => {
+  // build-test 不受收敛影响：push 时仍须全集构建（repo-gate 全局门禁依赖产物）
+  const bt = CI.slice(CI.indexOf('\n  build-test:'), CI.indexOf('\n  mutation-gate:'))
+  assert.ok(bt.includes('if: always() && needs.changes.result == \'success\''),
+    'build-test 的 if 必须保持 always() 全事件构建语义')
+
+  const mg = CI.slice(CI.indexOf('\n  mutation-gate:'), CI.indexOf('\n  repo-gate:'))
+  const m = /^    if: (.+)$/m.exec(mg)
+  assert.ok(m, 'mutation-gate 声明 job 级 if')
+  assert.equal(
+    m[1].trim(),
+    "github.event_name == 'pull_request' && needs.changes.result == 'success'",
+    'mutation-gate 的 if 必须精确为「仅 PR 且 changes 成功」——'
+    + '事件限制被删除（退化 push 全量变异）或被改坏（PR 门禁静默缺席）均判红',
+  )
+})
+
+test('#187: repo-gate-assert 判定表全组合锁定（事件 × 切片清单 × job 结果）', async () => {
+  const { evaluateGate } = await import('../gate/repo-gate-assert.mjs')
+  const base = {
+    event: 'pull_request',
+    changes: 'success',
+    buildTest: 'success',
+    mutation: 'success',
+    mutationPkgsJson: '["dsh-notifier"]',
+  }
+  const run = (over) => evaluateGate({ ...base, ...over })
+
+  // 前提闸：changes / build-test 非 success 一律红（含 cancelled / skipped）
+  for (const r of ['failure', 'cancelled', 'skipped']) {
+    assert.deepEqual({ ...run({ changes: r }), reason: undefined },
+      { ok: false, code: 1, reason: undefined }, `changes=${r} 必须红`)
+    assert.equal(run({ buildTest: r }).code, 1, `build-test=${r} 必须红`)
+  }
+
+  // PR + 非空切片：仅 success 放行；skipped = 该跑没跑的门禁静默绕过，必红
+  assert.equal(run({}).code, 0, 'PR 非空切片 success 放行')
+  for (const r of ['skipped', 'failure', 'cancelled']) {
+    const v = run({ mutation: r })
+    assert.equal(v.code, 1, `PR 非空切片 ${r} 必须红`)
+    assert.match(v.reason, /绕过|期望 success/, `${r} 判词须点名门禁绕过语义`)
+  }
+
+  // PR + 空矩阵：整体 skipped 是唯一合法形态
+  assert.equal(run({ mutationPkgsJson: '[]', mutation: 'skipped' }).code, 0, '空矩阵 skipped 合法放行')
+  for (const r of ['success', 'failure', 'cancelled']) {
+    assert.equal(run({ mutationPkgsJson: '[]', mutation: r }).code, 1, `空矩阵 ${r} 必须红`)
+  }
+
+  // 非 PR 事件：触发面收敛不变量——mutation-gate 必须 skipped；
+  // 若出现其他结果说明 ci.yml if 的事件限制已失效，显性红防静默退化全量
+  for (const ev of ['push', 'workflow_dispatch']) {
+    assert.equal(run({ event: ev, mutation: 'skipped', mutationPkgsJson: '[ ]' }).code, 0,
+      `${ev} + 整体 skipped 符合收敛预期`)
+    for (const r of ['success', 'failure', 'cancelled']) {
+      const v = run({ event: ev, mutation: r })
+      assert.equal(v.code, 1, `${ev} + mutation-gate=${r} 必须红`)
+      assert.match(v.reason, /收敛不变量/, `${ev} 下 ${r} 判词须点名收敛不变量`)
+    }
+  }
+
+  // 数据契约破坏：切片清单非合法 JSON 数组按环境错误处理（exit 2）
+  for (const bad of ['not-json', '{"a":1}', '"dsh-notifier"']) {
+    const v = run({ mutationPkgsJson: bad })
+    assert.equal(v.code, 2, `切片清单非法（${bad}）必须 exit 2`)
+  }
+})
+
+test('#187: repo-gate-assert CLI 退出码转发（GitHub Actions 判红依据）', () => {
+  const script = join(ROOT, 'scripts/gate/repo-gate-assert.mjs')
+  const envOf = (over) => ({
+    GATE_EVENT: over.event ?? '',
+    GATE_CHANGES: over.changes ?? '',
+    GATE_BUILD_TEST: over.buildTest ?? '',
+    GATE_MUTATION: over.mutation ?? '',
+    GATE_MUTATION_PKGS: over.mutationPkgsJson ?? '',
+  })
+  // 通过场景 exit 0
+  const okRun = spawnSync(process.execPath, [script], {
+    encoding: 'utf8',
+    env: { ...process.env, ...envOf({
+      event: 'push', changes: 'success', buildTest: 'success',
+      mutation: 'skipped', mutationPkgsJson: '[]',
+    }) },
+  })
+  assert.equal(okRun.status, 0, 'push + skipped 场景 CLI 必须 exit 0')
+  // 违约场景 exit 1 且输出 ::error:: 可检索的判词
+  const failRun = spawnSync(process.execPath, [script], {
+    encoding: 'utf8',
+    env: { ...process.env, ...envOf({
+      event: 'pull_request', changes: 'success', buildTest: 'success',
+      mutation: 'skipped', mutationPkgsJson: '["dsh-lan-proxy"]',
+    }) },
+  })
+  assert.equal(failRun.status, 1, 'PR 该跑没跑场景 CLI 必须 exit 1')
+  assert.match(failRun.stderr, /::error::/, '违约判词必须带 ::error:: 注解前缀（PR 页面可见）')
+  assert.match(failRun.stderr, /绕过/, '判词须点名门禁绕过语义')
 })
 
 test('#178: ci.yml 包名全集 ≡ gauntlet 变异六包 ∪ {dsh-plugins-all}（防清单漂移）', () => {

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -46,7 +46,7 @@ test('ci.yml: repo-gate 保持分支保护 required check 名', () => {
     'required check 名必须与旧单作业名一致（维护者分支保护无缝切换）')
 })
 
-test('ci.yml: repo-gate if always() 且首步 fail-closed 断言经判定脚本执行', () => {
+test('ci.yml: repo-gate if always() 且 fail-closed 断言经判定脚本执行', () => {
   const gate = CI.slice(CI.indexOf('\n  repo-gate:'))
   assert.ok(/if: always\(\)/.test(gate), 'repo-gate 必须 always() 运行（上游失败时仍执行判红）')
   assert.ok(/Fail-closed gate assertion/.test(gate), 'fail-closed 断言步骤在位')
@@ -56,6 +56,13 @@ test('ci.yml: repo-gate if always() 且首步 fail-closed 断言经判定脚本�
   for (const env of ['GATE_EVENT', 'GATE_CHANGES', 'GATE_BUILD_TEST', 'GATE_MUTATION', 'GATE_MUTATION_PKGS']) {
     assert.ok(new RegExp(`${env}: \\$\\{\\{`).test(gate), `判定脚本 env ${env} 注入缺失`)
   }
+  // 时序约束（run #32800733630 教训）：脚本版断言依赖工作区文件，必须排在
+  // Checkout 之后；旧内联 bash 无文件依赖曾掩盖该约束
+  const checkoutIdx = gate.indexOf('- name: Checkout')
+  const assertIdx = gate.indexOf('Fail-closed gate assertion')
+  assert.ok(checkoutIdx > 0, 'repo-gate 存在 Checkout 步骤')
+  assert.ok(assertIdx > checkoutIdx,
+    'fail-closed 断言步骤必须排在 Checkout 之后（脚本需要工作区存在 scripts/gate/）')
 })
 
 test('ci.yml: filter 失败 fallback 全量切片（fail-closed 双闸）', () => {
@@ -271,6 +278,14 @@ test('#187: repo-gate-assert 判定表全组合锁定（事件 × 切片清单 �
       assert.match(v.reason, /收敛不变量/, `${ev} 下 ${r} 判词须点名收敛不变量`)
     }
   }
+  // push fail-closed 真实形态（GATE_MUTATION_PKGS 的 push 取值）：changes 无 if
+  // 照常运行，before 基线不可用令 paths-filter 全量 fallback → 清单为非空全集；
+  // 判定表非 PR 分支不读清单内容，非空全集 + 整体 skipped 同样放行
+  assert.equal(run({
+    event: 'push',
+    mutation: 'skipped',
+    mutationPkgsJson: JSON.stringify(ALL_PACKAGES),
+  }).code, 0, 'push fail-closed 全量清单（七包非空数组）+ 整体 skipped 放行')
 
   // 数据契约破坏：切片清单非合法 JSON 数组按环境错误处理（exit 2）
   for (const bad of ['not-json', '{"a":1}', '"dsh-notifier"']) {

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -261,11 +261,18 @@ test('#187: repo-gate-assert 判定表全组合锁定（事件 × 切片清单 �
     assert.match(v.reason, /绕过|期望 success/, `${r} 判词须点名门禁绕过语义`)
   }
 
-  // PR + 空矩阵：整体 skipped 是唯一合法形态
-  assert.equal(run({ mutationPkgsJson: '[]', mutation: 'skipped' }).code, 0, '空矩阵 skipped 合法放行')
-  for (const r of ['success', 'failure', 'cancelled']) {
-    assert.equal(run({ mutationPkgsJson: '[]', mutation: r }).code, 1, `空矩阵 ${r} 必须红`)
+  // PR + 空切片：skipped / failure 均属合法缺席——GitHub 对零实例动态矩阵
+  // 实测回报 failure 而非官方口径 skipped（实证 run 32802575298：
+  // check-runs 无该 job 记录、jobs API total_count=9 无变异实例）
+  assert.equal(run({ mutationPkgsJson: '[]', mutation: 'skipped' }).code, 0, '空切片 skipped 合法放行')
+  assert.equal(run({ mutationPkgsJson: '[]', mutation: 'failure' }).code, 0,
+    '空切片 failure 合法放行（零实例动态矩阵实测形态，run 32802575298）')
+  for (const r of ['success', 'cancelled']) {
+    assert.equal(run({ mutationPkgsJson: '[]', mutation: r }).code, 1, `空切片 ${r} 必须红`)
   }
+  // 防回归对照：空切片放宽绝不外溢到非空切片——该跑没跑仍按门禁绕过判红
+  assert.equal(run({ mutation: 'failure' }).code, 1,
+    '非空切片 failure 必须仍红（空切片放宽不得削弱防绕过逻辑）')
 
   // 非 PR 事件：触发面收敛不变量——mutation-gate 必须 skipped；
   // 若出现其他结果说明 ci.yml if 的事件限制已失效，显性红防静默退化全量


### PR DESCRIPTION
## 概述

实施 #187（approved + 转向「只有夜间和发版前跑全量」）：mutation-gate 仅在 pull_request 事件实例化，main 变异覆盖由 observe.yml 夜间全量承接、发版由 release.yml tag 管线全量门禁承接。

## 关键语义修正（coder 实施中发现）

旧 repo-gate 内联判定无法区分两种 skipped：**PR + 非空切片 + 意外 skip（if 被改坏等）→ 静默放行 = 变异门禁绕过**。本次将判定收敛为独立脚本 `scripts/gate/repo-gate-assert.mjs` 三维判定表（事件 × 切片清单 × job 结果）：

| 场景 | 判定 |
|---|---|
| PR + success | 放行 |
| PR + 空切片 skipped | 放行（无命中包属正常）|
| **PR + 非空切片但非 success（含意外 skipped）** | **一律红（堵住绕过）** |
| 非 PR 事件 skipped | 放行（收敛不变量运行时断言，if 失效显性红而非静默退化）|

## 断言表

| 条目 | 级别 | 证据 |
|---|---|---|
| 五连门禁 | 硬性 | 0/0/0/0/0 |
| test:scripts 含 3 个新锚 | 硬性 | 39 pass；「删 if 必红」实证后还原复验 |
| 判定表全组合单测 | 硬性 | evaluateGate 纯函数覆盖 + CLI 退出码转发 |
| docs 分工表述 | 参考 | DEVELOPMENT.md 全量分工总述 |

## 验证计划

本 PR 自身远端 CI 为首次真实验证：push 事件（无，PR 事件）+ 合并后 main push 应不再实例化 mutation-gate。
