### PR TITLE
perf(mutation): dsh-web-file-preview concurrency 4→16（#220 方案 A）

### DIFF
--- a/stryker.conf.d/dsh-web-file-preview.json
+++ b/stryker.conf.d/dsh-web-file-preview.json
@@ -22,7 +22,7 @@
     ]
   },
   "plugins": ["@stryker-mutator/tap-runner"],
-  "concurrency": 4,
+  "concurrency": 16,
   "timeoutMS": 60000,
   "dryRunTimeoutMinutes": 5,
   "reporters": [


### PR DESCRIPTION
## 变更摘要

#220 方案 A（快速落地项）：dsh-web-file-preview 的 stryker concurrency 4→16。

## 依据

- #159 先例：notifier concurrency 16 后 6m54s→1m42s（e2e 定时器等待主导、CPU 占用低）
- 本 PR 实测：web-file-preview 并发 16 全量 777 mutant 14s 完成，covered 72.27% 与基线一致（无回归），无 flake

## 范围控制（风险评估后）

- **只改 web-file-preview**（纯 unit 测试，无固定端口/定时器场景，安全）
- provider-usage 并发 8 实测 covered 64.76% < 基线 67.28% + 13 errors → **已回滚保持 4**（端口/定时器用例多，高并发有害，#147 同款经验）
- lan-proxy 维持 4（#147 明确 unit-apply 19998 端口互踩风险）
- idle-archive 维持 4（testFiles 含 smoke.ts 固定端口）

## 验证

- 本地 DSH_HOME 隔离实测：777 mutant / 14s / covered 72.27%（与基线一致）
- 五连门禁待 CI

Partially addresses #220
