### PR TITLE
perf(mutation): mcp-manager 段再均衡——s4 收窄 + 新增 s5（#220）

### DIFF
--- a/scripts/data/gauntlet.config.json
+++ b/scripts/data/gauntlet.config.json
@@ -71,7 +71,7 @@
         "baselineDate": "2026-08-24",
         "baselineDuration": "3m0s",
         "baselineScope": "packages/dsh-mcp-manager/lib/index.js:8610-8696+17322-17456+19271-19915+19964-21027（self-written 四段：store、transport+scope、protocol/supervisor/catalog、import/routes/index；排除 esbuild 垫片、zod/@modelcontextprotocol/sdk/ajv 等大段内联 vendor、shared 契约层内联副本与纯 import 提升段）",
-        "config": "stryker.conf.d/dsh-mcp-manager-{1..4}.json（#220 B 段拆分，四段各自独立 matrix 实例）",
+        "config": "stryker.conf.d/dsh-mcp-manager-{1..5}.json（#220 B 段拆分+#269 实验后按 mutant 密度再均衡：s4 收窄至 import/routes/middleware，新增 s5=index 主体）",
         "hardeningNote": "#148 变异加固轮：6 个单测 commit 将 covered 由 29.37% 提升至 74.66%；耗时优化（#173）零杀伤 testFiles 移除 + conc8，3m52s→3m0s",
         "threshold": 60
       },

--- a/stryker.conf.d/dsh-mcp-manager-5.json
+++ b/stryker.conf.d/dsh-mcp-manager-5.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
-    "packages/dsh-mcp-manager/lib/index.js:19972-21262"
+    "packages/dsh-mcp-manager/lib/index.js:21263-22070"
   ],
   "testRunner": "tap",
   "tap": {
@@ -40,12 +40,12 @@
     "json"
   ],
   "jsonReporter": {
-    "fileName": "coverage/mutation/dsh-mcp-manager-4.json"
+    "fileName": "coverage/mutation/dsh-mcp-manager-5.json"
   },
   "coverageAnalysis": "perTest",
   "tempDirName": ".stryker-tmp",
   "cleanTempDir": true,
   "incremental": true,
-  "incrementalFile": "coverage/mutation/incremental-mcp-manager-4.json",
-  "_comment": "#220 B 拆分+#269 重测实验再均衡：原 s4 (19972-22070) 按 esbuild 分段边界对半拆为 s4/s5——重测实证 s4 独占该包绝大多数 mutant（wall-clock 323s 而其余段均≈固定成本）；s4 = import/routes/middleware 三模块。"
+  "incrementalFile": "coverage/mutation/incremental-mcp-manager-5.json",
+  "_comment": "#220 B 再均衡新增：index 主体段（Config/apply/路由收尾），与 s4 于分段边界 21262/21263 处切分。"
 }


### PR DESCRIPTION
## 关联 issue

#220（#269 重测实验的后续修复）

## 问题

实验实证（issue 台账）：mcp-manager 四段按行数机械拆分严重不均衡——s4 区间独占该包绝大多数 mutant，重测 wall-clock 323s 而其余三段均≈固定成本 29-30s，拆分对该包零收益。

## 修复

在 esbuild 分段边界 21262/21263 处对半拆分：
- s4 收窄为 import/routes/middleware（19972-21262）
- 新增 s5 = index 主体（21263-22070）
- 预期重测 wall-clock ≈ max(段) 从 323s → ~200s

## 已验证

- [x] mutate-scope-guard 15 区间全过（新区间锚定合法分段边界）；
- [x] workflow-assert 契约 23/23；
- [x] 新段配置命名约定自检通过。

## 注意

s4 区间变化 + s5 无基线 → 合并后首跑该包段实例 notice 降级全量一次（预期），当晚 observe 刷新基线后恢复增量。