### PR TITLE
docs: 测试产物零污染纪律 + .gitignore 兜底（#218 分阶段实施）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ Thumbs.db
 coverage/
 .stryker-tmp/
 .maintenance-drafts/
+
+# 测试运行时污染兜底（#218）：DSH_HOME 未正确注入时产生的 undefined 路径与历史数据
+packages/*/undefined/
+**/*.jsonl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,12 @@ smoke 全部无网络、无真实凭据，本地可直接运行；新功能/修�
 到临时目录 / 轮询替代固定 sleep）见
 [DEVELOPMENT.md §5](docs/DEVELOPMENT.md#5-smoke-测试防-flake-纪律)。
 
+**测试产物零污染纪律（#218）**：
+- 测试运行时落盘**必须**落在 `mkdtempSync` 隔离目录（DSH_HOME 已隔离），
+  **禁止**产生任何含 `undefined` 段的路径（如 `packages/*/undefined/**`）；
+- 提交前自查：`git status` 出现 `packages/*/undefined/`、`*.jsonl` 等运行时产物
+  一律视为污染，不得提交；自动收集脚本（基线等）只收白名单路径。
+
 ## 参考文档
 
 - 开发规范（宿主/客户端写法、构建契约、多端兼容、测试防 flake 纪律）：[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)


### PR DESCRIPTION
## 变更摘要

#218 分阶段实施第 1 步（用户指示：增加 AGENTS.md 纪律 + 增强测试纪律；issue 不关以观后续）。

## 改动

1. **AGENTS.md「测试纪律」新增「测试产物零污染纪律」**：
   - 测试落盘必须 `mkdtempSync` 隔离，禁止 `packages/*/undefined/**` 等含 undefined 段路径
   - 提交前自查 git status，运行时产物（*.jsonl 等）一律不得提交
   - 自动收集脚本只收白名单路径

2. **.gitignore 兜底**：
   - `packages/*/undefined/`（DSH_HOME 未注入时的默认目录）
   - `**/*.jsonl`（历史数据文件）

## 背景

#218 实证：基线 collect 把 `packages/dsh-provider-usage/undefined/.../2026-08-25.jsonl`（smoke 测试未隔离落盘）收入 main。纪律 + gitignore 双保险防复发。

## 后续（本 PR 不含）

- collect 脚本白名单过滤（脚本层修复，另行实施）
- 已入库污染文件移除（`git rm`）

Partially addresses #218（issue 保持 open 以观后续）
