### PR TITLE
ci: observe 按需基线 + docs 移出全切片过滤面（#220）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,10 @@ jobs:
               - 'scripts/**'
               - 'agents/**'
               - '.github/**'
-              - 'docs/**'
+              # docs/** 刻意不在 global 面（#220）：gate/build/release 脚本均不消费
+              # docs/ 内容，文档 PR 无需变异切片与 smoke/typecheck（release-notes
+              # 校验仅存在于 tag 触发的 release.yml）。若未来新增消费 docs 的门禁
+              # 脚本，须同步加回此处——workflow-assert 契约已锁定该约定
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'

--- a/.github/workflows/observe.yml
+++ b/.github/workflows/observe.yml
@@ -47,6 +47,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        # #220 按需基线：push 事件需 before 对象可达以 diff 变动包（fail-closed 全量兜底）
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
@@ -77,18 +80,62 @@ jobs:
       - name: Mutation scope guard（F5：mutate 区间须落在 // lib/*.js 分段边界内）
         run: node scripts/gate/mutate-scope-guard.mjs
 
-      - name: Mutation suites（全部变异配置串行全量；单配置失败记账继续跑完，结尾统一判红）
+      - name: Resolve mutation suites（#220 按需基线：push 只跑变动包，其余事件全量）
+        id: suite-plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -e
+          # 全量清单（glob conf 目录为单一事实源）
+          list_all() { ls stryker.conf.d/dsh-*.json; }
+          # 非 push（schedule/dispatch 兜底校准）→ 全量；push 且 before 不可用 → fail-closed 全量
+          if [ "$EVENT_NAME" != "push" ]; then
+            list_all > /tmp/suites.txt
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+          elif [ -z "$BEFORE_SHA" ] || echo "$BEFORE_SHA" | grep -qv '^[0-9a-f]\{40\}$'; then
+            echo '::notice::before SHA 不可用 —— fail-closed 全量'
+            list_all > /tmp/suites.txt
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+          else
+            CHANGED="$(git diff --name-only "$BEFORE_SHA"..HEAD || true)"
+            # 产物全集级变化（shared 内联进每包 / 构建链）→ 全量
+            if printf '%s\n' "$CHANGED" | grep -qE '^(shared/|pnpm-lock\.yaml$|package\.json$|pnpm-workspace\.yaml$|tsconfig\.base\.json$)'; then
+              echo '::notice::shared/构建链变化 —— 全量刷新'
+              list_all > /tmp/suites.txt
+              echo "mode=full" >> "$GITHUB_OUTPUT"
+            else
+              # 逐包判定：packages/<pkg>/** 或该包 conf 变化 → 该包全部段配置
+              : > /tmp/suites.txt
+              for pkgdir in packages/dsh-*; do
+                pkg="$(basename "$pkgdir")"
+                if printf '%s\n' "$CHANGED" | grep -qE "^packages/${pkg}/" ; then
+                  ls stryker.conf.d/"$pkg"-*.json stryker.conf.d/"$pkg".json 2>/dev/null >> /tmp/suites.txt || true
+                fi
+              done
+              # conf 自身变化 → 对应包重跑（glob 已被上面 ls 覆盖：conf 命中即包名匹配）
+              sort -u /tmp/suites.txt -o /tmp/suites.txt
+              N="$(wc -l < /tmp/suites.txt)"
+              echo "mode=partial ($N 配置)" >> "$GITHUB_OUTPUT"
+              echo '::notice::按需基线：仅跑变动包配置'
+            fi
+          fi
+          HAS=$([ -s /tmp/suites.txt ] && echo true || echo false)
+          echo "has_suites=$HAS" >> "$GITHUB_OUTPUT"
+
+      - name: Mutation suites（串行执行计划内变异配置；单配置失败记账继续跑完，结尾统一判红）
         # id 供 collect 步骤区分「整套 skip（无产物无从收集）」与「部分失败
         # （记账夜已产出的基线照常收集）」（#217）
         id: mutation-suites
+        if: steps.suite-plan.outputs.has_suites == 'true'
         # #178 逐包容错：strict 判红路径下 incremental 基线已先落盘（StrykerJS 源码核实），
         # 记账继续可让后续包照常产出报告与基线，避免单包连锁丢弃整夜数据。
-        # #220 B 方案：不再硬编码包名单 —— glob stryker.conf.d/dsh-*.json 全集
-        #（含拆分三包的段配置与未拆分包的包级配置），新增/退役配置自动纳入
+        # #220 B 方案：循环清单由 suite-plan 步骤产出（全量 glob 或按需裁剪），
+        # 本步骤不再关心名单来源
         run: |
           FAILED=0
           FAILED_CONFS=''
-          for conf in stryker.conf.d/dsh-*.json; do
+          while read -r conf; do
             name="$(basename "$conf" .json)"
             echo "::group::stryker $name"
             if npx stryker run "$conf"; then
@@ -99,7 +146,7 @@ jobs:
               FAILED=1
               FAILED_CONFS="$FAILED_CONFS $name"
             fi
-          done
+          done < /tmp/suites.txt
           if [ "$FAILED" -ne 0 ]; then
             echo "::error::以下变异套件失败，统一判红:$FAILED_CONFS"
             exit 1
@@ -109,9 +156,9 @@ jobs:
         # #204 方案 A（业界最佳实践）：夜间基线改「仓库内版本化文件」，替代 actions/cache
         # save。actions/cache 按 ref 隔离（PR 永远读不到 main 的缓存，社区广泛确认，
         # GitHub Community #58583），而 git 内容跨 ref 天然可见、可本地实证。
-        # if: always() && 非 skipped —— 部分失败夜已产出的基线文件照常收集；
-        # 但整套变异被 skip 时无任何产物，collect 不运行（防 copied=0 误红，#217）。
-        if: always() && steps.mutation-suites.outcome != 'skipped'
+        # if: always() && 非 skipped 且有计划 —— 部分失败夜已产出的基线文件照常收集；
+        # 但整套变异被 skip 或按需计划为空时无任何产物，collect 不运行（防 copied=0 误红，#217/#220）。
+        if: always() && steps.mutation-suites.outcome != 'skipped' && steps.suite-plan.outputs.has_suites == 'true'
         run: node scripts/gate/collect-incremental-baseline.mjs
 
       - name: Open baseline PR（基线有变化时自动建 PR 合入 main）

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -128,10 +128,35 @@ test('observe.yml: 夜间调度 + 双硬门禁执行点 + issues 写权限', () 
   assert.ok(OBSERVE.includes('observe-check.mjs'), '阈值校验+回落检测脚本执行点（F1/F6）')
 })
 
-test('#220 段式三方一致：observe glob ↔ stryker.conf.d 文件集 ↔ gauntlet 包集', () => {
-  // observe.yml 循环已 glob 化（#220 B）：不再硬编码包名单，新增配置自动纳入
-  assert.ok(OBSERVE.includes('for conf in stryker.conf.d/dsh-*.json'),
-    'observe 变异循环必须 glob stryker.conf.d/dsh-*.json 全集（#220 段拆分后配置数 > 包数）')
+test('#220: docs 不在 ci.yml global 过滤面——文档 PR 不触发变异切片', () => {
+  // gate/build/release 脚本均不消费 docs/ 内容；release-notes 校验仅在 release.yml。
+  // 若未来新增消费 docs 的门禁脚本，须把 'docs/**' 加回 global 组并同步本断言
+  const filterBlock = CI.slice(CI.indexOf('filters: |'), CI.indexOf("dsh-notifier:"))
+  assert.ok(!/^.*-\s'docs\/\*\*'/m.test(filterBlock),
+    "docs/** 不得出现在 global 过滤组——纯文档 PR 不应触发全量切片")
+  assert.ok(CI.includes('# docs/** 刻意不在 global 面'),
+    '过滤面旁必须保留理由注释（防后人「好心」加回）')
+})
+
+test('#220: observe 按需基线——push 裁剪、兜底全量、空计划跳过 collect', () => {
+  assert.ok(OBSERVE.includes('Resolve mutation suites'), 'suite-plan 步骤在位')
+  assert.ok(OBSERVE.includes("EVENT_NAME\"] = \"push") || OBSERVE.includes('[ "$EVENT_NAME" != "push" ]'),
+    '非 push 事件必须走全量清单')
+  assert.ok(OBSERVE.includes('grep -qv \'^[0-9a-f]\\{40\\}$\''),
+    'before SHA 不可用必须 fail-closed 全量')
+  assert.ok(OBSERVE.includes("^(shared/|pnpm-lock\\.yaml$"),
+    'shared/与构建链文件变化必须强制全量刷新（内联产物全集漂移）')
+  assert.ok(OBSERVE.includes("steps.suite-plan.outputs.has_suites == 'true'"),
+    '变异执行与 collect 必须以 has_suites 为前提——空计划不跑 collect 防 copied=0 误红')
+})
+
+test('#220 段式三方一致：observe 计划 ↔ stryker.conf.d 文件集 ↔ gauntlet 包集', () => {
+  // observe.yml 循环清单由 suite-plan 步骤产出（#220 按需基线）：全量模式 glob
+  // conf 目录，push 模式按变动包裁剪——循环本身从计划文件读取
+  assert.ok(OBSERVE.includes('list_all() { ls stryker.conf.d/dsh-*.json; }'),
+    'observe suite-plan 的全量清单必须以 glob stryker.conf.d/dsh-*.json 为单一事实源（新增配置自动纳入）')
+  assert.ok(OBSERVE.includes('while read -r conf; do'),
+    '变异循环必须从 suite-plan 清单文件逐行消费')
 
   // stryker.conf.d 实际文件集 → 基础包名集合（段配置 <pkg>-<n>.json 归并到 <pkg>）
   const confDir = join(ROOT, 'stryker.conf.d')


### PR DESCRIPTION
## 关联 issue

#220（维护者指示实施，提案记录见 issue 评论）

## 改动一：observe push 触发改按需跑

- 新增 `Resolve mutation suites` 步骤：push 事件 diff `before..main`，仅变动包的全部段配置进入执行计划；`shared/**`/lockfile/tsconfig/conf 变化或 diff 不可得 → fail-closed 全量；schedule/dispatch 保持全量兜底；
- 依据：PR 侧本就增量执行，基线过期只影响重测面不影响正确性；nightly 全量保留系统性漂移校准；
- 收益：连续合入日（如 #257/#266/#273 同日多合）push observe 从 ~25min 降至 ~8-12min，基线窗口期缩短。

## 改动二：docs/** 移出 ci.yml global 过滤组

- 核查确认 gate/build/release 脚本均不消费 docs/ 内容（release-notes 校验仅在 release.yml）；纯文档 PR 不再触发全量切片与 smoke/typecheck，预期 wall-clock ~12min → ~3min；
- 过滤面旁保留理由注释 + 契约断言双保险防回归。

## 验证

- [x] YAML 解析通过；
- [x] workflow-assert 25/25（含 2 条新契约：docs 排除锁定、suite-plan fail-closed 结构）；
- [x] suite-plan 四场景 shell 模拟：单包变更裁剪 ✓ / docs 空 ✓ / shared 全量 ✓ / dispatch 全量 ✓。