### PR TITLE
ci: mutation-gate 增量基线改仓库内版本化文件（#204）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,8 +196,11 @@ jobs:
   #   走 fail-closed 全量 fallback，变异会退化全量且与 observe.yml 夜间全量完全重复；
   #   主干变异覆盖归夜间、发版归 release.yml tag 管线——全量只在这两处真实执行。
   #   非 PR 事件下整体 skipped，由 repo-gate 判定脚本按事件语义显式放行
-  # - restore-only：只读夜间全量落下的 incremental 基线，绝不回写（防 PR 结果污染夜间基线源）
-  # - 缓存未命中（首夜前 / LRU 淘汰）天然降级为全量变异，门禁语义不变仅变慢
+  # - 基线来源（#204）：夜间 observe 把六包 incremental 基线提交进
+  #   scripts/gate/baseline/（仓库内版本化文件），本 job 直接读文件复制到
+  #   coverage/mutation/ —— git 跨 ref 天然可见，替代失效的 actions/cache
+  #   跨 ref 通道（#204 实证：actions/cache 按 ref 隔离，PR 永远 miss main 缓存）。
+  #   首夜/基线缺失时天然降级为全量变异，门禁语义不变仅变慢
   # - 双指标判分（scripts/gate/mutation-gate.mjs）：测试覆盖率（self-written 函数，
   #   恒硬）+ 变异测试率（covered ≥ threshold，受 mutation.strict 开关约束）
   # - 成败并入 repo-gate 聚合闸，不新增分支保护 required check 名
@@ -237,27 +240,25 @@ jobs:
       - name: Build all packages（变异对象与覆盖率口径均依赖全集 lib 产物）
         run: pnpm build
 
-      - name: Restore nightly incremental baseline（只读，无 save 后置步骤）
-        # 精确 key 永不命中（PR 的 run_id 与夜间不同）→ 必走 restore-keys 前缀，
-        # 命中最近一夜 observe-incremental-<run_id>；save 归档根 = coverage/mutation/
-        #（六份 incremental-*.json 同目录 glob），此处以同目录 path 解压还原。
+      - name: Restore repo incremental baseline（#204：读仓库内基线文件，替代失效的 actions/cache）
+        # #204 方案 A：夜间 observe 把六包 incremental 基线提交进 scripts/gate/baseline/，
+        # PR checkout（merge commit 含 base/main 内容）直接读文件——git 无 ref 隔离，
+        # 不依赖 actions/cache 的平台缓存跨 ref 可见性（#204 实证 PR 永远 miss）。
+        # 矩阵包名 dsh-<pkg> → 基线文件名 incremental-<pkg>.json。
         id: baseline
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: coverage/mutation
-          key: observe-incremental-${{ github.run_id }}
-          restore-keys: |
-            observe-incremental-
-
-      - name: Baseline cache verdict（hit/miss 审计标注）
-        env:
-          MATCHED_KEY: ${{ steps.baseline.outputs.cache-matched-key }}
         run: |
-          if [ -n "$MATCHED_KEY" ]; then
-            echo "incremental 基线命中：$MATCHED_KEY"
+          set -e
+          PKG="${MATRIX_PKG#dsh-}"
+          SRC="scripts/gate/baseline/incremental-${PKG}.json"
+          if [ -f "$SRC" ]; then
+            mkdir -p coverage/mutation
+            cp "$SRC" "coverage/mutation/incremental-${PKG}.json"
+            echo "incremental 基线命中：$SRC（仓库内文件）"
           else
-            echo '::notice::incremental 基线缓存 miss —— 本次降级为全量变异（首夜无基线或 LRU 淘汰均属预期，非缺陷）'
+            echo '::notice::incremental 基线文件缺失 —— 本次降级为全量变异（首夜无基线属预期，非缺陷）'
           fi
+        env:
+          MATRIX_PKG: ${{ matrix.package }}
 
       - name: Incremental mutation（incremental 生效跳过未变 mutant）
         run: npx stryker run stryker.conf.d/${{ matrix.package }}.json

--- a/.github/workflows/observe.yml
+++ b/.github/workflows/observe.yml
@@ -5,12 +5,14 @@ name: Observe (nightly)
 # - 六包全量变异（串行）+ mutate 面守卫（F5）
 # - 报告落 issue（幂等：同日不重开）；回落 >1pp 自动追评（隔夜必有工单）
 # 变异硬门禁在本 workflow 生效：任一包 covered < threshold 且 strict 开启 → 运行失败。
-# #178 v2 增量链路：
+# #178 v2 增量链路（#204 修订：缓存 → 仓库内版本化基线）：
 # - 本 workflow 刻意不做 actions/cache restore —— 无增量基线即天然全量，无需 --force；
 #   请勿"好心"补 restore 步骤（会破坏全量基线语义）。
-# - 全量运行末尾将六份 incremental 基线写入 actions/cache（save 用 if: always()
-#   保证部分失败夜也落盘已产出文件），key = observe-incremental-<run_id> 单条目；
-#   PR 侧 ci.yml 以 observe-incremental- 前缀 restore-only 读取。
+# - 全量运行末尾将六份 incremental 基线收集到 scripts/gate/baseline/（仓库内文件，
+#   #204 方案 A），有实质变化时经 create-pull-request 自动开 PR 合入 main；
+#   PR 侧 ci.yml mutation-gate 直接读该目录文件走增量变异。
+# - 背景：actions/cache 按 ref 隔离（PR 永远读不到 main 的缓存，社区广泛确认
+#   GitHub Community #58583），#204 实证此前增量链路对 PR 从未生效。
 
 on:
   schedule:
@@ -19,8 +21,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   issues: write
+  pull-requests: write
 
 concurrency:
   group: observe-nightly
@@ -87,15 +90,56 @@ jobs:
             exit 1
           fi
 
-      - name: Save incremental baseline cache（夜间新鲜基线 → PR 增量门禁读取）
-        # #178 v2：save 用 glob 使归档根 = coverage/mutation/（六文件同目录），
-        # PR 侧 restore 以同目录 path 解压。if: always() —— 部分失败夜已产出的
-        # 基线文件照常落缓存；key 带 run_id 单条目，旧夜靠 PR 侧 restore-keys 前缀兜底。
+      - name: Collect incremental baseline（#204：收集到仓库内 scripts/gate/baseline/）
+        # #204 方案 A（业界最佳实践）：夜间基线改「仓库内版本化文件」，替代 actions/cache
+        # save。actions/cache 按 ref 隔离（PR 永远读不到 main 的缓存，社区广泛确认，
+        # GitHub Community #58583），而 git 内容跨 ref 天然可见、可本地实证。
+        # if: always() —— 部分失败夜已产出的基线文件照常收集。
         if: always()
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        run: node scripts/gate/collect-incremental-baseline.mjs
+
+      - name: Open baseline PR（基线有变化时自动建 PR 合入 main）
+        # create-pull-request 只在有 diff 时创建 PR（无变化 = no-op，不产生噪音提交）。
+        # 受保护分支禁止 workflow 直接 push main → 走 PR + auto-merge 路径。
+        # PR 由 bot 身份创建，auto-merge 需在 PR 创建后由后续步骤开启（该 action 本身
+        # 不自动合并，仅建 PR；合并策略见下）。
+        if: always()
+        uses: peter-evans/create-pull-request@5e914681df9dc83dc4eef029a3d3d3038f73803b # v7
         with:
-          key: observe-incremental-${{ github.run_id }}
-          path: coverage/mutation/incremental-*.json
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ci/incremental-baseline
+          base: main
+          title: 'chore(ci): update incremental mutation baseline（夜间基线快照）'
+          body: |
+            夜间全量变异产出的 Stryker incremental 基线快照（#204 方案 A）。
+
+            变更内容：`scripts/gate/baseline/` 下的六包 incremental 基线文件与
+            manifest.json（仅当基线内容有实质变化时本 PR 才会被创建）。
+
+            无代码逻辑变更；合并后 PR 的 mutation-gate 将直接读取本目录基线
+            走增量变异（跳过未变 mutant），替代失效的 actions/cache 跨 ref 通道。
+          commit-message: 'chore(ci): update incremental mutation baseline（夜间基线快照）'
+          labels: 'ci'
+          delete-branch: true
+          signoff: false
+
+      - name: Auto-merge baseline PR（若被创建）
+        # create-pull-request 只建 PR 不合并；此处用 gh 开启 auto-merge。
+        # 注意：auto-merge 需要分支保护规则允许该 bot PR 自动合并（CI 全绿 + 无
+        # review 要求，或配置 auto-merge 通过条件）。若保护规则要求 review，本步骤
+        # 会失败并在日志提示，不影响夜间报告其余流程。
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR=$(gh pr list --repo "$GITHUB_REPOSITORY" --head ci/incremental-baseline --state open --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$PR" ]; then
+            echo "开启 auto-merge：PR #$PR"
+            gh pr merge "$PR" --repo "$GITHUB_REPOSITORY" --auto --squash || \
+              echo "::warning::auto-merge 开启失败（可能受分支保护 review 规则限制）——需人工合入 PR #$PR"
+          else
+            echo "无基线变更 PR（基线内容未变化），跳过 auto-merge"
+          fi
 
       - name: Threshold check & report body（阈值校验 + 回落检测 + 报告产出）
         id: report

--- a/scripts/gate/baseline/README.md
+++ b/scripts/gate/baseline/README.md
@@ -1,0 +1,18 @@
+# Incremental mutation baseline（#204）
+
+本目录存放夜间全量变异产出的 Stryker incremental 基线（每包一个 JSON，含 mutant
+指纹与覆盖信息），由 `.github/workflows/observe.yml` 每夜更新、经
+`create-pull-request` 自动合入 main。
+
+PR 的 `mutation-gate`（ci.yml）直接从本目录读取对应包基线文件，复制到
+`coverage/mutation/` 供 Stryker 增量模式跳过未变 mutant——替代失效的
+actions/cache 跨 ref 通道（actions/cache 按 ref 隔离，PR 永远 miss main 缓存，
+详见 #204）。
+
+文件：
+- `incremental-<pkg>.json`：六包 Stryker 基线（notifier / idle-archive /
+  web-file-preview / mcp-manager / provider-usage / lan-proxy）
+- `manifest.json`：各基线文件 size / mtime / sha256，供判断基线是否有实质变化
+
+手动重建：本地跑 `node scripts/gate/collect-incremental-baseline.mjs`（需先有
+`coverage/mutation/incremental-*.json` 产物）。

--- a/scripts/gate/collect-incremental-baseline.mjs
+++ b/scripts/gate/collect-incremental-baseline.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * collect-incremental-baseline — 夜间增量基线收集（#204，替代 actions/cache save）
+ *
+ * 把六包 Stryker incremental 基线从 coverage/mutation/ 收集到仓库内固定路径
+ * scripts/gate/baseline/，供 PR 的 mutation-gate 直接读文件（git 跨 ref 天然
+ * 可见，不依赖 actions/cache 的平台缓存 ref 隔离行为——#204 实证 PR 永远
+ * miss main 的缓存）。
+ *
+ * 用法：node scripts/gate/collect-incremental-baseline.mjs
+ * 行为：
+ *   1. 扫描 coverage/mutation/incremental-*.json（六包产物）；
+ *   2. 汇总拷贝到 scripts/gate/baseline/incremental-<pkg>.json；
+ *   3. 生成 scripts/gate/baseline/manifest.json（每包：源文件 mtime/size/hash），
+ *      供后续判定「基线是否有实质变化」（无变化不建 PR，防噪音提交）；
+ *   4. 退出码：0 = 有基线文件就绪；1 = 无任何基线产物（不应发生在夜间末尾）。
+ * 本脚本只做文件收集与清单输出，不 commit 不 push —— 仓库内改动由
+ * workflow 中 create-pull-request 步骤完成。
+ */
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, copyFileSync, existsSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const repoRoot = process.cwd();
+const srcDir = join(repoRoot, 'coverage', 'mutation');
+const dstDir = join(repoRoot, 'scripts', 'gate', 'baseline');
+
+const PKGS = ['notifier', 'idle-archive', 'web-file-preview', 'mcp-manager', 'provider-usage', 'lan-proxy'];
+
+if (!existsSync(srcDir)) {
+  console.error(`collect-incremental-baseline: 源目录不存在：${srcDir}`);
+  process.exit(1);
+}
+
+mkdirSync(dstDir, { recursive: true });
+
+const manifest = {};
+let copied = 0;
+
+for (const pkg of PKGS) {
+  const src = join(srcDir, `incremental-${pkg}.json`);
+  if (!existsSync(src)) {
+    console.warn(`collect-incremental-baseline: 缺少 ${pkg} 基线（跳过）：${src}`);
+    continue;
+  }
+  const dst = join(dstDir, `incremental-${pkg}.json`);
+  copyFileSync(src, dst);
+  const st = statSync(src);
+  const buf = readFileSync(src);
+  manifest[pkg] = {
+    size: buf.length,
+    mtime: st.mtime.toISOString(),
+    sha256: createHash('sha256').update(buf).digest('hex'),
+  };
+  copied++;
+  console.log(`collect-incremental-baseline: ${pkg} → scripts/gate/baseline/incremental-${pkg}.json (${buf.length} bytes)`);
+}
+
+if (copied === 0) {
+  console.error('collect-incremental-baseline: 无任何基线产物，夜间变异未产出可用基线');
+  process.exit(1);
+}
+
+writeFileSync(join(dstDir, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
+console.log(`collect-incremental-baseline: 完成，${copied}/6 包基线就绪`);

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -164,40 +164,46 @@ test('gauntlet: mutation.packages 全部带 threshold 字段且 ≥60（阶段�
   }
 })
 
-// ── #178 v2：Stryker 增量模式接入（夜间全量落缓存 + PR 增量切片门禁）──
+// ── #178 v2 + #204：Stryker 增量模式接入（夜间全量落仓库基线 + PR 增量切片门禁）──
+// #204 修订：actions/cache 按 ref 隔离（PR 永远 miss main 缓存，GitHub Community #58583），
+// 基线改「仓库内版本化文件」——夜间 collect 到 scripts/gate/baseline/ + create-pull-request 合入 main，
+// PR 侧直接读文件（git 跨 ref 天然可见、可本地实证）。
 
-test('#178: observe.yml 夜间保持全量——只落缓存不读缓存', () => {
-  assert.ok(OBSERVE.includes('actions/cache/save@'), '夜间全量运行末尾须保存 incremental 基线缓存')
+test('#178+#204: observe.yml 夜间保持全量——只收集仓库基线不读缓存', () => {
   assert.ok(
     !OBSERVE.includes('actions/cache/restore'),
     'observe.yml 严禁出现 restore 缓存步骤——无基线即天然全量（v2 架构定案，勿"好心"补 restore）',
   )
-  const idx = OBSERVE.indexOf('Save incremental baseline cache')
-  assert.ok(idx > 0, 'save 步骤在位')
-  const block = OBSERVE.slice(idx, OBSERVE.indexOf('- name:', idx + 10))
-  assert.ok(block.includes('if: always()'), 'save 步骤必须 if: always()（部分失败夜已产出的基线照常落盘，评审 P1#3）')
-  assert.ok(block.includes('observe-incremental-${{ github.run_id }}'), '缓存 key = 单条目 observe-incremental-<run_id>（v2 P2#2 偏离定案）')
-  assert.ok(block.includes('coverage/mutation/incremental-*.json'), 'save path 用 glob 收六份基线文件')
+  assert.ok(
+    !OBSERVE.includes('actions/cache/save@'),
+    'observe.yml 已改用仓库内基线（#204），不得出现 cache/save 步骤',
+  )
+  const collectIdx = OBSERVE.indexOf('Collect incremental baseline')
+  assert.ok(collectIdx > 0, 'collect 步骤在位（夜间基线 → 仓库内固定路径）')
+  const collectBlock = OBSERVE.slice(collectIdx, OBSERVE.indexOf('- name:', collectIdx + 10))
+  assert.ok(collectBlock.includes('if: always()'), 'collect 步骤必须 if: always()（部分失败夜已产出的基线照常收集）')
+  assert.ok(collectBlock.includes('collect-incremental-baseline.mjs'), 'collect 脚本执行点在位')
+  assert.ok(OBSERVE.includes('create-pull-request@'), '基线经 create-pull-request 自动开 PR 合入 main（受保护分支禁直接 push）')
+  assert.ok(OBSERVE.includes('peter-evans/create-pull-request'), '使用业界标准 peter-evans/create-pull-request')
+  assert.ok(OBSERVE.includes('contents: write'), 'observe.yml permissions 需 contents: write（自动 PR 创建需要）')
+  assert.ok(OBSERVE.includes('pull-requests: write'), 'observe.yml permissions 需 pull-requests: write')
 })
 
-test('#178: ci.yml PR 增量门禁——restore-only + 按命中包切片 + 并入 repo-gate', () => {
-  // 只读不回写：允许 cache/restore，禁止 cache/save（防 PR 结果污染夜间基线源）
-  assert.ok(CI.includes('actions/cache/restore@'), 'PR 侧 restore-only 读缓存')
+test('#178+#204: ci.yml PR 增量门禁——读仓库基线文件 + 按命中包切片 + 并入 repo-gate', () => {
+  // #204：直接读 scripts/gate/baseline/ 仓库内文件，替代 actions/cache restore（跨 ref 失效）
+  assert.ok(CI.includes('Restore repo incremental baseline'), 'mutation-gate 基线读取步骤在位（读仓库内文件）')
+  assert.ok(!CI.includes('actions/cache/restore@'), 'ci.yml 不得再用 actions/cache/restore（#204 已废弃跨 ref 缓存通道）')
   assert.ok(!CI.includes('actions/cache/save@'), 'ci.yml 禁止 save 缓存（PR 结果绝不回写夜间基线）')
+  assert.ok(!CI.includes('actions/cache/@'), 'ci.yml 禁用 actions/cache@ 主 action 形态')
 
   const gateIdx = CI.indexOf('\n  mutation-gate:')
   assert.ok(gateIdx > 0, 'mutation-gate job 在位')
   const mg = CI.slice(gateIdx, CI.indexOf('\n  repo-gate:'))
   assert.ok(mg.includes('package: ${{ fromJSON(needs.changes.outputs.mutationPackages) }}'),
     '动态 matrix ← changes.mutationPackages（命中包天然切片，未触包不实例化）')
-  assert.ok(mg.includes('restore-keys:'), '精确 key 必 miss 后走前缀兜底（命中最近一夜基线）')
-  assert.ok(mg.includes('observe-incremental-'), 'restore-keys 前缀与夜间 save key 同源')
-  // 主 action 形态自带 save 后置步骤即回写，一律禁用（只允许 restore/save 子 action）
-  assert.ok(!CI.includes('actions/cache/@'), 'ci.yml 禁用 actions/cache@ 主 action 形态（自带回写）')
-  assert.ok(!CI.includes('actions/cache/save@'), 'ci.yml 禁止 save 缓存（PR 结果绝不回写夜间基线）')
-  assert.ok(/timeout-minutes: 45/.test(mg), 'mutation-gate timeout ≥45 分钟（miss 首夜全量变异 + cov 全仓 smoke 的悬崖余量）')
-  assert.ok(mg.includes('cache-matched-key'), 'restore 步骤须暴露 cache-matched-key 供 hit/miss 审计')
-  assert.ok(mg.includes('::notice::'), '缓存 miss 时须打 notice 标注全量降级（首夜属预期，防误判缺陷）')
+  assert.ok(mg.includes('scripts/gate/baseline/incremental-'), '读仓库基线文件路径 scripts/gate/baseline/incremental-<pkg>.json')
+  assert.ok(mg.includes('#dsh-'), '矩阵包名 dsh-<pkg> → 基线文件名 incremental-<pkg>.json 的映射在位')
+  assert.ok(mg.includes('::notice::'), '基线缺失时须打 notice 标注全量降级（首夜属预期，防误判缺陷）')
   assert.ok(mg.includes('scripts/gate/mutation-gate.mjs'), '双指标判分脚本执行点在位')
   assert.ok(mg.includes('scripts/gate/self-cov.mjs'), '覆盖率指标数据源执行点在位')
   // build 必须全量（run #32790425132 教训）：pnpm cov = c8 包裹全仓 smoke，


### PR DESCRIPTION
## ci: mutation-gate 增量基线改仓库内版本化文件（#204 方案 A）

### 变更
1. **observe.yml**：夜间把六包 incremental 基线收集到 `scripts/gate/baseline/`（`collect-incremental-baseline.mjs`），有实质变化时经 `peter-evans/create-pull-request` 自动开 PR 合入 main（permissions 补 `contents: write` + `pull-requests: write`）；删除了失效的 `actions/cache/save`
2. **ci.yml**：mutation-gate 改为直接读仓库基线文件复制到 `coverage/mutation/`（git 跨 ref 天然可见），删除 `actions/cache/restore` 与 cache verdict 步骤
3. 新增 `scripts/gate/collect-incremental-baseline.mjs`（收集 + manifest sha256 指纹，供「无实质变化不建 PR」判定）
4. `scripts/gate/baseline/` 版本化基线目录（README 占位）

### 为什么
actions/cache 按 ref 隔离：夜间在 `refs/heads/main` 落缓存，PR 在 `refs/pull/<n>/merge` 作用域读取，跨 ref 永远 miss（社区广泛确认 GitHub Community #58583）。#204 实证此前增量链路对 PR 从未生效（每 PR 全量变异，provider-usage 11m42s）。方案 A 是业界最佳实践：Stryker incremental 本就是文件级机制，基线进 git 零阻抗、可本地实证。

### 授权
维护者本会话直接指令「改 ci 并直接跑一次，让 main 分支有对应的文件，应该能在 ci 自动发起 pr 并合入吧」——据此直接实施，方案评审见 #204 评论。
