### PR TITLE
docs(readme): 提炼核心优势并校正 mcp-manager 中间层描述

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -11,16 +11,32 @@ install them all at once as a single bundle, or pick individual plugins as neede
 
 - **Bundle package**: `@wingsky-1/dsh-plugins-all` — install everything in one shot
 - **Individual plugins**: `@wingsky-1/dsh-*` — install only what you need
-- All plugins mount through DSH's official profile mechanism (`dsh.bundle.patch`) — no DSH source changes; artifacts are self-contained with build-time inlining
+
+## Core advantages
+
+- **Security built into the defaults**: minimal exposure surface and minimal credential
+  flow — management surfaces answer only on loopback, keys by default never persist in
+  plaintext nor reach the browser; each plugin's threat model and hardening details live
+  in its README security section
+- **Context-cost-controlled MCP management**: project-level MCP is collapsed into the
+  two atomic tools `ws_mcp_search` / `ws_mcp_call` by default, so project-level scale
+  never balloons the context (`middleware: all` folds global servers into the middleware
+  too); per-working-directory project/global config tiers let each repo carry its own
+  MCP servers without cross-project interference
+- **Extensible usage-stats framework**: a generic v2 adapter contract with DeepSeek
+  official and OpenCode Go built in out of the box; write one mjs file to plug in any
+  data source, hot-swappable from the settings page
+- **Engineering-quality backing**: every plugin ships smoke assertions (route fences /
+  client contracts), plus build contract + pack checks + full gates run in CI
 
 ## Plugin list
 
 | Package | What it does | Docs | Status |
 |---|---|---|---|
 | `@wingsky-1/dsh-notifier` | Approval/completion/error event notifications (browser Notification + system toast) | [README](packages/dsh-notifier/README.md) | ✅ Published |
-| `@wingsky-1/dsh-provider-usage` | Multi-provider usage float pill (per-provider adapter framework, built-in OpenCode Go) | [README](packages/dsh-provider-usage/README.md) | ✅ Published |
+| `@wingsky-1/dsh-provider-usage` | Multi-provider usage float pill (generic adapter framework: DeepSeek official and OpenCode Go built in, plug in any data source with your own mjs) | [README](packages/dsh-provider-usage/README.md) | ✅ Published |
 | `@wingsky-1/dsh-lan-proxy` | Access the dsh web UI over LAN (HTTP/HTTPS/WS forwarding + TLS + HTTP response compression, Brotli/gzip) | [README](packages/dsh-lan-proxy/README.md) | ✅ Published |
-| `@wingsky-1/dsh-mcp-manager` | MCP server manager (stdio / HTTP, registers tools for the model) | [README](packages/dsh-mcp-manager/README.md) | ✅ Published |
+| `@wingsky-1/dsh-mcp-manager` | MCP server manager (stdio / HTTP; per-working-directory project/global config tiers, project-level MCP collapsed via middleware — no tool flood in the model surface) | [README](packages/dsh-mcp-manager/README.md) | ✅ Published |
 | `@wingsky-1/dsh-idle-archive` | Prompt to archive idle conversations | [README](packages/dsh-idle-archive/README.md) | ✅ Published |
 | `@wingsky-1/dsh-web-file-preview` | Click conversation file links to preview in the web UI (image / text / Markdown / code / Diff) | [README](packages/dsh-web-file-preview/README.md) | ✅ Published |
 

--- a/README.md
+++ b/README.md
@@ -10,16 +10,28 @@ DSH（DeepSeek Harness）Web GUI 插件集，npm 分发：一键装全家桶，�
 
 - 聚合包：`@wingsky-1/dsh-plugins-all`（一键装齐全部插件；观察期插件除外，见下文插件列表）
 - 单插件：`@wingsky-1/dsh-*`（按需安装）
-- 全部走 DSH 官方 profile 机制挂载（`dsh.bundle.patch`），不改 DSH 源码；发布物自包含，构建期内联打包
+
+## 核心优势
+
+- **安全内建于默认**：坚持最小暴露面与最小凭据流转——管理面只对本机开放，
+  密钥默认不明文落盘、不进浏览器；各插件的威胁模型与加固细节见其 README 安全章节
+- **上下文成本可控的 MCP 管理**：项目级 MCP 默认经中间层收敛为 `ws_mcp_search` /
+  `ws_mcp_call` 两个原子工具，项目级接入规模不再膨胀上下文（`middleware: all`
+  可把全局服务器也收进中间层）；分工作目录维护项目级/全局两级配置，
+  多仓库各配各的 MCP，互不串台
+- **可扩展的用量统计框架**：通用 v2 适配器契约，内置 DeepSeek 官方与 OpenCode Go
+  开箱即用；自写一个 mjs 文件即可接入任意数据源，设置页热插拔
+- **工程质量背书**：每个插件自带 smoke 断言（路由围栏 / 客户端契约），构建契约 +
+  打包校验等全部门禁在 CI 全量执行
 
 ## 插件列表
 
 | 包名 | 功能 | 文档 | 状态 |
 |---|---|---|---|
 | `@wingsky-1/dsh-notifier` | 审批/完成/错误事件通知（浏览器 Notification + 系统 toast） | [README](packages/dsh-notifier/README.md) | ✅ 已发布 |
-| `@wingsky-1/dsh-provider-usage` | 多 provider 用量悬浮框（按 Provider 适配器框架，内置 OpenCode Go） | [README](packages/dsh-provider-usage/README.md) | ✅ 已发布 |
+| `@wingsky-1/dsh-provider-usage` | 多 provider 用量统计悬浮框（通用适配器框架：内置 DeepSeek 官方与 OpenCode Go 开箱即用，自写 mjs 即可接入任意数据源） | [README](packages/dsh-provider-usage/README.md) | ✅ 已发布 |
 | `@wingsky-1/dsh-lan-proxy` | 局域网访问 dsh web UI（HTTP/HTTPS/WS 转发 + TLS + HTTP 响应压缩，Brotli/gzip 自适应） | [README](packages/dsh-lan-proxy/README.md) | ✅ 已发布 |
-| `@wingsky-1/dsh-mcp-manager` | MCP 服务器管理器（stdio/HTTP，工具注册给模型） | [README](packages/dsh-mcp-manager/README.md) | ✅ 已发布 |
+| `@wingsky-1/dsh-mcp-manager` | MCP 服务器管理器（stdio/HTTP；分工作目录维护项目级/全局两级配置，项目级 MCP 经中间层收敛、免于工具洪水） | [README](packages/dsh-mcp-manager/README.md) | ✅ 已发布 |
 | `@wingsky-1/dsh-idle-archive` | 会话闲置提醒归档 | [README](packages/dsh-idle-archive/README.md) | ✅ 已发布 |
 | `@wingsky-1/dsh-web-file-preview` | 点击对话文件链接在 web 端预览（图片/文本/Markdown/代码/Diff） | [README](packages/dsh-web-file-preview/README.md) | ✅ 已发布 |
 | `@wingsky-1/dsh-subagent-model-inherit` | 子 Agent 自动继承父会话模型与思考等级 | [README](packages/dsh-subagent-model-inherit/README.md) | 观察期（独立发包，暂不进聚合包） |

--- a/packages/dsh-mcp-manager/README.en.md
+++ b/packages/dsh-mcp-manager/README.en.md
@@ -4,11 +4,41 @@
 
 A **MCP server management plugin** for DSH (DeepSeek Harness): a floating window in the
 top-right of the session UI + a tiered panel + quick onboarding (manual form + paste
-`mcpServers` JSON import, **no servers preconfigured**), supporting **project-level MCP
-that follows session switches**. Tools from connected servers are registered for the model
-to call directly as `mcp__<serverName>__<rawName>`. The MCP protocol client is
-implemented directly on top of `node:child_process` and the global `fetch` —
-nothing extra to install.
+`mcpServers` JSON import, **no servers preconfigured**). The MCP protocol client is
+implemented directly on top of `node:child_process` and the global `fetch` — nothing
+extra to install.
+
+Three middleware modes (`middleware`): `off` — all servers register directly as
+`mcp__<server>__<tool>` (legacy behavior); `project` (**default**) — project-level
+servers go through the middleware while global ones register directly; `all` — global
+servers go through the middleware too, falling back to the virtual global root
+`@global` when cwd has no project, collapsing the model surface to exactly two atomic
+tools. Note on when changes take effect: `middleware` / `middlewarePolicy` are read
+once at plugin startup — **changing them requires restarting `dsh web`**; the server
+lists across both config tiers hot-reload without a restart (add/remove/toggle/edit).
+
+## Core advantages
+
+- **Context cost under control**: project-level MCP is collapsed through the middleware
+  by default — the model surface carries only `ws_mcp_search` / `ws_mcp_call`, so no
+  matter how many project-level servers or tools the current workspace connects the
+  system prompt never balloons; `middleware: all` folds global servers in too for full
+  collapse
+- **Per-working-directory maintenance**: project-level config `<project root>/.dsh/mcp.json`
+  travels with the repo and can be committed to git for team sharing; global config
+  `<DSH_HOME>/dsh-mcp.json` stays always connected; switching sessions auto-loads the
+  MCP set of the current directory
+- **Workspace isolation**: the middleware routes by the session's cwd to the matching
+  connection pool, with server-full-name consistency checks against cross-workspace
+  crosstalk; same-named servers in different directories never clash
+- **Secure by default**: configs store only `${ENV}` references, never key material
+  (0600 permissions + atomic writes); stdio subprocess environments are sanitized so
+  host credential-shaped variables never leak through; directory summaries and error
+  paths go through a redactor
+- **Low-maintenance operations**: tiered status display (running / connecting / failed…);
+  bounded exponential-backoff auto-reconnect on disconnects; direct-connect `mcp__`
+  tools truncate results at 8KB and accept a per-server timeout override
+  (`toolCallTimeoutMs`), while middleware calls use a fixed 30s timeout
 
 ## Installation
 
@@ -65,10 +95,11 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-mcp-manager
 | Server management | CRUD (project-level/global optional), connect / disconnect / reconnect; versioned JSON config, atomic write |
 | Two transports | stdio (local subprocess, env supports `${ENV}` references) and streamable-http (remote, header supports `${ENV}` references, auto-echoes `Mcp-Session-Id`) |
 | JSON import | Paste `mcpServers` JSON text to import (JSON format only; does not scan any application config files) |
-| Model tools | Tools from connected servers registered as `mcp__<server>__<tool>` (64 chars, `[A-Za-z0-9_-]`, hashed suffix on conflict) |
+| Model tools | Global servers register directly as `mcp__<server>__<tool>` (64 chars, `[A-Za-z0-9_-]`, hashed suffix on conflict); project-level servers go through the middleware's `ws_mcp_search` / `ws_mcp_call` by default (`middleware: project`, recommended), so workspaces never clash |
+| Workspace isolation | The middleware routes by the calling session's cwd to the matching workspace connection pool; server full-name consistency checks (`@<root>/<server>`) prevent cross-workspace crosstalk |
 | Reconnection | Exponential backoff (starts at 500ms, caps at 30s, gives up after 10 attempts and deregisters the tools) |
-| Result truncation | Tool results truncated at 8KB and marked (prevents oversized JSON from entering context in full) |
-| Timeout fallback | Tool call timeout defaults to 60s → 15s (overridable per server via `toolCallTimeoutMs`) |
+| Result truncation | Direct-connect tool results truncated at 8KB and marked (prevents oversized JSON from entering context in full) |
+| Timeout fallback | Direct-connect tool call timeout defaults to 60s → 15s (overridable per server via `toolCallTimeoutMs`); middleware calls use a fixed 30s timeout |
 
 ## Configuration (floating window position)
 

--- a/packages/dsh-mcp-manager/README.md
+++ b/packages/dsh-mcp-manager/README.md
@@ -3,10 +3,30 @@
 [![GitHub Releases](https://img.shields.io/github/v/release/wingsky-1/dsh-plugin-hub)](https://github.com/wingsky-1/dsh-plugin-hub/releases)
 
 DSH（DeepSeek Harness）的 **MCP 服务器管理插件**：会话界面右上角浮窗 + 分级面板 +
-快速接入（手工表单 + 粘贴 mcpServers JSON 导入，**不预设任何服务器**），支持
-**项目级 MCP 跟随会话切换**。已连接服务器的工具以 `mcp__<serverName>__<rawName>`
-注册给模型直接调用。MCP 协议客户端基于 `node:child_process`
-与全局 `fetch` 直接实现，无需额外安装。
+快速接入（手工表单 + 粘贴 mcpServers JSON 导入，**不预设任何服务器**）。
+MCP 协议客户端基于 `node:child_process` 与全局 `fetch` 直接实现，无需额外安装。
+
+三档中间层模式（`middleware`）：`off`——全部服务器直呼 `mcp__<server>__<tool>`（旧行为）；
+`project`（**默认**）——项目级走中间层、全局仍直呼；`all`——全局也走中间层，
+cwd 无项目时回落全局虚拟 root `@global`，模型面完全收敛为两个原子工具。
+注意生效时机：`middleware` / `middlewarePolicy` 只在插件启动时读取，**变更后需重启
+`dsh web`**；两级配置文件中的服务器列表（增删/启停/改配置）支持热加载、即时生效，
+无需重启。
+
+## 核心优势
+
+- **上下文成本可控**：项目级 MCP 默认经中间层收敛，模型面只占 `ws_mcp_search` /
+  `ws_mcp_call` 两个原子工具位——当前工作空间的项目级接多少台服务器、多少个工具都
+  不膨胀系统提示词；`middleware: all` 可把全局服务器也收进中间层，实现全量收敛
+- **分工作目录维护**：项目级配置 `<项目根>/.dsh/mcp.json` 随仓库走、可提交 git 团队共享；
+  全局配置 `<DSH_HOME>/dsh-mcp.json` 常连；切换会话自动加载当前目录的 MCP 集
+- **工作空间隔离**：中间层以会话 cwd 路由到对应连接池，server 全名一致性校验防跨空间
+  串台；不同目录注入同名 server 也互不冲突
+- **安全的默认值**：配置只存 `${ENV}` 引用、不落盘密钥本身（0600 权限 + 原子写入）；
+  stdio 子进程环境净化，宿主凭据形状变量不透传；目录摘要与错误路径经 redactor 脱敏
+- **运维省心**：运行中/连接中/失败等分级状态一目了然；断线有界指数退避自动重连；
+  直连模式下工具结果按 8KB 截断、调用超时可按 server 覆盖（`toolCallTimeoutMs`），
+  中间层调用超时固定 30s
 
 ## 安装
 
@@ -86,11 +106,13 @@ SSE events 通道推送一变，客户端自动重新拉取 `/api/dsh-mcp/config
 
 ## 配置（中间层）
 
-项目级 MCP 经中间层访问（`middleware: project`，默认）：模型面恒定两个工具
-`ws_mcp_search`（先检索当前工作空间 MCP 工具）/ `ws_mcp_call`（按 `@<root>/<server>`
-全名调用），执行时按调用方会话当前 cwd 路由到对应工作空间连接池，不同工作空间
-注入不同 MCP、无命名冲突。切换 `middleware: off` 回到旧行为（项目级也直接注册
-`mcp__` 工具）；`middleware: all` 则全局服务器也走中间层。
+项目级 MCP 经中间层访问（`middleware: project`，默认）：项目级服务器不再注册
+`mcp__` 工具，改经模型面两个原子工具访问——`ws_mcp_search`（先检索当前工作空间 MCP
+工具）/ `ws_mcp_call`（按 `@<root>/<server>` 全名调用），执行时按调用方会话当前 cwd
+路由到对应工作空间连接池，不同工作空间注入不同 MCP、无命名冲突；全局服务器仍直呼
+`mcp__<server>__<tool>`。切换 `middleware: off` 回到旧行为（项目级也直接注册 `mcp__`
+工具）；`middleware: all` 则全局服务器也走中间层（cwd 无项目时回落全局虚拟 root
+`@global`），模型面完全收敛为两个原子工具。
 
 | 键 | 值域 | 默认 |
 | --- | --- | --- |

--- a/packages/dsh-provider-usage/README.en.md
+++ b/packages/dsh-provider-usage/README.en.md
@@ -2,11 +2,38 @@
 [![npm](https://img.shields.io/npm/v/@wingsky-1/dsh-provider-usage)](https://www.npmjs.com/package/@wingsky-1/dsh-provider-usage)
 [![GitHub Releases](https://img.shields.io/github/v/release/wingsky-1/dsh-plugin-hub)](https://github.com/wingsky-1/dsh-plugin-hub/releases)
 
-DSH (DeepSeek Harness) Web GUI plugin: **usage statistics float widget** (v2 contract rewrite).
+DSH (DeepSeek Harness) Web GUI plugin: a **generic multi-provider usage statistics
+framework** (v2 adapter contract).
 
 A persistent capsule at the top-right of the chat view shows usage for the current model
-provider; click it to open a detail panel. Rendering happens on the **host side** — user
-adapters return HTML, the client only injects it.
+provider; click it to open a detail panel. Two adapters work out of the box —
+**DeepSeek official** (balance + peak/valley countdown badge + daily usage estimation)
+and **OpenCode Go** (official `/v1/usage`, three windows); any other data source can be
+plugged in by writing one mjs adapter file against the v2 contract (detect/add/toggle on
+the settings page, see "Adapter development guide"). Rendering happens on the **host
+side** — adapters return HTML, the client only injects it, and API keys never reach
+the browser.
+
+## Core advantages
+
+- **Generic framework, works out of the box**: one v2 adapter contract carries any
+  provider; DeepSeek official and OpenCode Go adapters are built in — usage shows up
+  right after install
+- **Any data source takes one mjs file**: three exports (`fetchData` / `formatCapsule` /
+  `formatPanel`) complete an integration; detect/add/toggle hot-swappable from the
+  settings page, file edits auto hot-reload
+- **Daily usage even without a usage API**: the built-in DeepSeek adapter estimates
+  daily usage via a balance-difference conservation formula (top-up/grant disturbances
+  cancel out, abnormal windows excluded), plus a peak/valley countdown badge and a
+  15-day usage bar panel
+- **Keys never leave the host**: fetching runs host-side with keys kept and used only
+  on the host, never sent to the browser (credential-chain / env injection recommended;
+  an explicit `apiKey` config persists in host config files, 0600-protected); rendered
+  output goes through double sanitization (`esc()` escaping duty + structured
+  sanitization fallback) for a two-layer XSS defense
+- **Recoverable history, cache-backed performance**: daily-sharded JSONL persistence
+  (0600) with age/size auto-cleanup; in-process panel render cache + stats cache +
+  background warmup — repeated requests with unchanged data cost zero recompute
 
 > 中文文档：[README.md](README.md)（authoritative）。架构图解（flow / sequence charts）：
 > [docs/architecture.md](docs/architecture.md)；适配器开发引导：[docs/adapter-guide.md](docs/adapter-guide.md)。
@@ -288,7 +315,8 @@ or the plugin home; non-normalized forms (`../` traversal) are rejected with 400
   bound with fail-closed empty output beyond it (bounding worst-case CPU cost) — the
   decoded view is used solely for locating matches and never written back, so
   legitimately escaped text passes through untouched
-- **Hot reload is off by default**; when enabled it polls mtime+size, atomically swaps in
+- **Hot reload is on by default** (`autoReload`, can be disabled explicitly); when
+  enabled it polls mtime+size, atomically swaps in
   the new version only after validation passes, and keeps the old version on failure
 - **Timeout discipline**: fetchData gets a forced 5s timeout (fixed, not configurable) + AbortSignal; when the lock
   is busy requests degrade to cache instead of queueing — page requests are never blocked

--- a/packages/dsh-provider-usage/README.md
+++ b/packages/dsh-provider-usage/README.md
@@ -2,10 +2,27 @@
 [![npm](https://img.shields.io/npm/v/@wingsky-1/dsh-provider-usage)](https://www.npmjs.com/package/@wingsky-1/dsh-provider-usage)
 [![GitHub Releases](https://img.shields.io/github/v/release/wingsky-1/dsh-plugin-hub)](https://github.com/wingsky-1/dsh-plugin-hub/releases)
 
-DSH（DeepSeek Harness）Web GUI 插件：**用量统计悬浮框**（v2 契约重构版）。
+DSH（DeepSeek Harness）Web GUI 插件：**多 provider 通用用量统计框架**（v2 适配器契约）。
 
-聊天界面右上角常驻悬浮胶囊，展示模型 provider 的用量信息；点击展开详情面板。
-渲染在**宿主端**完成——用户适配器返回 HTML，客户端只做注入。
+聊天界面右上角常驻悬浮胶囊，展示当前模型 provider 的用量信息；点击展开详情面板。
+内置两套适配器开箱即用——**DeepSeek 官方**（余额 + 峰谷倒计时徽标 + 每日用量推算）与
+**OpenCode Go**（官方 `/v1/usage` 三窗口用量）；其他任意数据源只需按 v2 契约写一个
+mjs 适配器文件即可接入（设置页检测/添加/切换热插拔，见「适配器开发指南」）。
+渲染在**宿主端**完成——适配器返回 HTML、客户端只做注入，密钥不进浏览器。
+
+## 核心优势
+
+- **通用框架 + 开箱即用**：一套 v2 适配器契约承载任意 provider；DeepSeek 官方与
+  OpenCode Go 两套适配器内置，装完即显示用量
+- **接入任意数据源只需一个 mjs 文件**：`fetchData` / `formatCapsule` / `formatPanel`
+  三个导出即完成接入；设置页检测/添加/切换热插拔，改文件自动热更新
+- **官方没有用量接口也能算**：DeepSeek 内置适配器以余额差守恒式推算每日用量
+  （充值/赠款扰动自动抵消、异常区间不计），附峰谷倒计时徽标与 15 日用量柱形面板
+- **密钥不出宿主**：取数在宿主端执行，密钥只在宿主端持有与使用、不下发浏览器
+  （推荐凭据链 / env 注入；显式 `apiKey` 配置会随宿主配置落盘并以 0600 保护）；
+  渲染输出双层净化（`esc()` 转义义务 + 结构化净化兜底），XSS 双重防线
+- **历史可回溯、性能有兜底**：按天分片 JSONL 落盘（0600）、超龄超量自动清理；
+  面板渲染进程内缓存 + stats 缓存 + 后台预热，数据未变时重复请求零重算
 
 ## 安装
 
@@ -253,7 +270,7 @@ plugins:
   协议型载体再按 WHATWG URL 语义剥除 Tab/LF/CR 后定位（jav&#9;ascript: 族同封）；
   净化只删不改并在宽松轮数上限内迭代收敛，超限 fail-closed 丢弃输出（约束最坏 CPU 成本）：
   解码副本仅用于定位、绝不回写输出，合法转义文本零损伤
-- **热更新安全**：默认关闭；开启后以 mtime+size 轮询检测变化，新版校验通过才原子切换，
+- **热更新安全**：默认开启（`autoReload`，可显式关闭）；开启后以 mtime+size 轮询检测变化，新版校验通过才原子切换，
   失败保留旧版并登记错误
 - **超时纪律**：fetchData 强制 5s 超时（固定值，不可配置）+ AbortSignal 传递；锁忙时不排队、直接降级返回缓存——
   任何情况下不阻塞页面其他请求


### PR DESCRIPTION
## 概要

纯文档改动（6 个 README，中英同步，+158/−32）：

### 主 README / README.en.md
- 新增「核心优势」节（4 条）：安全内建于默认 / 上下文成本可控的 MCP 管理 / 可扩展用量统计框架 / 工程质量背书
- 插件列表两行校正：mcp-manager 突出分工作目录维护与中间层收敛；provider-usage 补上内置 DeepSeek 官方适配器（原文仅提 OpenCode Go，与实际内置双适配器不符）

### packages/dsh-mcp-manager
- 简介重写：两大核心设计（分工作目录维护 / 中间层原子工具）+ 三档中间层模式说明 + 生效时机（`middleware`/`middlewarePolicy` 需重启；两级配置文件的服务器列表支持热加载）
- 修正「模型面恒定两工具」过度声明：默认 `project` 下全局服务器仍直呼 `mcp__` 工具，`all` 才全量收敛（含 cwd 无项目回落 `@global`）
- 修正「8KB 截断 / per-server 超时」为直连模式限定（源码实证中间层路径不适用，超时固定 30s）
- 英文能力表同步中文版：Model tools 分档表述、补 Workspace isolation 行、截断/超时行加直连限定

### packages/dsh-provider-usage
- 定位提升为「多 provider 通用用量统计框架」，内置双适配器前置
- 密钥声明修正：「apiKey 仅存宿主进程内存」→「宿主端持有与使用」（显式 `apiKey` 配置会随宿主配置落盘并以 0600 保护）
- 修正安全模型节「热更新默认关闭」既有错误（`autoReload` 实际默认开启，原句与本文件配置表自相矛盾）

## 验证

- 全部行为声明经主 checkout 源码逐条实证（middleware 三档语义/默认值/`@global` 回落/热载范围、supervisor 截断与超时路径、autoReload 默认值等）
- 经独立子 agent 对抗性复核：P1×2、P2×4 全部处置，排版维度无问题
- docs-only，不影响构建产物；门禁照常跑

## 备注

- 根 `README.en.md` bundle 行缺「观察期插件除外」对应翻译为既有问题（非本次引入），留待后续处理
