### PR TITLE
fix(provider-usage): smoke 固定 sleep 竞态 flake——await async handler 读取响应（#313）

### DIFF
--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -629,9 +629,10 @@ export function formatPanel() { return "<p>2</p>"; }
   // add 登记第二个文件（纳入热更监视）
   {
     let payload;
-    addRoute.handler(fakeReq({ method: "POST", body: JSON.stringify({ file: f2 }) }), { writeHead: () => {}, end: (c) => { payload = JSON.parse(c); } });
-    await new Promise((r) => setTimeout(r, 80));
-    assert.equal(payload.ok, true, "第二个适配器登记成功");
+    // #313：async handler 必须 await（writeJson 在 resolve 前同步调用 end 回调）——
+    // 旧「固定 sleep(80ms) 后读 payload」在 CI 慢 runner 下偶发 undefined 崩
+    await addRoute.handler(fakeReq({ method: "POST", body: JSON.stringify({ file: f2 }) }), { writeHead: () => {}, end: (c) => { payload = JSON.parse(c); } });
+    assert.equal(payload?.ok, true, "第二个适配器登记成功");
   }
   // 把 one.mjs 的导出 name 改为 u-two（与另一 user-file 撞名）→ 触发热更冲突路径
   writeFileSync(f1, `


### PR DESCRIPTION
## 关联 Issue

Partially addresses #313（方案 A 本次实施；方案 B 另行排期）

## 问题

#310 CI（run 33128037986）偶发失败：smoke.ts:634 `TypeError: Cannot read properties of undefined (reading 'ok')`。本地同 head 复跑全过 → 时序 flake。

## 根因与修复

`addRoute.handler`（src/apply.ts:649）为 async handler，内部多个真实 await（readJsonBody/loadUserAdapterChecked/persistUserAdapter/ensureHotReload）+ fire-and-forget warmupProviders；`writeJson` 在 resolve 前同步调用 end 回调。旧代码「同步调用 + 固定 sleep(80ms) + 直读 payload」在 CI 慢 runner 下超时 → payload undefined。

修复：直接 `await addRoute.handler(...)`，零 sleep、零时序依赖（事件驱动替代时间驱动）。

## 断言表

| 条目 | 断言 | 结果 |
|---|---|---|
| 硬性 | #212-B 段 add 登记 await async handler，无固定 sleep | 本地 provider-usage test 通过 |
| 硬性 | 全 smoke 无回归（1138+ 断言） | 本地全过 |

## 门禁

- 本地：`pnpm --filter @wingsky-1/dsh-provider-usage build && test` 通过