### PR TITLE
fix(mcp-manager,lan-proxy): 设置卡片去掉自带 margin，间距交由官方容器 gap 统一（#219）

### DIFF
--- a/packages/dsh-lan-proxy/src/client/style.css
+++ b/packages/dsh-lan-proxy/src/client/style.css
@@ -9,7 +9,6 @@
   border: 1px solid var(--dsw-alias-border-l2, #e2e5ea);
   border-radius: 12px;
   background: var(--dsw-alias-bg-layer-3, #fbfbfc);
-  margin-bottom: 8px;
   overflow: hidden;
   transition: border-color 0.16s, background 0.16s;
 }

--- a/packages/dsh-mcp-manager/src/client/style.css
+++ b/packages/dsh-mcp-manager/src/client/style.css
@@ -88,7 +88,7 @@
 
 /* 设置页插件卡（settings.plugin.item）——浮窗位置 / 偏移编辑区。
  * 前缀 dm-，颜色走 --dsw-alias-* 主题变量 + 浅色回退，明暗自适应。 */
-.dm-set-card{list-style:none;margin:0 0 8px;padding:0;border:1px solid var(--dsw-alias-border-l2,#e2e5ea);border-radius:12px;background:var(--dsw-alias-bg-layer-3,#fbfbfc);overflow:hidden;transition:border-color .16s,background .16s}
+.dm-set-card{list-style:none;margin:0;padding:0;border:1px solid var(--dsw-alias-border-l2,#e2e5ea);border-radius:12px;background:var(--dsw-alias-bg-layer-3,#fbfbfc);overflow:hidden;transition:border-color .16s,background .16s}
 .dm-set-card:hover{border-color:var(--dsw-alias-label-dimmed,#9ba1a6)}
 .dm-set-head{width:100%;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:14px 16px;background:transparent;border:none;cursor:pointer;text-align:left;color:var(--dsw-alias-label-primary,#1f2329)}
 .dm-set-head:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(0,0,0,.04))}


### PR DESCRIPTION
## 变更摘要

#219 跟进（重开）：用户实测发现卡片间距与官方不一致。

## 根因

官方设置页插件列表容器 `.pbvGtq_cards{flex-direction:column;gap:10px;...}` —— **间距由容器 gap:10px 控制，卡片自身无 margin**。

本仓 mcp-manager 带 `margin:0 0 8px`、lan-proxy 带 `margin-bottom:8px`，在官方容器（gap 10px）内造成 **8+10=18px 双倍间距**，与官方卡片（纯 gap 10px）不一致。

## 改动

- mcp-manager：`.dm-set-card` margin `0 0 8px` → `0`
- lan-proxy：`.lp-set-card` 删除 `margin-bottom: 8px`

间距完全交由官方容器 gap 统一（10px）。

## 验证

- 三包卡片在 settings.plugin.item 插槽内由宿主容器 gap 控制间距
- CI 待跑

Closes #219
