### PR TITLE
fix(ci): 快照 PR 日期闸只匹配 manifest.json 并统一 UTC 比较（#276 方案 A）

### DIFF
--- a/.github/workflows/observe.yml
+++ b/.github/workflows/observe.yml
@@ -121,14 +121,19 @@ jobs:
 
       - name: Baseline PR date gate（快照每日最多一次，防 git 膨胀 #276 方案 A）
         # 四班次全量变异照常执行、基线文件照常 collect；但「基线快照 PR 合入 main」
-        # 限制为每自然日最多一次：检查 main 上 scripts/gate/baseline/ 最近一次提交
-        # 是否今天（UTC）。今日已有快照 → 标记 skip_pr，Open baseline PR 步骤跳过。
-        # 变异执行不受本闸限制（push 触发已移除，四班次各自完整产出报告与阈值判分）。
+        # 限制为每自然日最多一次：检查 main 上基线的实质变更记录（manifest.json）
+        # 最近一次提交是否今天（UTC）。今日已有快照 → 标记 skip_pr，
+        # Open baseline PR 步骤跳过。变异执行不受本闸限制。
+        # 实现要点（#276 实证修正）：
+        #   1) 只匹配 manifest.json（collect 每次产出、含实质变更 hash），
+        #      避免 README.md 等随目录出现的静态文件重置日期闸；
+        #   2) 用 committer Unix 时间戳（%ct）+ `date -u -d` 转 UTC 日期，
+        #      杜绝 git log 本地时区与 date -u 混用导致的跨日误判。
         id: pr-gate
         run: |
-          LAST=$(git log -1 --format=%cd --date=format:%Y-%m-%d -- scripts/gate/baseline/ 2>/dev/null || echo "")
+          LAST_TS=$(git log -1 --format=%ct -- scripts/gate/baseline/manifest.json 2>/dev/null || echo "")
           TODAY=$(date -u +%Y-%m-%d)
-          if [ -n "$LAST" ] && [ "$LAST" = "$TODAY" ]; then
+          if [ -n "$LAST_TS" ] && [ "$(date -u -d "@$LAST_TS" +%Y-%m-%d)" = "$TODAY" ]; then
             echo "今日（$TODAY）已有基线快照提交，本次跳过快照 PR（变异报告照常）"
             echo "skip_pr=true" >> "$GITHUB_OUTPUT"
           else

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -149,6 +149,9 @@ test('#276 方案 A: observe 四班次全量——定时触发、无 push 裁剪
   assert.ok(OBSERVE.includes('skip_pr=true'), '快照 PR 日期闸（每日最多一次）在位')
   assert.ok(OBSERVE.includes("steps.pr-gate.outputs.skip_pr == 'false'"),
     'Open baseline PR 必须以日期闸放行为前提')
+  assert.ok(OBSERVE.includes('scripts/gate/baseline/manifest.json'),
+    '日期闸须只匹配 manifest.json（基线实质变更记录）——避免 README 等静态文件重置闸')
+  assert.ok(OBSERVE.includes('--format=%ct'), '日期闸须用 committer Unix 时间戳 + date -u 转 UTC（杜绝时区混用跨日误判）')
 })
 
 test('#220 段式三方一致：observe 计划 ↔ stryker.conf.d 文件集 ↔ gauntlet 包集', () => {


### PR DESCRIPTION
## 修复内容

验证 PR #295 期间实证的日期闸缺陷（observe 四班次基线重建被阻塞的隐患）：

1. **目录匹配干扰**：日期闸 `git log -- scripts/gate/baseline/` 会把随目录存在的 README.md 计入最近提交——README 更新会重置日期闸，导致「每日最多一次快照」语义失效；若 baseline 目录含近期合入的静态文件，则基线快照 PR 被永久误跳过（collect 产出但无法合入 main）。
2. **时区混用**：`git log --date=format:%Y-%m-%d` 用本地时区（+8），`date -u` 用 UTC——跨日边界窗口内判断翻转。

## 修正

- 日期闸只匹配 `scripts/gate/baseline/manifest.json`（collect 每次产出的实质变更记录，含每个基线文件的 hash）；
- 改用 committer Unix 时间戳（`%ct`）+ `date -u -d` 转 UTC 日期，杜绝时区混用；
- workflow-assert 契约补两条断言锁定修复（50/50 全绿）。

## 验证

- `pnpm test:scripts` 50/50 通过；
- 关联验证 PR #295（不合入）实证 src 级分段矩阵效果：只改 provider-usage → 仅实例化其 3 段，最慢 3m14s。