### PR TITLE
fix(dsh-mcp-manager): SSE 半开连接防护——服务端 30s 心跳 + 客户端 watchdog/回前台重建

### DIFF
--- a/packages/dsh-mcp-manager/README.en.md
+++ b/packages/dsh-mcp-manager/README.en.md
@@ -100,6 +100,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-mcp-manager
 | Reconnection | Exponential backoff (starts at 500ms, caps at 30s, gives up after 10 attempts and deregisters the tools) |
 | Result truncation | Direct-connect tool results truncated at 8KB and marked (prevents oversized JSON from entering context in full) |
 | Timeout fallback | Direct-connect tool call timeout defaults to 60s → 15s (overridable per server via `toolCallTimeoutMs`); middleware calls use a fixed 30s timeout |
+| Push self-healing | Triple safeguard on the SSE channel: server sends a data ping heartbeat every 30s; client reconnects (closing the stale EventSource first) after 60s of frame silence (watchdog); connection is force-rebuilt when the page becomes visible again — half-open connections silently severed by mobile OS backgrounding heal on their own instead of piling up as zombies |
 
 ## Configuration (floating window position)
 

--- a/packages/dsh-mcp-manager/README.md
+++ b/packages/dsh-mcp-manager/README.md
@@ -85,6 +85,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-mcp-manager
 | 断线重连 | 有界指数退避（500ms 起、30s 上限、10 次后停止后台重试；用户手动连接或 ws_mcp_call 触发可再试） |
 | 结果截断 | 工具结果按 8KB 截断并标注（防超长 JSON 全量进上下文） |
 | 超时下探 | 工具调用超时默认 60s → 15s（可按服务器 `toolCallTimeoutMs` 覆盖） |
+| 状态推送自愈 | SSE 通道三重防护：服务端每 30s 发 data ping 心跳、客户端 60s 无帧即关旧建新（watchdog）、页面回前台强制重建连接——移动端切后台被系统静默掐断的半开连接可自愈，不堆积僵尸连接 |
 
 ## 配置（浮窗位置）
 

--- a/packages/dsh-mcp-manager/src/client/index.ts
+++ b/packages/dsh-mcp-manager/src/client/index.ts
@@ -84,12 +84,26 @@ export function apply(ctx: any): void {
     };
     attemptRefresh(0);
 
-    // 状态推送（SSE）：宿主状态变化（连接/重连/失败）→ 节流刷新；SSE 真正
-    // 关闭（非自动重连）才降级为 10s 轮询兜底。
+    // 状态推送（SSE）：宿主状态变化（连接/重连/失败）→ 节流刷新；SSE 放弃
+    // （连续 CLOSED 3 次）才降级为 10s 轮询兜底。
+    //
+    // 半开连接防护（#268，移植 dsh-notifier 0.1.8 方案）：移动端切后台系统
+    // 冻结 JS 并静默掐断 TCP，两端均收不到 FIN/RST，onerror/close 都不触发。
+    // 三路防线：
+    //   - 服务端 30s data ping 心跳（routes.ts SSE_HEARTBEAT_MS）供失活信号；
+    //   - 60s watchdog：超时无帧判定半开，关旧建新；
+    //   - visibilitychange 回前台：强制关旧 EventSource 重建。
     let es: any = undefined;
     let refreshTimer: any = undefined;
     let esFailures = 0;
     let pollTimer: any = undefined;
+    // watchdog 状态：收到任意数据帧即喂狗；超时 → 受控重建。
+    const WATCHDOG_MS = 60_000;
+    let lastActivity = 0;
+    let lastReconnectAt = 0;
+    let watchdog: any = undefined;
+    // SSE 已放弃 → 轮询接管，禁止任何路径再建 EventSource。
+    let eventsRetired = false;
     const scheduleRefresh = () => {
       if (refreshTimer !== undefined) return;
       refreshTimer = setTimeout(() => {
@@ -98,6 +112,11 @@ export function apply(ctx: any): void {
       }, 500);
     };
     const startPolling = () => {
+      eventsRetired = true;
+      if (watchdog !== undefined) {
+        clearTimeout(watchdog);
+        watchdog = undefined;
+      }
       if (pollTimer !== undefined) return;
       const tick = () => {
         pollTimer = setTimeout(() => {
@@ -107,48 +126,95 @@ export function apply(ctx: any): void {
       };
       tick();
     };
-    try {
-      es = new EventSource(state.API.events);
-      es.onmessage = (ev: MessageEvent) => {
-        let msg: any;
-        try {
-          msg = JSON.parse(String(ev.data));
-        } catch {
-          msg = undefined;
-        }
-        if (msg !== undefined && msg.type === "ui-config-changed") {
-          // 配置变更（设置页保存 position/offset）→ 重新 GET /config 就地更新浮窗位置，
-          // 非仅刷新 /servers；更新 mcpUiConfig 后重新定位胶囊与（若展开的）面板。
-          void api(state.API.config).then((cfg: any) => {
-            if (cfg !== null && typeof cfg === "object") state.mcpUiConfig = cfg;
-            state.updateFloatState?.();
-          }).catch(() => {});
+    // 关旧连接：所有重建路径共用此入口——覆盖 source 引用不 close 会逐步
+    // 耗尽浏览器同源并发连接、其余请求全部 pending（dsh-notifier 0.1.8 同款
+    // 事故），故 new EventSource 前必先关旧。
+    const closeEvents = () => {
+      if (es === undefined) return;
+      try {
+        es.close();
+      } catch (error) {
+        console.warn("[dsh-mcp-manager] 关闭旧 SSE 连接失败：", error);
+      }
+      es = undefined;
+    };
+    /** SSE 半开连接看门狗：60s 无任何帧（summary/ui-config-changed/ping）→ 主动重建。 */
+    const armWatchdog = () => {
+      if (watchdog !== undefined) clearTimeout(watchdog);
+      watchdog = setTimeout(() => {
+        if (Date.now() - lastActivity > WATCHDOG_MS) {
+          forceReconnect();
         } else {
-          scheduleRefresh();
+          armWatchdog(); // 期间有活动，续期再查
         }
-      };
-      es.onerror = () => {
-        // 宿主重启/热重载/网络抖动会主动断开旧连接，浏览器随即自动重连
-        // （readyState 回到 CONNECTING）——这种瞬时断连不是失败，不累计。
-        // 只有连接真正关闭（如路由 404）才计数，3 次后放弃 SSE 改轮询。
-        if (es !== undefined && es.readyState === EventSource.CLOSED) {
-          esFailures += 1;
-          if (esFailures >= 3) {
-            es.close();
-            es = undefined;
-            startPolling();
+      }, WATCHDOG_MS + 5000);
+    };
+    const connectEvents = () => {
+      closeEvents();
+      try {
+        es = new EventSource(state.API.events);
+        lastActivity = Date.now();
+        es.onmessage = (ev: MessageEvent) => {
+          // 收到任意数据帧即喂狗（含心跳 ping 帧）：链路活性证明。
+          lastActivity = Date.now();
+          let msg: any;
+          try {
+            msg = JSON.parse(String(ev.data));
+          } catch {
+            msg = undefined;
           }
-        }
-      };
-    } catch {
-      // EventSource 不可用：直接轮询兜底。
-      startPolling();
-    }
+          if (msg !== undefined && msg.type === "ui-config-changed") {
+            // 配置变更（设置页保存 position/offset）→ 重新 GET /config 就地更新浮窗位置，
+            // 非仅刷新 /servers；更新 mcpUiConfig 后重新定位胶囊与（若展开的）面板。
+            void api(state.API.config).then((cfg: any) => {
+              if (cfg !== null && typeof cfg === "object") state.mcpUiConfig = cfg;
+              state.updateFloatState?.();
+            }).catch(() => {});
+          } else {
+            scheduleRefresh();
+          }
+        };
+        es.onerror = () => {
+          // 宿主重启/热重载/网络抖动会主动断开旧连接，浏览器随即自动重连
+          // （readyState 回到 CONNECTING）——这种瞬时断连不是失败，不累计。
+          // 只有连接真正关闭（如路由 404）才计数，3 次后放弃 SSE 改轮询；
+          // 未达阈值时 CLOSED 后浏览器不再自动重连，交 watchdog 受控重建兜底。
+          if (es !== undefined && es.readyState === EventSource.CLOSED) {
+            esFailures += 1;
+            if (esFailures >= 3) {
+              closeEvents();
+              startPolling();
+            }
+          }
+        };
+        armWatchdog();
+      } catch {
+        // EventSource 不可用：直接轮询兜底。
+        startPolling();
+      }
+    };
+    // 受控重建入口（关旧 + 5s 节流）：visibilitychange / watchdog 两路共用，
+    // 避免赤裸 connect 重复建连。
+    const forceReconnect = () => {
+      if (eventsRetired) return;
+      const now = Date.now();
+      if (now - lastReconnectAt < 5000) return;
+      lastReconnectAt = now;
+      connectEvents();
+    };
 
-    // 切回本标签页/窗口时兜底刷新：隐藏期间错过的 SSE 广播不会重放，
-    // 恢复可见后主动拉一次，避免 UI 停留在过期状态（如项目级显示未连接）。
+    // 首次建连（后续重建一律走 forceReconnect 受控入口）。
+    connectEvents();
+
+    // 切回本标签页/窗口时兜底刷新 + 强制重建 SSE（#268）：隐藏期间错过的
+    // SSE 广播不会重放需补拉一次；后台期间连接可能已被静默掐断成半开，
+    // onerror/close 均不触发，重建代价低（服务端首帧即全量 summary），换推送
+    // 链路确定性复活。5s 节流挡快速切换的重复建连。
     const onVisible = () => {
-      if (!document.hidden) void refresh(state, actions).catch(() => {});
+      if (!document.hidden) {
+        forceReconnect();
+        void refresh(state, actions).catch(() => {});
+      }
     };
     document.addEventListener("visibilitychange", onVisible);
 
@@ -156,7 +222,8 @@ export function apply(ctx: any): void {
       clearTimeout(retryTimer);
       if (refreshTimer !== undefined) clearTimeout(refreshTimer);
       if (pollTimer !== undefined) clearTimeout(pollTimer);
-      if (es !== undefined) es.close();
+      if (watchdog !== undefined) clearTimeout(watchdog);
+      closeEvents();
       document.removeEventListener("visibilitychange", onVisible);
       for (const dispose of disposers.splice(0)) dispose();
       if (state.overlay !== undefined && state.overlay.parentElement !== null) state.overlay.remove();

--- a/packages/dsh-mcp-manager/src/client/index.ts
+++ b/packages/dsh-mcp-manager/src/client/index.ts
@@ -163,6 +163,9 @@ export function apply(ctx: any): void {
           } catch {
             msg = undefined;
           }
+          // 心跳帧：仅喂狗即早退——若落入下方 else 触发 scheduleRefresh，SSE
+          // 会退化为隐性 30s 轮询（对齐 notifier 语义：ping 不驱动业务刷新）。
+          if (msg?.type === "ping") return;
           if (msg !== undefined && msg.type === "ui-config-changed") {
             // 配置变更（设置页保存 position/offset）→ 重新 GET /config 就地更新浮窗位置，
             // 非仅刷新 /servers；更新 mcpUiConfig 后重新定位胶囊与（若展开的）面板。

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -269,6 +269,8 @@ export class McpManager {
   /** 设置命名空间写入 sink（apply 时经 ctx.inject(["settings"]) 注入；注入不到则写不可用）。 */
   uiUpdate?: (patch: Record<string, unknown>) => Promise<unknown>;
   sseConnections?: Set<ServerResponse>;
+  /** SSE 心跳定时器清理函数（makeEventsRoute 注册；卸载 disposer 统一执行，#268）。 */
+  sseHeartbeatCleanups?: Set<() => void>;
   /** 中间层模式（Config.middleware 归一化）。 */
   middlewareMode: MiddlewareMode;
   /** 中间层实例（连接池 + 目录 + 路由；惰性创建）。 */
@@ -1055,6 +1057,10 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
       return () => {
         unsubscribeStatus();
         for (const dispose of disposers) dispose();
+        // 先清 SSE 心跳定时器（#268）：disposer 显式清 interval，不依赖
+        // 下方 res.destroy() 触发 close 的异步时序。
+        for (const stopHeartbeat of manager.sseHeartbeatCleanups ?? []) stopHeartbeat();
+        manager.sseHeartbeatCleanups?.clear();
         for (const res of manager.sseConnections ?? []) {
           try {
             res.destroy();
@@ -1224,7 +1230,7 @@ export {
   MAX_TOTAL_CATALOG_BYTES,
 } from "./middleware.js";
 // 路由
-export { ROUTES, makeRoutes, makeEventsRoute, makeHealthRoute, sseData, uiConfigChangedFrame, broadcastFrame } from "./routes.js";
+export { ROUTES, makeRoutes, makeEventsRoute, makeHealthRoute, sseData, uiConfigChangedFrame, broadcastFrame, SSE_HEARTBEAT_MS, SSE_PING_FRAME } from "./routes.js";
 export { SCOPE_GLOBAL, SCOPE_PROJECT, normalizeScope } from "./scope.js";
 // 仓库共享层（loopback 围栏 / writeJson / readJsonBody）
 export { isLoopbackRequest } from "../../../shared/loopback.js";

--- a/packages/dsh-mcp-manager/src/routes.ts
+++ b/packages/dsh-mcp-manager/src/routes.ts
@@ -391,11 +391,21 @@ export function makeEventsRoute(manager: RoutesManager, options?: { heartbeatMs?
       res.write(": connected\n\n");
       res.write(sseData({ type: "summary" }));
       connections.add(res);
-      // 每连接一条心跳定时器：close 时清；destroyed 自愈检查兜底 close 丢失的
-      // 极端场景（向死管道空转即自杀），unref 使其不阻止进程退出。
-      const heartbeat = setInterval(() => {
+      // 每连接一条心跳定时器（notifier 为 hub 级单 interval——本包 makeEventsRoute
+      // 无 hub 对象可挂，per-connection 使 close 清理与泄漏防线在同一闭包内自洽）。
+      // 三路清理收敛到 stopHeartbeat：close 事件 / 插件卸载 disposer / destroyed
+      // 自愈（close 丢失的极端场景，向死管道空转即自杀退出）；unref 使其不阻止
+      // 进程退出。
+      const cleanups = manager.sseHeartbeatCleanups ??= new Set();
+      let heartbeat: ReturnType<typeof setInterval> | undefined;
+      const stopHeartbeat = (): void => {
+        if (heartbeat !== undefined) clearInterval(heartbeat);
+        heartbeat = undefined;
+        cleanups.delete(stopHeartbeat);
+      };
+      heartbeat = setInterval(() => {
         if (res.destroyed || res.writableEnded) {
-          clearInterval(heartbeat);
+          stopHeartbeat();
           return;
         }
         try {
@@ -405,11 +415,6 @@ export function makeEventsRoute(manager: RoutesManager, options?: { heartbeatMs?
         }
       }, heartbeatMs);
       heartbeat.unref();
-      const cleanups = manager.sseHeartbeatCleanups ??= new Set();
-      const stopHeartbeat = (): void => {
-        clearInterval(heartbeat);
-        cleanups.delete(stopHeartbeat);
-      };
       cleanups.add(stopHeartbeat);
       res.on("close", () => {
         stopHeartbeat();

--- a/packages/dsh-mcp-manager/src/routes.ts
+++ b/packages/dsh-mcp-manager/src/routes.ts
@@ -35,6 +35,11 @@ export interface RoutesManager {
   projectStoreOrThrow(): Promise<McpStore>;
   store: McpStore;
   sseConnections?: Set<ServerResponse>;
+  /**
+   * SSE 心跳定时器的逐连接清理函数（makeEventsRoute 注册；close 时自删）。
+   * 插件卸载时由 apply 的路由 disposer 统一执行，防 interval 泄漏（#268）。
+   */
+  sseHeartbeatCleanups?: Set<() => void>;
   supervisors: Map<string, { status: string; tools: string[] }>;
   catalogCache: Map<string, unknown>;
   /** 中间层模式（off/project/all；health 计数展示用，缺省 off）。 */
@@ -331,6 +336,16 @@ export function uiConfigChangedFrame(): string {
   return sseData({ type: "ui-config-changed" });
 }
 
+/**
+ * SSE 心跳间隔：30s data ping（对齐 dsh-notifier HEARTBEAT_MS 形态，#268）。
+ * 必须用 data 而非注释帧——注释帧既不触发客户端 onmessage 也不触发 onerror，
+ * 半开连接（移动端切后台系统冻结 JS 并静默掐断 TCP）时客户端零事件无法自愈；
+ * data 帧喂客户端 60s watchdog 使其能检测失活并关旧建新。
+ */
+export const SSE_HEARTBEAT_MS = 30_000;
+/** 心跳 ping 帧（内容固定，模块级缓存避免逐次序列化）。 */
+export const SSE_PING_FRAME = sseData({ type: "ping" });
+
 /** 向全部 SSE 连接写出一帧（逐连接 try/catch，掉线忽略）。 */
 export function broadcastFrame(connections: Set<ServerResponse> | undefined, frame: string): void {
   for (const res of connections ?? []) {
@@ -347,8 +362,14 @@ export function broadcastFrame(connections: Set<ServerResponse> | undefined, fra
  * 广播 `{ type: "summary" }` 帧（内容不随帧传输，浏览器收到后自行拉取）。
  * 连接集合挂在 manager.sseConnections 上（惰性创建），插件卸载时由
  * apply 的清理函数统一 destroy。
+ *
+ * 半开连接防护（#268，对齐 dsh-notifier）：写完初始帧后每 30s 向本连接写一条
+ * data ping 心跳——移动端切后台系统冻结 JS 并静默掐断 TCP，两端均收不到
+ * FIN/RST，无心跳则客户端 watchdog 无失活信号可依；close 时清定时器防泄漏，
+ * 清理函数同时登记 manager.sseHeartbeatCleanups 供插件卸载 disposer 兜底。
  */
-export function makeEventsRoute(manager: RoutesManager): WebRoute {
+export function makeEventsRoute(manager: RoutesManager, options?: { heartbeatMs?: number }): WebRoute {
+  const heartbeatMs = options?.heartbeatMs ?? SSE_HEARTBEAT_MS;
   return {
     kind: "exact",
     path: ROUTES.events,
@@ -370,7 +391,28 @@ export function makeEventsRoute(manager: RoutesManager): WebRoute {
       res.write(": connected\n\n");
       res.write(sseData({ type: "summary" }));
       connections.add(res);
+      // 每连接一条心跳定时器：close 时清；destroyed 自愈检查兜底 close 丢失的
+      // 极端场景（向死管道空转即自杀），unref 使其不阻止进程退出。
+      const heartbeat = setInterval(() => {
+        if (res.destroyed || res.writableEnded) {
+          clearInterval(heartbeat);
+          return;
+        }
+        try {
+          res.write(SSE_PING_FRAME);
+        } catch {
+          // 连接已断，等待 close 事件清理
+        }
+      }, heartbeatMs);
+      heartbeat.unref();
+      const cleanups = manager.sseHeartbeatCleanups ??= new Set();
+      const stopHeartbeat = (): void => {
+        clearInterval(heartbeat);
+        cleanups.delete(stopHeartbeat);
+      };
+      cleanups.add(stopHeartbeat);
       res.on("close", () => {
+        stopHeartbeat();
         connections.delete(res);
       });
     },

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -9,6 +9,8 @@
 //   - McpStore 落盘/读回（临时目录）
 //   - makeRoutes：GET 列表 / POST 添加 / PATCH 更新 / DELETE 删除 /
 //     import/json 导入
+//   - SSE 半开防护（#268）：服务端 30s data ping 心跳 + 客户端 60s
+//     watchdog / 回前台强制重建（详见 unit-routes-sse 与下方产物断言）
 //   - apply：enabled:false 时不注册路由与提示词
 //
 // 运行：node dsh-mcp-manager/test/smoke.mjs
@@ -227,6 +229,33 @@ const main = async () => {
     const clientSrc = readFileSync(new URL("../lib/client.js", import.meta.url), "utf8");
     assert.ok(clientSrc.includes("settings.plugin.item"), "settings.plugin.item 卡已注册");
     assert.ok(clientSrc.includes("dsh-mcp-manager"), "卡片 key/id 引用宿主命名空间 dsh-mcp-manager");
+  });
+
+  console.log("SSE 半开连接防护（#268：服务端心跳 + 客户端 watchdog + 回前台重建）");
+  check("客户端 watchdog：60s 失活重建 + 建连前先关旧（0.1.8 同款防泄漏）", () => {
+    const clientSrc = readFileSync(new URL("../lib/client.js", import.meta.url), "utf8");
+    assert.match(clientSrc, /WATCHDOG_MS\s*=\s*(?:60_?000|6e4|60000)/, "60s watchdog 常量存在");
+    assert.ok(clientSrc.includes("forceReconnect"), "受控重建入口 forceReconnect 存在");
+    assert.ok(clientSrc.includes("closeEvents"), "关旧连接入口 closeEvents 存在");
+    // 关旧建新：new EventSource 前必先关旧——覆盖 source 引用不 close 会耗尽
+    // 浏览器同源并发连接（dsh-notifier 0.1.8 同款事故）。
+    assert.ok(
+      clientSrc.indexOf("closeEvents()") >= 0 && clientSrc.indexOf("closeEvents()") < clientSrc.indexOf("new EventSource"),
+      "建连前先执行关旧兜底",
+    );
+    assert.match(clientSrc, /lastActivity\s*=\s*Date\.now\(\)/, "收到数据帧即喂狗");
+    // 卸载清理：watchdog 定时器与 SSE 连接都要收掉（esbuild 产物 undefined 折叠为 void 0）。
+    assert.match(clientSrc, /if\s*\(watchdog\s*!==\s*(?:void 0|undefined)\)\s*clearTimeout\(watchdog\)/, "卸载清 watchdog");
+    assert.match(clientSrc, /closeEvents\(\);\s*document\.removeEventListener\("visibilitychange"/, "卸载关 SSE 并摘监听");
+  });
+  check("回前台强制重建 SSE（visibilitychange → forceReconnect + 补拉）", () => {
+    const clientSrc = readFileSync(new URL("../lib/client.js", import.meta.url), "utf8");
+    assert.match(clientSrc, /addEventListener\("visibilitychange",\s*onVisible\)/, "visibilitychange 监听已挂");
+    assert.match(
+      clientSrc,
+      /onVisible\s*=\s*\(\)\s*=>\s*\{\s*if\s*\(!document\.hidden\)\s*\{\s*forceReconnect\(\)/,
+      "回前台路径先强制重建 SSE",
+    );
   });
 
   check("设置卡片样式对齐官方风格（#219：12px 圆角 / bg-layer-3 底 / border-l2 / 15px 名称字 / 13px 描述字 / 14 16 padding / gap 4）", () => {

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -244,6 +244,8 @@ const main = async () => {
       "建连前先执行关旧兜底",
     );
     assert.match(clientSrc, /lastActivity\s*=\s*Date\.now\(\)/, "收到数据帧即喂狗");
+    // 心跳 ping 帧喂狗后早退，不得落入 else 触发 scheduleRefresh（否则 SSE 退化为隐性 30s 轮询）。
+    assert.match(clientSrc, /===\s*"ping"\)\s*return/, "ping 帧仅喂狗即早退");
     // 卸载清理：watchdog 定时器与 SSE 连接都要收掉（esbuild 产物 undefined 折叠为 void 0）。
     assert.match(clientSrc, /if\s*\(watchdog\s*!==\s*(?:void 0|undefined)\)\s*clearTimeout\(watchdog\)/, "卸载清 watchdog");
     assert.match(clientSrc, /closeEvents\(\);\s*document\.removeEventListener\("visibilitychange"/, "卸载关 SSE 并摘监听");

--- a/packages/dsh-mcp-manager/test/unit-routes-sse.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-routes-sse.test.ts
@@ -65,9 +65,16 @@ const fakeReq = (method, url, body, opts = {}) => ({
 });
 
 const fakeRes = () => {
-  const state = { status: 200, body: "", headers: {}, destroyed: false };
+  const state = { status: 200, body: "", headers: {}, destroyed: false, writableEnded: false };
   return {
     state,
+    // routes.ts 心跳回调读 res.destroyed / res.writableEnded 判定自愈清理。
+    get destroyed() {
+      return state.destroyed;
+    },
+    get writableEnded() {
+      return state.writableEnded;
+    },
     writeHead: (s, h) => {
       state.status = s;
       state.headers = h ?? {};
@@ -77,6 +84,7 @@ const fakeRes = () => {
     },
     end: (chunk) => {
       if (chunk) state.body += chunk.toString();
+      state.writableEnded = true;
     },
     setHeader: () => {},
     on: (event, cb) => {
@@ -195,6 +203,26 @@ const countPing = (res) => (res.state.body.match(/data: \{"type":"ping"\}/g) ?? 
     // 清理发生在首个 interval 跳之前（同步路径），两连接均应零心跳帧。
     assert.equal(countPing(resA), 0, "卸载后连接 A 心跳停止");
     assert.equal(countPing(resB), 0, "卸载后连接 B 心跳停止");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+{
+  // 自愈路径：destroy() 后（模拟 close 事件丢失的极端场景）下一跳心跳看到
+  // destroyed 即自杀清理——不再写帧，且从 disposer 注册表自删。
+  const { dir, manager } = setup();
+  try {
+    const route = makeEventsRoute(manager, { heartbeatMs: 10 });
+    const res = fakeRes();
+    route.handler(fakeReq("GET", ROUTES.events), res);
+    await sleep(45);
+    const pingsAtDestroy = countPing(res);
+    assert.ok(pingsAtDestroy >= 1, "destroy 前心跳在写帧");
+    res.destroy(); // 不触发 onClose：走 destroyed 自愈而非 close 清理
+    await sleep(45);
+    assert.equal(countPing(res), pingsAtDestroy, "destroy 后心跳停止写帧");
+    assert.equal(manager.sseHeartbeatCleanups.size, 0, "自愈路径自删 cleanup");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/dsh-mcp-manager/test/unit-routes-sse.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-routes-sse.test.ts
@@ -27,6 +27,8 @@ const {
   McpStore,
   McpManager,
   normalizeServer,
+  SSE_HEARTBEAT_MS,
+  SSE_PING_FRAME,
 } = await import("../lib/index.js");
 
 // ---- 帧格式 ----
@@ -139,6 +141,60 @@ const loopbackMethods = ["GET", "POST"];
     await new Promise((resolve) => setTimeout(resolve, 5));
     assert.equal(frames, 1);
     unsubscribe();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ---- SSE 心跳（#268）：data ping 帧 / 间隔常量 / close 与卸载 disposer 清理 ----
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const countPing = (res) => (res.state.body.match(/data: \{"type":"ping"\}/g) ?? []).length;
+
+{
+  // 常量契约：间隔对齐 dsh-notifier HEARTBEAT_MS（30s）；心跳必须是 data 帧而非
+  // 注释帧——注释帧不触发客户端 onmessage，watchdog 无失活信号可依。
+  assert.equal(SSE_HEARTBEAT_MS, 30_000, "心跳间隔 30s（对齐 notifier）");
+  assert.equal(SSE_PING_FRAME, 'data: {"type":"ping"}\n\n', "心跳为 data ping 帧");
+
+  const { dir, manager } = setup();
+  try {
+    const route = makeEventsRoute(manager, { heartbeatMs: 10 });
+    const res = fakeRes();
+    route.handler(fakeReq("GET", ROUTES.events), res);
+    assert.equal(manager.sseHeartbeatCleanups?.size, 1, "心跳清理函数已登记 disposer 注册表");
+    await sleep(45);
+    const pingsAtClose = countPing(res);
+    assert.ok(pingsAtClose >= 1, `心跳 data ping 帧按间隔到达（实际 ${pingsAtClose} 帧）`);
+    // close：注销连接 + 清心跳定时器（防泄漏），此后不再有新帧。
+    res.state.onClose();
+    assert.equal(manager.sseConnections.size, 0, "close 后注销");
+    assert.equal(manager.sseHeartbeatCleanups.size, 0, "close 自删 cleanup");
+    await sleep(45);
+    assert.equal(countPing(res), pingsAtClose, "close 后心跳停止");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+{
+  // 卸载路径：插件 disposer 显式执行全部 cleanups（index.ts apply 清理同款），
+  // 不依赖 res.destroy() 触发 close 的异步时序。
+  const { dir, manager } = setup();
+  try {
+    const route = makeEventsRoute(manager, { heartbeatMs: 10 });
+    const resA = fakeRes();
+    const resB = fakeRes();
+    route.handler(fakeReq("GET", ROUTES.events), resA);
+    route.handler(fakeReq("GET", ROUTES.events), resB);
+    assert.equal(manager.sseConnections.size, 2);
+    assert.equal(manager.sseHeartbeatCleanups.size, 2, "每连接一条 cleanup");
+    for (const stopHeartbeat of [...manager.sseHeartbeatCleanups]) stopHeartbeat();
+    assert.equal(manager.sseHeartbeatCleanups.size, 0, "disposer 清空注册表");
+    await sleep(45);
+    // 清理发生在首个 interval 跳之前（同步路径），两连接均应零心跳帧。
+    assert.equal(countPing(resA), 0, "卸载后连接 A 心跳停止");
+    assert.equal(countPing(resB), 0, "卸载后连接 B 心跳停止");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/stryker.conf.d/dsh-mcp-manager-4.json
+++ b/stryker.conf.d/dsh-mcp-manager-4.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
-    "packages/dsh-mcp-manager/lib/index.js:19972-21262"
+    "packages/dsh-mcp-manager/lib/index.js:19972-21286"
   ],
   "testRunner": "tap",
   "tap": {
@@ -47,5 +47,5 @@
   "cleanTempDir": true,
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-mcp-manager-4.json",
-  "_comment": "#220 B 拆分+#269 重测实验再均衡：原 s4 (19972-22070) 按 esbuild 分段边界对半拆为 s4/s5——重测实证 s4 独占该包绝大多数 mutant（wall-clock 323s 而其余段均≈固定成本）；s4 = import/routes/middleware 三模块。"
+  "_comment": "#220 B 拆分+#269 重测实验再均衡：原 s4 按 esbuild 分段边界对半拆为 s4/s5——重测实证 s4 独占该包绝大多数 mutant（wall-clock 323s 而其余段均≈固定成本）；s4 = import/routes/middleware 三模块。区间行号由 sync-mutate-segments 按产物派生（#280），不手工维护。"
 }

--- a/stryker.conf.d/dsh-mcp-manager-5.json
+++ b/stryker.conf.d/dsh-mcp-manager-5.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
-    "packages/dsh-mcp-manager/lib/index.js:21299-22113"
+    "packages/dsh-mcp-manager/lib/index.js:21323-22142"
   ],
   "testRunner": "tap",
   "tap": {
@@ -47,5 +47,5 @@
   "cleanTempDir": true,
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-mcp-manager-5.json",
-  "_comment": "#220 B 再均衡新增：index 主体段（Config/apply/路由收尾），与 s4 于分段边界 21262/21263 处切分。"
+  "_comment": "#220 B 再均衡新增：index 主体段（Config/apply/路由收尾），与 s4 于分段边界 21322/21323 处切分（#268 净增使边界自 21262/21263 后移，sync-mutate-segments 重算）。"
 }


### PR DESCRIPTION
## 关联

Refs #268 —— 本 PR 仅覆盖 P0-3（dsh-mcp-manager SSE 双缺失）子项，**不关闭 issue**：P0-1（lan-proxy WS 保活）、P0-2（session-pins）、P1（provider-usage fetch 超时）等其余子项由后续 PR 承接。

## 背景

移动端切后台 → 系统冻结 JS 并静默掐断 TCP → 半开连接：客户端 onerror/close 均不触发、服务端 `res.on("close")` 也不触发。mcp-manager 对照 notifier 全链路缺两块：服务端无心跳、客户端无 watchdog/回前台重建。后果是回前台 MCP 状态推送失效 + 服务端 sseConnections 僵尸连接堆积（广播向死管道 write）。

## 改动（仅 packages/dsh-mcp-manager/**）

### 服务端（src/routes.ts）

`makeEventsRoute` 写完初始帧后每连接启动 **30s data ping** 心跳（`SSE_HEARTBEAT_MS = 30_000`，形态对齐 notifier）：

- 必须用 data 帧而非注释帧——注释帧不触发客户端 onmessage/onerror，watchdog 无失活信号可依；
- `res.on("close")` 时 `clearInterval` 防泄漏；另有 `destroyed/writableEnded` 自愈检查兜底 close 丢失的极端场景；
- 清理函数登记 `manager.sseHeartbeatCleanups`，插件卸载时 apply 路由 disposer **显式执行**（不依赖 destroy 触发 close 的异步时序）；interval `unref()` 不阻止进程退出。

### 客户端（src/client/index.ts）

移植 notifier 0.1.8 方案（重构非照抄）：

- **60s 失活 watchdog**：收到任意数据帧即喂狗（`lastActivity`）；超时判定半开 → `forceReconnect()`；
- **visibilitychange 回前台强制重建**：关旧 EventSource + 重开 + 补拉 refresh；
- **受控重建单入口** `forceReconnect`（关旧 + 5s 节流）：watchdog / 回前台两路共用；`connectEvents` 开头必先 `closeEvents()` 兜底——0.1.8 教训：覆盖 source 引用不 close 会逐步耗尽浏览器同源并发连接；
- SSE 连续 CLOSED 3 次放弃后置 `eventsRetired` 门：轮询接管语义不变，且任何路径不再建连。

### 卸载清理

effect 清理函数补：`clearTimeout(watchdog)` + `closeEvents()`（原为裸 `es.close()`），并执行全部 `sseHeartbeatCleanups`。

## 断言表（对照 issue #268 P0-3 与初步修复建议第 2 条）

| AC 条目 | 级别 | 结论 | 证据 |
| --- | --- | --- | --- |
| 服务端 30s data ping 心跳（对齐 notifier HEARTBEAT_MS 形态） | P0-3 | 落实 | `SSE_HEARTBEAT_MS === 30_000` + `SSE_PING_FRAME === 'data: {"type":"ping"}\\n\\n'` 常量契约断言；unit 以 `heartbeatMs:10` 实测 ping 帧按间隔到达 |
| 连接关闭清定时器防泄漏 | P0-3 | 落实 | unit：close 后 `sseHeartbeatCleanups.size===0` 且再等 45ms 无新 ping 帧 |
| 插件卸载 disposer 清理 interval | 任务约束 | 落实 | unit：双连接各注册一条 cleanup，disposer 显式执行全部后两连接零心跳帧；index.ts 清理函数先行执行 cleanups 再 destroy 连接 |
| 客户端 ~60s 失活 watchdog（收数据喂狗、超时关旧建新） | P0-3 | 落实 | smoke 产物断言 `WATCHDOG_MS=60s`/`lastActivity=Date.now()` 喂狗/`forceReconnect` 受控入口/`closeEvents()` 先于 `new EventSource`（关旧建新顺序断言） |
| visibilitychange 回前台强制关旧重建 | P0-3 | 落实 | smoke 产物断言：`onVisible` 内先 `forceReconnect()` 再补拉 refresh；卸载路径清 watchdog + closeEvents + 摘监听 |
| 配套 smoke 断言 | 任务约束 | 落实 | unit-routes-sse 新增 2 个测试块（心跳行为 + 卸载双路径）；smoke.ts 新增 2 个 check（watchdog/回前台产物契约）；既有 events 路由 403/405 围栏用例不受影响全过 |
| README 同步 SSE 行为描述 | 任务约束 | 落实 | 「能力」表新增「状态推送自愈」行（30s 心跳 / 60s watchdog / 回前台重建三重防护） |
| 不改其他包 / 根文件 / .github/shared | 任务约束 | 落实 | git status 仅 packages/dsh-mcp-manager/** 六文件 |

## 验证（worktree wt-268-mcp @ 7144f36）

五连门禁全绿：

```
pnpm build       exit=0
pnpm test        exit=0   （含 dsh-mcp-manager 全部 smoke/unit）
pnpm contract    exit=0
pnpm pack:check  exit=0
pnpm typecheck   exit=0
```