### PR TITLE
fix(dsh-provider-usage): 热更新保持 enabled 语义并持久化，改名撞名保留旧条目并如实报错（#212）

### DIFF
--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -452,6 +452,27 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
     }
   };
 
+  // 启用选择落盘串行链 + 清单落盘串行链（连续写的完成顺序不依赖 IO 时序）
+  // #212：声明提前至热更新块之前——hr.start() 的初始同步回调在 apply 尚未走完时即可触发，
+  // 回调内 scheduleWriteAdapterState 必须已可及（let TDZ 防御，同 cache/panelCache 先例）。
+  let stateChain: Promise<void> = Promise.resolve();
+  /**
+   * 启用关系落盘（串行链）。#212：以磁盘现状为基线合并——历史显式 null 停用标记得以保留，
+   * 运行期有启用者的 provider 以运行期为准；override 仅 select 清空时用于显式写 null。
+   * （此前直接落 snapshot().enabled 会把磁盘上的 null 停用标记抹掉，热更/登记挂点均受累。）
+   */
+  function scheduleWriteAdapterState(override?: Record<string, string | null>): void {
+    stateChain = stateChain
+      .then(async () => {
+        const saved = await readAdapterState(historyRoot);
+        const merged: Record<string, string | null> = { ...saved };
+        for (const [provider, name] of Object.entries(registry.snapshot().enabled)) merged[provider] = name;
+        if (override !== undefined) Object.assign(merged, override);
+        await writeFile(adapterStateFile(historyRoot), JSON.stringify(merged));
+      })
+      .catch(() => {});
+  }
+
   // 3. 热更新（config.adapter 声明 + 设置页登记的文件；autoReload=true 时生效）
   // 运行时经设置页 add 的适配器也纳入监视（issue #206）：ensureHotReload 供启动与
   // add 路由共用，watchedFiles 去重防同一文件重复监视。
@@ -472,12 +493,18 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
         return;
       }
       if (hr.current !== null) {
-        // 原子替换：先移除旧文件注册，再注册新版本（改名场景不误报重复）
-        registry.removeByFile(resolved);
-        registry.register(hr.current, "user-file", resolved);
+        // #212：原子替换（冲突预检先行，撞名时旧条目保留并返回失败）；
+        // 替换只更新代码不改写启用关系（enabled 保持语义在 registry.replaceByFile 内实现）
+        const replaced = registry.replaceByFile(resolved, hr.current);
+        if (!replaced.ok) {
+          registry.recordError(key, "load", `热更新失败：${replaced.detail}`);
+          return;
+        }
         cache.clear();
         panelCache.clear(); // #105①：新版适配器代码语义已变，面板渲染缓存同清
-        registry.recordError(key, "load", `热更新成功：${hr.current.name}`);
+        // #212：热更新结果持久化（合并语义落盘，保持后的启用关系写入 adapter-state.json）
+        scheduleWriteAdapterState();
+        console.warn(`[dsh-provider-usage] 热更新成功：${replaced.name}（${basename(resolved)}）`);
       }
     });
     const started = await hr.start();
@@ -485,6 +512,17 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
       registry.recordError(`file:${basename(resolved)}`, "load", `热更新启动失败：${started.error}`);
     }
     hotReloaders.push(hr);
+  }
+
+  // #212：热更新监视初始化移至「adapter-state 恢复」之后——hr.start() 的初始同步回调
+  // 会经 replaceByFile → scheduleWriteAdapterState 落盘，若先于恢复执行，会把「默认启用、
+  // 尚未按持久化状态纠正」的中间态写进 adapter-state.json，与恢复逻辑产生竞态。
+
+  // 4. 恢复持久化的启用选择（adapter-state.json；null = 显式清空）
+  const savedEnabled = await readAdapterState(historyRoot);
+  for (const [provider, name] of Object.entries(savedEnabled)) {
+    if (name === null) registry.select(provider, null);
+    else registry.select(provider, name);
   }
 
   if (config.autoReload) {
@@ -496,13 +534,6 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
       const f = resolvePath(rec.file);
       if (f !== undefined) await ensureHotReload(f);
     }
-  }
-
-  // 4. 恢复持久化的启用选择（adapter-state.json；null = 显式清空）
-  const savedEnabled = await readAdapterState(historyRoot);
-  for (const [provider, name] of Object.entries(savedEnabled)) {
-    if (name === null) registry.select(provider, null);
-    else registry.select(provider, name);
   }
 
   // 5. 互斥锁（缓存已在上方声明）
@@ -580,11 +611,7 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
     });
   }
 
-  // 6. 启用选择落盘串行链 + 清单落盘串行链（连续写的完成顺序不依赖 IO 时序）
-  let stateChain: Promise<void> = Promise.resolve();
-  function scheduleWriteAdapterState(enabled: Record<string, string | null>): void {
-    stateChain = stateChain.then(() => writeFile(adapterStateFile(historyRoot), JSON.stringify(enabled)).catch(() => {}));
-  }
+  // 6. 清单落盘串行链（stateChain 声明提前至热更新块前，见 #212 注释）
   async function persistUserAdapter(rec: UserAdapterRecord): Promise<void> {
     const write = async (): Promise<void> => {
       const list = await readUserAdapters(historyRoot);
@@ -777,7 +804,9 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
       if (!ok) return writeJson(res, 404, { error: "adapter not found" });
       cache.clear();
       panelCache.clear(); // #105①：启用关系已变，面板渲染缓存同清（切换/清空后一律重算）
-      scheduleWriteAdapterState(clearing ? { ...registry.snapshot().enabled, [provider]: null } : registry.snapshot().enabled);
+      // #212：清空用 override 显式落 null（合并语义会保留磁盘旧值，无法表达显式停用）
+      if (clearing) scheduleWriteAdapterState({ [provider]: null });
+      else scheduleWriteAdapterState();
       writeJson(res, 200, { ok: true, provider, adapterName: clearing ? null : adapterName });
     },
   };
@@ -856,7 +885,7 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
       await ensureHotReload(file);
       cache.clear();
       panelCache.clear(); // #105①：候选/启用面已变，面板渲染缓存同清
-      scheduleWriteAdapterState(registry.snapshot().enabled);
+      scheduleWriteAdapterState(); // #212：合并语义落盘（保留磁盘 null 停用标记）
       writeJson(res, 200, {
         ok: true,
         adapter: { name: adapter.name, label: adapter.label ?? adapter.name, providers: adapter.providers, file: basename(file) },

--- a/packages/dsh-provider-usage/src/registry.ts
+++ b/packages/dsh-provider-usage/src/registry.ts
@@ -254,41 +254,41 @@ export function makeAdapterRegistry(opts: { diag?: (m: string) => void; sanitize
    * @param next - 新版适配器（契约校验失败同样拒绝且保留旧条目）。
    */
   function replaceByFile(file: string, next: unknown): ReplaceFileResult {
-  if (!isUsageStatsAdapter(next)) {
-    const detail = describeUsageStatsAdapterShape(next) ?? "未知形状问题";
-    return { ok: false, code: "invalid-adapter", detail: `契约校验失败（${detail}），已保留旧条目` };
-  }
-  const a = next;
-  // 收集本文件旧条目（同一条目可出现在多个 provider 桶，按 name 去重）
-  const oldEntries = new Map<string, AdapterEntry>();
-  for (const list of candidatesByProvider.values()) {
-    for (const e of list) {
-      if (e.file === file) oldEntries.set(e.name, e);
+    if (!isUsageStatsAdapter(next)) {
+      const detail = describeUsageStatsAdapterShape(next) ?? "未知形状问题";
+      return { ok: false, code: "invalid-adapter", detail: `契约校验失败（${detail}），已保留旧条目` };
     }
-  }
-  // 冲突预检：新 name 不属于本文件旧名、却已被其他来源占用 → 拒绝，旧条目原样保留
-  if (!oldEntries.has(a.name) && registeredNames.has(a.name)) {
-    return { ok: false, code: "duplicate-name", detail: `适配器 name 冲突：${a.name}（已被其他适配器占用，旧条目保留）` };
-  }
-  // 记录旧启用状态：本文件旧条目在其认领的每个 provider 上是否是当前启用者
-  const wasEnabledProviders = new Set<string>();
-  for (const entry of oldEntries.values()) {
-    for (const provider of entry.providers) {
-      if (enabledNames.get(provider) === entry.name) wasEnabledProviders.add(provider);
+    const a = next;
+    // 收集本文件旧条目（同一条目可出现在多个 provider 桶，按 name 去重）
+    const oldEntries = new Map<string, AdapterEntry>();
+    for (const list of candidatesByProvider.values()) {
+      for (const e of list) {
+        if (e.file === file) oldEntries.set(e.name, e);
+      }
     }
+    // 冲突预检：新 name 不属于本文件旧名、却已被其他来源占用 → 拒绝，旧条目原样保留
+    if (!oldEntries.has(a.name) && registeredNames.has(a.name)) {
+      return { ok: false, code: "duplicate-name", detail: `适配器 name 冲突：${a.name}（已被其他适配器占用，旧条目保留）` };
+    }
+    // 记录旧启用状态：本文件旧条目在其认领的每个 provider 上是否是当前启用者
+    const wasEnabledProviders = new Set<string>();
+    for (const entry of oldEntries.values()) {
+      for (const provider of entry.providers) {
+        if (enabledNames.get(provider) === entry.name) wasEnabledProviders.add(provider);
+      }
+    }
+    // 原子替换：移除旧条目后以「不默认启用」注册新版，再逐 provider 精确恢复原启用关系
+    // （同步执行无 await 间隙，中间态外部不可观察）
+    removeByFile(file);
+    if (!register(a, "user-file", file, false)) {
+      // 防御分支：契约与重名均已在上方排除，理论不可达
+      return { ok: false, code: "invalid-adapter", detail: "替换注册失败，已保留语义上的空缺" };
+    }
+    for (const provider of a.providers) {
+      if (wasEnabledProviders.has(provider)) select(provider, a.name);
+    }
+    return { ok: true, name: a.name };
   }
-  // 原子替换：移除旧条目后以「不默认启用」注册新版，再逐 provider 精确恢复原启用关系
-  // （同步执行无 await 间隙，中间态外部不可观察）
-  removeByFile(file);
-  if (!register(a, "user-file", file, false)) {
-    // 防御分支：契约与重名均已在上方排除，理论不可达
-    return { ok: false, code: "invalid-adapter", detail: "替换注册失败，已保留语义上的空缺" };
-  }
-  for (const provider of a.providers) {
-    if (wasEnabledProviders.has(provider)) select(provider, a.name);
-  }
-  return { ok: true, name: a.name };
-}
 
   return {
     register,

--- a/packages/dsh-provider-usage/src/registry.ts
+++ b/packages/dsh-provider-usage/src/registry.ts
@@ -48,6 +48,14 @@ interface AdapterEntry {
 }
 
 /**
+ * 热更新替换结果（#212）。
+ * ok=false 时旧条目**原样保留**（冲突预检先行，不做先删后注册），detail 供 health/日志如实呈现。
+ */
+export type ReplaceFileResult =
+  | { ok: true; name: string }
+  | { ok: false; code: "invalid-adapter" | "duplicate-name"; detail: string };
+
+/**
  * 适配器注册表（候选 + 唯一启用）。
  * @param opts.diag - 诊断收集器（缺省 console.warn）。
  * @param opts.sanitizePath - 错误消息路径脱敏（把绝对路径归约为 `~` 形态，信息面最小披露）。
@@ -237,6 +245,51 @@ export function makeAdapterRegistry(opts: { diag?: (m: string) => void; sanitize
     return removed;
   }
 
+  /**
+   * 热更新原子替换某文件注册的全部候选（#212）：
+   * - 冲突预检：新版 name 与**其他来源**已注册名重复 → 拒绝且不动旧条目（修复改名撞名静默丢失）；
+   * - enabled 保持：替换只更新代码不改写启用关系——本文件旧条目在其认领 provider 上
+   *   原本是启用者的，替换后新条目沿用；原本停用的不得变回启用；新增认领的 provider 不自动启用。
+   * @param file - 用户文件路径（定位被替换的旧条目）。
+   * @param next - 新版适配器（契约校验失败同样拒绝且保留旧条目）。
+   */
+  function replaceByFile(file: string, next: unknown): ReplaceFileResult {
+  if (!isUsageStatsAdapter(next)) {
+    const detail = describeUsageStatsAdapterShape(next) ?? "未知形状问题";
+    return { ok: false, code: "invalid-adapter", detail: `契约校验失败（${detail}），已保留旧条目` };
+  }
+  const a = next;
+  // 收集本文件旧条目（同一条目可出现在多个 provider 桶，按 name 去重）
+  const oldEntries = new Map<string, AdapterEntry>();
+  for (const list of candidatesByProvider.values()) {
+    for (const e of list) {
+      if (e.file === file) oldEntries.set(e.name, e);
+    }
+  }
+  // 冲突预检：新 name 不属于本文件旧名、却已被其他来源占用 → 拒绝，旧条目原样保留
+  if (!oldEntries.has(a.name) && registeredNames.has(a.name)) {
+    return { ok: false, code: "duplicate-name", detail: `适配器 name 冲突：${a.name}（已被其他适配器占用，旧条目保留）` };
+  }
+  // 记录旧启用状态：本文件旧条目在其认领的每个 provider 上是否是当前启用者
+  const wasEnabledProviders = new Set<string>();
+  for (const entry of oldEntries.values()) {
+    for (const provider of entry.providers) {
+      if (enabledNames.get(provider) === entry.name) wasEnabledProviders.add(provider);
+    }
+  }
+  // 原子替换：移除旧条目后以「不默认启用」注册新版，再逐 provider 精确恢复原启用关系
+  // （同步执行无 await 间隙，中间态外部不可观察）
+  removeByFile(file);
+  if (!register(a, "user-file", file, false)) {
+    // 防御分支：契约与重名均已在上方排除，理论不可达
+    return { ok: false, code: "invalid-adapter", detail: "替换注册失败，已保留语义上的空缺" };
+  }
+  for (const provider of a.providers) {
+    if (wasEnabledProviders.has(provider)) select(provider, a.name);
+  }
+  return { ok: true, name: a.name };
+}
+
   return {
     register,
     recordError,
@@ -248,6 +301,7 @@ export function makeAdapterRegistry(opts: { diag?: (m: string) => void; sanitize
     hasCandidates,
     hasName,
     removeByFile,
+    replaceByFile,
     snapshot,
   };
 }

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -10,7 +10,7 @@
  * - /health 快照形状
  * - 客户端 bundle 契约面与路由一致性
  */
-import { readFileSync, mkdtempSync, writeFileSync, existsSync } from "node:fs";
+import { readFileSync, mkdtempSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { assertClientProductContract, assertClientSourceContract } from "../../../test/smoke-lib.ts";
@@ -38,6 +38,7 @@ import {
   DEEPSEEK_OFFICIAL_PROVIDER,
   DEEPSEEK_OFFICIAL_ADAPTER_ID,
   userAdaptersFile,
+  adapterStateFile,
   PANEL_CACHE_TTL_MS,
   normalizeRangeDay,
   panelCacheKey,
@@ -440,36 +441,45 @@ export function formatPanel() { return "<p>p</p>"; }
   }
 
   // issue #206：add 后建立的适配器文件也纳入热更新监视——改文件 → 轮询周期内热更新生效
+  // #212 回归：成功不再伪装 error 记录（旧实现把「热更新成功」写进 health errors），
+  // 改以 adapters.json 中新版 label 可观测生效为准，并断言 errors 无「热更新成功」、enabled 保持。
   {
+    const adaptersRoute = routes.find((r) => r.path === ROUTES.adapters);
     const healthRoute = routes.find((r) => r.path === ROUTES.health);
+    const readAdapters = (): Promise<{ host: Array<{ name: string; label: string; file: string | null; enabled: boolean }>; enabled: Record<string, string>; errors: Array<{ key: string; message: string }> }> => {
+      let p;
+      adaptersRoute.handler(fakeReq(), { writeHead: () => {}, end: (c) => { p = JSON.parse(c); } });
+      return Promise.resolve(p);
+    };
     const readHealth = async (): Promise<Array<{ key: string; message: string }>> => {
       let p;
       healthRoute.handler(fakeReq(), { writeHead: () => {}, end: (c) => { p = JSON.parse(c); } });
       await new Promise((r) => setTimeout(r, 20));
       return p?.errors ?? [];
     };
-    // 改文件（formatCapsule 文案变化，mtime+size 均变）
+    // 改文件（label 文案变化，mtime+size 均变）
     writeFileSync(goodFile, `
 export const version = 2;
 export const name = "manage-stats";
-export const label = "管理测试";
+export const label = "管理测试二版";
 export const providers = ["opencode-go"];
 export async function fetchData() { return { v: 2 }; }
 export function formatCapsule() { return "<span>v2</span>"; }
 export function formatPanel() { return "<p>p2</p>"; }
 `, "utf8");
-    // 轮询等待热更新记录出现（热更新轮询 2s；用轮询等待防 flake，上限 ~5s）
-    let seen = false;
-    const deadline = Date.now() + 5000;
+    // 轮询等待热更新生效（热更新轮询 2s；用轮询等待防 flake，上限 ~6s）
+    let hot = false;
+    let snap;
+    const deadline = Date.now() + 6000;
     while (Date.now() < deadline) {
-      const errors = await readHealth();
-      if (errors.some((e) => e.message.includes("热更新成功：manage-stats"))) {
-        seen = true;
-        break;
-      }
       await new Promise((r) => setTimeout(r, 200));
+      snap = await readAdapters();
+      if (snap.host.some((a) => a.name === "manage-stats" && a.label === "管理测试二版")) { hot = true; break; }
     }
-    assert.ok(seen, "add 后修改文件应触发热更新（issue #206）");
+    assert.ok(hot, "add 后修改文件应触发热更新且新版代码生效（issue #206）");
+    assert.equal(snap.host.find((a) => a.name === "manage-stats")?.enabled, true, "热更新不改写启用关系：add 时成为的启用者保持启用（#212-A）");
+    const errors = await readHealth();
+    assert.ok(!errors.some((e) => e.message.includes("热更新成功")), "成功不得伪装为 error 记录（#212 日志真实）");
   }
 
   // select：切换回内置
@@ -504,6 +514,146 @@ export function formatPanel() { return "<p>p2</p>"; }
     await new Promise((r) => setTimeout(r, 60));
     assert.equal(s.reason, "no-enabled-adapter", "有候选但清空 → no-enabled-adapter");
   }
+}
+
+// ---------------------------------------------------------------- #212-A：热更新不改写 enabled 且持久化
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dou-212-a-"));
+  const histDir = join(dir, "hist");
+  const aFile = join(dir, "a.mjs");
+  writeFileSync(aFile, `
+export const version = 2;
+export const name = "p212-a";
+export const label = "A v1";
+export const providers = ["p212"];
+export async function fetchData() { return { v: 1 }; }
+export function formatCapsule() { return "<span>a1</span>"; }
+export function formatPanel() { return "<p>a1</p>"; }
+`, "utf8");
+  const { ctx, routes } = makeFakeCtx();
+  await apply(ctx, { ...ISOLATED_CONFIG, provider: "p212", adapter: aFile, historyDir: histDir });
+  await new Promise((r) => setTimeout(r, 300)); // 启动稳定（含 hr.start 初始同步）
+
+  const adaptersRoute = routes.find((r) => r.path === ROUTES.adapters);
+  const selectRoute = routes.find((r) => r.path === ROUTES.select);
+  const readAdapters = (): { host: Array<{ name: string; label: string; enabled: boolean }>; enabled: Record<string, string> } => {
+    let p;
+    adaptersRoute.handler(fakeReq(), { writeHead: () => {}, end: (c) => { p = JSON.parse(c); } });
+    return p;
+  };
+  // 用户显式停用（select provider null）
+  {
+    let payload;
+    selectRoute.handler(fakeReq({ method: "POST", body: JSON.stringify({ provider: "p212", adapterName: null }) }), { writeHead: () => {}, end: (c) => { payload = JSON.parse(c); } });
+    await new Promise((r) => setTimeout(r, 60));
+    assert.equal(payload.ok, true, "显式停用成功");
+  }
+  // 改文件触发热更新（label 变化可观测新版生效）
+  writeFileSync(aFile, `
+export const version = 2;
+export const name = "p212-a";
+export const label = "A v2";
+export const providers = ["p212"];
+export async function fetchData() { return { v: 2 }; }
+export function formatCapsule() { return "<span>a2</span>"; }
+export function formatPanel() { return "<p>a2</p>"; }
+// v2 marker —— 内容长度变化保证 stamp 可检出
+`, "utf8");
+  let snap;
+  let hot = false;
+  const deadline = Date.now() + 6000;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 200));
+    snap = readAdapters();
+    if (snap.host.some((a) => a.name === "p212-a" && a.label === "A v2")) { hot = true; break; }
+  }
+  assert.ok(hot, "停用的适配器文件编辑后热更新生效");
+  assert.equal(snap.host.find((a) => a.name === "p212-a")?.enabled, false, "停用的适配器热更新后保持停用，不得静默变回启用（#212-A）");
+  assert.equal(snap.enabled.p212, undefined, "provider 保持无启用者");
+  // 持久化：adapter-state.json 轮询等待落盘 null（scheduleWriteAdapterState 为异步串行链）
+  let persisted = false;
+  const stateFile = adapterStateFile(histDir);
+  const persistDeadline = Date.now() + 3000;
+  while (Date.now() < persistDeadline) {
+    if (existsSync(stateFile)) {
+      try {
+        const st = JSON.parse(readFileSync(stateFile, "utf8"));
+        if (st.p212 === null) { persisted = true; break; }
+      } catch { /* 写入中途，继续轮询 */ }
+    }
+    await new Promise((r) => setTimeout(r, 150));
+  }
+  assert.ok(persisted, "热更新后的启用关系已持久化到 adapter-state.json（#212-A）");
+}
+
+// ---------------------------------------------------------------- #212-B：改名撞名 → 冲突报错 + 旧条目保留 + 无假成功
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dou-212-b-"));
+  const histDir = join(dir, "hist");
+  const f1 = join(dir, "one.mjs");   // 经 config.adapter 登记
+  const f2 = join(dir, "two.mjs");   // 经 add 路由登记
+  writeFileSync(f1, `
+export const version = 2;
+export const name = "u-one";
+export const label = "One v1";
+export const providers = ["p212b"];
+export async function fetchData() { return { v: 1 }; }
+export function formatCapsule() { return "<span>1</span>"; }
+export function formatPanel() { return "<p>1</p>"; }
+`, "utf8");
+  writeFileSync(f2, `
+export const version = 2;
+export const name = "u-two";
+export const label = "Two v1";
+export const providers = ["p212c"];
+export async function fetchData() { return { v: 1 }; }
+export function formatCapsule() { return "<span>2</span>"; }
+export function formatPanel() { return "<p>2</p>"; }
+`, "utf8");
+  const { ctx, routes } = makeFakeCtx();
+  mkdirSync(histDir, { recursive: true }); // 清单/状态落盘目录（生产由插件 home 保证存在）
+  await apply(ctx, { ...ISOLATED_CONFIG, adapter: f1, historyDir: histDir });
+  const adaptersRoute = routes.find((r) => r.path === ROUTES.adapters);
+  const healthRoute = routes.find((r) => r.path === ROUTES.health);
+  const addRoute = routes.find((r) => r.path === ROUTES.add);
+  // add 登记第二个文件（纳入热更监视）
+  {
+    let payload;
+    addRoute.handler(fakeReq({ method: "POST", body: JSON.stringify({ file: f2 }) }), { writeHead: () => {}, end: (c) => { payload = JSON.parse(c); } });
+    await new Promise((r) => setTimeout(r, 80));
+    assert.equal(payload.ok, true, "第二个适配器登记成功");
+  }
+  // 把 one.mjs 的导出 name 改为 u-two（与另一 user-file 撞名）→ 触发热更冲突路径
+  writeFileSync(f1, `
+export const version = 2;
+export const name = "u-two";
+export const label = "One renamed";
+export const providers = ["p212b"];
+export async function fetchData() { return { v: 2 }; }
+export function formatCapsule() { return "<span>x</span>"; }
+export function formatPanel() { return "<p>x</p>"; }
+// rename marker —— 内容长度变化保证 stamp 可检出
+`, "utf8");
+  // 轮询等待冲突报错出现（health errors 可见）
+  let conflictErr = null;
+  const deadline = Date.now() + 6000;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 200));
+    let p;
+    healthRoute.handler(fakeReq(), { writeHead: () => {}, end: (c) => { p = JSON.parse(c); } });
+    const found = (p?.errors ?? []).find((e) => e.kind === "load" && e.message.includes("热更新失败") && e.message.includes("u-two"));
+    if (found !== undefined) { conflictErr = found; break; }
+  }
+  assert.ok(conflictErr !== null, "改名撞名应产生明确的冲突报错且 health 可见（#212-B）");
+  // 旧条目保留：one.mjs 仍以旧名 u-one 在候选列表，u-two 归属不变
+  let meta;
+  adaptersRoute.handler(fakeReq(), { writeHead: () => {}, end: (c) => { meta = JSON.parse(c); } });
+  const oneEntry = meta.host.find((a) => a.file === "one.mjs");
+  assert.ok(oneEntry !== undefined && oneEntry.name === "u-one", "撞名后 one.mjs 旧条目保留、未静默丢失（#212-B）");
+  assert.ok(meta.host.some((a) => a.name === "u-two" && a.file === "two.mjs"), "既有 u-two 条目不受牵连");
+  assert.ok(!meta.errors.some((e) => e.message.includes("热更新成功")), "不得出现假「热更新成功」记录（#212-B）");
 }
 
 // ---------------------------------------------------------------- 客户端契约

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -532,6 +532,7 @@ export function formatCapsule() { return "<span>a1</span>"; }
 export function formatPanel() { return "<p>a1</p>"; }
 `, "utf8");
   const { ctx, routes } = makeFakeCtx();
+  mkdirSync(histDir, { recursive: true }); // 清单/状态落盘目录（消除 warmup 时序依赖，对齐 #212-B）
   await apply(ctx, { ...ISOLATED_CONFIG, provider: "p212", adapter: aFile, historyDir: histDir });
   await new Promise((r) => setTimeout(r, 300)); // 启动稳定（含 hr.start 初始同步）
 

--- a/packages/dsh-provider-usage/test/unit-contract.test.ts
+++ b/packages/dsh-provider-usage/test/unit-contract.test.ts
@@ -424,7 +424,89 @@ function mkAdapter(over: Record<string, unknown> = {}): Record<string, unknown> 
   assert.equal(reg.removeByFile("/ghost.mjs"), 0, "移除不存在文件计 0");
 }
 
-// ================================================================ #150 二阶段：sanitizeHtml 白名单矩阵
+// ================================================================ #212：replaceByFile 热更新替换（enabled 保持 + 冲突保留旧条目）
+
+// A1：显式停用的适配器热更新后不得变回启用（缺陷 A 回归）
+{
+  const reg = makeAdapterRegistry();
+  assert.equal(reg.register(mkAdapter({ name: "f-one" }), "user-file", "/a.mjs"), true);
+  assert.equal(reg.select("prov-x", null), true, "用户显式停用");
+  const r = reg.replaceByFile("/a.mjs", mkAdapter({ name: "f-one", label: "v2" }));
+  assert.equal(r.ok, true, "同名替换成功");
+  const info = reg.snapshot().infos.find((i) => i.name === "f-one");
+  assert.equal(info?.enabled, false, "停用的适配器热更新后保持停用（#212-A）");
+  assert.equal(reg.getEntry("prov-x"), undefined, "prov-x 保持无启用者");
+}
+
+// A2：启用中的适配器替换后仍是启用者（保持语义的另一侧）
+{
+  const reg = makeAdapterRegistry();
+  reg.register(mkAdapter({ name: "on-a" }), "user-file", "/a.mjs");
+  const r = reg.replaceByFile("/a.mjs", mkAdapter({ name: "on-a", label: "v2" }));
+  assert.equal(r.ok, true);
+  assert.equal(reg.isEnabled("prov-x", "on-a"), true, "启用者热更新后仍启用（#212-A）");
+}
+
+// A3：多 provider 认领时逐 provider 精确恢复（部分启用部分停用）
+{
+  const reg = makeAdapterRegistry();
+  reg.register(mkAdapter({ name: "multi", providers: ["p1", "p2"] }), "user-file", "/m.mjs");
+  assert.equal(reg.select("p2", null), true, "仅停用 p2");
+  const r = reg.replaceByFile("/m.mjs", mkAdapter({ name: "multi", providers: ["p1", "p2"], label: "v2" }));
+  assert.equal(r.ok, true);
+  const snap = reg.snapshot();
+  assert.equal(snap.enabled.p1, "multi", "p1 启用关系保持");
+  assert.equal(snap.enabled.p2, undefined, "p2 停用关系保持（不得被默认启用覆盖）");
+}
+
+// B1：改名撞内置名 → 拒绝且旧条目原样保留（缺陷 B 回归；health 报错可见性见 smoke #212-B 集成用例）
+{
+  const reg = makeAdapterRegistry();
+  assert.equal(reg.register(mkAdapter({ name: "builtin-occ" }), "builtin"), true);
+  assert.equal(reg.register(mkAdapter({ name: "renamer" }), "user-file", "/r.mjs"), true);
+  const r = reg.replaceByFile("/r.mjs", mkAdapter({ name: "builtin-occ" }));
+  assert.equal(r.ok, false, "撞名拒绝替换");
+  assert.equal(r.code, "duplicate-name");
+  assert.ok(r.detail.includes("builtin-occ"), "拒绝结果携带冲突 name 详情");
+  const infos = reg.snapshot().infos;
+  assert.ok(infos.some((i) => i.name === "renamer" && i.file === "/r.mjs"), "旧条目未被删除（#212-B）");
+  assert.equal(reg.hasName("renamer"), true, "旧名仍在注册表");
+}
+
+// B2：改名撞另一 user-file 名 → 同样拒绝且两文件条目均保留
+{
+  const reg = makeAdapterRegistry();
+  reg.register(mkAdapter({ name: "u-first", providers: ["pq"] }), "user-file", "/u1.mjs");
+  reg.register(mkAdapter({ name: "u-second", providers: ["pr"] }), "user-file", "/u2.mjs");
+  const r = reg.replaceByFile("/u2.mjs", mkAdapter({ name: "u-first", providers: ["pr"] }));
+  assert.equal(r.ok, false, "撞 user-file 名拒绝");
+  assert.equal(r.code, "duplicate-name");
+  const infos = reg.snapshot().infos;
+  assert.ok(infos.some((i) => i.name === "u-second" && i.file === "/u2.mjs"), "u2 旧条目保留");
+  assert.ok(infos.some((i) => i.name === "u-first" && i.file === "/u1.mjs"), "u1 条目不受牵连");
+}
+
+// B3：改名不冲突 → 替换成功，旧名清理，启用关系跟随文件语义
+{
+  const reg = makeAdapterRegistry();
+  reg.register(mkAdapter({ name: "old-name" }), "user-file", "/c.mjs"); // 默认启用 prov-x
+  const r = reg.replaceByFile("/c.mjs", mkAdapter({ name: "new-name" }));
+  assert.equal(r.ok, true, "改名不冲突替换成功");
+  assert.equal(reg.hasName("old-name"), false, "旧名已清理");
+  assert.equal(reg.isEnabled("prov-x", "new-name"), true, "该文件原为启用者，新版沿用启用");
+}
+
+// B4：契约失败的新版同样拒绝且保留旧条目
+{
+  const reg = makeAdapterRegistry();
+  reg.register(mkAdapter({ name: "orig" }), "user-file", "/o.mjs");
+  const r = reg.replaceByFile("/o.mjs", { foo: 1 });
+  assert.equal(r.ok, false);
+  assert.equal(r.code, "invalid-adapter");
+  assert.ok(reg.snapshot().infos.some((i) => i.name === "orig"), "非法新版不破坏旧条目");
+}
+
+// ================================================================ #212：sanitizeHtml 白名单矩阵
 
 assert.equal(sanitizeHtml(""), "", "空串直通");
 assert.equal(sanitizeHtml("<p>plain</p>"), "<p>plain</p>", "无害 HTML 原样");

--- a/stryker.conf.d/dsh-provider-usage.json
+++ b/stryker.conf.d/dsh-provider-usage.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
     "packages/dsh-provider-usage/lib/index.js:1372-2792",
-    "packages/dsh-provider-usage/lib/index.js:2637-3727"
+    "packages/dsh-provider-usage/lib/index.js:2671-3727"
   ],
   "testRunner": "tap",
   "tap": {


### PR DESCRIPTION
## 概要

Closes #212

`@wingsky-1/dsh-provider-usage` 两处热更新缺陷修复（纯宿主逻辑，客户端零改动）：

- **缺陷 A**：热更新回调 `removeByFile + register` 未传 `enabledHint`，「已登记未启用」的适配器文件热更后被静默改回启用者，且不持久化；
- **缺陷 B**：改名撞名时先删旧条目、register 同名拒收返回值被忽略，条目静默丢失还记「热更新成功」假日志。

## 修复方式

1. **registry 新增 `replaceByFile(file, next)`**（原子替换，取代回调里的 remove→register 散装两步）：
   - 冲突预检先行：新版 name 与其他来源已注册名重复 → 直接拒绝且**旧条目原样保留**（不再先删后注册）；契约校验失败同样拒绝且保留旧条目；
   - enabled 保持：替换只更新代码——本文件旧条目在其认领 provider 上原本是启用者的，新版沿用；原本停用的不得变回启用；新增认领的 provider 不自动启用（逐 provider 精确恢复，同步执行无中间态可观察）。
2. **ensureHotReload 回调改接 `replaceByFile`**：
   - 失败（撞名/契约失败）：`recordError(key, "load", "热更新失败：<冲突详情>")`，health/日志可见且如实；
   - 成功：清缓存 + `scheduleWriteAdapterState()` 持久化 + `console.warn` 成功日志（成功不再伪装 error 记录）。
3. **`scheduleWriteAdapterState` 改磁盘基线合并语义**：以磁盘现状为基线保留历史显式 null 停用标记，运行期有启用者的 provider 以运行期为准覆盖；select 清空时以 override 显式落 null。三个挂点（select/add/热更新）统一该语义。（若按 issue 建议直接落 `snapshot().enabled`，会把磁盘上的 null 停用标记抹掉——enabled 映射不含 null 键，验收标准 2 会反向破坏 select(null) 语义。）
4. **启动时序修正**：热更监视初始化移至「adapter-state 恢复」之后。`hr.start()` 初始同步即触发回调，若先于恢复执行，接线后的落盘会把「默认启用、尚未按持久化状态纠正」的中间态写进 `adapter-state.json`（TDZ 风险同防：`stateChain` 声明提前至热更块前）。

## 与 issue 静态分析的差异说明

- 行号核对（main @ 5999966，含 PR#234 后代码）：`index.ts:476-477/480`、`registry.ts:107-110/124-126` **均无漂移**，分析成立；
- 补充发现一（加重因素）：`HotReloadableAdapter.start()` 会立即做一次初始加载并触发 `onReload({ok:true})`——即**每次启动**每个被监视文件都会走一遍 remove→register（enabled 被重置为默认启用）并向 health errors 写一条「热更新成功」。此前仅靠其后的 adapter-state 恢复兜底掩盖运行期状态，假成功记录则每次启动都在产生。本修复使该路径同样受益（同名替换保持 enabled、不再写 error）；
- 补充发现二：见上文第 3 点——issue 建议「替换后调用 scheduleWriteAdapterState 持久化」若按字面直落 snapshot().enabled 会抹掉显式 null 停用标记，实际落地需合并语义。

## 全量断言表

| 验收标准（issue #212） | 分级 | 结论 | 证据（机器可复验） |
|---|---|---|---|
| 1. 热更新只应更新代码，不应改写 enabled 启用关系（enabledHint 正确传递） | [硬性] | 落实 | 单测：`test/unit-contract.test.ts` #212-A1（停用者热更后保持停用）/A2（启用者保持启用）/A3（多 provider 逐个精确恢复）。集成：`test/smoke.ts` #206 改写用例（add 后热更，`adapters.json` 该条目 `enabled === true` 保持）；#212-A 用例（`select(provider,null)` 停用后编辑文件触发热更，断言 `host.find(name).enabled === false` 且 `snap.enabled.p212 === undefined`） |
| 2. 热更新结果应持久化（scheduleWriteAdapterState 接线） | [硬性] | 落实 | `src/index.ts` 热更回调内 `scheduleWriteAdapterState()` 接线（合并语义）；集成：smoke.ts #212-A 轮询读回 `adapterStateFile(histDir)`，断言落盘内容 `"p212": null`（停用关系经热更后仍在盘上） |
| 3a. 改名撞名保留旧条目不删除（失败不清理） | [硬性] | 落实 | 单测：#212-B1（撞内置名拒绝 + `/r.mjs` 旧条目保留）/B2（撞另一 user-file 名，两文件条目均保留）/B4（契约失败的新版不破坏旧条目）。集成：smoke.ts #212-B（`one.mjs` 改名撞 `u-two` 后，`host.find(file==="one.mjs").name === "u-one"` 旧条目在列，`u-two` 归属 two.mjs 不变） |
| 3b. 给出明确冲突报错（health/日志可见） | [硬性] | 落实 | `replaceByFile` 返回 `{ok:false, code:"duplicate-name", detail 含冲突 name}`；回调层 `recordError(key,"load","热更新失败：适配器 name 冲突：…")`。集成：smoke.ts #212-B 轮询 health errors 断言出现 `kind==="load" && message 含"热更新失败" && 含"u-two"` 的记录 |
| 4. 日志如实反映成功/失败，不得误报 | [硬性] | 落实 | 成功路径改为 `console.warn("[dsh-provider-usage] 热更新成功：<name>（<file>）")`，不再写入 health errors；集成：smoke.ts #206 用例断言热更生效后 `errors` 中无任何含"热更新成功"的记录；#212-B 用例断言冲突场景下同样无假成功记录 |

qa 复核提示：纯宿主逻辑改动（client bundle 未触碰，contract 门禁验证客户端契约面不变），实测豁免；上表全部断言位于包内自动化测试，`pnpm test` 可机器复验。

## 测试与门禁

- 新增单测矩阵：unit-contract.test.ts `replaceByFile` ×7 用例（A1/A2/A3/B1/B2/B3/B4）；
- smoke 集成：#206 用例改写至新语义 + 新增 #212-A/#212-B 两条端到端回归（真实文件 mtime+size 触发 2s 轮询热更，轮询等待防 flake，DSH_HOME / historyDir 全程 mkdtemp 隔离）；
- 五连门禁本地逐个实跑全绿：`pnpm build` / `pnpm test` / `pnpm contract` / `pnpm pack:check` / `pnpm typecheck` 均 exit 0；mutate-scope-guard 14/14 通过。

## 对抗评审必修项落实

- P1-1：rebase 最新 origin/main（#242 src 注释改动使 provider-usage bundle 行号漂移）→ `pnpm build` 重建产物 → stryker.conf.d/dsh-provider-usage.json 第二段起点对齐新 sanitize 段起点 2637→2671（参照 #235 做法，语义分段不变），scope guard 本地 exit=0（14/14）；
- P2-2：smoke #212-A 用例开头补 `mkdirSync(histDir, { recursive: true })`（对齐 #212-B 写法，消除 warmup 时序依赖）；
- P2-4：registry.ts replaceByFile 函数体缩进对齐工厂函数层级。

## 遗留项（评审判定不阻塞合并，记录跟踪）

- P2-3：热更挂点持久化的端到端用例可进一步加强（当前 #212-A 已覆盖「停用 → 热更 → 落盘 null」主链路，可再补启用者方向的热更落盘断言）；
- P2-5 / P2-6：对抗评审报告所列非阻塞建议项，详见评审记录，本 PR 不改码。
