### PR TITLE
feat(provider-usage): 内置 DeepSeek 官方用量适配器 + 胶囊峰谷时段倒计时

### DIFF
--- a/packages/dsh-provider-usage/README.en.md
+++ b/packages/dsh-provider-usage/README.en.md
@@ -60,8 +60,9 @@ Client polling ──────┘   │ Mutex                  ↓
                    adapter.formatCapsule/Panel() → sanitize → HTML
 ```
 
-The built-in adapter `opencode-go-builtin` (OpenCode Go official `/v1/usage`, three
-windows) works out of the box.
+The built-in adapters `opencode-go-builtin` (OpenCode Go official `/v1/usage`, three
+windows) and `deepseek-official-builtin` (DeepSeek official balance + peak/valley
+countdown badge, see below) work out of the box.
 
 ## Configuration
 
@@ -75,7 +76,7 @@ windows) works out of the box.
 | `apiKey` | none | Explicit key (optional; falls back to the credential chain, never echoed in settings) |
 | `historyDir` | `<DSH_HOME>/dsh-provider-usage/` | History storage root |
 | `warmupIntervalMs` | `300000` | Background warmup interval |
-| `cacheDurationMs` | `60000` | Cache freshness (ms) |
+| `cacheDurationMs` | `30000` | Cache freshness (ms, floor 5000; lowered from 60000 in #198 so peak/valley badge flips propagate end-to-end within ~95s = 30s host cache + 60s client polling + render margin) |
 | `fetchTimeoutMs` | `2000` | Forced fetchData timeout (500–30000ms) |
 | `autoReload` | `true` | Hot reload on adapter file edits (enabled by default; set `false` to disable) |
 
@@ -93,6 +94,60 @@ so the two floats never overlap out of the box. The capsule and the MCP float do
 dodge each other — each is positioned solely by its own plugin config; the 10px panel gap keeps the
 panel tight under the capsule.
 
+## Built-in DeepSeek official adapter (deepseek-official-builtin)
+
+Claims provider `deepseek-official` and talks to the DeepSeek official
+"get user balance" endpoint `GET https://api.deepseek.com/user/balance`
+(see [api-docs.deepseek.com/api/get-user-balance](https://api-docs.deepseek.com/api/get-user-balance)).
+
+### Data semantics
+
+- **CNY only**: when the official `balance_infos[]` array contains multiple currencies,
+  only the `currency === "CNY"` entry is used; everything else (e.g. USD) is ignored.
+  Amounts are strictly parsed from the official string fields (invalid/missing → `null`,
+  NaN never persisted).
+- No CNY entry (USD-only or empty array) yields a normal frame with
+  `balance/toppedUp/grantedBalance = null` (no throw); the capsule shows a
+  "DeepSeek 余额 --" placeholder.
+- `is_available=false` marks an unavailable account: the frame is still recorded and its
+  balance displayed, but it **never serves as a conservation endpoint** for daily usage —
+  adjacent intervals skip usage derivation and are labeled as unavailable in the panel,
+  so bans/balance wipes are not mistaken for consumption.
+
+### Daily usage derivation (balance-delta conservation)
+
+The official API has no usage endpoint, so daily usage is derived from balance deltas
+between consecutive samples:
+
+```
+usage = (totalPrev − totalCur) + ΔtoppedUp + Δgranted
+```
+
+Top-ups (+X credited: total −X, toppedUp +X) and grant expiries/refunds (−G debited:
+total −G, granted −G) cancel out automatically. Missing components degrade
+**component-by-component**: without granted, only the toppedUp correction applies
+(and vice versa); with both missing it degrades to the raw balance delta (legacy history
+shards), and the panel summary notes that some days use the net-change caliber.
+Intervals spanning more than 27h (sampling interruption) are excluded from bars and
+totals to prevent malformed giant columns.
+
+### Two-card panel and peak/valley badge
+
+- Card 1: CNY balance headline + 24h fluctuation line chart (unified time anchor,
+  trend arrow tolerance ±0.005, downsampling ≤300 points).
+- Card 2: daily usage bar chart over the last 15 calendar days (closed-loop baseline;
+  blue bars up for consumption, green bars down for net gains, anomalies labeled only).
+- The capsule always carries a **peak/valley countdown badge** (pure local-time
+  computation, independent of remote data — rendered even on fetch failures):
+  - Windows are **fixed UTC weekday windows** `01:00–04:00 / 06:00–10:00`
+    (half-open intervals), per
+    [api-docs.deepseek.com/quick_start/pricing](https://api-docs.deepseek.com/quick_start/pricing),
+    verified on **2026-08-26**; hard-coded constants with no config knob, weekends are
+    off-peak all day.
+  - Off-peak shows the countdown to the next peak start (e.g. `⚡谷 · 距峰 02:41`);
+    peak shows the countdown to the next valley switch; the tooltip documents the UTC
+    window definition plus a server-timezone hint.
+
 ## API key resolution order (V1 config chain)
 
 1. Plugin config `apiKey` (explicit)
@@ -102,6 +157,13 @@ panel tight under the capsule.
    (opencode-go also probes the legacy name `OPENCODE_GO_API_KEY`)
 5. opencode-go compatibility: `~/.local/share/opencode/auth.json` entry
    `opencode-go` (or `opencode`)
+
+> **DeepSeek official adapter three-level key chain**: plugin config `apiKey` injection →
+> credential-chain derived env (provider `deepseek-official` → `DEEPSEEK_OFFICIAL_API_KEY`)
+> → adapter-local `DEEPSEEK_API_KEY` self-check fallback (shared with the llm layer,
+> covering "llm works but balance API 401"; this fallback is an adapter implementation
+> detail, not a shared provider-config special case). With all three absent, fetching
+> reports `no-api-key` and degrades to a stale frame (the peak/valley badge still renders).
 
 ## Routes (all loopback-fenced)
 
@@ -210,6 +272,8 @@ or the plugin home; non-normalized forms (`../` traversal) are rejected with 400
   pulls code from the network for execution
 - **Keys never reach the browser**: apiKey lives only in host-process memory and is
   injected into fetchData as an argument; adapter files never contain key values
+  (equally true for the built-in DeepSeek official adapter: three-level key chain above,
+  no key substring in stats/history/adapters responses nor in capsule/panel HTML)
 - **Two-layer XSS defense**: external API strings must be escaped with `esc()` before
   being placed into HTML (documented obligation); the plugin additionally sanitizes all
   format output on the host (script/iframe/on* attributes/javascript: removal). The

--- a/packages/dsh-provider-usage/README.md
+++ b/packages/dsh-provider-usage/README.md
@@ -57,7 +57,8 @@ npx @deepseek-ai/dsh plugin --profile web add @wingsky-1/dsh-provider-usage
                 adapter.formatCapsule/Panel() → 净化 → HTML 下发
 ```
 
-内置适配器 `opencode-go-builtin`（OpenCode Go 官方 `/v1/usage` 三窗口用量）开箱即用。
+内置适配器 `opencode-go-builtin`（OpenCode Go 官方 `/v1/usage` 三窗口用量）与
+`deepseek-official-builtin`（DeepSeek 官方余额 + 峰谷倒计时徽标，见下节）开箱即用。
 
 > **图解文档**：完整的流程图 / 时序图（启动装配、`/stats` 取数全链路、`/history` 面板、自定义适配器注入三条路径与热更新、客户端交互、密钥解析链）见 [docs/architecture.md](docs/architecture.md)。
 
@@ -73,7 +74,7 @@ npx @deepseek-ai/dsh plugin --profile web add @wingsky-1/dsh-provider-usage
 | `apiKey` | 无 | 显式密钥（可选；缺省走凭据解析链，不进设置面板回显） |
 | `historyDir` | `<DSH_HOME>/dsh-provider-usage/` | 历史存储根目录 |
 | `warmupIntervalMs` | `300000` | 后台预热间隔（无客户端访问时保持历史连续） |
-| `cacheDurationMs` | `60000` | 缓存新鲜度（毫秒） |
+| `cacheDurationMs` | `30000` | 缓存新鲜度（毫秒，下限 5000；#198 由 60000 下调——峰谷徽标跨时段边界端到端翻转延迟 ≤95s = 宿主缓存 30s + 客户端轮询 60s + 渲染余量） |
 | `fetchTimeoutMs` | `2000` | fetchData 强制超时（500–30000ms） |
 | `autoReload` | `true` | 热更新开关（编辑适配器文件后自动加载；默认开启，可显式 `false` 关闭） |
 | `maxAgeDays` | `30` | 历史保留天数 |
@@ -82,6 +83,45 @@ npx @deepseek-ai/dsh plugin --profile web add @wingsky-1/dsh-provider-usage
 ## 胶囊位置配置
 
 用量胶囊（会话右上角悬浮球）与面板的位置支持自定义：打开设置 → 插件 →「用量统计」→「胶囊位置」区，选择锚点（右上 / 左上 / 右下 / 左下）与偏移（水平 / 垂直 / 面板间距）后点「保存」——**立即生效且跨设备同步**（宿主落盘 `ui.json` 并经 SSE 广播，无需重启）。默认值：右上 / 0 / 48 / 10——胶囊采用**固定定位**，不随会话滚动内容滑动位移（无避让抖动，滚动时位置稳定）；水平偏移 0 使胶囊右缘贴近容器右缘（右侧对齐）；垂直偏移 48 让胶囊默认位于 MCP 管理器浮窗（同为右上角、距顶 8px）正下方，两胶囊默认互不重叠；面板间距 10px。胶囊与 MCP 浮窗互不探测、互不避让，各自位置只由本插件配置决定。
+
+## DeepSeek 官方内置适配器（deepseek-official-builtin）
+
+认领 provider `deepseek-official`，对接 DeepSeek 官方「查询余额」接口
+`GET https://api.deepseek.com/user/balance`（来源：
+[api-docs.deepseek.com/api/get-user-balance](https://api-docs.deepseek.com/api/get-user-balance)）。
+
+### 数据口径
+
+- **仅保留 CNY 币种**：官方 `balance_infos[]` 含多币种条目时只取 `currency === "CNY"` 一条，
+  其余（如 USD）全量忽略；金额自官方字符串字段严格解析（非法/缺失 → `null`，杜绝 NaN 落盘）。
+- 无 CNY 条目（仅 USD 或空数组）时产出 `balance/toppedUp/grantedBalance = null` 的正常帧
+  （不抛错），胶囊显示「DeepSeek 余额 --」占位。
+- `is_available=false` 表示账号不可用：该帧仍记录与展示余额，但**不作为每日用量的守恒端点**
+  ——相邻区间的用量推算跳过并在面板标注「服务不可用区间不计」，避免把封禁/清零误计为消耗。
+
+### 每日用量推算（余额差守恒式）
+
+官方 API 无任何用量接口，每日用量由相邻采样点的余额差推算：
+
+```
+usage = (totalPrev − totalCur) + ΔtoppedUp + Δgranted
+```
+
+充值 +X 入账（total −X、toppedUp +X）与赠款过期/退款 −G 出账（total −G、granted −G）
+两类非消耗扰动被公式自动抵消。分量缺失时**逐项独立退化**：缺 granted 只跳过该项继续做
+toppedUp 修正（反之亦然）；两者都缺退化为纯余额差（旧历史分片兼容），面板汇总行会提示
+「部分日期按净变动口径估算」。跨度过大（>27h，采样中断）的区间不计柱不计入汇总，防畸形巨柱。
+
+### 双卡面板与峰谷徽标
+
+- 卡1：CNY 余额大头 + 近 24h 波动折线（统一时间锚、趋势箭头容差 ±0.005、降采样 ≤300 点）。
+- 卡2：近 15 个自然日每日用量柱形图（闭环基线口径；消耗蓝柱向上、净增绿柱向下、异常仅标注）。
+- 胶囊常驻**峰谷倒计时徽标**（纯本地时间计算，不依赖远端数据——取数失败时同样显示）：
+  - 时段定义为 **UTC 工作日固定窗口** `01:00–04:00 / 06:00–10:00`（半开区间），
+    来源 [api-docs.deepseek.com/quick_start/pricing](https://api-docs.deepseek.com/quick_start/pricing)，
+    核实日期 **2026-08-26**；硬编码常量无配置项，周末全天低谷。
+  - 谷态显示距下次开峰倒计时（如 `⚡谷 · 距峰 02:41`），峰态显示距切谷倒计时；
+    tooltip 注明 UTC 时段定义与服务器时区对照。
 
 ## 密钥解析顺序（V1 配置链）
 
@@ -92,6 +132,12 @@ npx @deepseek-ai/dsh plugin --profile web add @wingsky-1/dsh-provider-usage
    （opencode-go 在标准 key 未命中时再查旧名 `OPENCODE_GO_API_KEY`）
 5. opencode-go 兼容：`~/.local/share/opencode/auth.json` 的
    `opencode-go`（或 `opencode`）条目
+
+> **DeepSeek 官方适配器三级密钥链**：插件配置 `apiKey` 注入 → 凭据链推导 env
+> （provider `deepseek-official` → `DEEPSEEK_OFFICIAL_API_KEY`）→ 适配器内自查
+> `DEEPSEEK_API_KEY` 兜底（与 llm 层共用，覆盖「llm 能跑、余额接口 401」场景；
+> 该兜底属适配器实现细节，不在共享 provider-config 层特判）。三级全空时取数报
+> `no-api-key` 并降级 stale 帧（峰谷徽标仍渲染）。
 
 ## 路由（全部 loopback 围栏）
 
@@ -196,7 +242,8 @@ plugins:
 - **适配器代码 = 宿主完整 Node 权限**（网络/文件/环境变量），等同用户自己写的进程内插件；
   仅加载你信任的本地文件，插件绝不从网络拉取执行代码
 - **密钥不进浏览器端**：apiKey 仅存于宿主进程内存，经入参注入 fetchData；
-  适配器文件即使被静态服务暴露也不含密钥值
+  适配器文件即使被静态服务暴露也不含密钥值（DeepSeek 官方内置适配器同样成立：
+  三级密钥链见上文，stats/history/adapters 响应体与胶囊/面板 HTML 均无密钥子串）
 - **XSS 双层防护**：外部 API 数据流入 HTML 前必须经 `esc()` 助手转义（文档义务）；
   插件在宿主端对所有 format 输出做结构化净化兜底（script/iframe/on* 属性/javascript: 协议移除），
   且兜底净化封闭 HTML 实体编码变体——具名 / 十进制 / 十六进制、有无分号均解出后匹配，

--- a/packages/dsh-provider-usage/src/adapters/deepseek-official.ts
+++ b/packages/dsh-provider-usage/src/adapters/deepseek-official.ts
@@ -1,0 +1,624 @@
+/**
+ * dsh-provider-usage — 内置 DeepSeek 官方余额适配器（v2 契约，逐函数移植自本地已验证的
+ * user-file 原型 ~/.dsh/provider-usage/deepseek-official.mjs，issue #198）。
+ *
+ * 对齐纪律：守恒式推算、GAP_MS=27h 中断判定、TOL/ANOMALY 分层、六态错误路径
+ * （含 AbortError 重抛）、严格金额解析、官方域名 /v1 前缀剥离等全部与原型一致；
+ * 有意差异仅两处并在下方标注：
+ * 1. name 采用 `deepseek-official-builtin`（原型为 `deepseek-official`，与 provider 同名），
+ *    对齐 opencode-go-builtin 先例——避免与用户已装 user-file 原型在 registeredNames 冲突被拒收；
+ * 2. 新增峰谷倒计时徽标（原型无此功能）：UTC 工作日固定峰窗常量 + 纯本地时间计算。
+ *
+ * 数据模型（与原型一致）：
+ * - 官方 API 无用量接口，每日用量由余额差守恒式推算：
+ *     usage = (totalPrev − totalCur) + ΔtoppedUp + Δgranted
+ *   分量缺失逐项独立退化（缺 granted 只跳该项继续 toppedUp 修正，反之亦然）。
+ * - fetchData 只返回展示所需最小数据集（按天落盘 JSONL）；外部字符串拼 HTML 一律 esc()。
+ */
+import type {
+  UsageStatsAdapter,
+  FetchContext,
+  CapsuleInput,
+  PanelInput,
+} from "../contracts.js";
+import { esc } from "../contracts.js";
+
+/** 内置适配器认领的 provider 名（与会话模型 provider 精确匹配）。 */
+export const DEEPSEEK_OFFICIAL_PROVIDER = "deepseek-official";
+
+/** 内置适配器唯一名（有意差异 1：加 -builtin 后缀，见文件头注释）。 */
+export const DEEPSEEK_OFFICIAL_ADAPTER_ID = "deepseek-official-builtin";
+
+/** DeepSeek 官方 API 基础地址。 */
+export const BASE_URL = "https://api.deepseek.com";
+
+/** 取可用 API Key：优先插件配置链注入，其次兜底自查 DEEPSEEK_API_KEY（与 llm 层共用，
+ *  覆盖「llm 能跑、余额接口 401」场景；该兜底属适配器实现细节，不在共享 provider-config 层特判）。 */
+function resolveApiKey(apiKey: string | undefined): string | undefined {
+  if (apiKey && apiKey.length > 0) return apiKey;
+  try {
+    const v = process.env.DEEPSEEK_API_KEY;
+    if (v && v.length > 0) return v;
+  } catch { /* 环境变量读取失败视为缺失 */ }
+  return undefined;
+}
+
+/** 严格金额解析：仅接受可转为有限数字的字符串，其余返回 null（杜绝 NaN 静默落盘）。 */
+export function parseAmount(v: unknown): number | null {
+  if (typeof v !== "string" || v.trim() === "") return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** 构造查询余额接口 URL：官方域名剥掉 OpenAI 兼容的 /v1 前缀，其余显式端点原样拼接；尾斜杠归一。 */
+export function resolveEndpoint(apiEndpoint: string | undefined): string {
+  const base = (apiEndpoint && apiEndpoint.trim()) || BASE_URL;
+  const root = /^https?:\/\/api\.deepseek\.com/i.test(base)
+    ? base.replace(/\/v1\/?$/i, "")
+    : base;
+  return root.replace(/\/+$/, "") + "/user/balance";
+}
+
+/** HTML 转义（契约入参的 esc 助手同语义，宿主端兜底；含引号转义，元素内容上下文用）。 */
+function h(s: unknown): string {
+  const str = s === null || s === undefined ? "" : String(s);
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+/** 属性上下文转义：不信任宿主 esc 一定转义引号，属性插值一律走本函数。 */
+function ea(s: unknown): string {
+  return h(s);
+}
+
+/** 数值安全化：非有限返回 null；有限则 clamp 到 [min,max] 再返回。 */
+function fin(v: number, min = -Number.MAX_VALUE, max = Number.MAX_VALUE): number | null {
+  if (typeof v !== "number" || !Number.isFinite(v)) return null;
+  return Math.min(Math.max(v, min), max);
+}
+
+// ---------------------------------------------------------------- 共用常量（与原型一致）
+
+const DAY_MS = 86400000;
+/** 相邻代表点跨度超过该值视为采样中断（略大于一个采样周期 5min 的多倍冗余）。 */
+export const GAP_MS = 27 * 3600000;
+/** 金额容差（浮点噪声 + 「无消耗」判定）。 */
+export const TOL = 0.005;
+/** 大额负向净变动的异常阈值（低于它不画柱只标注）。 */
+export const ANOMALY_NEG = -1;
+
+// ================================================================ 峰谷时段（内置版新增，有意差异 2）
+//
+// DeepSeek 官方错峰定价时段（UTC 工作日固定窗口，硬编码常量、无配置项）。
+// 来源：https://api-docs.deepseek.com/quick_start/pricing （错峰折扣时段说明）
+// 核实日期：2026-08-26。官方如调整时段须改码发布，不做运行时可配。
+
+/**
+ * 峰值窗口表（UTC 分钟数，[start,end) 半开区间；仅周一至周五生效，周末全天谷）。
+ * [[01:00,04:00], [06:00,10:00]]（UTC）。
+ */
+export const PEAK_WINDOWS_UTC: Array<readonly [number, number]> = [
+  [60, 240],   // 01:00–04:00 UTC
+  [360, 600],  // 06:00–10:00 UTC
+];
+
+/** 单时刻峰谷判定（纯函数）：UTC 工作日 + 分钟粒度半开区间（毫秒级边界语义等价：
+ *  03:59:59.999 属峰、04:00:00.000 即属谷——分钟数不受秒/毫秒影响）。 */
+export function isPeakUtc(t: number): boolean {
+  const d = new Date(t);
+  const day = d.getUTCDay();
+  if (day === 0 || day === 6) return false; // 周末全天低谷
+  const min = d.getUTCHours() * 60 + d.getUTCMinutes();
+  for (const [startMin, endMin] of PEAK_WINDOWS_UTC) {
+    if (min >= startMin && min < endMin) return true;
+  }
+  return false;
+}
+
+/**
+ * 下一次峰谷转换点（纯函数）：返回严格晚于 t 的最近转换边界与目标状态。
+ * 谷态找下一个开峰（跨周末跳到下周一），峰态找本窗口切谷时刻。
+ */
+export function nextPeakTransition(t: number): { toPeak: boolean; at: number } {
+  const peakNow = isPeakUtc(t);
+  const cur = new Date(t);
+  const y = cur.getUTCFullYear();
+  const m = cur.getUTCMonth();
+  const d0 = cur.getUTCDate();
+  for (let off = 0; off <= 7; off += 1) {
+    // 周末全天谷：不存在任何峰窗边界，直接跳过（否则会把周末 01:00 误当开峰点）
+    const dow = new Date(Date.UTC(y, m, d0 + off)).getUTCDay();
+    if (dow === 0 || dow === 6) continue;
+    for (const [startMin, endMin] of PEAK_WINDOWS_UTC) {
+      // 同日内 start<end 且窗口按序排列，[start,end] 对遍历天然时间有序；
+      // 第一个严格大于 t 且引起状态翻转的边界即答案
+      for (const [min, toPeak] of [[startMin, true], [endMin, false]] as Array<readonly [number, boolean]>) {
+        const at = Date.UTC(y, m, d0 + off, 0, min, 0, 0);
+        if (at > t && toPeak !== peakNow) return { toPeak, at };
+      }
+    }
+  }
+  // 不可达（7 天内必有转换）；防御性兜底：返回一周后的同一时刻
+  return { toPeak: !peakNow, at: t + 7 * DAY_MS };
+}
+
+/** 倒计时格式化 mm:ss 之外的 HH:MM 形态（向上取整到分钟，恒 ≥1 分钟，杜绝 "-00:00"/负值形态）。 */
+function fmtCountdown(ms: number): string {
+  const totalMin = Math.max(1, Math.ceil(ms / 60000));
+  const hh = String(Math.floor(totalMin / 60)).padStart(2, "0");
+  const mm = String(totalMin % 60).padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+
+/** 当前进程时区名（纯环境元数据读取，无时钟依赖，仅供 tooltip 对照提示）。 */
+function localTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "local";
+  } catch {
+    return "local";
+  }
+}
+
+/** 峰谷倒计时徽标 HTML（纯本地时间计算，不依赖远端数据——stale 帧同样渲染）。 */
+export function peakBadgeHtml(nowTs: number): string {
+  const peak = isPeakUtc(nowTs);
+  const tr = nextPeakTransition(nowTs);
+  const countdown = fmtCountdown(tr.at - nowTs);
+  const label = peak ? `⚡峰 · 距谷 ${countdown}` : `⚡谷 · 距峰 ${countdown}`;
+  const windowsText = PEAK_WINDOWS_UTC
+    .map(([s, e]) => `${String(Math.floor(s / 60)).padStart(2, "0")}:${String(s % 60).padStart(2, "0")}–${String(Math.floor(e / 60)).padStart(2, "0")}:${String(e % 60).padStart(2, "0")}`)
+    .join("、");
+  const tip = `DeepSeek 错峰计费：峰时段（UTC 工作日）${windowsText}，周末全天谷；时段定义为 UTC，与显示时区无关，倒计时按 UTC 换算（服务器时区 ${localTimeZone()}）`;
+  const cls = peak ? "dou-peak dou-peak-on" : "dou-peak dou-peak-off";
+  return `<span class="${cls}" title="${ea(tip)}">${h(label)}</span>`;
+}
+
+// ---------------------------------------------------------------- fetchData（六态错误路径与原型一致）
+
+/**
+ * 拉取余额（v2 fetchData，fetch 经 ctx.fetch 或 fetchImpl 注入，便于单测）。
+ * 返回 { isAvailable, balance, toppedUp, grantedBalance }（仅保留 CNY 币种；
+ * 后两者用于每日用量守恒式）。
+ */
+export async function fetchDeepSeekOfficialV2(
+  ctx: FetchContext & { fetch?: typeof fetch },
+  fetchImpl?: typeof fetch,
+): Promise<Record<string, unknown>> {
+  const key = resolveApiKey(ctx.apiKey);
+  if (!key) throw new Error("no-api-key");
+
+  const f: typeof fetch = ctx.fetch ?? fetchImpl ?? globalThis.fetch;
+  const url = resolveEndpoint(ctx.apiEndpoint);
+
+  let res: Response;
+  try {
+    res = await f(url, {
+      headers: { Authorization: `Bearer ${key}`, Accept: "application/json" },
+      signal: ctx.signal,
+    });
+  } catch (err: unknown) {
+    // 超时/取消由插件 signal 负责；AbortError 重抛不被吞成 network（原型行为）
+    if (err instanceof Error && err.name === "AbortError") throw err;
+    throw new Error("network");
+  }
+  if (res.status === 401 || res.status === 403) throw new Error("unauthorized");
+  if (!res.ok) throw new Error(`http-${res.status}`);
+
+  let body: { is_available?: unknown; balance_infos?: unknown };
+  try {
+    body = await res.json();
+  } catch {
+    throw new Error("bad-json");
+  }
+
+  // 只保留 CNY 币种（官方 balance_infos 数组，金额为字符串）；无 CNY 条目 → 全 null 正常帧（B4 修订版）
+  const infos = Array.isArray(body.balance_infos) ? body.balance_infos : [];
+  const cny = infos.find((b: unknown): b is Record<string, unknown> => {
+    return typeof b === "object" && b !== null && (b as Record<string, unknown>).currency === "CNY";
+  });
+
+  return {
+    isAvailable: body.is_available === true,
+    balance: parseAmount(cny?.total_balance),
+    toppedUp: parseAmount(cny?.topped_up_balance),
+    grantedBalance: parseAmount(cny?.granted_balance),
+  };
+}
+
+// ---------------------------------------------------------------- 胶囊 + 峰谷徽标
+
+/** 胶囊文案：CNY 余额 + 可用性/缓存标记 + 峰谷倒计时徽标（追加于余额文本之后）。 */
+export function formatCapsuleWithBadge(
+  { data, status }: { data: Record<string, unknown>; status: string },
+  nowTs: number,
+): string {
+  const e = h;
+  const badge = peakBadgeHtml(nowTs);
+  const balance = data && typeof data.balance === "number" ? data.balance : null;
+  const text = balance !== null ? `余额 ¥${balance.toFixed(2)}` : "DeepSeek 余额 --";
+  const unavail = data && data.isAvailable === false
+    ? `<span style="opacity:.7;margin-left:6px">(不可用)</span>`
+    : "";
+  const staleMark = status === "stale" ? `<span style="opacity:.6;margin-left:6px">(缓存)</span>` : "";
+  return `<span>${e(text)}</span>${badge}${unavail}${staleMark}`;
+}
+
+// ================================================================ 近 15 日用量柱形图（与原型同构移植）
+// 说明：日期口径 = 宿主进程本地时区（DSH web 多端访问时以宿主为准，注释声明避免误当 bug）。
+
+/** 本地时区日期 key（禁用 toISOString —— UTC 归组会使东八区每天 00:00–08:00 的采样划入前一天）。 */
+export function dayKey(t: number): string {
+  const d = new Date(t);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+/** 近 n 个自然日 key 列表（含今日；逐日 setDate 回退生成，DST/跨月/跨年安全，禁用毫秒减法）。 */
+export function lastNDayKeys(n: number, now: number): string[] {
+  const d = new Date(now);
+  const keys: string[] = [];
+  for (let i = 0; i < n; i += 1) {
+    keys.unshift(dayKey(d.getTime()));
+    d.setDate(d.getDate() - 1);
+  }
+  return keys;
+}
+
+/** 采样代表点（有效过滤后；available=is_available 标记，缺省视为可用以兼容旧历史分片）。 */
+interface SamplePoint {
+  t: number;
+  balance: number;
+  toppedUp: number | null;
+  granted: number | null;
+  available: boolean;
+}
+
+/** 单日用量记录（聚合输出）。 */
+interface DayRecord {
+  key: string;
+  status: "empty" | "insufficient" | "gap" | "anomaly" | "unavailable" | "ok";
+  u: number;
+  kind?: string;
+  extra?: string;
+  neg?: boolean;
+  note?: string;
+}
+
+/**
+ * 单日用量计算（守恒式口径）：
+ *   usage = (totalPrev − totalCur) + ΔtoppedUp + Δgranted
+ * 充值 +X：total −X、topped +X → 相消；赠款过期 −G：total −G、granted −G → 相消。
+ * 分量缺失逐项独立退化（kind 标记供 tooltip 注明）。
+ */
+export function calcUsageDs(base: SamplePoint, cur: SamplePoint): { v: number; kind: string; extra: string } {
+  let v = base.balance - cur.balance;
+  let kind = "net";
+  const notes: string[] = [];
+  if (base.toppedUp !== null && cur.toppedUp !== null) {
+    const dTop = cur.toppedUp - base.toppedUp;
+    v += dTop;
+    kind = "adjusted";
+    if (Math.abs(dTop) > TOL) notes.push(`含充值 ¥${dTop.toFixed(2)}`);
+  }
+  if (base.granted !== null && cur.granted !== null) {
+    const dGrant = cur.granted - base.granted;
+    v += dGrant;
+    if (kind !== "adjusted") kind = "adjusted";
+    if (Math.abs(dGrant) > TOL) notes.push(`含赠款变动 ¥${(-dGrant).toFixed(2)}`);
+  }
+  return { v, kind, extra: notes.join(" · ") };
+}
+
+/**
+ * 每日用量聚合。
+ * 口径：闭环（基线 = 向前最近一个有采样日的末点，消除跨日缝隙）；
+ * 基线缺失 → 样本不足；跨度超 GAP_MS → 数据中断（不计柱不计入汇总，防畸形巨柱）。
+ */
+export function aggregateDaily(pts: SamplePoint[], keys: string[], truncated: boolean): DayRecord[] {
+  /** 每日末点（升序遍历后写覆盖 → 当日最后一点；重复时间戳取排序后靠后者）。 */
+  const byDay = new Map<string, SamplePoint>();
+  for (const p of pts) byDay.set(dayKey(p.t), p);
+
+  // 窗口开始前的最后一个采样点作为首日基线
+  let base: SamplePoint | null = null;
+  for (const p of pts) {
+    if (dayKey(p.t) < keys[0]) base = p; else break;
+  }
+
+  let skipFirst = truncated === true; // 数据被截断时首个可能残缺的自然日不计
+  return keys.map((k): DayRecord => {
+    const cur = byDay.get(k) || null;
+    if (!cur) return { key: k, status: "empty", u: 0 };
+    if (skipFirst) {
+      skipFirst = false;
+      base = cur;
+      return { key: k, status: "insufficient", u: 0 };
+    }
+    let rec: DayRecord;
+    if (!base) rec = { key: k, status: "insufficient", u: 0 };
+    else if (cur.t - base.t > GAP_MS) rec = { key: k, status: "gap", u: 0 };
+    // is_available=false 的帧不作为守恒端点：跳过其相邻区间的用量推算（C8；
+    // 内置化新增策略，原型无此逻辑——不可用期余额变动不代表真实消耗）
+    else if (base.available === false || cur.available === false) rec = { key: k, status: "unavailable", u: 0 };
+    else {
+      const c = calcUsageDs(base, cur);
+      const v = fin(c.v);
+      // 分层渲染规则：|u|≤容差 → 0；轻微负值 → 可显示的绿柱（余额净增）；大额负值 → 异常标注
+      if (v === null) rec = { key: k, status: "anomaly", u: 0, note: "数值异常" };
+      else if (Math.abs(v) <= TOL) rec = { key: k, status: "ok", u: 0, ...c };
+      else if (v < 0 && v >= ANOMALY_NEG) rec = { key: k, status: "ok", u: v, neg: true, ...c };
+      else if (v < ANOMALY_NEG) rec = { key: k, status: "anomaly", u: 0, note: `余额净增 ¥${Math.abs(v).toFixed(2)}（异常）`, ...c };
+      else rec = { key: k, status: "ok", u: v, ...c };
+    }
+    base = cur; // 基线传递：空槽日不改写基线（向前最近非空日）
+    return rec;
+  });
+}
+
+/** 柱形图 y 轴上限取整到 1/2/5×10^k 的好看步长。 */
+export function niceCeil(v: number): number {
+  if (!(typeof v === "number" && Number.isFinite(v) && v > 0)) return 10;
+  const p = Math.pow(10, Math.floor(Math.log10(v)));
+  const n = v / p;
+  const m = n <= 1 ? 1 : n <= 2 ? 2 : n <= 5 ? 5 : 10;
+  return m * p;
+}
+
+/** 卡2：标题行 + 柱形 SVG + 汇总行。 */
+function renderDailyUsageCard(pts: SamplePoint[], truncated: boolean, e: (s: unknown) => string, now: number): string {
+  const keys = lastNDayKeys(15, now);
+  const records = aggregateDaily(pts, keys, truncated);
+
+  const sumUse = records.reduce((s, r) => s + (r.status === "ok" && !r.neg ? r.u : 0), 0);
+  const mixedCaliber = records.some((r) => r.kind === "net" || r.status === "gap" || r.status === "insufficient" || r.status === "unavailable");
+
+  const svgAttrs = [
+    `role="img"`,
+    `aria-label="${ea(`近15日每日用量柱形图，合计消耗约${sumUse.toFixed(2)}元`)}"`,
+  ].join(" ");
+  const summary = `<p style="margin:4px 0 0 0;font-size:11px;color:var(--dsw-alias-label-tertiary,#9aa0ab);text-align:center">近 15 日消耗约 ¥${sumUse.toFixed(2)}${
+    mixedCaliber ? `<span style="opacity:.65">（部分日期按净变动口径估算）</span>` : ""
+  }</p>`;
+
+  return `<div class="dou-card">
+    <div class="dou-cardHead">
+      <div class="dou-cardMeta">
+        <span class="dou-legendDot" style="background:var(--dsw-alias-state-business-primary,#3b82f6)"></span>
+        <h4 class="dou-cardName">近 15 日用量</h4>
+      </div>
+      <p class="dou-cardLimit">余额差 + 充值/赠款变动修正</p>
+    </div>
+    <div class="dou-miniChart"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 100" ${svgAttrs}>${dailyBarsSvg(records, e)}</svg></div>
+    ${summary}
+  </div>`;
+}
+
+/** 柱形几何：双向域 [lo, hi]、基线 y=0 实线；消耗蓝柱向上、净增绿柱向下、异常 0 高。 */
+function dailyBarsSvg(records: DayRecord[], e: (s: unknown) => string): string {
+  const W = 320, H = 100, PL = 36, PR = 6, PT = 8, PB = 14;
+  const plotW = W - PL - PR;
+  const bottom = PT + (H - PT - PB);
+
+  const posMax = Math.max(0, ...records.map((r) => r.u));
+  const negMin = Math.min(0, ...records.filter((r) => r.neg).map((r) => r.u));
+  // 全零窗口落固定默认域，防除零产生 NaN/Infinity 进 SVG 属性
+  const hi = posMax > 0 ? niceCeil(posMax) : negMin < 0 ? 0 : 10;
+  const lo = negMin < 0 ? -niceCeil(-negMin) : 0;
+  const span = hi - lo;
+  if (!(span > 0)) return "";
+
+  const yOf = (v: number): number => PT + ((hi - v) / span) * (bottom - PT);
+  const y0 = yOf(0);
+  const fmtVal = (v: number): string => (Math.abs(v) >= 100 ? String(Math.round(v)) : v.toFixed(Math.abs(v) >= 10 ? 1 : 2));
+
+  const parts: string[] = [];
+  // 网格：顶/底两条 + 基线实线
+  for (const gv of [...new Set([lo, hi])]) {
+    const gy = yOf(gv);
+    parts.push(`<line x1="${PL}" y1="${gy.toFixed(1)}" x2="${W - PR}" y2="${gy.toFixed(1)}" style="stroke:var(--dsw-alias-border-l2,#e8eaf0);stroke-width:1;stroke-dasharray:3 3"/>`);
+    parts.push(`<text x="${PL - 4}" y="${(gy + 3).toFixed(1)}" text-anchor="end" style="font-size:9px">${fmtVal(gv)}</text>`);
+  }
+  parts.push(`<line x1="${PL}" y1="${y0.toFixed(1)}" x2="${W - PR}" y2="${y0.toFixed(1)}" style="stroke:var(--dsw-alias-border-l2,#e8eaf0);stroke-width:1"/>`);
+
+  const consumptionColor = "var(--dsw-alias-state-business-primary,#3b82f6)";
+  const netIncreaseColor = "var(--dsw-alias-state-success-primary,#16a34a)";
+  const slotW = plotW / records.length;
+  const barW = Math.min(slotW * 0.62, 18);
+
+  // 金额简短格式化
+  const fmtAmt = (v: number): string => `¥${v.toFixed(2)}`;
+
+  records.forEach((r, i) => {
+    const x = PL + slotW * i + (slotW - barW) / 2;
+    const cx = x + barW / 2;
+    const isToday = i === records.length - 1;
+    const dateLabel = isToday ? "今日" : r.key.slice(5);
+    const opacity = isToday ? 0.55 : 1; // 今日未结束，半透明示意
+    let titleText: string;
+    if (r.status === "empty") titleText = `${dateLabel} 无采样`;
+    else if (r.status === "insufficient") titleText = `${dateLabel} 样本不足`;
+    else if (r.status === "gap") titleText = `${dateLabel} 数据中断`;
+    else if (r.status === "unavailable") titleText = `${dateLabel} 服务不可用区间不计`;
+    else if (r.status === "anomaly") titleText = `${dateLabel} ${r.note || "数值异常"}`;
+    else if (r.neg) titleText = `${dateLabel} 余额净增 ¥${Math.abs(r.u).toFixed(2)}${r.extra ? `（${r.extra}）` : ""}`;
+    else titleText = `${dateLabel} 消耗 ¥${r.u.toFixed(2)}${r.extra ? `（${r.extra}）` : ""}`;
+
+    if (r.u > TOL && r.status === "ok") {
+      const yTop = yOf(fin(r.u, 0, hi)!);
+      const barH = Math.max(1, y0 - yTop);
+      parts.push(`<rect x="${x.toFixed(1)}" y="${yTop.toFixed(1)}" width="${barW.toFixed(1)}" height="${barH.toFixed(1)}" fill="${consumptionColor}" fill-opacity="${opacity}" rx="1.5"><title>${e(titleText)}</title></rect>`);
+      // 金额：柱顶上方（柱高<16px 时放基线上方避免压基线）
+      const labelY = y0 - yTop > 16 ? yTop - 4 : y0 - 14;
+      parts.push(`<text x="${cx.toFixed(1)}" y="${labelY.toFixed(1)}" text-anchor="middle" style="font-size:8px;fill:${consumptionColor}">${fmtAmt(r.u)}</text>`);
+    } else if (r.neg && r.u < -TOL) {
+      const yBot = yOf(fin(r.u, lo, 0)!);
+      const barH = Math.max(1, yBot - y0);
+      parts.push(`<rect x="${x.toFixed(1)}" y="${y0.toFixed(1)}" width="${barW.toFixed(1)}" height="${barH.toFixed(1)}" fill="${netIncreaseColor}" fill-opacity="${opacity}" rx="1.5"><title>${e(titleText)}</title></rect>`);
+      // 金额：柱底下方（降到日期上方为止，避免压日期标签）
+      const negLabelY = Math.min(yBot + 12, H - 9);
+      parts.push(`<text x="${cx.toFixed(1)}" y="${negLabelY.toFixed(1)}" text-anchor="middle" style="font-size:8px;fill:${netIncreaseColor}">${fmtAmt(Math.abs(r.u))}</text>`);
+    } else {
+      // 占位极矮条：保证空槽/异常日在轴上可感知位置
+      parts.push(`<rect x="${x.toFixed(1)}" y="${(y0 - 0.75).toFixed(1)}" width="${barW.toFixed(1)}" height="0.75" fill="${consumptionColor}" fill-opacity=".18"><title>${e(titleText)}</title></rect>`);
+    }
+
+    // x 轴日期标签：隔一显示，强制保留首位与今日
+    if (i % 2 === 0 || isToday) {
+      parts.push(`<text x="${cx.toFixed(1)}" y="${(H - 6).toFixed(1)}" text-anchor="middle" style="font-size:8.5px">${e(dateLabel)}</text>`);
+    }
+  });
+
+  return parts.join("");
+}
+
+/** 余额走势 SVG（自适应值域 + 网格 + 折线 + 末点高亮 + x 轴时间刻度）。 */
+function balanceSvg(values: SamplePoint[], e: (s: unknown) => string): string {
+  if (values.length < 2) return "";
+  const W = 320, H = 100, PL = 44, PR = 8, PT = 14, PB = 16;
+  const xw = W - PL - PR, plotH = H - PT - PB;
+  const t0 = values[0].t, t1 = values[values.length - 1].t;
+  const spanMs = t1 > t0 ? t1 - t0 : 60000;
+
+  // y 域：自适应（余额型，不设百分比参考线）
+  let lo = Infinity, hi = -Infinity;
+  for (const p of values) {
+    if (p.balance < lo) lo = p.balance;
+    if (p.balance > hi) hi = p.balance;
+  }
+  if (lo === Infinity) return "";
+  const pad = (hi - lo) * 0.15 || Math.max(hi * 0.1, 0.01);
+  lo = Math.max(0, lo - pad);
+  hi = hi + pad;
+  if (hi - lo < 1e-6) { lo = Math.max(0, lo - 1); hi = hi + 1; }
+
+  const xOf = (t: number): number => PL + ((t - t0) / spanMs) * xw;
+  const yOf = (v: number): number => PT + ((hi - v) / (hi - lo)) * plotH;
+  const fmtVal = (v: number): string => (Math.abs(v) >= 100 ? String(Math.round(v)) : v.toFixed(2));
+
+  const parts: string[] = [];
+  // 网格三线 + 数值标签
+  for (const gv of [lo, (lo + hi) / 2, hi]) {
+    const gy = yOf(gv);
+    parts.push(`<line x1="${PL}" y1="${gy.toFixed(1)}" x2="${W - PR}" y2="${gy.toFixed(1)}" style="stroke:var(--dsw-alias-border-l2,#e8eaf0);stroke-width:1;stroke-dasharray:3 3"/>`);
+    parts.push(`<text x="${PL - 4}" y="${(gy + 3).toFixed(1)}" text-anchor="end" style="font-size:9.5px">${fmtVal(gv)}</text>`);
+  }
+  // 折线 + 面积（降采样 ≤300 点）
+  const pts = values.map((p) => ({ x: xOf(p.t), y: yOf(p.balance) }));
+  let line = pts;
+  if (pts.length > 300) {
+    const step = pts.length / 300;
+    const out: Array<{ x: number; y: number }> = [];
+    for (let i = 0; i < pts.length; i += step) out.push(pts[Math.floor(i)]);
+    out.push(pts[pts.length - 1]);
+    line = out;
+  }
+  let d = `M ${line[0].x.toFixed(1)} ${line[0].y.toFixed(1)}`;
+  for (let i = 1; i < line.length; i += 1) d += ` L ${line[i].x.toFixed(1)} ${line[i].y.toFixed(1)}`;
+  const last = line[line.length - 1];
+  const btm = PT + plotH;
+  const color = "var(--dsw-alias-state-business-primary,#3b82f6)";
+  parts.push(`<path d="${d} L ${last.x.toFixed(1)} ${btm} L ${line[0].x.toFixed(1)} ${btm} Z" style="fill:${color};fill-opacity:.13"/>`);
+  parts.push(`<path d="${d}" style="fill:none;stroke:${color};stroke-width:1.6;stroke-linecap:round;stroke-linejoin:round"/>`);
+  parts.push(`<circle cx="${last.x.toFixed(1)}" cy="${last.y.toFixed(1)}" r="2.6" style="fill:${color};stroke:var(--dsw-alias-bg-base,#fdfdfd);stroke-width:1.2"/>`);
+
+  // x 轴时间刻度（≤7 个）
+  const stepMs = spanMs / 6;
+  for (let k = 0; k <= 6; k += 1) {
+    const tt = t0 + stepMs * k;
+    const tx = xOf(Math.min(tt, t1));
+    const dDate = new Date(tt);
+    const label = spanMs >= DAY_MS
+      ? `${dDate.getMonth() + 1}-${String(dDate.getDate()).padStart(2, "0")}`
+      : `${String(dDate.getHours()).padStart(2, "0")}:${String(dDate.getMinutes()).padStart(2, "0")}`;
+    const anchorAttr = k === 0 ? "start" : k === 6 ? "end" : "middle";
+    parts.push(`<text x="${tx.toFixed(1)}" y="${H - 4}" text-anchor="${anchorAttr}" style="font-size:9.5px">${e(label)}</text>`);
+  }
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}">${parts.join("")}</svg>`;
+}
+
+// ---------------------------------------------------------------- 适配器对象
+
+/**
+ * 面板内容（两张卡片）：
+ * 卡1：余额大头 + 近 24h 余额波动折线（锚点 = min(末采样点, 现在)，宿主时区口径）。
+ * 卡2：近 15 个自然日每日用量柱形图（守恒式口径：余额差 + 充值/赠款变动修正）。
+ * 「现在」以 range.end 注入（T3 防 flake：面板判定路径不取墙钟；history 路由 end=查询时刻）。
+ */
+function formatPanelImpl(input: PanelInput): string {
+  const e: (s: unknown) => string = input.esc || h;
+  if (!Array.isArray(input.entries) || input.entries.length === 0) return "<p>暂无历史数据</p>";
+
+  const now = input.range.end;
+  // 过滤有效点 + 剔除未来时间戳（容差一个采样周期）+ 防御性稳定排序（契约保证升序，宿主升级兜底）
+  const pts: SamplePoint[] = input.entries
+    .map((en) => ({
+      t: en && typeof en.time === "number" ? en.time : NaN,
+      balance: en && en.data && typeof en.data.balance === "number" ? en.data.balance : NaN,
+      toppedUp: en && en.data && typeof en.data.toppedUp === "number" ? en.data.toppedUp : null,
+      granted: en && en.data && typeof en.data.grantedBalance === "number" ? en.data.grantedBalance : null,
+      available: !(en && en.data && en.data.isAvailable === false),
+    }))
+    .filter((p) => Number.isFinite(p.t) && Number.isFinite(p.balance))
+    .filter((p) => p.t <= now + GAP_MS)
+    .sort((a, b) => a.t - b.t);
+  if (pts.length === 0) return "<p>暂无历史数据</p>";
+
+  // 统一时间锚：折线「近 24h」与柱形窗口共用，避免停滞数据下两图基准割裂
+  const anchor = Math.min(pts[pts.length - 1].t, now);
+
+  // ---- 卡1：余额 + 近 24h 折线 ----
+  const values24 = pts.filter((p) => p.t >= anchor - DAY_MS);
+  const latest = values24[values24.length - 1] || pts[pts.length - 1];
+  const first24 = values24[0];
+  const balance = latest.balance;
+
+  let trendHtml = "";
+  if (first24 && first24.t !== latest.t) {
+    const d = latest.balance - first24.balance;
+    if (d > TOL) trendHtml = `<span class="dou-trend-up" title="${ea("较24小时前")}">▲ +${d.toFixed(2)}</span>`;
+    else if (d < -TOL) trendHtml = `<span class="dou-trend-down" title="${ea("较24小时前")}">▼ ${d.toFixed(2)}</span>`;
+    else trendHtml = `<span class="dou-trend-flat" title="${ea("较24小时前")}">— 0.00</span>`;
+  }
+
+  const head = `<div class="dou-cardHead">
+    <div class="dou-cardMeta">
+      <span class="dou-legendDot" style="background:var(--dsw-alias-state-business-primary,#3b82f6)"></span>
+      <h4 class="dou-cardName">余额</h4>
+      <span class="dou-cardCur">${balance !== null && Number.isFinite(balance) ? `¥${balance.toFixed(2)}` : "--"}</span>
+      ${trendHtml}
+    </div>
+    <p class="dou-cardLimit">DeepSeek 官方（CNY） · 近 24 小时波动</p>
+  </div>`;
+
+  let chartHtml = "";
+  if (values24.length >= 2) {
+    chartHtml = `<div class="dou-miniChart">${balanceSvg(values24, e)}</div>`;
+  } else if (input.entries.length < 2) {
+    chartHtml = `<p class="dou-chartEmpty">数据采集中：每次刷新记录一个采样点（约每 5 分钟一次），≥2 个点后显示趋势。</p>`;
+  } else {
+    chartHtml = `<p class="dou-chartEmpty">近 24 小时内采样不足（&lt;2 点），随时间积累后显示。</p>`;
+  }
+
+  const card1 = `<div class="dou-card">${head}${chartHtml}</div>`;
+  const card2 = renderDailyUsageCard(pts, input.truncated === true, e, now);
+  return card1 + card2;
+}
+
+/** 内置 DeepSeek 官方适配器（v2 契约，行为与原型一致；name 加 -builtin 后缀）。 */
+export const deepSeekOfficialAdapter: UsageStatsAdapter = {
+  version: 2,
+  name: DEEPSEEK_OFFICIAL_ADAPTER_ID,
+  label: "DeepSeek 官方余额",
+  providers: [DEEPSEEK_OFFICIAL_PROVIDER],
+
+  async fetchData(ctx: FetchContext): Promise<Record<string, unknown>> {
+    return fetchDeepSeekOfficialV2(ctx as FetchContext & { fetch?: typeof fetch });
+  },
+
+  formatCapsule(input: CapsuleInput): string {
+    return formatCapsuleWithBadge(input, input.time);
+  },
+
+  formatPanel(input: PanelInput): string {
+    return formatPanelImpl(input);
+  },
+};

--- a/packages/dsh-provider-usage/src/client/style.css
+++ b/packages/dsh-provider-usage/src/client/style.css
@@ -95,6 +95,25 @@
 }
 .dou-label { white-space: nowrap; }
 
+/* #198 峰谷倒计时徽标：峰态橙（计费高）、谷态绿（折扣中）；
+   窄断点（≤380px）下与余额同排 nowrap + 省略号截断，不撑破胶囊容器 */
+.dou-peak {
+  display: inline-block;
+  max-width: 132px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+  margin-left: 6px;
+  font-size: 11px;
+  font-weight: 600;
+}
+.dou-peak-on { color: var(--dsw-alias-state-warn-primary, #c9820b); }
+.dou-peak-off { color: var(--dsw-alias-state-success-primary, #0f9d6e); }
+@media (max-width: 380px) {
+  .dou-peak { max-width: 88px; }
+}
+
 .dou-cardMeta { display: flex; align-items: center; gap: 5px; min-width: 0; }
 .dou-cardCur {
   font-weight: 700;

--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -29,6 +29,7 @@ import type { UsageStatsAdapter } from "./contracts.js";
 import { describeUsageStatsAdapterShape, ADAPTER_CONTRACT_VERSION } from "./contracts.js";
 import { makeAdapterRegistry } from "./registry.js";
 import { openCodeGoAdapter, OPENCODE_GO_PROVIDER, OPENCODE_GO_ADAPTER_ID } from "./adapters/opencode-go.js";
+import { deepSeekOfficialAdapter, DEEPSEEK_OFFICIAL_PROVIDER, DEEPSEEK_OFFICIAL_ADAPTER_ID } from "./adapters/deepseek-official.js";
 import { runV2Pipeline, runV2PanelPipeline, panelCacheKey, isPanelCacheStale, type V2PipelineResult, type PanelCacheEntry } from "./pipeline/v2.js";
 import { HistoryStore, migrateLegacyV3 } from "./core/history.js";
 import { resolveProviderConfig } from "./provider-config.js";
@@ -41,6 +42,7 @@ import { resolvePath, pluginHome, expandHomePath } from "./path-resolve.js";
 export * from "./contracts.js";
 export * from "./registry.js";
 export * from "./adapters/opencode-go.js";
+export * from "./adapters/deepseek-official.js";
 export * from "./provider-config.js";
 export { HistoryStore, parseJsonl, startOfDay, migrateLegacyV3, legacySampleToData, listAdapters } from "./core/history.js";
 export type { HistoryEntry } from "./core/history.js";
@@ -79,7 +81,9 @@ export const DEFAULT_CONFIG = {
   apiKey: "",
   historyDir: "",
   warmupIntervalMs: 300000,
-  cacheDurationMs: 60000,
+  // #198 H1：由 60000 下调至 30000——峰谷徽标倒计时跨时段边界的展示翻转延迟
+  // = 宿主缓存 + 客户端轮询（60s）+ 渲染余量，缓存减半使端到端 ≤95s 可达。
+  cacheDurationMs: 30000,
   fetchTimeoutMs: 2000,
   autoReload: true,
   maxAgeDays: 30,
@@ -369,8 +373,11 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
     /* 迁移失败不阻断启动（下次启动重试） */
   }
 
-  // 1. 注册内置 opencode-go 适配器
+  // 1. 注册内置适配器（builtin 先注册、默认启用；user-file 清单后注册覆盖启用者）
   registry.register(openCodeGoAdapter, "builtin");
+  // #198：内置 DeepSeek 官方余额适配器（name=deepseek-official-builtin，与用户已装
+  // user-file 原型 deepseek-official 可共存，注册顺序覆盖语义见 F 组验收）
+  registry.register(deepSeekOfficialAdapter, "builtin");
 
   // 2. 加载用户适配器（两来源：config.adapter 兼容声明 + 设置页登记的清单）
   async function loadUserHostAdapterFile(file: string): Promise<unknown> {

--- a/packages/dsh-provider-usage/src/pipeline/v2.ts
+++ b/packages/dsh-provider-usage/src/pipeline/v2.ts
@@ -77,6 +77,18 @@ export async function runV2Pipeline(ctx: V2PipelineContext): Promise<V2PipelineR
   }, ctx.timeoutMs);
 
   if (fetched.error !== undefined) {
+    // #198 A 组：取数失败仍产出 stale 胶囊（空 data + status:'stale' + error），
+    // 让峰谷徽标等纯本地信息在错误帧常驻；不带 rawData → 上层不落盘历史（错误帧绝不以
+    // fresh 身份进历史）。formatCapsule 对该输入渲染「无数据」占位且不抛错（safeFormat 隔离）。
+    const failCapsInput = {
+      time: fetchedAt,
+      data: {},
+      status: 'stale' as const,
+      error: fetched.error,
+      esc,
+    };
+    const failFormatted = await safeFormat(() => adapter.formatCapsule(failCapsInput), 'formatCapsule', ctx.timeoutMs);
+    const failCapsuleHtml = failFormatted.html !== undefined ? sanitizeHtml(failFormatted.html) : undefined;
     return {
       ok: false,
       configured: true,
@@ -86,6 +98,7 @@ export async function runV2Pipeline(ctx: V2PipelineContext): Promise<V2PipelineR
       provider,
       adapterName: adapter.name,
       status: 'stale',
+      ...(failCapsuleHtml !== undefined ? { capsuleHtml: failCapsuleHtml } : {}),
     };
   }
 

--- a/packages/dsh-provider-usage/test/smoke-pure.ts
+++ b/packages/dsh-provider-usage/test/smoke-pure.ts
@@ -80,6 +80,14 @@ assert.equal(sanitizeHtml("<script>alert(1)</script><b>ok</b>"), "<b>ok</b>");
 assert.equal(sanitizeHtml('<img src="x" onerror="alert(1)">'), '<img src="x">');
 assert.equal(sanitizeHtml('<a href="javascript:alert(1)">x</a>'), '<a href="alert(1)">x</a>');
 assert.equal(sanitizeHtml('<iframe src="x"></iframe>y'), "y");
+// #198 D5/I2 净化契约：SVG 图表结构存活且净化面干净（错误文案含 <script> 注入面同样被双层防护）
+{
+  const svgOut = sanitizeHtml('<svg role="img"><rect onmouseover="evil()" fill="#fff"></rect><title>ok</title></svg>');
+  assert.ok(svgOut.includes("<svg") && svgOut.includes("role=\"img\""), "sanitize 后 SVG 结构存活");
+  assert.ok(!svgOut.includes("onmouseover"), "SVG 内 on* 事件属性被移除");
+  const injected = sanitizeHtml('<span>&lt;script&gt;alert(1)&lt;/script&gt;</span><script>alert(2)</script>');
+  assert.ok(!injected.includes("<script"), "脚本标签被移除（esc 实体化文本不受影响）");
+}
 
 // ------------------------------------------------- sanitize：实体编码变体封闭（#105③）
 

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -27,6 +27,7 @@ import "./unit-history.test.ts";
 import "./unit-v1.test.ts";
 import "./unit-apply.test.ts";
 import "./unit-detect.test.ts";
+import "./unit-deepseek-official.test.ts";
 
 import {
   apply,
@@ -34,6 +35,8 @@ import {
   ADAPTER_CONTRACT_VERSION,
   OPENCODE_GO_PROVIDER,
   OPENCODE_GO_ADAPTER_ID,
+  DEEPSEEK_OFFICIAL_PROVIDER,
+  DEEPSEEK_OFFICIAL_ADAPTER_ID,
   userAdaptersFile,
   PANEL_CACHE_TTL_MS,
   normalizeRangeDay,
@@ -47,8 +50,8 @@ const here = dirname(fileURLToPath(import.meta.url));
 process.env.DSH_HOME = mkdtempSync(join(tmpdir(), "dou-home-"));
 
 // 网络隔离（红线）：清掉可能存在于真实环境的密钥变量，防内置适配器发起真实请求；
-// 测试结束后恢复。
-const SAVED_ENV_KEYS = ["OPENCODE_GO_API_KEY", "OPENCODE_GO_PROVIDER_API_KEY"];
+// 测试结束后恢复（#198：deepseek 系列密钥一并清空——T2 无真实凭据纪律）。
+const SAVED_ENV_KEYS = ["OPENCODE_GO_API_KEY", "OPENCODE_GO_PROVIDER_API_KEY", "DEEPSEEK_API_KEY", "DEEPSEEK_OFFICIAL_API_KEY"];
 const savedEnv: Record<string, string | undefined> = {};
 for (const k of SAVED_ENV_KEYS) {
   savedEnv[k] = process.env[k];
@@ -420,11 +423,11 @@ export function formatPanel() { return "<p>p</p>"; }
     assert.equal(payload.adapter.name, "manage-stats");
     assert.ok(payload.enabled[OPENCODE_GO_PROVIDER] === "manage-stats", "新增适配器成为该 provider 启用者");
 
-    // adapters.json 现在有两条候选（内置 + 用户）
+    // adapters.json 现在有三条候选（两个内置 + 用户；#198 新增 deepseek-official-builtin）
     const adaptersRoute = routes.find((r) => r.path === ROUTES.adapters);
     let meta;
     adaptersRoute.handler(fakeReq(), { writeHead: () => {}, end: (c) => { meta = JSON.parse(c); } });
-    assert.equal(meta.host.length, 2, "候选列表含内置 + 用户");
+    assert.equal(meta.host.length, 3, "候选列表含两个内置 + 用户");
   }
 
   // add：重复 name → 409
@@ -495,6 +498,176 @@ export function formatPanel() { return "<p>p</p>"; }
 }
 
 console.log("[smoke] 全部断言通过 ✓ (v2 集成)");
+
+// ---------------------------------------------------------------- #198 deepseek-official 内置适配器集成
+//
+// 覆盖：A1（失败 stale 帧 + capsuleHtml）/ A3（错误帧不落盘）/ A5（成功帧落盘）/
+// E4（no-api-key → stale + 徽标常驻 G8）/ F1（builtin 默认启用）/ F2/K12（与 user-file
+// 原型共存且注册顺序覆盖成立）/ F4（候选列表 source 区分）/ E5（密钥不出现在响应体）。
+// 网络纪律：apiEndpoint 指向不可达回环（快速 network 失败），无任何出网请求。
+
+{
+  // 用户 mjs 原型模拟：name 与 provider 同名（deepseek-official，原型形态），
+  // 用于 K12 有意差异断言——与内置 -builtin 后缀名共存不冲突
+  const userDir = mkdtempSync(join(tmpdir(), "dou-ds-user-"));
+  const userFile = join(userDir, "deepseek-official.mjs");
+  writeFileSync(userFile, `
+export const version = 2;
+export const name = "deepseek-official";
+export const label = "DeepSeek 官方余额(用户)";
+export const providers = ["${DEEPSEEK_OFFICIAL_PROVIDER}"];
+export async function fetchData() { return { isAvailable: true, balance: 42.5, toppedUp: null, grantedBalance: null }; }
+export function formatCapsule(i) { return "<span>USER ¥" + (typeof i.data.balance === "number" ? i.data.balance.toFixed(2) : "--") + "</span>"; }
+export function formatPanel() { return "<p>user-panel</p>"; }
+`, "utf8");
+
+  const historyRoot = join(process.env.DSH_HOME, "dsh-provider-usage");
+  const withBody = (body) => fakeReq({ method: "POST", body });
+  const getJSON = async (route, url) => {
+    let payload;
+    await route.handler(fakeReq({ url }), { writeHead: () => {}, end: (c) => { payload = JSON.parse(c); } });
+    await new Promise((r) => setTimeout(r, 30));
+    return payload;
+  };
+
+  // ---- 场景 1：纯 builtin（warmup 关闭避免缓存/锁竞争，手动触发取数）----
+  {
+    const disposers = [];
+    const { ctx, routes } = makeFakeCtx({
+      effect(fn) {
+        const d = fn();
+        if (typeof d === "function") disposers.push(d);
+        return typeof d === "function" ? d : () => {};
+      },
+    });
+    await apply(ctx, { ...ISOLATED_CONFIG, provider: DEEPSEEK_OFFICIAL_PROVIDER, warmupIntervalMs: 0 });
+
+    // F1：默认注册后 adapters.json 启用者 = builtin、source=builtin
+    const adaptersRoute = routes.find((r) => r.path === ROUTES.adapters);
+    const meta = await getJSON(adaptersRoute, ROUTES.adapters);
+    assert.equal(meta.enabled[DEEPSEEK_OFFICIAL_PROVIDER], DEEPSEEK_OFFICIAL_ADAPTER_ID,
+      "F1: deepseek-official 默认启用者为 deepseek-official-builtin");
+    const dsBuiltin = meta.host.find((a) => a.name === DEEPSEEK_OFFICIAL_ADAPTER_ID);
+    assert.ok(dsBuiltin !== undefined && dsBuiltin.source === "builtin", "F1: 候选含 builtin 条目且 source=builtin");
+
+    // 启动即预热会把失败帧写进缓存（warmupIntervalMs 有下限 clamp 无法关闭）；
+    // select 语义自带 cache.clear()，重选 builtin 后下一次 stats 即全新取数
+    await new Promise((r) => setTimeout(r, 350));
+    const selectRoute1 = routes.find((r) => r.path === ROUTES.select);
+    await new Promise((resolve) => {
+      selectRoute1.handler(withBody(JSON.stringify({ provider: DEEPSEEK_OFFICIAL_PROVIDER, adapterName: DEEPSEEK_OFFICIAL_ADAPTER_ID })), {
+        writeHead: () => {}, end: (c) => resolve(JSON.parse(c)),
+      });
+    });
+
+    // A1：取数失败（不可达回环）→ HTTP 形状仍 200 由路由保证；ok=false / status=stale / capsuleHtml 非空
+    const stats = routes.find((r) => r.path === ROUTES.stats);
+    const failPayload = await getJSON(stats, `${ROUTES.stats}?provider=${DEEPSEEK_OFFICIAL_PROVIDER}`);
+    assert.equal(failPayload.ok, false, "A1: 失败帧 ok=false");
+    assert.equal(failPayload.status, "stale", "A1: 失败帧 status=stale");
+    assert.equal(failPayload.reason, "fetch-failed");
+    assert.ok(typeof failPayload.capsuleHtml === "string" && failPayload.capsuleHtml.length > 0, "A1: 失败帧 capsuleHtml 非空");
+    assert.ok(failPayload.capsuleHtml.includes("DeepSeek 余额 --"), "A1: 空 data 渲染占位文案");
+    assert.ok(failPayload.capsuleHtml.includes("dou-peak"), "G8: stale 帧峰谷徽标常驻");
+    assert.ok(failPayload.error === "network", `A1: 错误码 network（实际 ${failPayload.error}）`);
+
+    // A3：错误帧绝不落盘历史——builtin 历史目录不应存在
+    const builtinHistDir = join(historyRoot, DEEPSEEK_OFFICIAL_PROVIDER, DEEPSEEK_OFFICIAL_ADAPTER_ID);
+    assert.ok(!existsSync(builtinHistDir), "A3: 取数失败后历史目录无 builtin 条目（错误帧未落盘）");
+
+    // E5：密钥不出现在任一响应体
+    for (const p of [meta, failPayload]) {
+      assert.ok(!JSON.stringify(p).includes("sk-smoke-test"), "E5: 响应体不含密钥子串");
+    }
+
+    for (const d of [...disposers].reverse()) { try { d(); } catch {} }
+  }
+
+  // ---- 场景 2：三级密钥全空 → no-api-key → stale 帧 + 徽标（E4/G8）----
+  {
+    const disposers = [];
+    const { ctx, routes } = makeFakeCtx({
+      effect(fn) {
+        const d = fn();
+        if (typeof d === "function") disposers.push(d);
+        return typeof d === "function" ? d : () => {};
+      },
+    });
+    await apply(ctx, { apiKey: "", apiEndpoint: "http://127.0.0.1:9", provider: DEEPSEEK_OFFICIAL_PROVIDER, warmupIntervalMs: 0 });
+    // 等预热完成后 select 清缓存，确保下一次 stats 走全新取数路径（同场景 1）
+    await new Promise((r) => setTimeout(r, 350));
+    const selectRoute2 = routes.find((r) => r.path === ROUTES.select);
+    await new Promise((resolve) => {
+      selectRoute2.handler(withBody(JSON.stringify({ provider: DEEPSEEK_OFFICIAL_PROVIDER, adapterName: DEEPSEEK_OFFICIAL_ADAPTER_ID })), {
+        writeHead: () => {}, end: (c) => resolve(JSON.parse(c)),
+      });
+    });
+    const stats = routes.find((r) => r.path === ROUTES.stats);
+    const payload = await getJSON(stats, `${ROUTES.stats}?provider=${DEEPSEEK_OFFICIAL_PROVIDER}`);
+    assert.equal(payload.status, "stale", "E4: 三级全空 → stale 帧");
+    assert.equal(payload.error, "no-api-key", "E4: 错误码 no-api-key");
+    assert.ok(payload.capsuleHtml?.includes("dou-peak"), "G8: no-api-key 下徽标仍渲染（纯本地时间计算）");
+    assert.ok(!JSON.stringify(payload).includes("sk-"), "E4: 响应不含任何密钥形态子串");
+    for (const d of [...disposers].reverse()) { try { d(); } catch {} }
+  }
+
+  // ---- 场景 3：add user-file 原型（name=deepseek-official）→ 共存 + 覆盖启用（K12/F2/F4/A5）----
+  {
+    const disposers = [];
+    const { ctx, routes } = makeFakeCtx({
+      effect(fn) {
+        const d = fn();
+        if (typeof d === "function") disposers.push(d);
+        return typeof d === "function" ? d : () => {};
+      },
+    });
+    await apply(ctx, { ...ISOLATED_CONFIG, provider: DEEPSEEK_OFFICIAL_PROVIDER, warmupIntervalMs: 0 });
+
+    const addRoute = routes.find((r) => r.path === ROUTES.add);
+    const addPayload = await new Promise((resolve) => {
+      addRoute.handler(withBody(JSON.stringify({ file: userFile })), {
+        writeHead: () => {},
+        end: (c) => resolve(JSON.parse(c)),
+      });
+    });
+    await new Promise((r) => setTimeout(r, 60));
+    assert.equal(addPayload.ok, true, `K12: user-file 原型注册成功（${JSON.stringify(addPayload).slice(0, 120)}）`);
+    assert.equal(addPayload.enabled[DEEPSEEK_OFFICIAL_PROVIDER], "deepseek-official",
+      "F2: 后注册的 user-file 认领同名 provider 时成为启用者");
+
+    // F4：设置页候选列表同时展示 builtin 与 user-file 且 source 区分
+    const adaptersRoute = routes.find((r) => r.path === ROUTES.adapters);
+    const meta = await getJSON(adaptersRoute, ROUTES.adapters);
+    const sources = Object.fromEntries(meta.host.filter((a) => a.providers.includes(DEEPSEEK_OFFICIAL_PROVIDER)).map((a) => [a.name, a.source]));
+    assert.equal(sources[DEEPSEEK_OFFICIAL_ADAPTER_ID], "builtin", "F4: builtin 条目 source=builtin");
+    assert.equal(sources["deepseek-official"], "user-file", "F4: user-file 条目 source=user-file");
+    assert.ok(!JSON.stringify(meta).includes("sk-smoke-test"), "E5: adapters.json 不含密钥");
+
+    // stats：用户版生效 → fresh + 用户胶囊文案（本地数据零网络）
+    const stats = routes.find((r) => r.path === ROUTES.stats);
+    const fresh = await getJSON(stats, `${ROUTES.stats}?provider=${DEEPSEEK_OFFICIAL_PROVIDER}`);
+    await new Promise((r) => setTimeout(r, 40));
+    const freshRetry = await getJSON(stats, `${ROUTES.stats}?provider=${DEEPSEEK_OFFICIAL_PROVIDER}`);
+    const finalFresh = freshRetry.status === "fresh" ? freshRetry : fresh;
+    assert.equal(finalFresh.adapterName, "deepseek-official", "K12: 用户原型适配器接管取数");
+    assert.ok(["fresh", "cached"].includes(finalFresh.status), `A5: 成功帧 fresh/cached（实际 ${finalFresh.status}）`);
+    assert.ok(finalFresh.capsuleHtml?.includes("USER ¥42.50"), "A5: 用户版胶囊文案渲染");
+    assert.ok(!JSON.stringify(finalFresh).includes("sk-smoke-test"), "E5: stats 响应不含密钥");
+
+    // A5：成功帧正常落盘历史（对照 A3 的失败帧不落盘）
+    await new Promise((r) => setTimeout(r, 80));
+    const userHistDir = join(historyRoot, DEEPSEEK_OFFICIAL_PROVIDER, "deepseek-official");
+    assert.ok(existsSync(userHistDir), "A5: fresh 帧已按 (provider, adapterName) 落盘历史目录");
+
+    // history 路由对用户版可用（面板管线不崩）
+    const historyRoute = routes.find((r) => r.path === ROUTES.history);
+    const hist = await getJSON(historyRoute, `${ROUTES.history}?provider=${DEEPSEEK_OFFICIAL_PROVIDER}&days=1`);
+    assert.equal(hist.adapterName, "deepseek-official");
+    assert.ok(!JSON.stringify(hist).includes("sk-smoke-test"), "E5: history 响应不含密钥");
+
+    for (const d of [...disposers].reverse()) { try { d(); } catch {} }
+  }
+}
 
 // ---------------------------------------------------------------- #156 warmup 串行采样回归
 

--- a/packages/dsh-provider-usage/test/unit-config.test.ts
+++ b/packages/dsh-provider-usage/test/unit-config.test.ts
@@ -114,6 +114,12 @@ assert.equal(normalizeConfig({ cacheDurationMs: 1000 }).cacheDurationMs, 5000, "
 assert.equal(normalizeConfig({ cacheDurationMs: 10000 }).cacheDurationMs, 10000, "cacheDurationMs 合法透传");
 assert.equal(normalizeConfig({ cacheDurationMs: "x" }).cacheDurationMs, DEFAULT_CONFIG.cacheDurationMs, "cacheDurationMs 非法丢弃");
 
+// #198 H1/H2：默认缓存由 60000 下调至 30000；显式配置语义与下限 clamp 保持
+assert.equal(DEFAULT_CONFIG.cacheDurationMs, 30000, "#198 H1: 默认 cacheDurationMs=30000");
+assert.equal(normalizeConfig({}).cacheDurationMs, 30000, "#198 H1: 未配置时生效 30000");
+assert.equal(normalizeConfig({ cacheDurationMs: 60000 }).cacheDurationMs, 60000, "#198 H2: 显式 60000 生效 60000");
+assert.equal(normalizeConfig({ cacheDurationMs: 4999 }).cacheDurationMs, 5000, "#198 H2: 下限 clamp 保持");
+
 assert.equal(normalizeConfig({ apiKey: "sk-abc123" }).apiKey, "sk-abc123", "apiKey 字符串透传");
 assert.equal(normalizeConfig({ apiKey: 123 }).apiKey, "", "apiKey 非字符串丢弃回默认空串");
 

--- a/packages/dsh-provider-usage/test/unit-deepseek-official.test.ts
+++ b/packages/dsh-provider-usage/test/unit-deepseek-official.test.ts
@@ -1,0 +1,795 @@
+// @ts-nocheck
+/**
+ * dsh-provider-usage — unit：内置 DeepSeek 官方适配器（issue #198）。
+ *
+ * 覆盖（对照验收清单分组）：
+ * - B 组：取数归一化 / 多币种过滤 / 无 CNY 修订版行为 / 错误码 / 请求形态
+ * - C 组：余额差守恒式 + 分量缺失逐项独立退化 + 可加性 + is_available=false 端点策略
+ * - E 组：三级密钥链（显式注入 → V1 链 env 推导 → DEEPSEEK_API_KEY 自查兜底）
+ * - G 组：峰谷时段常量 / 半开区间 / 周末全谷 / 倒计时单调与钳制 / 徽标渲染
+ * - K 组：原型对齐断言（严格解析 / 端点剥离 / 六态错误路径 / GAP 判定 / 分层渲染 /
+ *   时区口径 / skipFirst / 面板结构 / 胶囊文案）
+ *
+ * 纪律：全程无网络（fetch 全部 mock 注入）；无真实凭据（env 用例 try/finally 恢复）；
+ * 峰谷判定与倒计时全部以 timestamp 入参注入固定 epoch，判定路径无墙钟调用（T3）。
+ */
+console.error("EVAL-ORDER-TAG: DS-OFFICIAL");
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import { mkdtempSync } from "node:fs";
+import { assert } from "./helpers.ts";
+import {
+  esc,
+  sanitizeHtml,
+  isUsageStatsAdapter,
+  resolveProviderConfig,
+  runV2Pipeline,
+  openCodeGoAdapter,
+  OPENCODE_GO_ADAPTER_ID,
+  deepSeekOfficialAdapter,
+  DEEPSEEK_OFFICIAL_PROVIDER,
+  DEEPSEEK_OFFICIAL_ADAPTER_ID,
+  PEAK_WINDOWS_UTC,
+  isPeakUtc,
+  nextPeakTransition,
+  peakBadgeHtml,
+  parseAmount,
+  resolveEndpoint,
+  calcUsageDs,
+  aggregateDaily,
+  dayKey,
+  lastNDayKeys,
+  niceCeil,
+  GAP_MS,
+  TOL,
+  ANOMALY_NEG,
+} from "../lib/index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------- 时间戳辅助（固定 epoch，T3）
+
+/** UTC 时间戳便捷构造（月份 1–12）。 */
+const utc = (y, mo, d, hh, mi, ss = 0, ms = 0) => Date.UTC(y, mo - 1, d, hh, mi, ss, ms);
+// 2026-08-24 为周一（24/25/26/27/28 = 一至五；29/30 = 六/日）
+const MON = (hh, mi, ss = 0, ms = 0) => utc(2026, 8, 24, hh, mi, ss, ms);
+const SAT = (hh, mi, ss = 0, ms = 0) => utc(2026, 8, 29, hh, mi, ss, ms);
+const SUN = (hh, mi, ss = 0, ms = 0) => utc(2026, 8, 30, hh, mi, ss, ms);
+
+/** 构造 mock Response（官方文档示例 JSON 形态蓝本）。 */
+function mockRes(status, body) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+/** 构造官方 balance 响应体。 */
+function officialBody(cny = {}, extraInfos = [], isAvailable = true) {
+  return {
+    is_available: isAvailable,
+    balance_infos: [
+      {
+        currency: "CNY",
+        total_balance: "110.00",
+        topped_up_balance: "90.00",
+        granted_balance: "20.00",
+        ...cny,
+      },
+      ...extraInfos,
+    ],
+  };
+}
+
+/** 捕获请求形态的 mock fetch。 */
+function capturingFetch(res) {
+  const calls = [];
+  const f = (url, init) => {
+    calls.push({ url: String(url), init });
+    return Promise.resolve(typeof res === "function" ? res(url, init) : res);
+  };
+  return { f: f as unknown as typeof fetch, calls };
+}
+
+// ================================================================ B1 + 契约自检
+
+{
+  assert.equal(isUsageStatsAdapter(deepSeekOfficialAdapter), true, "内置 DeepSeek 适配器通过 v2 契约校验");
+  assert.equal(deepSeekOfficialAdapter.name, DEEPSEEK_OFFICIAL_ADAPTER_ID);
+  assert.equal(deepSeekOfficialAdapter.name, "deepseek-official-builtin", "name 加 -builtin 后缀（有意差异 K12）");
+  assert.equal(deepSeekOfficialAdapter.version, 2, "version===2");
+  assert.deepEqual(deepSeekOfficialAdapter.providers, ["deepseek-official"], "认领 deepseek-official provider");
+  assert.equal(typeof deepSeekOfficialAdapter.fetchData, "function");
+  assert.equal(typeof deepSeekOfficialAdapter.formatCapsule, "function");
+  assert.equal(typeof deepSeekOfficialAdapter.formatPanel, "function");
+}
+
+// ================================================================ B2/K1 余额解析 + 归一化输出
+
+{
+  const { f, calls } = capturingFetch(mockRes(200, officialBody()));
+  const out = await deepSeekOfficialAdapter.fetchData({
+    apiEndpoint: "https://api.deepseek.com", staticPath: "", apiKey: "sk-unit",
+    provider: DEEPSEEK_OFFICIAL_PROVIDER, timeoutMs: 2000, fetch: f,
+  });
+  assert.equal(out.isAvailable, true);
+  assert.equal(out.balance, 110, 'total_balance:"110.00" → 数值 110');
+  assert.equal(out.toppedUp, 90);
+  assert.equal(out.grantedBalance, 20);
+  // B6 请求形态：Bearer 密钥在头里，URL 与查询串不含密钥
+  assert.match(calls[0].init.headers.Authorization, /^Bearer sk-unit$/, "Authorization: Bearer <key>");
+  assert.ok(!String(calls[0].url).includes("sk-unit"), "URL 不携带密钥");
+  assert.equal(calls[0].init.headers.Accept, "application/json");
+}
+
+{
+  // 金额非法形态 → null（杜绝 NaN 落盘）
+  const { f } = capturingFetch(mockRes(200, officialBody({ total_balance: "abc", topped_up_balance: "", granted_balance: undefined })));
+  const out = await deepSeekOfficialAdapter.fetchData({
+    apiEndpoint: "", staticPath: "", apiKey: "sk-unit",
+    provider: DEEPSEEK_OFFICIAL_PROVIDER, timeoutMs: 2000, fetch: f,
+  });
+  assert.equal(out.balance, null, "非法金额字符串 → null");
+  assert.equal(out.toppedUp, null, "空串 → null");
+  assert.equal(out.grantedBalance, null, "缺失字段 → null");
+}
+
+assert.equal(parseAmount("12.34"), 12.34);
+assert.equal(parseAmount("  5 "), 5);
+assert.equal(parseAmount(""), null);
+assert.equal(parseAmount("abc"), null);
+assert.equal(parseAmount("NaN"), null);
+assert.equal(parseAmount(undefined), null);
+assert.equal(parseAmount(null), null);
+assert.equal(parseAmount("Infinity"), null, "Infinity 非有限数 → null");
+
+// ================================================================ B3 多币种仅留 CNY
+
+{
+  const usd = { currency: "USD", total_balance: "15.50", topped_up_balance: "15.50", granted_balance: "0.00" };
+  const { f } = capturingFetch(mockRes(200, officialBody({}, [usd])));
+  const out = await deepSeekOfficialAdapter.fetchData({
+    apiEndpoint: "", staticPath: "", apiKey: "sk-unit",
+    provider: DEEPSEEK_OFFICIAL_PROVIDER, timeoutMs: 2000, fetch: f,
+  });
+  assert.equal(out.balance, 110, "USD 共存时仍取 CNY 余额");
+}
+
+// ================================================================ B4（修订版）无 CNY → null 正常帧
+
+{
+  for (const infos of [
+    [{ currency: "USD", total_balance: "15.50" }],
+    [],
+  ]) {
+    const { f } = capturingFetch(mockRes(200, { is_available: true, balance_infos: infos }));
+    const out = await deepSeekOfficialAdapter.fetchData({
+      apiEndpoint: "", staticPath: "", apiKey: "sk-unit",
+      provider: DEEPSEEK_OFFICIAL_PROVIDER, timeoutMs: 2000, fetch: f,
+    });
+    assert.deepEqual(
+      [out.balance, out.toppedUp, out.grantedBalance],
+      [null, null, null],
+      `无 CNY 条目（${JSON.stringify(infos).slice(0, 30)}…）→ 全 null 正常帧不抛错`,
+    );
+    assert.equal(out.isAvailable, true);
+  }
+}
+
+// ================================================================ B5/K3 错误路径六态（参数化）
+
+{
+  const baseCtx = { apiEndpoint: "", staticPath: "", apiKey: "sk-unit", provider: DEEPSEEK_OFFICIAL_PROVIDER, timeoutMs: 2000 };
+
+  // no-api-key
+  await assert.rejects(
+    () => deepSeekOfficialAdapter.fetchData({ ...baseCtx, apiKey: undefined }),
+    (e) => e.message === "no-api-key",
+  );
+
+  // AbortError 重抛（超时取消不被吞成 network）
+  const abortErr = Object.assign(new Error("The operation was aborted"), { name: "AbortError" });
+  const abortF = (() => Promise.reject(abortErr)) as unknown as typeof fetch;
+  await assert.rejects(
+    () => deepSeekOfficialAdapter.fetchData({ ...baseCtx, fetch: abortF }),
+    (e) => e.name === "AbortError" && e.message === "The operation was aborted",
+    "AbortError 必须原样重抛",
+  );
+
+  // 连接异常 → network
+  const boomF = (() => Promise.reject(new Error("ECONNREFUSED"))) as unknown as typeof fetch;
+  await assert.rejects(() => deepSeekOfficialAdapter.fetchData({ ...baseCtx, fetch: boomF }), (e) => e.message === "network");
+
+  // 401 / 403 → unauthorized；其他非 2xx → http-<code>；非 JSON → bad-json
+  for (const [status, expected] of [[401, "unauthorized"], [403, "unauthorized"], [500, "http-500"], [429, "http-429"]]) {
+    await assert.rejects(
+      () => deepSeekOfficialAdapter.fetchData({ ...baseCtx, fetch: (() => Promise.resolve(mockRes(status, {}))) as unknown as typeof fetch }),
+      (e) => e.message === expected,
+      `${status} → ${expected}`,
+    );
+  }
+  const badJsonF = (() => Promise.resolve({ status: 200, ok: true, json: async () => { throw new Error("Unexpected token"); } })) as unknown as typeof fetch;
+  await assert.rejects(
+    () => deepSeekOfficialAdapter.fetchData({ ...baseCtx, fetch: badJsonF }),
+    (e) => e.message === "bad-json",
+  );
+}
+
+// ================================================================ K2 端点解析（/v1 剥离）
+
+{
+  assert.equal(resolveEndpoint(undefined), "https://api.deepseek.com/user/balance", "缺省用官方基址");
+  assert.equal(resolveEndpoint(""), "https://api.deepseek.com/user/balance");
+  assert.equal(resolveEndpoint("https://api.deepseek.com"), "https://api.deepseek.com/user/balance");
+  assert.equal(resolveEndpoint("https://api.deepseek.com/v1"), "https://api.deepseek.com/user/balance", "官方域名剥 /v1");
+  assert.equal(resolveEndpoint("https://api.deepseek.com/v1/"), "https://api.deepseek.com/user/balance", "剥 /v1/ 尾斜杠");
+  assert.equal(resolveEndpoint("https://API.DEEPSEEK.COM/V1"), "https://API.DEEPSEEK.COM/user/balance", "大小写不敏感剥前缀");
+  assert.equal(resolveEndpoint("http://127.0.0.1:9"), "http://127.0.0.1:9/user/balance", "非官方端点原样拼接");
+  assert.equal(resolveEndpoint("http://127.0.0.1:9///"), "http://127.0.0.1:9/user/balance", "多尾斜杠归一");
+  // 实际请求 URL 经捕获断言（mock 注入）
+  const { f, calls } = capturingFetch(mockRes(200, officialBody()));
+  await deepSeekOfficialAdapter.fetchData({
+    apiEndpoint: "https://api.deepseek.com/v1/", staticPath: "", apiKey: "sk-unit",
+    provider: DEEPSEEK_OFFICIAL_PROVIDER, timeoutMs: 2000, fetch: f,
+  });
+  assert.equal(String(calls[0].url), "https://api.deepseek.com/user/balance");
+}
+
+// ================================================================ E 组 三级密钥链
+
+{
+  // E1 显式注入优先，env 干扰不影响
+  const savedEnvKey = process.env.DEEPSEEK_OFFICIAL_API_KEY;
+  const savedDsKey = process.env.DEEPSEEK_API_KEY;
+  try {
+    process.env.DEEPSEEK_OFFICIAL_API_KEY = "sk-env-noise";
+    process.env.DEEPSEEK_API_KEY = "sk-ds-noise";
+    const resolved = await resolveProviderConfig(DEEPSEEK_OFFICIAL_PROVIDER, undefined, { apiKey: "sk-explicit" });
+    assert.equal(resolved.apiKey, "sk-explicit", "ctx.apiKey 有值时不读 env");
+  } finally {
+    if (savedEnvKey === undefined) delete process.env.DEEPSEEK_OFFICIAL_API_KEY; else process.env.DEEPSEEK_OFFICIAL_API_KEY = savedEnvKey;
+    if (savedDsKey === undefined) delete process.env.DEEPSEEK_API_KEY; else process.env.DEEPSEEK_API_KEY = savedDsKey;
+  }
+}
+
+{
+  // E2 V1 链推导：provider deepseek-official → env DEEPSEEK_OFFICIAL_API_KEY
+  const saved = { dsh: process.env.DSH_HOME, home: process.env.HOME, env: process.env.DEEPSEEK_OFFICIAL_API_KEY };
+  try {
+    process.env.DSH_HOME = mkdtempSync(join(tmpdir(), "dou-e2-"));
+    process.env.HOME = process.env.DSH_HOME;
+    process.env.DEEPSEEK_OFFICIAL_API_KEY = "sk-from-derived-env";
+    const resolved = await resolveProviderConfig(DEEPSEEK_OFFICIAL_PROVIDER, undefined, {});
+    assert.equal(resolved.apiKey, "sk-from-derived-env", "大写+连字符转下划线规则推导 env");
+  } finally {
+    if (saved.dsh === undefined) delete process.env.DSH_HOME; else process.env.DSH_HOME = saved.dsh;
+    if (saved.home === undefined) delete process.env.HOME; else process.env.HOME = saved.home;
+    if (saved.env === undefined) delete process.env.DEEPSEEK_OFFICIAL_API_KEY; else process.env.DEEPSEEK_OFFICIAL_API_KEY = saved.env;
+  }
+}
+
+{
+  // E3 适配器内自查 DEEPSEEK_API_KEY 兜底（llm 能跑、余额接口 401 场景）
+  const savedDs = process.env.DEEPSEEK_API_KEY;
+  try {
+    process.env.DEEPSEEK_API_KEY = "sk-ds-fallback";
+    const { f, calls } = capturingFetch(mockRes(200, officialBody()));
+    const out = await deepSeekOfficialAdapter.fetchData({
+      apiEndpoint: "", staticPath: "", apiKey: undefined,
+      provider: DEEPSEEK_OFFICIAL_PROVIDER, timeoutMs: 2000, fetch: f,
+    });
+    assert.equal(calls[0].init.headers.Authorization, "Bearer sk-ds-fallback", "DEEPSEEK_API_KEY 自查兜底生效");
+    assert.equal(out.balance, 110);
+  } finally {
+    if (savedDs === undefined) delete process.env.DEEPSEEK_API_KEY; else process.env.DEEPSEEK_API_KEY = savedDs;
+  }
+}
+
+// ================================================================ C/K4 守恒式 + 分量逐项独立退化
+
+{
+  const pt = (t, balance, toppedUp, granted) => ({ t, balance, toppedUp, granted });
+
+  // C1 纯消耗：prev{total:100,topped:90,granted:10} → cur{total:95,topped:90,granted:10}
+  const c1 = calcUsageDs(pt(0, 100, 90, 10), pt(1, 95, 90, 10));
+  assert.equal(c1.v, 5, "纯消耗 usage=5");
+  assert.equal(c1.kind, "adjusted", "分量存在（零变化）即 adjusted（原型口径）；extra 无充值/赠款注记");
+  assert.equal(c1.extra, "");
+
+  // C2 充值扰动抵消：total 100→135、topped 90→130（充值 +40、消耗 5）→ usage=5
+  const c2 = calcUsageDs(pt(0, 100, 90, 10), pt(1, 135, 130, 10));
+  assert.equal(c2.v, 5, "充值 +40 相消后 usage=5 而非 −35");
+  assert.equal(c2.kind, "adjusted", "有修正分量 → kind=adjusted");
+  assert.ok(c2.extra.includes("充值"), "extra 注明充值额");
+
+  // C3 赠款变动抵消：total 100→110、granted 10→20（零消耗）→ usage=0
+  const c3 = calcUsageDs(pt(0, 100, 90, 10), pt(1, 110, 90, 20));
+  assert.equal(c3.v, 0, "赠款 +10 到账相消后 usage=0 而非 −10");
+  assert.equal(c3.kind, "adjusted");
+  assert.ok(c3.extra.includes("赠款"), "extra 注明赠款变动");
+
+  // C4 退化①：cur 缺 granted 分量 → 按 Δtotal + ΔtoppedUp 继续产出（逐项独立，不整体放弃）
+  const c4 = calcUsageDs(pt(0, 100, 90, 10), pt(1, 96, 91, null));
+  assert.equal(c4.v, 5, "缺 granted 只跳该项：(100−96)+(91−90)=4+1=5");
+  assert.equal(c4.kind, "adjusted");
+
+  // 反向退化：cur 缺 toppedUp 但有 granted → 只做赠款修正
+  const c4b = calcUsageDs(pt(0, 100, 90, 10), pt(1, 96, null, 12));
+  assert.equal(c4b.v, 6, "缺 toppedUp 只跳该项：(100−96)+(12−10)=4+2=6");
+
+  // C5 退化②：cur 仅剩 total → usage=totalPrev−totalCur
+  const c5 = calcUsageDs(pt(0, 100, 90, 10), pt(1, 93, null, null));
+  assert.equal(c5.v, 7, "纯净变动口径：usage=7");
+  assert.equal(c5.kind, "net", "无任何修正 → kind=net");
+}
+
+{
+  // C7 同日分段求和一致性：3 个采样区间守恒值之和 === 全天总量口径（可加性）
+  const p0 = { t: MON(1, 0), balance: 100, toppedUp: 90, granted: 10 };
+  const p1 = { t: MON(5, 0), balance: 97, toppedUp: 90, granted: 10 };    // 区间1：纯消耗 3
+  const p2 = { t: MON(9, 0), balance: 96, toppedUp: 94, granted: 10 };    // 区间2：充值 +4、消耗 5
+  const p3 = { t: MON(13, 0), balance: 93, toppedUp: 94, granted: 12 };   // 区间3：赠款 +2、消耗 5
+  const seg = (a, b) => calcUsageDs(a, b).v;
+  assert.equal(seg(p0, p1), 3);
+  assert.equal(seg(p1, p2), 5);
+  assert.equal(seg(p2, p3), 5);
+  const sumSegs = seg(p0, p1) + seg(p1, p2) + seg(p2, p3);
+  const whole = seg(p0, p3);
+  assert.ok(Math.abs(sumSegs - whole) < 1e-9, `分段之和 ${sumSegs} === 总量 ${whole}`);
+  assert.equal(sumSegs, 13, "全天净消耗 13（3+5+5）");
+}
+
+// ================================================================ C/K5/K6/K7/K9 日聚合（闭环基线 / GAP / 分层 / skipFirst）
+
+{
+  // K6 GAP 中断判定：相邻代表点跨度 >27h → 该日 status='gap'
+  const far = 30 * 3600000;
+  const pts = [
+    { t: MON(0, 0), balance: 100, toppedUp: 90, granted: 10 },
+    { t: MON(0, 0) + far, balance: 95, toppedUp: 90, granted: 10 }, // 跨度 30h > GAP_MS
+  ];
+  const recs = aggregateDaily(pts, [dayKey(MON(0, 0)), dayKey(MON(0, 0) + far)], false);
+  const gapRec = recs.find((r) => r.status === "gap");
+  assert.ok(gapRec !== undefined, "30h 间隔产出 gap 日");
+  assert.equal(gapRec.u, 0, "gap 日不计柱");
+  assert.equal(GAP_MS, 27 * 3600000, "GAP_MS=27h 移植不走样");
+}
+
+{
+  // K5 闭环基线：空槽日不改写基线（向前最近非空日的末点作下一有效日基线）。
+  // 构造注意：空槽两侧末点跨度须 ≤27h（否则先触发 K6 的 GAP 中断判定）——
+  // 本地周六 23:30 → 下周一 01:30 = 26h，中间周日为空槽日。
+  // 用本地时间构造采样点，dayKey 归属（宿主时区口径）与时区无关地确定。
+  const sat = new Date(2026, 7, 29, 23, 30).getTime(); // 本地周六
+  const mon = new Date(2026, 7, 31, 1, 30).getTime();  // 本地下周一
+  assert.ok(mon - sat <= GAP_MS && (mon - sat) / 3600000 === 26, "前提：跨度 26h ≤ GAP_MS");
+  const pts = [
+    { t: sat, balance: 100, toppedUp: 90, granted: 10 },
+    { t: mon, balance: 94, toppedUp: 90, granted: 10 },
+  ];
+  const keys = lastNDayKeys(15, mon);
+  const recs = aggregateDaily(pts, keys, false);
+  const satRec = recs.find((r) => r.key === dayKey(sat));
+  const sunRec = recs.find((r) => r.key === "2026-08-30");
+  const monRec = recs.find((r) => r.key === dayKey(mon));
+  assert.equal(satRec.status, "insufficient", "周六为窗口内首个有效日且窗口前无采样 → 样本不足不计柱");
+  assert.equal(sunRec.status, "empty", "周日无采样 → empty");
+  assert.equal(monRec.u, 6, "周一基线=周六末点（空槽不改写）：100−94=6");
+  assert.notEqual(monRec.status, "gap", "26h 跨度不触发中断判定");
+}
+
+{
+  // 窗口开始前的最后一个采样点作首日基线（本地时间构造保证日归属确定）
+  const before = new Date(2026, 7, 30, 20, 0).getTime(); // 本地周日 20:00（窗口开始前一天）
+  const today = new Date(2026, 7, 31, 8, 0).getTime();   // 本地周一 08:00
+  const pts = [
+    { t: before, balance: 50, toppedUp: 45, granted: 5 },
+    { t: today, balance: 47, toppedUp: 45, granted: 5 },
+  ];
+  const recs = aggregateDaily(pts, [dayKey(today)], false);
+  assert.equal(recs.length, 1);
+  assert.equal(recs[0].status, "ok");
+  assert.equal(recs[0].u, 3, "首日基线取窗口前最后采样：50−47=3");
+}
+
+{
+  // C6 prev 缺失：单帧历史 → 当日柱 insufficient/0，不得把余额绝对值误计为用量
+  const only = { t: MON(8, 0), balance: 88, toppedUp: 80, granted: 8 };
+  const recs = aggregateDaily([only], [dayKey(MON(8, 0))], false);
+  assert.equal(recs[0].status, "insufficient", "无前驱 → 样本不足");
+  assert.equal(recs[0].u, 0, "不计柱");
+}
+
+{
+  // K7 分层渲染：|u|≤TOL → 0(ok)；轻微负值 → neg 绿柱；大额负值 → anomaly 仅标注
+  const d1 = new Date(2026, 7, 24, 9, 0).getTime(); // 本地周一
+  const d2 = new Date(2026, 7, 25, 10, 0).getTime(); // 本地周二（跨日，25h ≤ GAP_MS）
+  const mk = (bPrev, bCur, top = 90, grant = 10) => [
+    { t: d1, balance: bPrev, toppedUp: top, granted: grant },
+    { t: d2, balance: bCur, toppedUp: top, granted: grant },
+  ];
+  const zero = aggregateDaily(mk(100, 100 - TOL / 2), [dayKey(d2)], false)[0];
+  assert.equal(zero.status, "ok", "|u|≤TOL → ok");
+  assert.equal(zero.u, 0, "容差内归零");
+
+  const gainSmall = aggregateDaily(mk(100, 100.5), [dayKey(d2)], false)[0];
+  assert.equal(gainSmall.neg, true, "轻微负值 → neg 标记（绿柱净增展示）");
+  assert.ok(gainSmall.u < 0 && gainSmall.u >= ANOMALY_NEG, "neg 值域 [−1, 0)");
+  assert.equal(gainSmall.status, "ok", "neg 仍属 ok 可展示");
+
+  const anom = aggregateDaily(mk(100, 102.5), [dayKey(d2)], false)[0];
+  assert.equal(anom.status, "anomaly", "v<−1 → anomaly 仅标注不画柱");
+  assert.equal(anom.u, 0);
+  assert.ok(String(anom.note).includes("异常"));
+  assert.ok(TOL === 0.005 && ANOMALY_NEG === -1, "TOL/ANOMALY 常量移植不走样");
+}
+
+{
+  // K9 truncated=true 时首日不计（skipFirst）语义保留：
+  // 窗口前有基线时，非截断的首日照常推算；截断的首日强制 insufficient，
+  // 但其末点仍作为次日起的闭环基线（次日数值不受影响）。
+  const dBefore = new Date(2026, 7, 23, 20, 0).getTime(); // 本地周日（窗口前）
+  const d1 = new Date(2026, 7, 24, 9, 0).getTime();       // 本地周一
+  const d2 = new Date(2026, 7, 25, 9, 0).getTime();       // 本地周二
+  const pts = [
+    { t: dBefore, balance: 50, toppedUp: 45, granted: 5 },
+    { t: d1, balance: 47, toppedUp: 45, granted: 5 },
+    { t: d2, balance: 45, toppedUp: 45, granted: 5 },
+  ];
+  const keys = [dayKey(d1), dayKey(d2)];
+  const recTrunc = aggregateDaily(pts, keys, true);
+  assert.equal(recTrunc[0].status, "insufficient", "truncated 首日 skipFirst 不计");
+  assert.equal(recTrunc[0].u, 0);
+  assert.equal(recTrunc[1].u, 2, "次日起以首日末点为新基线：47−45=2");
+
+  const recFull = aggregateDaily(pts, keys, false);
+  assert.equal(recFull[0].status, "ok", "非截断时首日以窗口前采样为基线照常计算");
+  assert.equal(recFull[0].u, 3, "非截断首日：50−47=3");
+}
+
+{
+  // C8 is_available=false 的帧不作为守恒端点：跳过其相邻区间的用量推算
+  const d1 = MON(1, 0);
+  const d2 = utc(2026, 8, 25, 1, 0);
+  const d3 = utc(2026, 8, 26, 1, 0);
+  // 周二帧不可用：周一→周二 与 周二→周三 两个相邻区间都不计柱不计入汇总
+  const pts = [
+    { t: d1, balance: 100, toppedUp: 90, granted: 10, available: true },
+    { t: d2, balance: 40, toppedUp: 90, granted: 10, available: false },
+    { t: d3, balance: 38, toppedUp: 90, granted: 10, available: true },
+  ];
+  const recs = aggregateDaily(pts, [dayKey(d1), dayKey(d2), dayKey(d3)], false);
+  assert.equal(recs[0].status, "insufficient", "首日无窗口前基线 → 样本不足");
+  assert.equal(recs[1].status, "unavailable", "不可用端点相邻区间标注 unavailable");
+  assert.equal(recs[2].status, "unavailable", "前一帧不可用同样跳过推算");
+  assert.ok(recs.every((r) => r.u === 0 || r.status !== "ok" ? true : r.u >= 0), "无异常巨柱");
+  // 对照：全部可用时正常计算
+  const okPts = pts.map((p) => ({ ...p, available: true }));
+  const okRecs = aggregateDaily(okPts, [dayKey(d1), dayKey(d2), dayKey(d3)], false);
+  assert.equal(okRecs[2].u, 2, "全可用时周三照常计 (100−40)+(40−38) 链式口径的当日差 2 元");
+}
+
+// ================================================================ K8 日聚合时区口径
+
+{
+  // dayKey 用宿主进程本地时区：本地某日 07:00（东八区即 UTC 前一日 23:00）不得划入前一天
+  const localMorning = new Date(2026, 7, 24, 7, 0, 0).getTime();
+  assert.equal(dayKey(localMorning), "2026-08-24", "本地时区归组（禁 toISOString 的 UTC 归组）");
+  // 本地零点前后各一秒同日
+  const midnight = new Date(2026, 7, 24, 0, 0, 0).getTime();
+  assert.equal(dayKey(midnight), "2026-08-24");
+  assert.equal(dayKey(midnight - 1), "2026-08-23", "零点前一秒属前一日（本地口径）");
+
+  // lastNDayKeys 逐日 setDate 回退：跨月/数量/升序/今日收尾
+  const now = new Date(2026, 2, 1, 12, 0).getTime(); // 2026-03-01 本地
+  const keys = lastNDayKeys(15, now);
+  assert.equal(keys.length, 15);
+  assert.equal(keys[14], "2026-03-01", "末日=今日");
+  assert.equal(keys[13], "2026-02-28", "跨月回退正确（2026 非闰年）");
+  assert.equal(new Set(keys).size, 15, "无重复日");
+  assert.deepEqual([...keys].sort(), keys, "升序排列");
+}
+
+// ================================================================ niceCeil
+
+{
+  assert.equal(niceCeil(0), 10, "非正数回默认 10");
+  assert.equal(niceCeil(-5), 10);
+  assert.equal(niceCeil(0.7), 1);
+  assert.equal(niceCeil(1.4), 2);
+  assert.equal(niceCeil(3.2), 5);
+  assert.equal(niceCeil(7), 10);
+  assert.equal(niceCeil(17), 20);
+  assert.equal(niceCeil(140), 200);
+}
+
+// ================================================================ G 组 峰谷时段常量与倒计时
+
+{
+  // G1 常量存在 + 源码注释附官方定价 URL 与核实日期
+  assert.deepEqual(PEAK_WINDOWS_UTC.map(([s, e]) => [s, e]), [[60, 240], [360, 600]], "PEAK_WINDOWS_UTC=[[01:00,04:00],[06:00,10:00]]（分钟）");
+  const src = readFileSync(join(here, "..", "src", "adapters", "deepseek-official.ts"), "utf8");
+  assert.ok(src.includes("https://api-docs.deepseek.com/quick_start/pricing"), "注释附官方定价 URL");
+  assert.ok(src.includes("2026-08-26"), "注释附核实日期");
+}
+
+{
+  // G2 半开区间（毫秒精度）：周一 UTC 01:00:00.000 属峰；03:59:59.999 属峰；04:00:00.000 属谷；
+  // 06:00 开峰；10:00:00.000 切谷
+  assert.equal(isPeakUtc(MON(1, 0, 0, 0)), true, "01:00:00.000 属峰（左闭）");
+  assert.equal(isPeakUtc(MON(3, 59, 59, 999)), true, "03:59:59.999 属峰");
+  assert.equal(isPeakUtc(MON(4, 0, 0, 0)), false, "04:00:00.000 即属谷（右开）");
+  assert.equal(isPeakUtc(MON(6, 0, 0, 0)), true, "06:00 开峰");
+  assert.equal(isPeakUtc(MON(9, 59, 59, 999)), true, "09:59:59.999 属峰");
+  assert.equal(isPeakUtc(MON(10, 0, 0, 0)), false, "10:00 切谷");
+  assert.equal(isPeakUtc(MON(0, 59, 59, 999)), false, "00:59:59.999 属谷");
+}
+
+{
+  // G3 工作日窗口外全谷
+  assert.equal(isPeakUtc(MON(0, 30)), false, "周一 00:30 谷");
+  assert.equal(isPeakUtc(MON(5, 0)), false, "04:00–06:00 间谷");
+  assert.equal(isPeakUtc(MON(12, 0)), false, "午间谷");
+  assert.equal(isPeakUtc(utc(2026, 8, 28, 23, 0)), false, "周五 23:00 谷");
+  assert.equal(isPeakUtc(utc(2026, 8, 28, 15, 0)), false, "周五 15:00 谷（10:00 切谷后）");
+}
+
+{
+  // G4 周末全天低谷（issue 点名用例）
+  for (const [hh, mi] of [[0, 0], [2, 30], [7, 0], [8, 0], [12, 0], [23, 59]]) {
+    assert.equal(isPeakUtc(SAT(hh, mi)), false, `周六 ${hh}:${mi} 谷`);
+    assert.equal(isPeakUtc(SUN(hh, mi)), false, `周日 ${hh}:${mi} 谷`);
+  }
+  // 跨日衔接：周六 23:59:59.999 → 周日 00:00:00.000 均谷；周日 23:59:59.999 → 周一 00:00:00.000 均谷
+  assert.equal(isPeakUtc(SAT(23, 59, 59, 999)), false);
+  assert.equal(isPeakUtc(SUN(0, 0, 0, 0)), false);
+  assert.equal(isPeakUtc(SUN(23, 59, 59, 999)), false);
+  assert.equal(isPeakUtc(MON(0, 0, 0, 0)), false, "周一 00:00 仍谷（01:00 才开峰）");
+}
+
+{
+  // G6 边界钳制翻转：边界后滞后时刻显示新状态且倒计时 ≥0，无负值/"-00:00"
+  const justAfter = MON(4, 0, 0, 500); // 04:00:00.500
+  assert.equal(isPeakUtc(justAfter), false, "已翻转到谷");
+  const tr = nextPeakTransition(justAfter);
+  assert.equal(tr.toPeak, true, "谷态下一次转换为开峰");
+  assert.equal(tr.at, MON(6, 0), "转换点是 06:00");
+  const badge = peakBadgeHtml(justAfter);
+  assert.ok(!badge.includes("-00:"), "不出现负值形态");
+  assert.ok(badge.includes("距峰 02:"), `倒计时约 2 小时（实际 ${badge}）`);
+
+  // 边界前 1ms 仍属峰、指向切谷
+  const justBefore = MON(4, 0, 0, 0) - 1;
+  assert.equal(isPeakUtc(justBefore), true);
+  assert.equal(nextPeakTransition(justBefore).at, MON(4, 0), "峰态下一切换为切谷");
+}
+
+{
+  // G7 倒计时单调递减 + 长谷段有效非负
+  const t1 = MON(1, 30);
+  const t2 = MON(1, 31);
+  const tr1 = nextPeakTransition(t1);
+  const tr2 = nextPeakTransition(t2);
+  assert.equal(tr1.at, tr2.at, "同时段转换点相同");
+  assert.ok(tr1.at - t1 > tr2.at - t2, "t2>t1 → 剩余时长严格变小");
+  // 长谷段：周日 12:00 UTC 距周一 01:00 约 13h
+  const sunNoon = SUN(12, 0);
+  const trSun = nextPeakTransition(sunNoon);
+  assert.equal(trSun.toPeak, true);
+  assert.equal(trSun.at, utc(2026, 8, 31, 1, 0), "周末谷的下一次开峰在下周一 01:00 UTC");
+  const remainMin = Math.round((trSun.at - sunNoon) / 60000);
+  assert.equal(remainMin, 13 * 60, "恰 13 小时");
+  const badge = peakBadgeHtml(sunNoon);
+  assert.match(badge, /距峰 13:00/, "长谷段产出有效非负倒计时");
+  // 最长谷段：周五 10:00 切谷 → 下周一 01:00 = 63h
+  const friAfter = utc(2026, 8, 28, 10, 0);
+  assert.equal(nextPeakTransition(friAfter).at, utc(2026, 8, 31, 1, 0), "周五切谷后的下次开峰跨周末");
+  assert.match(peakBadgeHtml(friAfter), /距峰 63:00/);
+}
+
+{
+  // G5/G9 徽标渲染于胶囊余额文本之后 + tooltip 注明 UTC 定义与时区对照
+  const caps = deepSeekOfficialAdapter.formatCapsule({
+    time: SUN(12, 0),
+    data: { balance: 110.5, isAvailable: true },
+    status: "fresh",
+    esc,
+  });
+  assert.ok(caps.includes("余额 ¥110.50"), "余额两位小数");
+  assert.ok(caps.indexOf("余额 ¥") < caps.indexOf("dou-peak"), "徽标追加于余额文本之后");
+  assert.match(caps, /⚡谷 · 距峰 \d{2,}:\d{2}/, "谷态显示距下次开峰倒计时");
+  assert.ok(caps.includes("title="), "tooltip 存在");
+  assert.ok(caps.includes("UTC"), "tooltip 注明 UTC 时段定义");
+  assert.ok(caps.includes("服务器时区"), "tooltip 含服务器时区对照提示");
+
+  const capsPeak = deepSeekOfficialAdapter.formatCapsule({
+    time: MON(2, 0),
+    data: { balance: 110.5, isAvailable: true },
+    status: "fresh",
+    esc,
+  });
+  assert.match(capsPeak, /⚡峰 · 距谷 \d{2,}:\d{2}/, "峰态显示距切谷倒计时");
+  assert.ok(capsPeak.includes("dou-peak-on"), "峰态配色类");
+
+  // K11 无数据 / 不可用 / 缓存标记
+  const empty = deepSeekOfficialAdapter.formatCapsule({
+    time: MON(2, 0), data: {}, status: "stale", esc,
+  });
+  assert.ok(empty.includes("DeepSeek 余额 --"), "无数据显示 -- 占位");
+  assert.ok(empty.includes("(缓存)"), "stale 显示 (缓存) 标记");
+  const unavail = deepSeekOfficialAdapter.formatCapsule({
+    time: MON(2, 0), data: { balance: 5, isAvailable: false }, status: "fresh", esc,
+  });
+  assert.ok(unavail.includes("(不可用)"), "is_available=false 显示 (不可用)");
+
+  // K13/G10 徽标加入后胶囊文案不回归 + CSS 截断规则存在
+  assert.ok(empty.includes("dou-peak"), "stale 帧徽标仍渲染");
+  const css = readFileSync(join(here, "..", "src", "client", "style.css"), "utf8");
+  assert.ok(css.includes(".dou-peak"), "style.css 含 .dou-peak 规则");
+  assert.ok(css.includes("@media (max-width: 380px)") && css.includes("text-overflow: ellipsis"), "窄断点截断防溢出规则存在");
+}
+
+// ================================================================ K10/D 组 面板结构（双卡 SVG）
+
+{
+  const now = MON(12, 0);
+  const entries = [];
+  // 近 24h 内 5 个采样点（余额递减）+ 前 3 天历史
+  const balances = [100, 99, 98.5, 98.2, 98];
+  for (let i = 0; i < 5; i += 1) {
+    entries.push({ time: now - (4 - i) * 3600000, data: { balance: balances[i], toppedUp: 90, grantedBalance: 10, isAvailable: true } });
+  }
+  entries.push({ time: now - 3 * 86400000, data: { balance: 120, toppedUp: 90, grantedBalance: 10, isAvailable: true } });
+  entries.push({ time: now - 2 * 86400000, data: { balance: 112, toppedUp: 90, grantedBalance: 10, isAvailable: true } });
+  entries.push({ time: now - 86400000, data: { balance: 101, toppedUp: 90, grantedBalance: 10, isAvailable: true } });
+
+  const panel = deepSeekOfficialAdapter.formatPanel({
+    entries,
+    range: { start: now - 86400000, end: now },
+    truncated: false,
+    esc,
+  });
+  // D1 双卡结构
+  assert.equal((panel.match(/<div class="dou-card">/g) || []).length, 2, "恰含两个 dou-card 容器");
+  assert.ok(panel.includes("<svg"), "内嵌 SVG 图表");
+  assert.ok(panel.includes("近 15 日用量"), "卡2 柱形图卡");
+  assert.ok(panel.includes("近 24 小时波动"), "卡1 余额波动卡");
+  // D3 主题变量 + 浅色回退
+  assert.ok(panel.includes("var(--dsw-alias-") && panel.includes("#3b82f6"), "主题变量 + 浅色回退形态");
+  // K10 卡2 结构细节
+  assert.ok(panel.includes('role="img"'), "SVG role=img");
+  assert.ok(panel.includes("aria-label=\"近15日每日用量柱形图"), "aria-label 汇总口径");
+  assert.ok(panel.includes("近 15 日消耗约 ¥"), "汇总行");
+  // 卡1 TOL 趋势箭头（98 − 100 < −TOL → ▼）
+  assert.ok(panel.includes("▼"), "趋势箭头 ▼（下降）");
+
+  // D2 注入 >15 天历史仅呈现最近 15 个自然日（SVG 内日期槽位数 = 15）
+  const manyEntries = [];
+  for (let i = 0; i <= 20; i += 1) {
+    manyEntries.push({ time: now - i * 86400000, data: { balance: 100 - (20 - i), toppedUp: 90, grantedBalance: 10, isAvailable: true } });
+  }
+  const panelMany = deepSeekOfficialAdapter.formatPanel({
+    entries: manyEntries,
+    range: { start: now - 21 * 86400000, end: now },
+    truncated: false,
+    esc,
+  });
+  const barsInCard2 = (panelMany.match(/rx="1\.5"/g) || []).length;
+  assert.ok(barsInCard2 <= 16, `柱形槽位 ≤15+占位（实际 ${barsInCard2}）`);
+  assert.ok(!panelMany.includes(dayKey(now - 20 * 86400000).slice(5)), "20 天前日期不在窗口内");
+
+  // D4 空 history 占位不抛错
+  const emptyPanel = deepSeekOfficialAdapter.formatPanel({
+    entries: [], range: { start: 0, end: now }, truncated: false, esc,
+  });
+  assert.ok(emptyPanel.includes("暂无历史数据"));
+
+  // K10 mixedCaliber 提示（gap/insufficient 存在时）
+  const gapEntries = [
+    { time: now - 40 * 3600000, data: { balance: 100, toppedUp: 90, grantedBalance: 10, isAvailable: true } },
+    { time: now, data: { balance: 95, toppedUp: 90, grantedBalance: 10, isAvailable: true } },
+  ];
+  const panelGap = deepSeekOfficialAdapter.formatPanel({
+    entries: gapEntries,
+    range: { start: now - 86400000, end: now },
+    truncated: false,
+    esc,
+  });
+  assert.ok(panelGap.includes("部分日期按净变动口径估算") || panelGap.includes("数据中断"), "缺口场景出现口径提示");
+
+  // 降采样 ≤300 点（构造 400 点折线输入）
+  const dense = [];
+  for (let i = 0; i < 400; i += 1) {
+    dense.push({ time: now - (400 - i) * 60000, data: { balance: 100 + Math.sin(i) , toppedUp: 90, grantedBalance: 10, isAvailable: true } });
+  }
+  const panelDense = deepSeekOfficialAdapter.formatPanel({
+    entries: dense,
+    range: { start: now - 400 * 60000, end: now },
+    truncated: false,
+    esc,
+  });
+  const circleCount = (panelDense.match(/<circle /g) || []).length;
+  assert.equal(circleCount, 1, "折线仅末点高亮一个 circle（降采样后仍单线）");
+}
+
+{
+  // C8 集成面：is_available=false 帧不作为守恒端点（经 formatPanel 数据通路）
+  const now = utc(2026, 8, 26, 12, 0); // 周三
+  const entries = [
+    { time: now - 48 * 3600000, data: { balance: 100, toppedUp: 90, grantedBalance: 10, isAvailable: true } },   // 周一
+    { time: now - 24 * 3600000, data: { balance: 40, toppedUp: 90, grantedBalance: 10, isAvailable: false } },  // 周二（不可用）
+    { time: now, data: { balance: 38, toppedUp: 90, grantedBalance: 10, isAvailable: true } },                  // 周三
+  ];
+  const panel = deepSeekOfficialAdapter.formatPanel({
+    entries,
+    range: { start: now - 3 * 86400000, end: now },
+    truncated: false,
+    esc,
+  });
+  assert.ok(panel.includes("服务不可用"), "不可用端点相邻区间标注「服务不可用」而非计入巨柱");
+  assert.ok(!panel.includes("消耗 ¥60"), "不可用帧的 60 元差额未被误计为用量");
+  // 相邻两区间（周一→周二、周二→周三）均被跳过 → 汇总不含虚高值
+  assert.ok(panel.includes("消耗约 ¥0.00"), "汇总仅含有效区间（本场景为 0）");
+}
+
+// ================================================================ A2 opencode-go 空 data 防御回归
+
+{
+  const html = openCodeGoAdapter.formatCapsule({
+    time: Date.now(),
+    data: {},
+    status: "stale",
+    error: "network",
+    esc,
+  });
+  assert.equal(html, "<span>无数据</span>", "opencode-go 空 data + stale → 「无数据」占位不抛错");
+  assert.ok(openCodeGoAdapter.formatPanel({ entries: [], range: { start: 0, end: 1 }, truncated: false, esc }).includes("暂无历史数据"),
+    `opencode-go formatPanel 空 entries 回归（${OPENCODE_GO_ADAPTER_ID}）`);
+}
+
+// ================================================================ 管线集成：runV2Pipeline 失败分支 stale 帧
+
+{
+  const netFail = (() => Promise.reject(new Error("ECONNREFUSED"))) as unknown as typeof fetch;
+  const result = await runV2Pipeline({
+    adapter: deepSeekOfficialAdapter,
+    provider: DEEPSEEK_OFFICIAL_PROVIDER,
+    config: { apiEndpoint: "http://127.0.0.1:9", apiKey: "sk-pipe" },
+    staticPath: "",
+    timeoutMs: 2000,
+    fetchImpl: netFail,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.status, "stale");
+  assert.equal(result.error, "network");
+  assert.ok(typeof result.capsuleHtml === "string" && result.capsuleHtml.length > 0, "失败分支 capsuleHtml 非空");
+  assert.ok(result.capsuleHtml.includes("DeepSeek 余额 --"), "空 data 渲染占位");
+  assert.ok(result.capsuleHtml.includes("dou-peak"), "峰谷徽标 stale 帧常驻（G8）");
+  assert.equal(result.rawData, undefined, "错误帧不带 rawData（不落盘前提）");
+  // I2 错误文案无插值注入面：净化后无脚本执行面
+  assert.ok(!result.capsuleHtml.includes("<script"), "capsuleHtml 无脚本载体");
+
+  // 成功分支 fresh 帧 rawData 正常
+  const okResult = await runV2Pipeline({
+    adapter: deepSeekOfficialAdapter,
+    provider: DEEPSEEK_OFFICIAL_PROVIDER,
+    config: { apiEndpoint: "", apiKey: "sk-pipe" },
+    staticPath: "",
+    timeoutMs: 2000,
+    fetchImpl: (() => Promise.resolve(mockRes(200, officialBody()))) as unknown as typeof fetch,
+  });
+  assert.equal(okResult.ok, true);
+  assert.equal(okResult.status, "fresh");
+  assert.equal(okResult.rawData?.balance, 110);
+  assert.ok(okResult.capsuleHtml.includes("余额 ¥110.00"));
+  // D5 sanitizeHtml 后 SVG 结构存活且净化面干净（panelHtml 走同一 sanitize 出口）
+  const sanitized = sanitizeHtml('<svg role="img"><rect onmouseover="x()" fill="#fff"></rect></svg><a href="javascript:alert(1)">y</a>');
+  assert.ok(sanitized.includes("<svg"), "sanitize 后 svg 结构存活");
+  assert.ok(!sanitized.includes("onmouseover"), "on* 事件属性被移除");
+  assert.ok(!sanitized.includes("javascript:"), "javascript: URI 被移除");
+}
+
+console.log("[unit-deepseek-official] 全部断言通过 ✓ (#198 B/C/E/G/K)");


### PR DESCRIPTION
## 概述

实现 issue #198：dsh-provider-usage 内置 DeepSeek 官方用量适配器 + 胶囊峰谷时段倒计时。

核心方法论为**逐函数移植本地已验证的 user-file 原型**（`~/.dsh/provider-usage/deepseek-official.mjs`）：守恒式推算、`GAP_MS=27h` 中断判定、TOL/ANOMALY 分层渲染、六态错误路径（含 AbortError 重抛）、严格金额解析、官方域名 `/v1` 前缀剥离、本地时区日聚合等行为全部对齐原型，防「移植走样」。

### 有意差异与偏离注明

| 项 | 内容 | 理由 |
| --- | --- | --- |
| 有意差异（K12） | 适配器 name 用 `deepseek-official-builtin` | 对齐 opencode-go-builtin 先例；避免与用户已装 user-file 原型 `deepseek-official` 在 registeredNames 冲突被拒收。smoke 场景 3 断言两者共存且注册顺序覆盖语义成立 |
| 有意差异（K13） | 新增峰谷倒计时徽标 | 原型无此功能，本 issue 的核心增量之一 |
| 偏离注明 1 | `is_available=false` 的帧不作守恒端点（相邻区间跳过推算并标注「服务不可用区间不计」） | 主清单 C8 硬性要求，原型无此逻辑；不可用期余额变动不代表真实消耗。README 已同步宣称（J5/C8 互证） |
| 偏离注明 2 | `formatPanel` 的「现在」以 `PanelInput.range.end` 注入而非 `Date.now()` | T3 防 flake 硬性要求（判定路径零墙钟调用）；history 路由 `end=Date.now()` 语义一致 |

## AC 断言表（71 条）

主清单 58 条 + K 组增量 13 条（B4 为修订版）。证据列指向断言所在测试块。

### T. 测试纪律横切（3/3 全落实）

| 条目 | 结论 | 证据 |
| --- | --- | --- |
| T1 无网络 | PASS | 全部 fetch 经 mock 注入或不可达回环 `http://127.0.0.1:9`；smoke 集成仅 loopback 本地服务/回环失败路径，零出网请求 |
| T2 无真实凭据 | PASS | smoke.ts SAVED_ENV_KEYS 清空 DEEPSEEK_API_KEY / DEEPSEEK_OFFICIAL_API_KEY 并收尾恢复；unit E1/E2/E3 try/finally 恢复模式 |
| T3 时钟注入 | PASS | `isPeakUtc(t)`/`nextPeakTransition(t)`/`peakBadgeHtml(t)` 均 timestamp 入参；unit G 组固定 epoch（2026-08-24~31 UTC 序列）；formatPanel 以 range.end 作时钟 |

### A. 管线 stale 帧（6/6 全落实）

| 条目 | 结论 | 证据 |
| --- | --- | --- |
| A1 失败仍 200+stale+capsuleHtml | PASS | smoke #198 场景 1 failPayload：ok=false/status='stale'/capsuleHtml 非空含「DeepSeek 余额 --」；HTTP 200 由 stats 路由 writeJson(res,200,…) 保证 |
| A2 opencode-go 空 data 防御 | PASS | unit-deepseek-official A2 块：formatCapsule({data:{},status:'stale'}) === `<span>无数据</span>` 不抛错 |
| A3 错误帧不落盘 | PASS | smoke 场景 1：取数失败后 existsSync(builtinHistDir)===false（v2.ts 失败分支不带 rawData，index.ts 仅 fresh 落盘） |
| A4 formatPanel 空 entries 回归 | PASS | unit-deepseek-official A2 块：「暂无历史数据」占位不抛错 |
| A5 成功帧行为不变 | PASS | smoke 场景 3：用户适配器 fresh 帧 capsuleHtml=USER ¥42.50 且历史目录落盘；既有 smoke 全绿 |
| A6 busy/no-adapter 形状不变 | PASS | v2.ts 仅改失败分支；busy/no-enabled-adapter 分支代码零改动；既有 smoke no-enabled-adapter 用例保持绿 |

### B. deepseek-official-builtin 取数（6/6 全落实）

| 条目 | 结论 | 证据 |
| --- | --- | --- |
| B1 契约导出 | PASS | unit B1：isUsageStatsAdapter=true、name='deepseek-official-builtin'、version===2、providers=['deepseek-official']、三方法齐备 |
| B2 官方响应归一化 | PASS | unit B2：官方文档示例 JSON → {isAvailable:true, balance:110, toppedUp:90, grantedBalance:20}（"110.00"→数值 110） |
| B3 多币种仅留 CNY | PASS | unit B3：CNY+USD 共存时 balance=110（USD 忽略） |
| B4（修订版）无 CNY 正常帧 | PASS | unit B4：仅 USD / 空数组 → balance/toppedUp/grantedBalance 全 null 不抛错（对齐原型行为，未改抛 bad-data）；stats 路由集成由 A1 场景同构覆盖 |
| B5 错误码参数化 | PASS | unit B5：401/403→unauthorized、连接异常→network、非 JSON→bad-json、500→http-500、429→http-429 |
| B6 请求形态 | PASS | unit B2 捕获 mock fetch 入参：Authorization: Bearer sk-unit、Accept: application/json、URL 不含密钥子串 |

### C. 余额差守恒式日用量推算（8/8 全落实）

| 条目 | 结论 | 证据 |
| --- | --- | --- |
| C1 纯消耗 | PASS | unit C1：prev{100,90,10}→cur{95,90,10} usage=5 |
| C2 充值抵消 | PASS | unit C2：total 100→135/topped 90→130 → usage=5 非 −35 |
| C3 赠款抵消 | PASS | unit C3：total 100→110/granted 10→20 → usage=0 非 −10 |
| C4 退化①缺 granted | PASS | unit C4：(100−96)+(91−90)=5 继续产出不整体放弃；反向缺 toppedUp → (100−96)+(12−10)=6 |
| C5 退化②再缺 toppedUp | PASS | unit C5：仅 total → usage=totalPrev−totalCur=7 |
| C6 prev 缺失不计 | PASS | unit C6：单帧历史 → insufficient/u=0，余额绝对值未误计为用量 |
| C7 同日分段求和一致 | PASS | unit C7：3 区间守恒和 13 === 全天总量 13（可加性 <1e-9） |
| C8 is_available=false 不作端点 | PASS | unit C8 直连：相邻两区间 status='unavailable' u=0；formatPanel 集成面标注「服务不可用」且汇总 ¥0.00 无虚高；README J5 宣称一致 |

### D. 面板双卡 SVG（5/5 全落实）

| 条目 | 结论 | 证据 |
| --- | --- | --- |
| D1 双卡容器 | PASS | unit D 块：panelHtml 恰含 2 个 `<div class="dou-card">`（卡1 余额折线 + 卡2 近15日柱形） |
| D2 >15 天截窗 | PASS | unit D 块：注入 20 天 entries 后柱形槽位 ≤16 且 20 天前日期标签不在输出中 |
| D3 主题变量+浅色回退 | PASS | unit D 块字符串断言：var(--dsw-alias-* 与 #3b82f6 回退形态并存 |
| D4 空 history 占位 | PASS | unit D 块：「暂无历史数据」不抛错 |
| D5 净化后 SVG 存活 | PASS | smoke-pure D5/I2 块：sanitize 后 `<svg`/role="img" 存活、onmouseover/javascript: 移除 |

### E. 凭据链（5/5 全落实）

| 条目 | 结论 | 证据 |
| --- | --- | --- |
| E1 显式注入优先 | PASS | unit E1：ctx.apiKey=sk-explicit 时设干扰 env 仍取显式值 |
| E2 V1 链 env 推导 | PASS | unit E2：provider deepseek-official → env DEEPSEEK_OFFICIAL_API_KEY（大写+连字符转下划线） |
| E3 DEEPSEEK_API_KEY 兜底 | PASS | unit E3：apiKey 缺失 + env DEEPSEEK_API_KEY=sk-ds-fallback → Authorization Bearer sk-ds-fallback；provider-config 共享层零特判 |
| E4 三级全空 stale 帧 | PASS | smoke 场景 2：error=no-api-key/status=stale/capsuleHtml 含 dou-peak 徽标 |
| E5 密钥不出现在响应体 | PASS | smoke 场景 1/2/3：stats/adapters/history 响应 JSON.stringify 全文不含 sk-smoke-test/sk- 子串 |

### F. 注册顺序行为锁定（4/4 全落实）

| 条目 | 结论 | 证据 |
| --- | --- | --- |
| F1 builtin 默认启用 | PASS | smoke 场景 1：adapters.json enabled['deepseek-official']='deepseek-official-builtin'、source=builtin |
| F2 user-file 后注册覆盖 | PASS | smoke 场景 3：add 用户版后 enabled 切换为 'deepseek-official' |
| F3 adapter-state.json 恢复优先 | PASS | index.ts 恢复逻辑（readAdapterState→select）零改动，builtin 先注册默认启用被持久化选择覆盖的语义不受影响；全量回归绿 |
| F4 候选列表 source 区分 | PASS | smoke 场景 3：sources 映射 {deepseek-official-builtin: builtin, deepseek-official: user-file} |

### G. 峰谷时段常量与倒计时徽标（10/10 全落实）

| 条目 | 结论 | 证据 |
| --- | --- | --- |
| G1 常量存在+注释溯源 | PASS | unit G1：deepEqual [[60,240],[360,600]]；源码注释含官方定价 URL 与核实日期 2026-08-26 |
| G2 半开区间毫秒级 | PASS | unit G2：01:00:00.000 峰 / 03:59:59.999 峰 / 04:00:00.000 谷 / 06:00 开峰 / 09:59:59.999 峰 / 10:00 谷 |
| G3 工作日窗口外全谷 | PASS | unit G3：周一 00:30/05:00/12:00、周五 15:00/23:00 均谷 |
| G4 周末全天低谷 | PASS | unit G4：周六/周日任意时刻均谷，含周六 23:59:59.999→周日 00:00、周日 23:59:59.999→周一 00:00 跨日衔接 |
| G5 徽标追加余额后+倒计时文案 | PASS | unit G5：capsuleHtml 中 dou-peak 位于余额文本之后；谷态 `⚡谷 · 距峰 HH:MM`、峰态 `⚡峰 · 距谷 HH:MM` |
| G6 边界钳制翻转 | PASS | unit G6：04:00:00.500 → 谷态、距峰 02:、无负值/"-00:" 形态 |
| G7 单调递减+长谷段 | PASS | unit G7：同时段 t2>t1 剩余严格变小；周日 12:00 距下周一 01:00 恰 13h（距峰 13:00）；周五切谷跨周末 63h |
| G8 stale 帧徽标常驻 | PASS | smoke 场景 1/2：network/no-api-key 失败帧 capsuleHtml 均含 dou-peak |
| G9 tooltip UTC 定义+时区对照 | PASS | unit G5：title 含「UTC 工作日」窗口定义与「服务器时区 …」对照提示 |
| G10 窄断点无溢出 | PASS | style.css nowrap+ellipsis+max-width(132px/380px 断点 88px)；playwright 380×700 实测：docScrollWidth=380 无横向溢出、徽标 clamp 88px+ellipsis 激活、胶囊在视口内 |

### H. 缓存节奏（3/3 落实，H3 见未竟项说明）

| 条目 | 结论 | 证据 |
| --- | --- | --- |
| H1 默认 30000 | PASS | unit-config：DEFAULT_CONFIG.cacheDurationMs===30000 且 normalizeConfig({}) 生效 30000 |
| H2 显式配置语义不变 | PASS | unit-config：显式 60000 生效 60000；clamp 下限保持（1000→5000、4999→5000） |
| H3 端到端翻转 ≤95s（量级） | PASS（推导口径） | 数字推导自本 issue 方案参数：宿主缓存 30s（H1 断言锁死）+ 客户端轮询 REFRESH_MS=60s（未改动）+ 渲染余量 ≤5s = ≤95s；归因本 PR cacheDurationMs 60000→30000。集成计时/浏览器实测未采集，见「未竟项」 |

### I. 安全语义（3/3 全落实）

| 条目 | 结论 | 证据 |
| --- | --- | --- |
| I1 密钥仅宿主内存注入 | PASS | fetchDeepSeekOfficialV2 经 ctx.apiKey 入参取用；既有 smoke 安全断言保持绿；E5 响应体净化互证 |
| I2 错误文案无插值注入面 | PASS | smoke-pure：script 标签移除 + esc 实体化文本不受影响；unit 尾部错误帧 capsuleHtml 无脚本载体 |
| I3 围栏回归 | PASS | smoke 九路由 403（非回环）/405（方法错）循环保持绿；零新增路由 |

### J. README 一致性（5/5 全落实）

| 条目 | 结论 | 证据 |
| --- | --- | --- |
| J1 内置适配器一节 | PASS | README.md「DeepSeek 官方内置适配器」：数据源 GET /user/balance URL、仅 CNY、守恒式公式+逐级退化、双卡面板 |
| J2 峰谷引用官方页+核实日期 | PASS | README.md 峰谷徽标小节：定价页 URL + 核实日期 2026-08-26 + UTC 定义 + 周末全谷 |
| J3 三级密钥链宣称 | PASS | README.md 密钥解析节 blockquote：apiKey 注入 → env 推导 → DEEPSEEK_API_KEY 自查兜底；安全模型节「密钥不进浏览器端」语义扩展声明 |
| J4 README.en.md 同步 | PASS | README.en.md 同构新增 Built-in DeepSeek official adapter 节与安全模型更新 |
| J5 近似语义一一对应 | PASS | README「数据口径」节明确 is_available=false 不作守恒端点策略与净变动口径近似提示，与 C4/C8 断言互证 |

### K. 原型对齐增量（13/13 全落实）

| 条目 | 结论 | 证据 |
| --- | --- | --- |
| K1 余额解析对齐 | PASS | unit K1：parseAmount 矩阵（"12.34"/"  5 "/""/"abc"/"NaN"/undefined/null/"Infinity"）+ 输出形状四字段 |
| K2 端点解析对齐 | PASS | unit K2：官方域名剥 /v1（大小写不敏感、尾斜杠归一）、非官方原样拼接、缺省 BASE_URL；实际请求 URL 捕获断言 |
| K3 六态错误路径 | PASS | unit K3 参数化：no-api-key / AbortError 重抛（name/message 原样保留）/ network / unauthorized(401,403) / http-<code>(500,429) / bad-json |
| K4 守恒式公式+kind | PASS | unit K4：公式三分量 + kind 语义对齐原型（任一修正分量存在即 adjusted、全缺才 net）——C1 断言曾按直觉写反，以原型行为为准修正测试 |
| K5 闭环基线口径 | PASS | unit K5：周六 23:30→周一 01:30（26h≤GAP_MS）中间周日空槽，周一基线=周六末点 100−94=6；空槽日不改写基线 |
| K6 GAP_MS=27h 移植 | PASS | unit K6：30h 间隔 → status='gap' u=0；GAP_MS===27*3600000 常量不走样断言 |
| K7 分层渲染 | PASS | unit K7：|u|≤TOL→ok/u=0；轻微负值→neg 绿柱（[−1,0)）；v<−1→anomaly 仅标注 |
| K8 日聚合本地时区口径 | PASS | unit K8：dayKey 本地零点前后归属 + 本地某日 07:00 不划入前一天（东八区即 UTC 前一日场景）+ lastNDayKeys setDate 回退跨月（2026-03-01→02-28）/无重复/升序 |
| K9 truncated skipFirst | PASS | unit K9：三帧场景 truncated 首日 insufficient、次日以首日末点为新基线 47−45=2；非截断首日照常 50−47=3 对照 |
| K10 面板结构细节 | PASS | unit K10/D 块：统一时间锚（anchor=min(末采样,now)）、TOL 趋势箭头 ▼、降采样后单 circle 末点高亮、sumUse 只计 ok 非负、mixedCaliber 提示、SVG role="img"+aria-label |
| K11 胶囊文案对齐 | PASS | unit G5/K11：余额 ¥110.50 两位小数 / DeepSeek 余额 -- 占位 / (不可用) / (缓存) 标记 |
| K12 name=-builtin 共存 | PASS | smoke 场景 3：builtin 与用户版 deepseek-official 同时在候选列表（source 区分）且 add 后覆盖启用、切换生效 |
| K13 峰谷徽标新增不回归 | PASS | unit G5/K11：徽标加入后余额展示/--/(缓存) 文案共存于同一 capsuleHtml；stale 帧同样渲染 |

## 未竟项

- **H3 浏览器/集成计时实测未采集**：端到端翻转延迟当前以参数推导背书（30s 缓存断言 + 60s 轮询常量 + 余量 ≤5s = ≤95s）。实测需在真实 dsh web 会话内观察跨峰谷边界的胶囊刷新，留待 review/合并后补证；若实测超阈，回退手段为回调 cacheDurationMs 配置。
- G10 已用最小 DOM + 构建产物 CSS 规则经 playwright 380px 视口实测通过；完整 dsh web 真机胶囊形态建议 review 时顺带目检。

## 门禁凭据

```
build=OK test=OK contract=OK pack:check=OK typecheck=OK   （worktree task/198 五连全绿）
pnpm test: [smoke-pure]/[unit-*]/[smoke] 全部断言通过 ✓，#156 warmup 串行采样回归 ✓
diff stat: 10 files changed, 1768 insertions(+), 12 deletions(-)
```

Closes #198
