### PR TITLE
chore(release): bump v0.1.13（七包 0.1.12→0.1.13）

### DIFF
--- a/packages/dsh-idle-archive/package.json
+++ b/packages/dsh-idle-archive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-idle-archive",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "会话闲置自动提醒：超过 X 小时未对话的会话弹窗询问是否归档，拒绝后 Y 小时不重复提示",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-lan-proxy/package.json
+++ b/packages/dsh-lan-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-lan-proxy",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "局域网访问 dsh web UI：在 0.0.0.0:<port> 监听，把 HTTP/HTTPS 与 WebSocket/wss 转发到回环 web 服务器（默认 127.0.0.1:3080）。重写 Host/Origin 以通过 /api 浏览器信任围栏，仅接受 IP 字面量或 localhost 的 Host 头（DNS 重绑定防护）。HTTPS 默认并存（3443），证书可配置或自动生成自签名。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-mcp-manager/package.json
+++ b/packages/dsh-mcp-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-mcp-manager",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "DSH MCP 管理器：Web 侧边栏「MCP」入口，面板按状态分级展示 MCP 服务器（运行中/连接中/已配置/失败），支持快速接入（stdio / streamable-http 表单）与粘贴 mcpServers JSON 导入。已连接服务器的工具以 mcp__<server>__<tool> 注册给模型直接调用。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-notifier/package.json
+++ b/packages/dsh-notifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-notifier",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "审批/完成/错误事件通知：浏览器 Notification + 系统原生 toast（Windows PowerShell WinRT / macOS osascript / Linux notify-send，均无需额外安装）；提示音可配、每条通知独立显示不互相替换、非安全上下文自动降级横幅",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-plugins-all/package.json
+++ b/packages/dsh-plugins-all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-plugins-all",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "DSH 插件全家桶聚合包：一键安装全部功能插件（idle-archive / notifier / provider-usage / mcp-manager / lan-proxy / web-file-preview）。装它 = 子包 dependencies 拉齐 + 聚合 cordis patch 激活。dsh-gzip 已退役（压缩合并进 lan-proxy），不再随全家桶分发。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-provider-usage/package.json
+++ b/packages/dsh-provider-usage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-provider-usage",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "用量统计悬浮框（v2 契约）：胶囊 + 详情面板，宿主端渲染 HTML 注入；用户 mjs 适配器三函数接入任意数据源（fetchData/formatCapsule/formatPanel），密钥配置链注入、按天分片 JSONL 历史、热更新可选；内置 OpenCode Go 官方用量适配器",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-web-file-preview/package.json
+++ b/packages/dsh-web-file-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-web-file-preview",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "点击对话中的文件链接在 web 端预览：宿主端按 MIME 服务会话工作区内文件（图片直出/文本 UTF-8 直出 + git diff），客户端拦截文件链接弹出预览 Modal（Markdown/代码高亮/Diff/图片灯箱）",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## chore(release): bump v0.1.13

全包版本 0.1.12 → 0.1.13（七包同版），为 v0.1.13 tag 前置。

- dsh-provider-usage
- dsh-web-file-preview
- dsh-notifier
- dsh-mcp-manager
- dsh-lan-proxy
- dsh-idle-archive
- dsh-plugins-all

最终基线 e2ea302 五连门禁（build/test/contract/pack:check/typecheck）已在本会话全量验证通过；本 PR 仅版本号变更，CI 复核一遍后即可合并，随后推 tag v0.1.13 触发发布管线。
