### PR TITLE
[负例验证，勿合并] chore(meta): idle-archive 阈值临时上调至 99（#178 补录②）

### DIFF
--- a/scripts/data/gauntlet.config.json
+++ b/scripts/data/gauntlet.config.json
@@ -44,7 +44,7 @@
         "baselineDuration": "12.7s",
         "baselineScope": "packages/dsh-idle-archive/lib/index.js:1055-1060+1146-1375（self-written 段；排除 esbuild 垫片、cosmokit/schemastery 内联 vendor、shared 契约层内联副本）",
         "config": "stryker.conf.d/dsh-idle-archive.json",
-        "threshold": 60
+        "threshold": 99
       },
       "dsh-web-file-preview": {
         "baselineScore": 42.6,


### PR DESCRIPTION
## 目的

#178 补录②：实证 strict=true 下 PR 变异硬门禁的拦截能力。将 dsh-idle-archive threshold 60→99（covered 67.46 必然不达），预期 **Mutation gate (dsh-idle-archive) FAILURE + repo-gate 判红**。

验证完成后本 PR 将被关闭，不合并。