### PR TITLE
fix(docs): v0.1.11 / v0.1.12 发布说明锚点回修为双锚补位写法

### DIFF
--- a/docs/release-notes/v0.1.11.md
+++ b/docs/release-notes/v0.1.11.md
@@ -1,8 +1,8 @@
 # v0.1.11 发布说明 / Release Notes
 
-> **[中文](#zh)** · **[English](#en)**
+> **[中文](#user-content-zh)** · **[English](#user-content-en)**
 
-<a id="zh"></a>
+<a id="zh"></a><a id="user-content-zh"></a>
 
 ## 中文
 
@@ -30,7 +30,7 @@
 - [types] 删除自建类型层 `types/dsh.d.ts`，宿主端全量切换官方 `@deepseek-ai/*` 类型导出（catalog 锁版，仅 import type）。
 - [docs] agent 规程交叉引用补全；lan-proxy 安全模型节披露 health 元数据经代理对局域网可见。
 
-<a id="en"></a>
+<a id="en"></a><a id="user-content-en"></a>
 
 ## English
 

--- a/docs/release-notes/v0.1.12.md
+++ b/docs/release-notes/v0.1.12.md
@@ -1,8 +1,8 @@
 # v0.1.12 发布说明 / Release Notes
 
-> **[中文](#zh)** · **[English](#en)**
+> **[中文](#user-content-zh)** · **[English](#user-content-en)**
 
-<a id="zh"></a>
+<a id="zh"></a><a id="user-content-zh"></a>
 
 ## 中文
 
@@ -31,7 +31,7 @@
 - [meta] **维护编排「重开原 issue」纪律**（#127）：合并后同域未满/新 bug 重开原 issue 继续修，仅跨领域另开。
 - [docs] release notes 语言跳转锚点改为显式 HTML 标记 + ASCII id（中文标题 slug 各渲染器不可靠）（#78）。
 
-<a id="en"></a>
+<a id="en"></a><a id="user-content-en"></a>
 
 ## English
 


### PR DESCRIPTION
## 内容

按 #258 同一方案回修历史版本 release notes 的语言跳转锚点：

- v0.1.11 / v0.1.12：href 直写 `#user-content-*` + 分节处双锚补位（与 v0.1.13 一致）；
- v0.1.8 ~ v0.1.10：中英混排单节格式、无语言导航，**不涉及**，未改动。

合并后逐版 `gh release edit` 同步已发布 body 并浏览器抽测验证。