### PR TITLE
test(lan-proxy,provider-usage): 固定端口改 port 0 + K12 断言轮询化（#217）

### DIFF
--- a/packages/dsh-lan-proxy/test/unit-apply.test.ts
+++ b/packages/dsh-lan-proxy/test/unit-apply.test.ts
@@ -223,9 +223,10 @@ const { createServer } = await import("node:http");
   const applyHome = mkdtempSync(join(tmpdir(), "dsh-lan-proxy-apply-listenfail-"));
   const prevHome = process.env.DSH_HOME;
   process.env.DSH_HOME = applyHome;
-  // 占用一个具体端口
+  // 占用一个随机端口（#217：port 0 由内核分配，避免 CI 并行固定端口互踩）
   const occupied = createServer();
-  await new Promise((r) => occupied.listen(19998, "127.0.0.1", r));
+  await new Promise((r) => occupied.listen(0, "127.0.0.1", r));
+  const occupiedPort = occupied.address().port;
   const routes = [];
   const rpcHandles = [];
   const disposers = [];
@@ -240,7 +241,7 @@ const { createServer } = await import("node:http");
     effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
   };
   const { apply } = await import("../lib/index.js");
-  apply(ctx, { host: "127.0.0.1", port: 19998, httpsEnabled: false, printBanner: false, wsCompressEnabled: false, httpCompressEnabled: false });
+  apply(ctx, { host: "127.0.0.1", port: occupiedPort, httpsEnabled: false, printBanner: false, wsCompressEnabled: false, httpCompressEnabled: false });
   await sleep(200); // 等 listen 异步 reject
   // health 路由存在，但 listening: false
   const healthRoute = routes.find((r) => r.path === ROUTES.health);

--- a/packages/dsh-lan-proxy/test/unit-apply.test.ts
+++ b/packages/dsh-lan-proxy/test/unit-apply.test.ts
@@ -223,10 +223,11 @@ const { createServer } = await import("node:http");
   const applyHome = mkdtempSync(join(tmpdir(), "dsh-lan-proxy-apply-listenfail-"));
   const prevHome = process.env.DSH_HOME;
   process.env.DSH_HOME = applyHome;
-  // 占用一个随机端口（#217：port 0 由内核分配，避免 CI 并行固定端口互踩）
+  // 占用一个具体端口（#217 回滚：unit-apply 在 stryker 变异面内，port 0 随机化
+  // 破坏变异覆盖（covered 57.9% < 60% 阈值）；19998 在单包 tap runner 上下文安全，
+  // 真正 CI flake 来自 smoke 端口另见 #217 子项）
   const occupied = createServer();
-  await new Promise((r) => occupied.listen(0, "127.0.0.1", r));
-  const occupiedPort = occupied.address().port;
+  await new Promise((r) => occupied.listen(19998, "127.0.0.1", r));
   const routes = [];
   const rpcHandles = [];
   const disposers = [];
@@ -241,7 +242,7 @@ const { createServer } = await import("node:http");
     effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
   };
   const { apply } = await import("../lib/index.js");
-  apply(ctx, { host: "127.0.0.1", port: occupiedPort, httpsEnabled: false, printBanner: false, wsCompressEnabled: false, httpCompressEnabled: false });
+  apply(ctx, { host: "127.0.0.1", port: 19998, httpsEnabled: false, printBanner: false, wsCompressEnabled: false, httpCompressEnabled: false });
   await sleep(200); // 等 listen 异步 reject
   // health 路由存在，但 listening: false
   const healthRoute = routes.find((r) => r.path === ROUTES.health);

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -677,12 +677,17 @@ export function formatPanel() { return "<p>user-panel</p>"; }
     assert.ok(!JSON.stringify(meta).includes("sk-smoke-test"), "E5: adapters.json 不含密钥");
 
     // stats：用户版生效 → fresh + 用户胶囊文案（本地数据零网络）
+    // #217：轮询替代固定 sleep——注册后 warmup 采样时序不定（CI 并行下更明显），
+    // 反复查 stats 直到用户版接管（adapterName=deepseek-official），超时 3s 兜底。
     const stats = routes.find((r) => r.path === ROUTES.stats);
-    const fresh = await getJSON(stats, `${ROUTES.stats}?provider=${DEEPSEEK_OFFICIAL_PROVIDER}`);
-    await new Promise((r) => setTimeout(r, 40));
-    const freshRetry = await getJSON(stats, `${ROUTES.stats}?provider=${DEEPSEEK_OFFICIAL_PROVIDER}`);
-    const finalFresh = freshRetry.status === "fresh" ? freshRetry : fresh;
-    assert.equal(finalFresh.adapterName, "deepseek-official", "K12: 用户原型适配器接管取数");
+    let finalFresh = null;
+    const pollDeadline = Date.now() + 3000;
+    while (Date.now() < pollDeadline) {
+      const snap = await getJSON(stats, `${ROUTES.stats}?provider=${DEEPSEEK_OFFICIAL_PROVIDER}`);
+      if (snap.adapterName === "deepseek-official") { finalFresh = snap; break; }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    assert.ok(finalFresh, "K12: 用户原型适配器接管取数（轮询 3s 内应生效）");
     assert.ok(["fresh", "cached"].includes(finalFresh.status), `A5: 成功帧 fresh/cached（实际 ${finalFresh.status}）`);
     assert.ok(finalFresh.capsuleHtml?.includes("USER ¥42.50"), "A5: 用户版胶囊文案渲染");
     assert.ok(!JSON.stringify(finalFresh).includes("sk-smoke-test"), "E5: stats 响应不含密钥");


### PR DESCRIPTION
## 变更摘要

#217：K12 断言 CI flake 根治。

## 修正说明（两轮实测后收敛）

- **lan-proxy port 0 已回滚**：unit-apply 在 stryker 变异面内，port 0 随机化使 covered 57.9% < 60% 阈值（2 次实测均 fail）——负收益。19998 在单包 tap runner 上下文安全。
- **真正 CI flake 来自 smoke 端口（19091/19092）**：另开 issue 跟踪（#217 子项）。

## 保留改动

**provider-usage K12 断言轮询化**（根治 K12 flake 的关键）：
- 固定 sleep(60+40ms) 改**轮询**：反复查 stats 直到 `adapterName === "deepseek-official"`（3s 超时兜底）
- 遵循防 flake 纪律（轮询替代固定 sleep）

## 验证

- 五连门禁全绿（K12 轮询版通过）
- CI 待跑（连续观测无 K12 flake）

Partially addresses #217
