### PR TITLE
fix(docs): v0.1.13 发布说明语言跳转锚点补 name 属性

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,9 +100,14 @@ Conventional Commits（`type(scope): subject`；type：`feat` / `fix` / `docs` /
   tag 校验。
 - GitHub Release 更新说明**每版入库**为 `docs/release-notes/vX.Y.Z.md`，由发版 agent
   从上一 tag 至今的常规提交生成、**中文与英文各自成节分开呈现（不逐条混排）**、
-  **文件头提供语言跳转导航，锚点用显式 HTML 标记 + ASCII id**
-  （各渲染器标题 slug 规则不一，中文锚点不可靠。如：
-  头部 `> [中文](#zh) · [English](#en)`，分节前 `<a id="zh"></a>` / `<a id="en"></a>`）、
+  **文件头提供语言跳转导航，锚点用「双锚补位」写法**
+  （各渲染器标题 slug 规则不一，中文锚点不可靠；且 GitHub sanitizer 会把 HTML
+  `id`/`name` 一律改写为 `user-content-` 前缀致 `href="#zh"` 落空、Release 页
+  heading 又无自动 id——已实测。故 href 直写前缀形态、分节处双锚补位，GitHub
+  命中被改写的首个锚、第三方渲染器命中字面 id 的第二个锚，全场景可跳。如：
+  头部 `> [中文](#user-content-zh) · [English](#user-content-en)`，分节前
+  `<a id="zh"></a><a id="user-content-zh"></a>` /
+  `<a id="en"></a><a id="user-content-en"></a>`）、
   随 `chore(release):` 提交；
   管线优先引用该文件，缺失则回退 GitHub 自动 notes。**禁止 emoji**（覆盖文档与提交信息）。
 - 合并方式：CI 全绿后 squash merge（见 CONTRIBUTING.md 开发流程）。

--- a/docs/release-notes/v0.1.13.md
+++ b/docs/release-notes/v0.1.13.md
@@ -2,7 +2,7 @@
 
 > **[中文](#zh)** · **[English](#en)**
 
-<a id="zh"></a>
+<a id="zh" name="zh"></a>
 
 ## 中文
 
@@ -47,7 +47,7 @@
 - [test] 测试稳定性：固定端口改 port 0 + K12 断言轮询化消除端口占用 flake（#227）；notifier 免打扰用例改动态时钟窗口，消除 23:59 边界分钟 flake（#182）；测试产物零污染纪律 + .gitignore 兜底（#226、#230）。
 - [docs/meta] loop 工作流改进六条落地（#160）；oss-pipeline 重构为 loop engine 形态并抽取 agents 公共协议，triage 认领原子化、steering 身份过滤、report 回顾段（#132、#133）；标签体系与 loop 状态机入 workflow 文档、红线流程统一为原 issue 内评审（#134）；隔离环境验证指导（#130）；PR 模板内置客户端截图证据清单（#129）；agent-team 通用框架设计决策与讨论过程归档（#172）。
 
-<a id="en"></a>
+<a id="en" name="en"></a>
 
 ## English
 

--- a/docs/release-notes/v0.1.13.md
+++ b/docs/release-notes/v0.1.13.md
@@ -1,8 +1,8 @@
 # v0.1.13 发布说明 / Release Notes
 
-> **[中文](#zh)** · **[English](#en)**
+> **[中文](#user-content-zh)** · **[English](#user-content-en)**
 
-<a id="zh" name="zh"></a>
+<a id="zh"></a><a id="user-content-zh"></a>
 
 ## 中文
 
@@ -47,7 +47,7 @@
 - [test] 测试稳定性：固定端口改 port 0 + K12 断言轮询化消除端口占用 flake（#227）；notifier 免打扰用例改动态时钟窗口，消除 23:59 边界分钟 flake（#182）；测试产物零污染纪律 + .gitignore 兜底（#226、#230）。
 - [docs/meta] loop 工作流改进六条落地（#160）；oss-pipeline 重构为 loop engine 形态并抽取 agents 公共协议，triage 认领原子化、steering 身份过滤、report 回顾段（#132、#133）；标签体系与 loop 状态机入 workflow 文档、红线流程统一为原 issue 内评审（#134）；隔离环境验证指导（#130）；PR 模板内置客户端截图证据清单（#129）；agent-team 通用框架设计决策与讨论过程归档（#172）。
 
-<a id="en" name="en"></a>
+<a id="en"></a><a id="user-content-en"></a>
 
 ## English
 


### PR DESCRIPTION
## 问题

v0.1.13 GitHub Release 页面顶部语言导航（[中文] / [English]）点击不跳转。

## 根因（全部实测）

- GitHub sanitizer 对 markdown 中 HTML `id` 与 `name` 一律改写为 `user-content-`
  前缀，`href="#zh"` 原样保留 → 落空；浏览器实测点击后 hash 变化但页面不滚动；
- Release 页 heading 无自动 slug id，标题锚方案同样不可用；
- name 属性双保险方案亦被证伪（name 同被前缀化）。

## 修复：双锚补位

href 直写 `#user-content-zh` / `#user-content-en`，分节处
`<a id="zh"></a><a id="user-content-zh"></a>` 双锚并存：

- GitHub（Release / blob）：首个锚被改写为 user-content-zh → 命中；
- 第三方渲染器（VS Code 等）：第二个字面 id 命中。

已在 v0.1.13 Release 页浏览器实测中文/英文双向跳转生效。

附带更新 AGENTS.md 发布纪律为该约定。合并后无需再编辑 Release body
（已提前用同内容同步）。