### PR TITLE
fix(mcp-manager): 目录条目双缺省时剥离 text 字段——恢复目录消息 JSON 可序列化

### DIFF
--- a/packages/dsh-mcp-manager/src/catalog.ts
+++ b/packages/dsh-mcp-manager/src/catalog.ts
@@ -107,7 +107,10 @@ export function composeCatalogEntries(supervisors: Map<string, SupervisorLite>, 
       const cached = cache?.get(name);
       if (typeof cached?.summary === "string" && cached.summary !== "") text = cached.summary;
     }
-    entries.push({ name, text });
+    // 无描述时剥离 text 属性（不产出 `text: undefined`）：条目保持干净可
+    // JSON 序列化，否则目录消息 append 为 user/message 事件会被 dsh-session
+    // 序列化校验拒绝（issue #192）。
+    entries.push(text === undefined ? { name } : { name, text });
   }
   return entries;
 }

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -51,6 +51,7 @@ import {
   parseSsePayload,
   publicToolName,
   renderMcpCatalogMessage,
+  renderMcpCatalogUpdate,
   resolveCatalogInjection,
   ROUTES,
   SCOPE_GLOBAL,
@@ -1123,7 +1124,8 @@ const main = async () => {
     const entries = composeCatalogEntries(supervisors, 6, cache);
     assert.equal(entries[0].text, "自定义描述 A", "用户配置优先");
     assert.equal(entries[1].text, "缓存摘要 B", "缓存摘要 fallback（无需用户配置）");
-    assert.equal(entries[2].text, undefined, "无配置无缓存 → 仅名字");
+    assert.equal(entries[2].name, "srv-c", "无配置无缓存 → 条目按名称保留");
+    assert.equal(Object.hasOwn(entries[2], "text"), false, "双缺省条目不含 text 属性（值断言防不了 text: undefined，必须查存在性）");
     // digest 稳定性：实时连接状态（tools/toolMeta）变化不影响目录 digest
     const connected = new Map([
       ["srv-a", { server: { description: "自定义描述 A" }, tools: ["t1"], toolMeta: new Map([["x", { description: "实时描述" }]]) }],
@@ -1207,6 +1209,12 @@ const main = async () => {
     assert.match(msg.content[0].text, /不代表当前连接状态/);
     assert.match(msg.content[0].text, /`code-graph`: 代码图谱/);
     assert.ok(typeof msg.id === "string" && msg.id.length > 0);
+
+    // #192 AC-3：双缺省行仅渲染名字（无冒号描述），带描述条目渲染不变
+    const mixed = renderMcpCatalogMessage([{ name: "bare-x" }, { name: "code-graph", text: "代码图谱" }]);
+    assert.match(mixed.content[0].text, /^- `bare-x`$/m, "双缺省行仅名字");
+    assert.doesNotMatch(mixed.content[0].text, /`bare-x`: /);
+    assert.match(mixed.content[0].text, /^- `code-graph`: 代码图谱$/m, "带描述行保持");
   });
   check("findCatalogMessage 定位既有目录", () => {
     const catalog = renderMcpCatalogMessage([{ name: "a", text: "b" }]);
@@ -1351,6 +1359,56 @@ const main = async () => {
     // reject 不处理
     const rejected = resolveCatalogInjection({ kind: "reject" }, [], supervisors, 6, undefined, agent2);
     assert.equal(rejected.kind, "reject");
+  });
+
+  // ---------- issue #192：双缺省条目不得产出 text: undefined ----------
+
+  check("composeCatalogEntries 双缺省条目干净可序列化（#192 AC-1/AC-2）", () => {
+    const supervisors = new Map([
+      ["bare-a", { server: { description: "" }, tools: [], toolMeta: new Map() }],
+      ["bare-b", { server: {}, tools: [], toolMeta: new Map() }],
+      ["with-desc", { server: { description: "有描述" }, tools: [], toolMeta: new Map() }],
+    ]);
+    const entries = composeCatalogEntries(supervisors, 6, undefined);
+    assert.equal(entries.length, 3, "双缺省服务器按名称保留不丢弃");
+    assert.deepEqual(entries.map((e) => e.name), ["bare-a", "bare-b", "with-desc"]);
+    for (const bare of [entries[0], entries[1]]) {
+      assert.equal(Object.hasOwn(bare, "text"), false, `双缺省条目 ${bare.name} 不含 text 属性`);
+    }
+    assert.equal(entries[2].text, "有描述");
+
+    // AC-2：两条渲染路径的完整消息 JSON 往返后深度相等（载荷无 undefined 属性）
+    for (const rendered of [renderMcpCatalogMessage(entries), renderMcpCatalogUpdate(entries)]) {
+      assert.doesNotThrow(() => JSON.stringify(rendered));
+      assert.deepEqual(JSON.parse(JSON.stringify(rendered)), rendered, "完整消息 JSON 往返深度相等");
+      assert.equal(
+        rendered.source.entries.map((e) => Object.hasOwn(e, "text")).join(","),
+        "false,false,true",
+        "source.entries 全部干净",
+      );
+    }
+  });
+
+  check("双缺省服务器目录消息可 append 为 user/message 且去重（#192 AC-4）", () => {
+    const supervisors = new Map([["bare-only", { server: { description: "" }, tools: [], toolMeta: new Map() }]]);
+    const agent = makeAgent();
+    let messages = [{ id: "m1", role: "user", content: [] }];
+    let result = runStep({ kind: "enter", messages: [...messages] }, messages, supervisors, undefined, agent);
+    messages = result.messages;
+    const catalogEvents = agent.session.events.filter((e) => e.type === "user/message" && e.data?.source?.kind === "mcp-catalog");
+    assert.equal(catalogEvents.length, 1, "首轮注入成功（append 为 user/message 未被拒绝）");
+    const appended = catalogEvents[0].data;
+    assert.equal(Object.hasOwn(appended.source.entries[0], "text"), false, "append 后事件载荷仍无 text 属性");
+    assert.doesNotThrow(() => JSON.stringify(appended), "事件载荷可 JSON 序列化（dsh-session 序列化校验等价物）");
+    assert.deepEqual(JSON.parse(JSON.stringify(appended)), appended, "往返深度相等");
+
+    // digest 去重语义不变：同集合再次 pre-step 不重复注入
+    result = runStep({ kind: "enter", messages: [...messages] }, messages, supervisors, undefined, agent);
+    assert.equal(
+      agent.session.events.filter((e) => e.type === "user/message" && e.data?.source?.kind === "mcp-catalog").length,
+      1,
+      "次轮不重复注入（digest 去重不变）",
+    );
   });
 
   // ---------- SDK 端到端（issue #11 PoC 契约不漂移证据：真实 stdio 连接 /

--- a/packages/dsh-mcp-manager/test/unit-catalog.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-catalog.test.ts
@@ -63,7 +63,8 @@ assert.equal(DEFAULT_CATALOG_MAX_ENTRIES, 6);
   const entries = composeCatalogEntries(supervisors, 10, cache);
   assert.equal(entries.length, 4);
   assert.deepEqual(entries[0], { name: "s1", text: "desc1" }, "自定义 description 优先");
-  assert.deepEqual(entries[1], { name: "s2", text: undefined }, "无描述无缓存 → 只显示名");
+  assert.deepEqual(entries[1], { name: "s2" }, "无描述无缓存 → 只显示名（不含 text 属性）");
+  assert.equal(Object.hasOwn(entries[1], "text"), false, "双缺省不产出 text: undefined（#192）");
   assert.deepEqual(entries[2], { name: "s3", text: "cached-summary" }, "缓存摘要回落");
   assert.equal(entries[3].text, undefined, "空串缓存视为无");
 


### PR DESCRIPTION
## 变更摘要

修复 issue #192：`composeCatalogEntries()` 在服务器 `description` 与目录缓存 `summary` 双缺省时产出 `{ name, text: undefined }`，该条目经 `renderMcpCatalogMessage()` / `renderMcpCatalogUpdate()` 进入消息 `source.entries` 后，pre-step 注入的 `user/message` 事件被 dsh-session 序列化校验拒绝，能力目录注入即失败。

最小修复（仅 packages/dsh-mcp-manager 内 3 文件，+65/-3）：

- `src/catalog.ts`：构造条目时按 `text` 是否缺省条件携带（`text === undefined ? { name } : { name, text }`），entries 始终干净可 JSON 序列化；无描述服务器仅按名称渲染，渲染文本侧行为不变
- `test/smoke.ts`：原 L1126 值断言升级为 `Object.hasOwn(entry, "text") === false` 属性存在性检查（属性缺失时读取同样是 undefined，值断言防不了回归）；新增双缺省场景用例两条；`renderMcpCatalogMessage 结构与声明` 用例扩展双缺省行断言
- `test/unit-catalog.test.ts`：deepEqual 同步为 `{ name: "s2" }` 形状并补属性存在性断言（deepStrictEqual 区分 own key，修复后原断言必红）

## AC 逐条断言表（对照 spec-writer round 1 六条验收标准）

| # | 验收标准 | 结论 | 测试用例 / 门禁证据 |
|---|---|---|---|
| AC-1 | 双缺省条目仅含 name（按名称保留、不含 text 属性） | PASS | smoke「composeCatalogEntries 数据源」：`entries[2].name === "srv-c"` + `Object.hasOwn(entries[2], "text") === false`（原 `=== undefined` 值断言已升级）；smoke「composeCatalogEntries 双缺省条目干净可序列化（#192 AC-1/AC-2）」：3 条目名序断言 + 两条双缺省条目 hasOwn 取反；unit-catalog：`deepEqual(entries[1], { name: "s2" })` + hasOwn 取反 |
| AC-2 | 目录消息始终可 JSON 序列化（两条渲染路径往返深度相等） | PASS | 同上新增 smoke 用例：对含双缺省条目的输入，`renderMcpCatalogMessage()` 与 `renderMcpCatalogUpdate()` 完整消息对象均通过 `JSON.stringify -> JSON.parse` 往返后 `deepEqual` 原对象，且 `source.entries` 的 text 属性存在性序列恰为 `false,false,true` |
| AC-3 | 渲染文本行为保持（双缺省仅渲染名字、带描述转义规则不变） | PASS | smoke「renderMcpCatalogMessage 结构与声明」扩展：`match(/^- \`bare-x\`$/m)`（仅名字无冒号）、`doesNotMatch(/\`bare-x\`: /)`、带描述行 `match(/^- \`code-graph\`: 代码图谱$/m)` 保持；system-reminder 其余文案断言不变 |
| AC-4 | 注入链路端到端可用（append 成功 + digest 去重不变） | PASS | 新增 smoke「双缺省服务器目录消息可 append 为 user/message 且去重（#192 AC-4）」：单双缺省服务器经 `resolveCatalogInjection` 决策后成功 append 为 `user/message` 事件（session append 等价物），事件载荷 `JSON.stringify` 不抛且往返深度相等；同集合再次 pre-step 目录事件恒为 1（去重语义不变） |
| AC-5 | 既有语义零回归 | PASS | 五连门禁全绿：`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck`（本地实跑，commit ba04949）。description 优先于 summary（unit-catalog「自定义 description 优先」+ smoke「用户配置优先」）、maxEntries 截断（smoke「条目上限」+ unit-catalog）、digest 仅含 name（smoke「digestCatalogEntries 只含服务器集合」+ unit-catalog）、readCatalogEntries 容错面（unit-catalog 坏数据断言组）全数通过 |
| AC-6 | 文档一致性（不改配置键，README 宣称仍成立） | PASS | 未改动任何配置键与 README；`announceCatalog` 默认 true 不变（DEFAULT_ANNOUNCE_CATALOG = true 断言保留）；人工比对 README.md「能力目录注入含来源标注与"不代表当前连接状态"说明」（约 L104）在修复后仍成立 |

## 门禁证据

```
pnpm build        # 全包构建通过（mcp-manager lib 产物自包含）
pnpm test         # mcp-manager: all checks passed（含新增 2 条 #192 用例）
pnpm contract     # 客户端契约全部通过
pnpm pack:check   # tarball 完整性全部通过
pnpm typecheck    # 全包 tsc --noEmit 通过
```

Closes #192
