### PR TITLE
fix(meta): provider-usage mutate 区间对齐 #183 后的产物分段——修 F5 夜间判红（#186）

### DIFF
--- a/stryker.conf.d/dsh-provider-usage.json
+++ b/stryker.conf.d/dsh-provider-usage.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
-    "packages/dsh-provider-usage/lib/index.js:1372-2769",
-    "packages/dsh-provider-usage/lib/index.js:2805-3696"
+    "packages/dsh-provider-usage/lib/index.js:1372-2792",
+    "packages/dsh-provider-usage/lib/index.js:2829-3727"
   ],
   "testRunner": "tap",
   "tap": {
@@ -40,5 +40,5 @@
   "cleanTempDir": true,
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-provider-usage.json",
-  "_comment": "#150 接入：mutate 限定 lib/index.js 的 self-written 两段（esbuild 路径注释 // lib/* 分界）：1372-2769 contracts/registry/adapters-opencode-go/core-guards/sanitize/pipeline-v2/history/provider-config/hotreload 九段连续自写模块、2805-3696 path-resolve/client-logic/index 主体。排除头部 var __* 垫片（1-30）、cosmokit/schemastery/async-mutex/untildify 等 node_modules 内联 vendor 大段（31-1054、1163-1368、2775-2804）、shared/loopback+host-utils+settings-namespace 内联契约层副本（1062-1162，shared 由仓库级禁改规则保护且多包重复计账会使 score 横向不可比）、1055-1061 与 1369-1371 与 2770-2774 的纯 ESM import 提升段（无可变异面）。tap.nodeArgs 注入 mutation-tap-bridge.cjs（#151 全局生效）将未捕获异常转写 TAP not ok，RuntimeError 计 Killed。"
+  "_comment": "#150 接入：mutate 限定 lib/index.js 的 self-written 两段（esbuild 路径注释 // lib/* 分界；#183 re-export 使产物分段整体后移，#186 已对齐实测边界）：1372-2792 contracts/registry/adapters-opencode-go/core-guards/sanitize/pipeline-v2/history/provider-config/hotreload 九段连续自写模块、2829-3727 path-resolve/client-logic/index 主体（path-resolve 标记出现两次系 esbuild 对 untildify 内联的输出布局：2794 首标记下挂 import 提升与 vendor 副本，2829 次标记起为自写实现）。排除头部 var __* 垫片（1-30）、cosmokit/schemastery/async-mutex/untildify 等 node_modules 内联 vendor 大段（31-1054、1163-1368、2794-2828）、shared/loopback+host-utils+settings-namespace 内联契约层副本（1062-1162，shared 由仓库级禁改规则保护且多包重复计账会使 score 横向不可比）、1055-1061 与 1369-1371 与 2795-2797 的纯 ESM import 提升段（无可变异面）。tap.nodeArgs 注入 mutation-tap-bridge.cjs（#151 全局生效）将未捕获异常转写 TAP not ok，RuntimeError 计 Killed。"
 }


### PR DESCRIPTION
## 概述

修 #186：#183 的 re-export 使 lib/index.js 分段漂移（第二段起点 2805 落入代码），F5 夜间守卫判红（run 32798165676 实证）。

## 断言表

| 条目 | 级别 | 证据 |
|---|---|---|
| mutate 区间对齐实测分段 | 硬性 | 段1 1372-2792、段2 2829-3727；边界经产物 grep 实证（path-resolve 双标记 2794/2829，2829 后纯自写） |
| F5 守卫 | 硬性 | 13 区间 0 失败（含 #184 合入后的最新产物复验） |
| 五连门禁 | 硬性 | build/test/contract/pack:check/typecheck = 0/0/0/0/0 |

Closes #186