### PR TITLE
perf(mutation): provider-usage 并发 8→16（#220 方案 A 收尾）

### DIFF
--- a/stryker.conf.d/dsh-provider-usage-1.json
+++ b/stryker.conf.d/dsh-provider-usage-1.json
@@ -28,7 +28,7 @@
   "plugins": [
     "@stryker-mutator/tap-runner"
   ],
-  "concurrency": 8,
+  "concurrency": 16,
   "timeoutMS": 30000,
   "dryRunTimeoutMinutes": 5,
   "reporters": [

--- a/stryker.conf.d/dsh-provider-usage-2.json
+++ b/stryker.conf.d/dsh-provider-usage-2.json
@@ -28,7 +28,7 @@
   "plugins": [
     "@stryker-mutator/tap-runner"
   ],
-  "concurrency": 8,
+  "concurrency": 16,
   "timeoutMS": 30000,
   "dryRunTimeoutMinutes": 5,
   "reporters": [


### PR DESCRIPTION
## 关联 issue

#220（方案 A 最后一级）

## 改动

`stryker.conf.d/dsh-provider-usage-{1,2}.json` concurrency 8→16，各一行。

## 基准依据

| 轮次 | seg1 | seg2 | score 口径 | error |
|---|---|---|---|---|
| 16 并发（本机实测） | **235.2s** | **148.1s** | 62.20%/66.96%（与 CI 报告一致） | 13/0 |
| 8 并发（#257 基准折算） | ~305s | ~148s | 同口径 | — |

- 温和提速 ~15%，无假阳性迹象；
- 本机为 8 核（2 倍超订）；CI runner 4 核（4 倍超订）下收益预期更小甚至持平——合并后按既有三项判据观察：total 不变 / timeout-error 不抬升 / score 与基线一致；
- 不达标即回退 8（一行回滚）。

纯配置改动，不触发变异切片（验证顺延至下一个触及该包源码的 PR）。