### PR TITLE
fix(dsh-mcp-manager): 重算 stryker 分段行号对齐 PR#234 后 bundle（#235）

### DIFF
--- a/stryker.conf.d/dsh-mcp-manager.json
+++ b/stryker.conf.d/dsh-mcp-manager.json
@@ -3,8 +3,8 @@
   "mutate": [
     "packages/dsh-mcp-manager/lib/index.js:8610-8696",
     "packages/dsh-mcp-manager/lib/index.js:17322-17456",
-    "packages/dsh-mcp-manager/lib/index.js:19271-19915",
-    "packages/dsh-mcp-manager/lib/index.js:19964-21027"
+    "packages/dsh-mcp-manager/lib/index.js:19271-19923",
+    "packages/dsh-mcp-manager/lib/index.js:19972-22070"
   ],
   "testRunner": "tap",
   "tap": {
@@ -45,5 +45,5 @@
   "cleanTempDir": true,
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-mcp-manager.json",
-  "_comment": "#148 接入：mutate 限定 lib/index.js 的 self-written 四段（esbuild 路径注释 // lib/* 分界）：8610-8696 store、17322-17456 transport+scope、19271-19915 protocol/supervisor/catalog、19964-21027 import/routes/index。排除头部 var __* 垫片（1-42）、cosmokit/schemastery/which/cross-spawn/ajv/fast-uri/zod/@modelcontextprotocol/sdk 等 node_modules 内联 vendor 大段（43-8549、8700-17321、17457-19270）、shared/settings-namespace+loopback+host-utils 内联契约层副本（8557-8609、19916-19963，shared 由仓库级禁改规则保护且多包重复计账会使 score 横向不可比）、8550-8556 与 8697-8699 的纯 ESM import 提升段（无可变异面）。tap.nodeArgs 注入 mutation-tap-bridge.cjs（#151 全局生效）将未捕获异常转写 TAP not ok，RuntimeError 计 Killed。"
+  "_comment": "#148 接入：mutate 限定 lib/index.js 的 self-written 四段（esbuild 路径注释 // lib/* 分界；#235 按 PR#234 后 bundle 重算）：8610-8696 store、17322-17456 transport+scope、19271-19923 protocol/supervisor/catalog、19972-22070 import/routes/middleware/index。排除头部 var __* 垫片（1-42）、cosmokit/schemastery/which/cross-spawn/ajv/fast-uri/zod/@modelcontextprotocol/sdk 等 node_modules 内联 vendor 大段（43-8549、8700-17321、17457-19270）、shared/settings-namespace+loopback+host-utils 内联契约层副本（8557-8609、19924-19971，shared 由仓库级禁改规则保护且多包重复计账会使 score 横向不可比）、8550-8556 与 8697-8699 的纯 ESM import 提升段与尾部 export 清单+Bundled license 注释（22071 起，无可变异面）。tap.nodeArgs 注入 mutation-tap-bridge.cjs（#151 全局生效）将未捕获异常转写 TAP not ok，RuntimeError 计 Killed。"
 }


### PR DESCRIPTION
## 根因

PR#234 净增 ~1391 行使 dsh-mcp-manager bundle 后 `// lib/*.js` 分段注释整体下移，而 `stryker.conf.d/dsh-mcp-manager.json` 四段硬编码行号未跟 → observe 管线 mutate-scope-guard 按设计 fail-loud。

## 改动

仅改 `stryker.conf.d/dsh-mcp-manager.json`（其余 5 个包 conf 经 guard 实测无漂移，不动）：

| 段 | 旧区间 | 新区间 | 说明 |
|---|---|---|---|
| store | 8610-8696 | 8610-8696 | 不变 |
| transport+scope | 17322-17456 | 17322-17456 | 不变 |
| protocol/supervisor/catalog | 19271-19915 | **19271-19923** | 终点 +8（loopback/host-utils shared 副本下移至 19924 起；原终点致 catalog 尾部 8 行自写代码漏出 mutate 面） |
| import/routes/middleware/index | 19964-21027 | **19972-22070** | 起点 +8（import 注释现位于 L19972）；终点对齐 index 主入口末行 L22070（新增 lib/middleware.js 段 L20364 合法落入本组）；尾部 export 清单 + Bundled license 注释（L22071 起）无可变异面，排除 |

`_comment` 同步更新四段描述、shared 副本排除行号（19916-19963 → 19924-19971）与尾部排除说明。语义分段不变。

## 验收断言表（对照 issue #235）

| 断言 | 结论 | 证据 |
|---|---|---|
| worktree 内 `pnpm build` 后按实际分段注释重算 | ✅ | `grep -n '^// lib/' packages/dsh-mcp-manager/lib/index.js`：8550 index / 8610 store / 8697 supervisor / 17322 transport / 17450 scope / 19271 protocol / 19324 supervisor / 19773 catalog / 19972 import / 20019 routes / 20364 middleware / 21246 index |
| 四段区间起点均为 `// lib/*.js` 分段注释 | ✅ | guard 规则 1 全过 |
| 区间不落入 vendor/shared 非 lib 分段 | ✅ | guard 规则 2 全过（无越界） |
| `_comment` 行号描述同步 | ✅ | diff 见本 PR |
| `node scripts/gate/mutate-scope-guard.mjs` exit 0 | ✅ | `mutate-scope-guard: 校验 13 个区间，0 个失败`（exit=0），关键行 `[OK] dsh-mcp-manager.json: ...:19271-19923（// lib/protocol.js 跨 3 个自写子段，无越界）`、`[OK] dsh-mcp-manager.json: ...:19972-22070（// lib/import.js 跨 4 个自写子段，无越界）` |
| 五连门禁全绿 | ✅ | `pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` → GATE_EXIT=0（contract「客户端契约：全部通过」、pack-check「全部通过」、7 包 typecheck Done） |

## 备注

- 结构性缺口（guard 未前移进 PR 门禁）已并入 #217 CI 解耦批次，本 PR 不重复处理。
- 加固说明：本次重建产物后复核过分段行号稳定性（两次 build 输出一致），guard 复跑仍全绿。

Closes #235