### PR TITLE
fix(ci): observe 回落标记改文件传递，规避 GITHUB_OUTPUT 多行定界符解析失败（#204）

### DIFF
--- a/.github/workflows/observe.yml
+++ b/.github/workflows/observe.yml
@@ -157,10 +157,10 @@ jobs:
         run: |
           set -e
           node scripts/gate/observe-check.mjs --body-file observe-body.md --marker-file observe-marker.txt
-          echo "body=observe-body.md" >> "$GITHUB_OUTPUT"
-          # 回落标记不写入 $GITHUB_OUTPUT（#204：heredoc 多行值在中文+换行内容下
-          # 触发 "Matching delimiter not found" 解析失败），改由下游步骤直接读文件
-          # 判断（-s = 文件非空即真）。
+          # 报告与回落标记均以文件传递（#204：$GITHUB_OUTPUT 多行值在中文+换行内容下
+          # 触发 "Matching delimiter not found" 解析失败；GitHub 官方文档明示值不可控时
+          # 应写文件而非用 delimiter 格式）。下游步骤直接读 observe-body.md /
+          # observe-marker.txt（[ -s file ] 判断非空）。
 
       - name: Create/update observe issue（幂等：同日重跑不重复建；回落即追评）
         if: always() && steps.report.outcome == 'success'

--- a/.github/workflows/observe.yml
+++ b/.github/workflows/observe.yml
@@ -158,18 +158,14 @@ jobs:
           set -e
           node scripts/gate/observe-check.mjs --body-file observe-body.md --marker-file observe-marker.txt
           echo "body=observe-body.md" >> "$GITHUB_OUTPUT"
-          # 回落标记可能为多行文本，用 heredoc 定界符写入（裸 key=value 会截断/污染 outputs）
-          {
-            echo "marker<<MARKER_EOF"
-            cat observe-marker.txt
-            echo "MARKER_EOF"
-          } >> "$GITHUB_OUTPUT"
+          # 回落标记不写入 $GITHUB_OUTPUT（#204：heredoc 多行值在中文+换行内容下
+          # 触发 "Matching delimiter not found" 解析失败），改由下游步骤直接读文件
+          # 判断（-s = 文件非空即真）。
 
       - name: Create/update observe issue（幂等：同日重跑不重复建；回落即追评）
         if: always() && steps.report.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
-          MARKER: ${{ steps.report.outputs.marker }}
         run: |
           set -e
           TITLE="chore(observe): 夜间质量报告 $(date -u +%Y-%m-%d)"
@@ -180,7 +176,7 @@ jobs:
             gh issue create --title "$TITLE" --body-file observe-body.md
           fi
           # F6 回落闭环：标记文件非空 = 存在指标回落 → 在当日 issue 上追加警示评论
-          if [ -n "$MARKER" ]; then
+          if [ -s observe-marker.txt ]; then
             NUM=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number')
             gh issue comment "$NUM" --body-file observe-marker.txt || true
           fi


### PR DESCRIPTION
## 变更摘要

issue #204 关联：observe Threshold 步骤失败修复。

## 根因

`observe-marker.txt` 非空（回落检测 regression=2）时，workflow 用 heredoc 写入 `$GITHUB_OUTPUT` 多行值，GitHub Actions 解析报错：

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid value. Matching delimiter not found 'MARKER_EOF'
```

回落文本含中文 + 换行，触发多行值定界符解析边界 bug（#204 已实证）。

## 修法

**去掉多行输出，改文件传递**：
1. Threshold 步骤删除 heredoc 写 `$GITHUB_OUTPUT` 段，marker 内容留在 `observe-marker.txt`；
2. Create/update observe issue 步骤删除 `MARKER` env，改用 `[ -s observe-marker.txt ]` 判断文件非空后直接 `--body-file` 追评。

## 验证

- YAML 解析通过
- 逻辑等价：原 `$MARKER` 非空 = 文件非空（observe-check.mjs 落盘条件不变）
- 下一夜 observe run 应全程成功并正常创建 issue

Refs #204
