### PR TITLE
perf(mutation): dsh-provider-usage concurrency 4→8（#220 方案 A 第二格）

### DIFF
--- a/stryker.conf.d/dsh-provider-usage.json
+++ b/stryker.conf.d/dsh-provider-usage.json
@@ -29,7 +29,7 @@
   "plugins": [
     "@stryker-mutator/tap-runner"
   ],
-  "concurrency": 4,
+  "concurrency": 8,
   "timeoutMS": 60000,
   "dryRunTimeoutMinutes": 5,
   "reporters": [


### PR DESCRIPTION
## 关联 issue

#220（方案 A 第二格；web-file-preview 4→16 已由 #223 落地）

## 改动

- `stryker.conf.d/dsh-provider-usage.json` concurrency 4→8，单行改动，对齐 #159/#223 先例风格。

## 调研依据（#220 本轮调研结论）

- provider-usage 五个 stryker testFiles 经逐文件核查**无任何 server.listen 固定端口绑定**（apiEndpoint 用 discard 端口 http://127.0.0.1:9、socket 为 mock 字面量对象），#147 式 EADDRINUSE 互踩风险不适用本包；
- 收益窗口：增量基线全命中时该包 job 仅约 21s（install+build 主导），调并发只优化「大改→基线失效重测」长尾（PR#209 实测 339s）；
- 不直接跳 16：unit 测试偏 CPU 密集，4 核 runner 超订一倍即近收益上限，16 有上下文切换/缓存污染转负风险（区别于 #159 notifier 定时器等待主导的形态）。

## 实测观察项（合并判据）

CI mutation-gate 实跑确认：
- [ ] job 无 flake，score 与基线口径一致；
- [ ] **timeout / error 计数无异常抬升**——Stryker 将 timeout 计入 detected，虚高会掩盖真存活 mutant（lan-proxy timeoutMS=15000 敏感性为前车之鉴）；
- [ ] 观察 2 个以上触及本包的 PR 后再评估是否升 16。