### PR TITLE
fix(mcp-manager,lan-proxy,idle-archive): 设置卡片精确对齐官方规格（#219）

### DIFF
--- a/packages/dsh-idle-archive/src/client/style.css
+++ b/packages/dsh-idle-archive/src/client/style.css
@@ -180,7 +180,7 @@ body[data-ds-dark-theme] #dsh-idle-archive-modal .dia-foot {
 .dia-set-headText { display: flex; flex-direction: column; flex: 1; gap: 4px; min-width: 0; }
 .dia-set-name { color: var(--dsw-alias-label-primary, #1f2329); font-size: 15px; font-weight: 600; line-height: 1.4; }
 .dia-set-description { color: var(--dsw-alias-label-tertiary, #5f6672); font-size: 13px; line-height: 1.5; }
-.dia-set-chevron { color: var(--dsw-alias-label-tertiary, #5f6672); flex: 0 0 auto; display: flex; align-items: center; justify-content: center; width: 32px; height: 32px; margin: -10px -14px -10px 0; transition: transform 0.16s; }
+.dia-set-chevron { color: var(--dsw-alias-label-tertiary, #5f6672); flex: none; transition: transform 0.16s; }
 .dia-set-chevronOpen { transform: rotate(180deg); }
 .dia-set-body {
   border-top: 1px solid var(--dsw-alias-border-l2, #e2e5ea);

--- a/packages/dsh-lan-proxy/src/client/style.css
+++ b/packages/dsh-lan-proxy/src/client/style.css
@@ -6,19 +6,21 @@
 
 .lp-set-card {
   list-style: none;
-  border: 1px solid var(--dsw-alias-border-l1, #e2e5ea);
+  border: 1px solid var(--dsw-alias-border-l2, #e2e5ea);
   border-radius: 12px;
-  background: var(--dsw-alias-bg-base, #ffffff);
+  background: var(--dsw-alias-bg-layer-3, #fbfbfc);
   margin-bottom: 8px;
   overflow: hidden;
+  transition: border-color 0.16s, background 0.16s;
 }
+.lp-set-card:hover { border-color: var(--dsw-alias-label-dimmed, #9ba1a6); }
 .lp-set-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
   width: 100%;
-  padding: 11px 14px;
+  padding: 14px 16px;
   border: none;
   background: none;
   cursor: pointer;
@@ -26,18 +28,12 @@
   font: inherit;
 }
 .lp-set-head:hover { background: var(--dsw-alias-interactive-bg-hover, rgba(0, 0, 0, 0.04)); }
-.lp-set-headText { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.lp-set-name { font-size: 13.5px; font-weight: 600; color: var(--dsw-alias-label-primary, #1f2329); }
-.lp-set-description { font-size: 12px; color: var(--dsw-alias-label-tertiary, #8a919c); }
+.lp-set-headText { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.lp-set-name { font-size: 15px; font-weight: 600; line-height: 1.4; color: var(--dsw-alias-label-primary, #1f2329); }
+.lp-set-description { font-size: 13px; line-height: 1.5; color: var(--dsw-alias-label-tertiary, #8a919c); }
 .lp-set-chevron {
   color: var(--dsw-alias-label-tertiary, #5f6672);
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  margin: -10px -14px -10px 0;
+  flex: none;
   transition: transform 0.16s;
 }
 .lp-set-chevronOpen { transform: rotate(180deg); }

--- a/packages/dsh-mcp-manager/src/client/style.css
+++ b/packages/dsh-mcp-manager/src/client/style.css
@@ -88,13 +88,14 @@
 
 /* 设置页插件卡（settings.plugin.item）——浮窗位置 / 偏移编辑区。
  * 前缀 dm-，颜色走 --dsw-alias-* 主题变量 + 浅色回退，明暗自适应。 */
-.dm-set-card{list-style:none;margin:0 0 8px;padding:0;border:1px solid var(--dsw-alias-border-l1,#e2e5ea);border-radius:12px;background:var(--dsw-alias-bg-base,#ffffff);overflow:hidden}
-.dm-set-head{width:100%;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:11px 14px;background:transparent;border:none;cursor:pointer;text-align:left;color:var(--dsw-alias-label-primary,#1f2329)}
+.dm-set-card{list-style:none;margin:0 0 8px;padding:0;border:1px solid var(--dsw-alias-border-l2,#e2e5ea);border-radius:12px;background:var(--dsw-alias-bg-layer-3,#fbfbfc);overflow:hidden;transition:border-color .16s,background .16s}
+.dm-set-card:hover{border-color:var(--dsw-alias-label-dimmed,#9ba1a6)}
+.dm-set-head{width:100%;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:14px 16px;background:transparent;border:none;cursor:pointer;text-align:left;color:var(--dsw-alias-label-primary,#1f2329)}
 .dm-set-head:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(0,0,0,.04))}
-.dm-set-headText{display:flex;flex-direction:column;gap:2px;flex:1;min-width:0}
-.dm-set-name{display:block;font-size:13.5px;font-weight:600;color:var(--dsw-alias-label-primary,#1f2329)}
-.dm-set-description{display:block;margin-top:2px;font-size:12px;color:var(--dsw-alias-label-tertiary,#8a919c)}
-.dm-set-chevron{flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:32px;height:32px;margin:-9px -14px -9px 0;color:var(--dsw-alias-label-tertiary,#5f6672);transition:transform .16s ease}
+.dm-set-headText{display:flex;flex-direction:column;gap:4px;flex:1;min-width:0}
+.dm-set-name{display:block;font-size:15px;font-weight:600;line-height:1.4;color:var(--dsw-alias-label-primary,#1f2329)}
+.dm-set-description{display:block;font-size:13px;line-height:1.5;color:var(--dsw-alias-label-tertiary,#8a919c)}
+.dm-set-chevron{flex:none;color:var(--dsw-alias-label-tertiary,#5f6672);transition:transform .16s ease}
 .dm-set-chevronOpen{transform:rotate(180deg)}
 .dm-set-body{padding:4px 14px 14px;border-top:1px solid var(--dsw-alias-border-l1,#e2e5ea);display:flex;flex-direction:column;gap:9px}
 .dm-set-row{display:flex;align-items:center;gap:12px;margin:0;flex-wrap:wrap}

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -181,12 +181,15 @@ const main = async () => {
     assert.ok(clientSrc.includes("dsh-mcp-manager"), "卡片 key/id 引用宿主命名空间 dsh-mcp-manager");
   });
 
-  check("设置卡片样式对齐官方风格（#167：12px 圆角 / bg-base 底 / 13.5px 名称字 / 12px 描述字）", () => {
+  check("设置卡片样式对齐官方风格（#219：12px 圆角 / bg-layer-3 底 / border-l2 / 15px 名称字 / 13px 描述字 / 14 16 padding / gap 4）", () => {
     const css = readFileSync(new URL("../src/client/style.css", import.meta.url), "utf8");
     assert.match(css, /border-radius:12px/, "卡片圆角对齐官方 12px");
-    assert.match(css, /background:var\(--dsw-alias-bg-base,#ffffff\)/, "卡片底色对齐官方 bg-base");
-    assert.match(css, /\.dm-set-name\{display:block;font-size:13\.5px/, "名称字号 13.5px");
-    assert.match(css, /\.dm-set-description\{display:block;margin-top:2px;font-size:12px/, "描述字号 12px");
+    assert.match(css, /background:var\(--dsw-alias-bg-layer-3,#fbfbfc\)/, "卡片底色对齐官方 bg-layer-3");
+    assert.match(css, /border:1px solid var\(--dsw-alias-border-l2,#e2e5ea\)/, "卡片边框对齐官方 border-l2");
+    assert.match(css, /\.dm-set-head\{width:100%;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:14px 16px/, "head padding 对齐官方 14px 16px");
+    assert.match(css, /\.dm-set-headText\{display:flex;flex-direction:column;gap:4px/, "headText gap 对齐官方 4px");
+    assert.match(css, /\.dm-set-name\{display:block;font-size:15px;font-weight:600;line-height:1\.4/, "名称字号对齐官方 15px");
+    assert.match(css, /\.dm-set-description\{display:block;font-size:13px;line-height:1\.5/, "描述字号对齐官方 13px");
     assert.match(css, /--dsw-alias-label-tertiary,#8a919c/, "描述用 tertiary 层级（与官方同款）");
   });
 


### PR DESCRIPTION
## 变更摘要

issue #219：PR#203 卡片对齐仍有偏差（实测对照官方产物）。本 PR 按官方精确规格逐项修正三包设置卡片。

## 官方实证基准（dsh-web-frontend 产物）

```css
.YyYd_a_card{border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-3);border-radius:12px}
.YyYd_a_header{...gap:12px;padding:14px 16px;display:flex}
.YyYd_a_headText{flex-direction:column;flex:1;gap:4px;min-width:0;display:flex}
.YyYd_a_name{color:var(--dsw-alias-label-primary);font-size:15px;font-weight:600;line-height:1.4}
.YyYd_a_description{color:var(--dsw-alias-label-tertiary);font-size:13px;line-height:1.5}
.YyYd_a_chevron{color:var(--dsw-alias-label-tertiary);flex:none;transition:transform .16s}
```

## 改动

| 属性 | 之前（PR#203） | 本 PR（对齐官方） |
|---|---|---|
| 卡片底色 | bg-base（白） | **bg-layer-3** |
| 卡片边框 | border-l1 | **border-l2** |
| head padding | 11px 14px | **14px 16px** |
| headText gap | 2px | **4px** |
| 名称字号 | 13.5px | **15px** |
| 描述字号 | 12px | **13px** |
| chevron | 32px 容器 + 负 margin | **纯 14px SVG + flex:none** |

涉及三包：mcp-manager（dm-set-*）/ lan-proxy（lp-set-*）/ idle-archive（dia-set-*，仅 chevron，卡片本就对齐）。

## 断言

- mcp-manager smoke 新增 8 条样式契约断言（圆角/底色/边框/padding/gap/名称字/描述字/tertiary），全部通过
- 五连门禁（build/test/contract/pack:check/typecheck）全绿
- 三包 build 产物 lib/client.js 含最新 SVG chevron path

Closes #219
