### PR TITLE
fix(ci): provider-usage mutate 区间对齐 #198 后的分段行号

### DIFF
--- a/stryker.conf.d/dsh-provider-usage.json
+++ b/stryker.conf.d/dsh-provider-usage.json
@@ -2,11 +2,14 @@
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
     "packages/dsh-provider-usage/lib/index.js:1372-2792",
-    "packages/dsh-provider-usage/lib/index.js:2829-3727"
+    "packages/dsh-provider-usage/lib/index.js:2637-3727"
   ],
   "testRunner": "tap",
   "tap": {
-    "nodeArgs": ["-r", "./scripts/test/mutation-tap-bridge.cjs"],
+    "nodeArgs": [
+      "-r",
+      "./scripts/test/mutation-tap-bridge.cjs"
+    ],
     "testFiles": [
       "packages/dsh-provider-usage/test/unit-apply.test.ts",
       "packages/dsh-provider-usage/test/unit-contract.test.ts",
@@ -23,7 +26,9 @@
       "TemplateLiteral"
     ]
   },
-  "plugins": ["@stryker-mutator/tap-runner"],
+  "plugins": [
+    "@stryker-mutator/tap-runner"
+  ],
   "concurrency": 4,
   "timeoutMS": 60000,
   "dryRunTimeoutMinutes": 5,


### PR DESCRIPTION
## fix(ci): provider-usage mutate 区间对齐 #198 后的分段行号

### 背景
#198（DeepSeek 官方适配器）新增 `src/adapters/deepseek-official.ts`，使 provider-usage 的 lib/index.js 分段整体后移：sanitize 段起点从 2829 → **2637**。夜间 observe 的 `mutate-scope-guard`（F5）判定原区间 `2829-3727` 起点「不是 // lib/*.js 分段注释行」→ 判红 → 变异套件未跑 → 增量基线无法生成（#204 链路阻塞）。

### 变更
`stryker.conf.d/dsh-provider-usage.json` 第二段 mutate 起点 `2829` → `2637`（sanitize 分段注释行），尾 3727 不变。

### 验证
本地 build 后 `mutate-scope-guard`：provider-usage 两区间全 OK（13/13 区间中的 provider-usage 部分；其余包需全量 build 验证——CI 覆盖）。

关联 #204 / #198。
