### PR TITLE
feat(dsh-mcp-manager): 中间层新增 ws_mcp_list / ws_mcp_detail，修复 all 模式全局可见性（#312）

### DIFF
--- a/docs/proposals/issue-312-tool-design-standards.md
+++ b/docs/proposals/issue-312-tool-design-standards.md
@@ -1,0 +1,144 @@
+# dsh-mcp-manager 中间层工具设计规范（业界实践调研固化）
+
+> 依据：issue #312 维护者要求「设计 tool 多参考业界优秀实践，输入输出、异常提示」。
+> 本规范指导新增 ws_mcp_list / ws_mcp_detail，并**回溯优化既有 ws_mcp_search / ws_mcp_call**。
+> 关联 issue：[#312](https://github.com/wingsky-1/dsh-plugin-hub/issues/312)
+
+## 1. 业界实践调研结论（含参考链接）
+
+### 1.1 两级/渐进式工具发现（meta-tool 模式）——本次新增工具的骨架
+
+**Giant Swarm Muster**（[Meta-tools and tool discovery](https://docs.giantswarm.io/overview/ai-agents/meta-tools/)）
+是当前最完整的落地范例，管理集群可暴露数百个 MCP 工具，用 meta-tool 间接层避免
+上下文污染：
+
+| Muster meta-tool | 用途 | 对应本项目 |
+|---|---|---|
+| `list_tools` | 发现全部工具 | **ws_mcp_list** |
+| `filter_tools` | 廉价筛选：按名/描述/自然语言/标签，返回**有界摘要页** + `truncated` 信号 | ws_mcp_search（优化点） |
+| `describe_tool` | 权威完整描述 + schema（**唯一的完整 schema 来源**） | **ws_mcp_detail** |
+| `call_tool` | 按名执行 | ws_mcp_call |
+
+关键设计（直接采纳）：
+- **摘要页 vs 权威详情分离**：列表只给一行摘要 + `truncated: true` 分页信号，
+  完整 schema 只经 describe 按需拉取 → 上下文成本随任务触达，不随平台规模膨胀。
+- **懒发现**：服务器未启动时不加载其工具定义；启动后 list 立即反映新能力。
+- **命名前缀**：`x_<server>_<tool>` 避免跨服务器冲突（本项目 `@root/server` 全名同理）。
+
+**mcp2cli**（[npm](https://www.npmjs.com/package/@weibaohui/mcp2cli)）：
+「按需加载工具 schema + 把 discover-then-call 解析为单次调用——把工具定义挡在
+上下文窗口之外」，印证摘要/详情分离的价值。
+
+**OpenBB Progressive Tool Discovery**（[DeepWiki](https://deepwiki.com/MagnusS0/openbb-pydantic-ai/5.4-progressive-tool-discovery)）：
+同样「先摘要后详情」的渐进发现，避免一次性注入全部 schema。
+
+### 1.2 工具描述规范（Anthropic 官方，[Tool Design — Writing Tools Claude Uses Correctly](https://github.com/anthropics/claude-plugins-official/blob/main/plugins/mcp-server-dev/skills/build-mcp-server/references/tool-design.md)）
+
+**描述是契约**——它是 Claude 在决定是否调用前唯一读的东西。要求：
+1. 说清**做什么** + **返回什么** + **不做什么**（防止错误调用）。
+2. **兄弟工具互引**：相似工具各自描述「什么时候用另一个」。
+3. **参数收紧**：每个约束都是少一次运行时错误的机会——
+   `limit` 给 `int().min(1).max(100).default(20)`，选择给 `enum`，可选参数给默认值说明。
+4. **描述每个参数**：`.describe()` 文本直接进 schema，省略 = 浪费。
+5. **返回形状可解析**：结构化数据返回 JSON；截断大 payload 并明说
+   （`"Showing 10 of 847 results"`）。
+6. **错误给下一步**：`"Item X not found. Use search_items to find valid IDs."` ——
+   把死路变成下一步。
+7. **工具数量**：30+ 时切换 search+execute（本插件正是此形态）。
+
+**MCP 官方 Client Best Practices**（[modelcontextprotocol.org](https://modelcontextprotocol.org/docs/2025-06-18/develop/clients/client-best-practices)）：
+客户端应缓存工具列表、处理分页、尊重服务器能力声明。
+
+### 1.3 输入输出设计（业界共识）
+
+| 维度 | 共识 | 落实 |
+|---|---|---|
+| 输入 | 参数收紧：类型/范围/枚举/默认/描述全显式 | 新增工具 parameters 全字段 describe |
+| 输出 | 结构化 JSON（模型可解析）+ render 人类可读文本 | output.schema + render |
+| 截断 | 大 payload 截断并**明示**（`truncated`/`Showing N of M`） | list 的 `toolsTruncated` |
+| 错误 | 显式异常 + 下一步提示，不静默空 | 新增工具错误三分 + 下一步 |
+| 幂等/并发 | 纯读声明 readOnlyHint / isConcurrencySafe | 新增工具 `isConcurrencySafe: () => true` |
+
+### 1.4 对既有工具的优化点（本 issue 顺带落地）
+
+对照上述规范，`ws_mcp_search` / `ws_mcp_call` 现状与差距：
+
+| 现状 | 规范要求 | 优化 |
+|---|---|---|
+| search 描述「空 query 返回能力摘要表」——实际受 limit 截断且无语义区分 | 摘要页应给 `truncated` 信号 | search 输出补 `truncated` 字段（是否因 limit 截断）；描述明确「盘点用 ws_mcp_list、检索用本工具」 |
+| search `limit` 默认 5/上限 10 | 参数收紧 + 显式默认 | 保持（兼容），描述补「上限 10」；文档引导大盘点走 list |
+| call 描述「server/tool 来自 ws_mcp_search」 | 兄弟工具互引 | 描述补「来自 ws_mcp_search / ws_mcp_list」；错误分支补「用 ws_mcp_list 盘点、ws_mcp_detail 查 schema」的下一步 |
+| call 错误「未连接或连接失败，请先 ws_mcp_search」 | 错误给下一步 | 补「请先 ws_mcp_search 或 ws_mcp_list 确认 server 已连接」 |
+| 无 readOnlyHint / destructiveHint | 注解 | 新增工具补 `readOnlyHint: true`（宿主支持时）；call 保持无（会执行远端） |
+| MCP_GUIDANCE / 目录消息只教 search+call | 引导完整工具面 | 补「盘点用 ws_mcp_list、查 schema 用 ws_mcp_detail」 |
+
+## 2. 新增工具设计（最终稿）
+
+### ws_mcp_list —— 盘点（对应 Muster list_tools）
+
+```
+参数（全部可选）：
+  server: string         全名 @<root>/<server> 或裸名；全名 root 不属于当前
+                         工作空间 → 抛路由一致性错误（防跨空间串台）
+  perServerLimit: number 每服务器工具条数上限（默认 50，上限 500；超限
+                         toolsTruncated=true，模型可按需调大）
+输出（结构化 JSON）：
+  {
+    workspace: string,       // 当前工作空间 root；all 模式无项目 cwd 时为 "@global"
+    mode: "project" | "all", // 中间层模式（模型据此理解可见范围）
+    servers: [
+      {
+        server: string,       // @<root>/<server> 全名
+        disabled?: boolean,   // 用户已禁用（工具来自 last-good 目录缓存）
+        unavailable?: string, // 发现失败原因
+        tools: [ { tool: string, description: string } ],
+        toolsTruncated: boolean,  // 该服务器工具数超 perServerLimit
+      }
+    ],
+    totalServers: number,
+    totalTools: number,
+    toolsTruncated: boolean,  // 任一服务器截断即为 true（分页信号）
+    message?: string,         // 空返回时明确提示（区分无配置/发现中）
+  }
+```
+
+### ws_mcp_detail —— 权威 schema（对应 Muster describe_tool）
+
+```
+参数（必填）：
+  server: string  必须：@<root>/<server> 全名（来自 ws_mcp_list）
+  tool:   string  必须：远端工具裸名（兼容 mcp__<server>__<tool> 前缀）
+输出：
+  {
+    server: string,
+    tool: string,
+    description: string,
+    inputSchema: Record<string, unknown>,  // 完整 schema（唯一权威来源）
+    fresh: boolean,                         // 目录是否新鲜（TTL 内）
+    disabled?: boolean,                     // 用户已禁用
+  }
+错误（显式 + 下一步）：
+  - server 发现失败：`server X 发现失败：<原因>。可稍后重试或检查服务器配置`
+  - server 未连接/未发现：`server X 未连接或未发现。先 ws_mcp_list 确认已连接`
+  - tool 不存在：`server X 无工具 Y。用 ws_mcp_list 查看该服务器全部工具`
+```
+
+### all 模式全局可见性（维护者要求 + 对抗评审 A）
+
+`findProjectRoot` 恒返回非 undefined → `resolveRoot` 的 @global fallback 仅无 cwd
+时触发；all 模式全局 supervisor 已停、mcp__ 不注册 → **有 cwd 的会话中全局服务器
+不可见**（既有缺陷）。修复：
+- search/list/detail 在 all 模式合并查询「项目 root 单元 + @global 单元」；
+- call 放行 `parsed.root === "@global"`（全局配置跨工作空间共享）；
+- off/project 模式行为不变。
+
+## 3. 落地清单
+
+1. `middleware-utils.ts`：`listCatalog` / `findToolDetail` / `searchCatalogMulti` 纯函数
+2. `middleware-types.ts`：`ListServerEntry` / `ListToolEntry` / `ToolDetail` 类型
+3. `middleware-const.ts`：`LIST_DEFAULT_TOOLS_PER_SERVER=50` / `LIST_MAX_TOOLS_PER_SERVER=500`
+4. `middleware-register.ts`：注册两工具 + search/call 描述与错误优化 + mode 分支
+5. `apply.ts`：传 mode；MCP_GUIDANCE 同步
+6. `catalog.ts`：目录消息引导同步
+7. 测试：unit-middleware（纯函数 + 场景）/ smoke（注册 4 工具 + 路由断言）
+8. 文档：README 中英 + 工具描述契约

--- a/docs/proposals/issue-312-ws-mcp-list-detail.md
+++ b/docs/proposals/issue-312-ws-mcp-list-detail.md
@@ -1,0 +1,159 @@
+# Issue #312 方案 v2（对抗评审修订版）：中间层新增 ws_mcp_list / ws_mcp_detail
+
+> 状态：对抗评审已完成，本版为修订稿
+> 范围：packages/dsh-mcp-manager 中间层（ws_mcp_search / ws_mcp_call 同风格扩展）
+
+## 背景与问题
+
+`ws_mcp_search` 空 query 本应返回「能力摘要表」，但实现受 `limit`（默认 5、上限 10）
+截断——服务器/工具数超限时只能看到前 N 条，无法盘点工作空间到底配了哪些 MCP、
+每个有哪些工具；`SearchHit.inputSchema` 虽在目录缓存中，但无「按 server+tool 精确命中、
+返回完整 schema」的独立入口。
+
+## 目标
+
+1. **ws_mcp_list**：列出当前工作空间全部 MCP 服务器 + 每台服务器完整工具清单
+   （server、tool、description），不受关键词/limit 截断；支持 server 过滤；
+   空返回给出明确提示。
+2. **ws_mcp_detail**：按 `@<root>/<server>` + tool 裸名精确查询单个工具详情，
+   返回完整 `inputSchema`（properties / required / enum / description）。
+3. 兼容性：不改变现有 `ws_mcp_search` / `ws_mcp_call` 在 off/project 模式的行为；
+   策略 guard（deny 优先）对新增工具一视同仁。
+4. **用户级 MCP（维护者要求）**：all 模式下新增工具必须能看到/查询全局服务器。
+
+## 对抗评审结论（已吸收）
+
+独立 subagent 评审发现并已纳入本版：
+
+| # | 评审发现 | 本版决策 |
+|---|---|---|
+| A | all 模式 + 有 cwd 会话中全局服务器不可见（resolveRoot 的 @global fallback 仅在无 cwd 时触发；all 模式全局 supervisor 已停、mcp__ 不注册）——「用户级 MCP」未满足 | **修复路由**：search/list/detail 在 all 模式合并查询「项目 root 单元 + @global 单元」；call 在 all 模式放行 `@global` root（全局配置跨工作空间共享，语义成立）。off/project 模式行为不变 |
+| B | list 输出 `status` 字段无数据源（disabled 服务器无 connection entry） | 砍掉 `status`；保留 `unavailable`（发现失败原因）；`userDisabled` 的服务器标 `disabled: true`（工具来自 last-good 目录，明示） |
+| C | 「上限 500 可全量」数值错误（目录采集上限 512 工具 / 256KB 总量） | 输出加 `toolsTruncated`（per-server + 全局汇总）；默认 50 / 上限 500 入 const 具名常量；文档明确目录是「采集边界内的 last-good 快照」 |
+| D | 首次调用竞态：list/detail 不等待 in-flight 发现会空/未命中 | 与 search 对齐：等待 in-flight（8s 预算），超时不阻塞（返回已有目录） |
+| E | detail 错误分支不全 | 三分：`unavailable`（发现失败，附原因）/ 服务器未发现 / 工具不存在 |
+| F | detail 的 tool 无归一化（call 有 mcp__ 前缀容错） | detail 复用 `normalizeToolName` |
+| G | limit 同名不同义（search 全局上限 vs list 每服务器上限） | list 参数改名 `perServerLimit`，描述强制区分 |
+| H | server 过滤语义分裂 | list 支持全名/裸名；全名 root 不属于当前 roots → 抛路由一致性错误（与 call 口径一致，防跨空间串台）；search 行为不变 |
+| I | MCP_GUIDANCE / README / 目录消息未同步 | 全部同步（见「文档同步」节） |
+| J | 常量魔法数 | `LIST_DEFAULT_TOOLS_PER_SERVER` / `LIST_MAX_TOOLS_PER_SERVER` 入 middleware-const.ts |
+| K | all 模式全局配置变更不重建 @global 单元（既有缺陷） | 本 issue 不修（既有行为，另开跟踪）；文档注明「全局服务器增删改后重启/触达才刷新目录」 |
+
+## 业界实践（维护者要求：参考优秀实践，确保 agent 好用）
+
+- **两级工具发现（list → detail）**是 MCP 生态标准形态：
+  [MCP tool discovery（The Neural Base）](http://theneuralbase.com/function-calling/learn/intermediate/mcp-tool-discovery/)、
+  [MCP Protocol Tools（Claude Code 参考）](https://mintlify.wiki/sanbuphy/claude-code-source-code/reference/tools/mcp-tools)、
+  [Meta-tools and tool discovery（Giant Swarm）](https://docs.giantswarm.io/overview/ai-agents/meta-tools/)：
+  列表只给摘要防上下文膨胀，详情按需拉取完整 schema。
+- **工具描述规范**（[Writing Effective MCP Tool Definitions](https://docs.unique.ai/administrators/mcp/the-mcp-hub/writing-effective-mcp-tool-definitions)、
+  [Tool Schema Design for Agents](https://apidog.com/blog/designing-api-tool-schemas-for-agents/)）：
+  描述写明「何时用我、怎么用、返回什么、失败怎么办」；输出结构化 JSON；
+  参数必填/可选、默认值、上限全部显式。
+- **错误显式化**：参数校验失败、路由不一致、未找到——一律抛带原因的错误，
+  不静默返回空（避免模型误判「无配置」）。
+
+## 工具设计
+
+### ws_mcp_list
+
+```
+参数（全部可选）：
+  server: string        可选：@<root>/<server> 全名或裸名过滤（全名 root 不属于
+                        当前工作空间 → 抛路由一致性错误）
+  perServerLimit: number 可选：每服务器工具条数上限（默认 50，上限 500；
+                        超过置 toolsTruncated=true，模型可按需调大）
+输出：
+  {
+    workspace: string,      // 当前工作空间 root；all 模式无项目 cwd 时为 "@global"
+    mode: "project" | "all",// 中间层模式（模型据此理解可见范围）
+    servers: [
+      {
+        server: string,     // @<root>/<server> 全名
+        disabled?: boolean, // 用户已禁用（工具来自 last-good 目录缓存）
+        unavailable?: string, // 发现失败原因
+        tools: [ { tool: string, description: string } ],
+        toolsTruncated: boolean,
+      }
+    ],
+    totalServers: number,
+    totalTools: number,
+    toolsTruncated: boolean, // 任一服务器截断即为 true
+    message?: string,       // 空返回时：无项目级 MCP 配置（project）/ 无可用服务器（all）
+  }
+```
+
+- **不受 limit 截断服务器**：每台服务器完整列出（工具数受 perServerLimit 保护）。
+- all 模式：项目 root 单元 + @global 单元合并；project 模式仅项目单元。
+- 空返回 message 区分场景（无配置 vs 发现中——in-flight 等待后仍空）。
+
+### ws_mcp_detail
+
+```
+参数（必填）：
+  server: string  必须：@<root>/<server> 全名（来自 ws_mcp_list）
+  tool:   string  必须：远端工具裸名（兼容 mcp__<server>__<tool> 前缀，复用 normalizeToolName）
+输出：
+  {
+    server: string,
+    tool: string,
+    description: string,
+    inputSchema: Record<string, unknown>,  // 完整 schema（properties/required/enum/description）
+    fresh: boolean,                         // 目录是否新鲜（TTL 内）
+    disabled?: boolean,                     // 用户已禁用
+  }
+```
+
+- 精确命中：不做关键词打分、不受 limit 截断。
+- 错误三分：`server 发现失败：<原因>` / `server 未连接或未发现` / `tool 不存在`。
+- all 模式：允许查询 @global 单元（同 call 口径）。
+- 复用目录缓存，与 search 同数据源；等待 in-flight 发现（8s 预算）后再查。
+
+### 路由修复（评审 A，all 模式全局可见）
+
+- search：all 模式合并查询项目 root + @global 单元（off/project 不变）。
+- call：all 模式放行 `parsed.root === "@global"`（全局配置跨工作空间共享）。
+  仍拒绝非当前 root 的其他项目 root（防跨空间串台）。
+- registerMiddlewareTools 新增 `mode` 参数（apply.ts 传入 middlewareMode）。
+
+### 策略 guard
+
+新增工具纯读本地目录（不执行远端工具），与 ws_mcp_search 一致不触达策略 guard；
+ws_mcp_call 仍唯一受策略约束（deny 优先）。README 安全模型节注明此边界。
+
+## 实现要点
+
+1. `middleware-utils.ts` 新增纯函数：
+   - `listCatalog(units, roots, serverFilter, toolLimit)` → 完整服务器+工具清单
+   - `findToolDetail(units, root, server, tool)` → 单工具详情（含 schema）
+   - `searchCatalogMulti(units, roots, query, limit)` → 多单元合并检索
+     （searchCatalog 保持单 root 包装，兼容既有测试）
+2. `middleware-types.ts`：`ListServerEntry` / `ListToolEntry` / `ToolDetail` 类型。
+3. `middleware-const.ts`：`LIST_DEFAULT_TOOLS_PER_SERVER` / `LIST_MAX_TOOLS_PER_SERVER`。
+4. `middleware-register.ts`：注册 ws_mcp_list / ws_mcp_detail；search/call 按 mode
+   修复 all 模式全局可见性。
+5. `apply.ts`：registerMiddlewareTools 传 mode；MCP_GUIDANCE 补 list/detail 引导。
+6. `catalog.ts`：renderMcpCatalogMessage 引导补「完整盘点用 ws_mcp_list」。
+7. 测试：
+   - `unit-middleware.test.ts` / `.src.test.ts`：listCatalog / findToolDetail /
+     searchCatalogMulti 纯函数单测（完整清单 / 过滤 / 空返回 / 截断标志 /
+     unavailable / disabled / detail 三分错误 / tool 归一化）
+   - `smoke.ts`：注册 4 工具断言；list/detail execute 路由断言（agent-less 拒绝、
+     空返回提示、all 模式 @global 覆盖、call all 模式放行 @global）
+8. 文档：README.md / README.en.md 工具列表 + 配置节 + 安全模型节同步。
+
+## 兼容性
+
+- off/project 模式：search/call 行为完全不变；新增工具纯增量。
+- all 模式：search/call 修复全局可见性（既有缺陷修复，非破坏）。
+- 无新增依赖；无 Config 变更；inject / ROUTES / 契约不变。
+
+## 验收标准
+
+1. ws_mcp_list 返回工作空间全部服务器与每台工具清单（不受 search 的 limit 截断）；
+   支持 server 过滤；空返回有明确 message。
+2. ws_mcp_detail 按 server+tool 精确返回完整 inputSchema；错误三分清晰。
+3. all 模式：list/search 能看到全局服务器，call 可调用 @global 服务器；
+   project 模式：全局仍走 mcp__ 直呼（不经中间层，list 不列全局）。
+4. 策略 guard 对新增工具不拦截（纯读）；ws_mcp_call 仍受策略约束。
+5. 五连门禁全绿；新增 smoke/unit 断言覆盖上述场景。

--- a/packages/dsh-mcp-manager/README.en.md
+++ b/packages/dsh-mcp-manager/README.en.md
@@ -156,11 +156,11 @@ full-name/bare-name filtering; `perServerLimit` caps tools per server at 50 by d
 / 500 max, setting `toolsTruncated` when exceeded; empty results carry an explicit
 `message`) / `ws_mcp_detail` (exact single-tool lookup by `@<root>/<server>` + bare tool
 name, returning the complete `inputSchema`; three-way errors: discovery failed with
-reason / server not connected or not found / tool does not exist) / `ws_mcp_search`
-(keyword search, search first then call) / `ws_mcp_call` (invoke by
-`@<root>/<server>`), routed by the calling session's current cwd to the matching
-workspace connection pool, so different workspaces inject different MCPs without name
-clashes; global servers still register directly as `mcp__<server>__<tool>`. Switch
+reason / server not connected or not found / tool does not exist) / `ws_mcp_search` (keyword search, search first then call; returns a `truncated` flag
+when results hit the `limit`) / `ws_mcp_call` (invoke by `@<root>/<server>`, verify
+argument schema with `ws_mcp_detail`), routed by the calling session's current cwd to
+the matching workspace connection pool, so different workspaces inject different MCPs
+without name clashes; global servers still register directly as `mcp__<server>__<tool>`. Switch
 `middleware: off` to restore the legacy behavior (project-level also registers `mcp__`);
 `middleware: all` routes global servers through the middleware too (falling back to the
 virtual global root `@global` when cwd has no project), collapsing the model surface to
@@ -198,7 +198,9 @@ add/remove/edit refreshes the `@global` unit only after a restart or a session t
 - **Middleware tool read-only boundary**: `ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search`
   only read the local catalog cache (never touch remote servers or execute tools) and bypass
   the policy guard; `ws_mcp_call` is the only entry point that executes remote tools and is
-  governed by the policy (deny-first)
+  governed by the policy (deny-first); `ws_mcp_call` error messages follow an
+  "explicit + next step" style (confirm the server connection / verify the argument schema
+  with `ws_mcp_detail` / check the policy configuration)
 - The capability catalog injection includes source annotations and a "does not represent current
   connection status" note
 

--- a/packages/dsh-mcp-manager/README.en.md
+++ b/packages/dsh-mcp-manager/README.en.md
@@ -12,18 +12,20 @@ Three middleware modes (`middleware`): `off` — all servers register directly a
 `mcp__<server>__<tool>` (legacy behavior); `project` (**default**) — project-level
 servers go through the middleware while global ones register directly; `all` — global
 servers go through the middleware too, falling back to the virtual global root
-`@global` when cwd has no project, collapsing the model surface to exactly two atomic
-tools. Note on when changes take effect: `middleware` / `middlewarePolicy` are read
+`@global` when cwd has no project, collapsing the model surface to exactly four atomic
+tools (`ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search` / `ws_mcp_call`).
+Note on when changes take effect: `middleware` / `middlewarePolicy` are read
 once at plugin startup — **changing them requires restarting `dsh web`**; the server
 lists across both config tiers hot-reload without a restart (add/remove/toggle/edit).
 
 ## Core advantages
 
 - **Context cost under control**: project-level MCP is collapsed through the middleware
-  by default — the model surface carries only `ws_mcp_search` / `ws_mcp_call`, so no
-  matter how many project-level servers or tools the current workspace connects the
-  system prompt never balloons; `middleware: all` folds global servers in too for full
-  collapse
+  by default — the model surface carries only `ws_mcp_list` / `ws_mcp_detail` /
+  `ws_mcp_search` / `ws_mcp_call`, so no matter how many project-level servers or tools
+  the current workspace connects the system prompt never balloons; `middleware: all`
+  folds global servers in too for full collapse (two-level discovery: `ws_mcp_list`
+  for a full inventory → `ws_mcp_detail` to pull the complete schema on demand)
 - **Per-working-directory maintenance**: project-level config `<project root>/.dsh/mcp.json`
   travels with the repo and can be committed to git for team sharing; global config
   `<DSH_HOME>/dsh-mcp.json` stays always connected; switching sessions auto-loads the
@@ -95,7 +97,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-mcp-manager
 | Server management | CRUD (project-level/global optional), connect / disconnect / reconnect; versioned JSON config, atomic write |
 | Two transports | stdio (local subprocess, env supports `${ENV}` references) and streamable-http (remote, header supports `${ENV}` references, auto-echoes `Mcp-Session-Id`) |
 | JSON import | Paste `mcpServers` JSON text to import (JSON format only; does not scan any application config files) |
-| Model tools | Global servers register directly as `mcp__<server>__<tool>` (64 chars, `[A-Za-z0-9_-]`, hashed suffix on conflict); project-level servers go through the middleware's `ws_mcp_search` / `ws_mcp_call` by default (`middleware: project`, recommended), so workspaces never clash |
+| Model tools | Global servers register directly as `mcp__<server>__<tool>` (64 chars, `[A-Za-z0-9_-]`, hashed suffix on conflict); project-level servers go through the middleware's `ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search` / `ws_mcp_call` by default (`middleware: project`, recommended), so workspaces never clash |
 | Workspace isolation | The middleware routes by the calling session's cwd to the matching workspace connection pool; server full-name consistency checks (`@<root>/<server>`) prevent cross-workspace crosstalk |
 | Reconnection | Exponential backoff (starts at 500ms, caps at 30s, gives up after 10 attempts and deregisters the tools) |
 | Result truncation | Direct-connect tool results truncated at 8KB and marked (prevents oversized JSON from entering context in full) |
@@ -143,6 +145,36 @@ without manually refreshing the page: the host pushes a frame over the existing 
 channel, and the client automatically re-fetches `/api/dsh-mcp/config` and updates the
 floating position in place.
 
+## Configuration (middleware)
+
+Project-level MCP goes through the middleware (`middleware: project`, default):
+project-level servers no longer register `mcp__` tools; instead the model surface carries
+four atomic tools (two-level discovery, the standard MCP ecosystem shape) —
+`ws_mcp_list` (full inventory of the current workspace's servers and each server's
+complete tool list, not truncated by `ws_mcp_search`'s `limit`; supports `server`
+full-name/bare-name filtering; `perServerLimit` caps tools per server at 50 by default
+/ 500 max, setting `toolsTruncated` when exceeded; empty results carry an explicit
+`message`) / `ws_mcp_detail` (exact single-tool lookup by `@<root>/<server>` + bare tool
+name, returning the complete `inputSchema`; three-way errors: discovery failed with
+reason / server not connected or not found / tool does not exist) / `ws_mcp_search`
+(keyword search, search first then call) / `ws_mcp_call` (invoke by
+`@<root>/<server>`), routed by the calling session's current cwd to the matching
+workspace connection pool, so different workspaces inject different MCPs without name
+clashes; global servers still register directly as `mcp__<server>__<tool>`. Switch
+`middleware: off` to restore the legacy behavior (project-level also registers `mcp__`);
+`middleware: all` routes global servers through the middleware too (falling back to the
+virtual global root `@global` when cwd has no project), collapsing the model surface to
+exactly four atomic tools — list/search/detail then merge queries across the "project
+root unit + `@global` unit", and call allows the `@global` root (global config is shared
+across workspaces, so the semantics hold). Note: in `all` mode, global server
+add/remove/edit refreshes the `@global` unit only after a restart or a session touch
+(existing behavior).
+
+| Key | Allowed values | Default |
+| --- | --- | --- |
+| `middleware` | `off` / `project` (recommended) / `all` | `project` |
+| `middlewarePolicy` | `{ allowTools: {<serverKey>: [glob]}, denyTools: {<serverKey>: [glob]} }` (serverKey is `@<root>/<server>` full name (workspace isolation) or bare name (shared across workspaces); full name wins; deny-first) | `{}` |
+
 ## Routes (all loopback-fenced)
 
 | Route | Description |
@@ -163,6 +195,10 @@ floating position in place.
   process's permissions; only configure trusted servers
 - **MCP tools execute on the real server — confirm before acting**; tool results are returned
   as-is and may contain sensitive information; treat tool descriptions/results as untrusted input
+- **Middleware tool read-only boundary**: `ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search`
+  only read the local catalog cache (never touch remote servers or execute tools) and bypass
+  the policy guard; `ws_mcp_call` is the only entry point that executes remote tools and is
+  governed by the policy (deny-first)
 - The capability catalog injection includes source annotations and a "does not represent current
   connection status" note
 
@@ -181,6 +217,9 @@ node test/smoke.mjs
 
 - Does not subscribe to the MCP `tools/list_changed` notification (no long-lived SSE
   connection); tool list changes are re-synced on reconnect / manual refresh
+- The middleware catalog is a "last-good snapshot within collection bounds" (≤512 tools /
+  ≤256KB total per server); on discovery failure `ws_mcp_list` surfaces the `unavailable`
+  reason
 - Only bridges tool capabilities; MCP resources and prompts have no harness consumption
   interface yet
 - Requires Node ≥ 20

--- a/packages/dsh-mcp-manager/README.md
+++ b/packages/dsh-mcp-manager/README.md
@@ -130,8 +130,9 @@ SSE events 通道推送一变，客户端自动重新拉取 `/api/dsh-mcp/config
 每服务器工具条数上限默认 50 / 上限 500，超限置 `toolsTruncated`；空返回附明确
 `message`）/ `ws_mcp_detail`（按 `@<root>/<server>` + tool 裸名精确查询单工具
 完整 `inputSchema`，错误三分：发现失败附原因 / 服务器未连接或未发现 / 工具
-不存在）/ `ws_mcp_search`（关键词检索，先搜后调）/ `ws_mcp_call`（按
-`@<root>/<server>` 全名调用），执行时按调用方会话当前 cwd 路由到对应工作空间
+不存在）/ `ws_mcp_search`（关键词检索，先搜后调，输出 `truncated` 标志提示结果是否因
+limit 截断）/ `ws_mcp_call`（按 `@<root>/<server>` 全名调用，参数 schema 用
+`ws_mcp_detail` 核对），执行时按调用方会话当前 cwd 路由到对应工作空间
 连接池，不同工作空间注入不同 MCP、无命名冲突；全局服务器仍直呼
 `mcp__<server>__<tool>`。切换 `middleware: off` 回到旧行为（项目级也直接注册
 `mcp__` 工具）；`middleware: all` 则全局服务器也走中间层（cwd 无项目时回落全局
@@ -168,7 +169,9 @@ SSE events 通道推送一变，客户端自动重新拉取 `/api/dsh-mcp/config
   策略 guard（allowTools/denyTools，deny 优先）按 `@<root>/<server>` 全名或裸名配置（全名优先，工作空间隔离）
 - **中间层工具只读边界**：`ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search` 纯读
   本地目录缓存（不触达远端服务器、不执行工具），不经过策略 guard；`ws_mcp_call`
-  是唯一执行远端工具并受策略约束（deny 优先）的入口
+  是唯一执行远端工具并受策略约束（deny 优先）的入口；`ws_mcp_call` 错误消息按
+  「显式 + 下一步」规范给出（确认 server 连接 / 用 `ws_mcp_detail` 核对参数 /
+  检查策略配置）
 - **凭据脱敏**：目录摘要与错误路径经 redactor 把 env/headers/URL 用户信息等
   凭据形状替换为 `[REDACTED]`
 - 能力目录注入含来源标注与"不代表当前连接状态"说明

--- a/packages/dsh-mcp-manager/README.md
+++ b/packages/dsh-mcp-manager/README.md
@@ -8,16 +8,19 @@ MCP 协议客户端基于 `node:child_process` 与全局 `fetch` 直接实现，
 
 三档中间层模式（`middleware`）：`off`——全部服务器直呼 `mcp__<server>__<tool>`（旧行为）；
 `project`（**默认**）——项目级走中间层、全局仍直呼；`all`——全局也走中间层，
-cwd 无项目时回落全局虚拟 root `@global`，模型面完全收敛为两个原子工具。
+cwd 无项目时回落全局虚拟 root `@global`，模型面完全收敛为四个原子工具
+（`ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search` / `ws_mcp_call`）。
 注意生效时机：`middleware` / `middlewarePolicy` 只在插件启动时读取，**变更后需重启
 `dsh web`**；两级配置文件中的服务器列表（增删/启停/改配置）支持热加载、即时生效，
 无需重启。
 
 ## 核心优势
 
-- **上下文成本可控**：项目级 MCP 默认经中间层收敛，模型面只占 `ws_mcp_search` /
-  `ws_mcp_call` 两个原子工具位——当前工作空间的项目级接多少台服务器、多少个工具都
-  不膨胀系统提示词；`middleware: all` 可把全局服务器也收进中间层，实现全量收敛
+- **上下文成本可控**：项目级 MCP 默认经中间层收敛，模型面只占 `ws_mcp_list` /
+  `ws_mcp_detail` / `ws_mcp_search` / `ws_mcp_call` 四个原子工具位——当前工作空间
+  的项目级接多少台服务器、多少个工具都不膨胀系统提示词；`middleware: all` 可把
+  全局服务器也收进中间层，实现全量收敛（两级发现：`ws_mcp_list` 完整盘点 →
+  `ws_mcp_detail` 按需拉完整 schema）
 - **分工作目录维护**：项目级配置 `<项目根>/.dsh/mcp.json` 随仓库走、可提交 git 团队共享；
   全局配置 `<DSH_HOME>/dsh-mcp.json` 常连；切换会话自动加载当前目录的 MCP 集
 - **工作空间隔离**：中间层以会话 cwd 路由到对应连接池，server 全名一致性校验防跨空间
@@ -80,7 +83,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-mcp-manager
 | 服务器管理 | 增删改查（可选项目级/全局）、连接 / 断开 / 重连；配置版本化 JSON，原子写入 |
 | 两种传输 | stdio（本地子进程，env 支持 `${ENV}` 引用）与 streamable-http（远程，header 支持 `${ENV}` 引用，自动回传 `Mcp-Session-Id`） |
 | JSON 导入 | 粘贴 mcpServers JSON 文本导入（仅 JSON 格式；不扫描任何应用配置文件） |
-| 模型工具 | 全局服务器工具以 `mcp__<server>__<tool>` 注册（64 字符、`[A-Za-z0-9_-]`、冲突时哈希后缀）；项目级服务器默认经中间层 `ws_mcp_search` / `ws_mcp_call` 访问（`middleware: project`，推荐），不同工作空间互不冲突 |
+| 模型工具 | 全局服务器工具以 `mcp__<server>__<tool>` 注册（64 字符、`[A-Za-z0-9_-]`、冲突时哈希后缀）；项目级服务器默认经中间层 `ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search` / `ws_mcp_call` 访问（`middleware: project`，推荐），不同工作空间互不冲突 |
 | 工作空间隔离 | 中间层按调用方会话当前 cwd 路由到对应工作空间的连接池；server 全名 `@<root>/<server>` 一致性校验防跨空间串台 |
 | 断线重连 | 有界指数退避（500ms 起、30s 上限、10 次后停止后台重试；用户手动连接或 ws_mcp_call 触发可再试） |
 | 结果截断 | 工具结果按 8KB 截断并标注（防超长 JSON 全量进上下文） |
@@ -121,12 +124,21 @@ SSE events 通道推送一变，客户端自动重新拉取 `/api/dsh-mcp/config
 ## 配置（中间层）
 
 项目级 MCP 经中间层访问（`middleware: project`，默认）：项目级服务器不再注册
-`mcp__` 工具，改经模型面两个原子工具访问——`ws_mcp_search`（先检索当前工作空间 MCP
-工具）/ `ws_mcp_call`（按 `@<root>/<server>` 全名调用），执行时按调用方会话当前 cwd
-路由到对应工作空间连接池，不同工作空间注入不同 MCP、无命名冲突；全局服务器仍直呼
-`mcp__<server>__<tool>`。切换 `middleware: off` 回到旧行为（项目级也直接注册 `mcp__`
-工具）；`middleware: all` 则全局服务器也走中间层（cwd 无项目时回落全局虚拟 root
-`@global`），模型面完全收敛为两个原子工具。
+`mcp__` 工具，改经模型面四个原子工具访问（两级发现，业界标准形态）——
+`ws_mcp_list`（完整盘点当前工作空间全部服务器 + 每台完整工具清单，不受
+`ws_mcp_search` 的 limit 截断；支持 `server` 全名/裸名过滤，`perServerLimit`
+每服务器工具条数上限默认 50 / 上限 500，超限置 `toolsTruncated`；空返回附明确
+`message`）/ `ws_mcp_detail`（按 `@<root>/<server>` + tool 裸名精确查询单工具
+完整 `inputSchema`，错误三分：发现失败附原因 / 服务器未连接或未发现 / 工具
+不存在）/ `ws_mcp_search`（关键词检索，先搜后调）/ `ws_mcp_call`（按
+`@<root>/<server>` 全名调用），执行时按调用方会话当前 cwd 路由到对应工作空间
+连接池，不同工作空间注入不同 MCP、无命名冲突；全局服务器仍直呼
+`mcp__<server>__<tool>`。切换 `middleware: off` 回到旧行为（项目级也直接注册
+`mcp__` 工具）；`middleware: all` 则全局服务器也走中间层（cwd 无项目时回落全局
+虚拟 root `@global`），模型面完全收敛为四个原子工具——此时 list/search/detail
+合并查询「项目 root 单元 + `@global` 单元」，call 放行 `@global` root（全局配置
+跨工作空间共享，语义成立）。注：all 模式全局服务器增删改后需重启或触发会话
+触达才刷新目录（既有行为）。
 
 | 键 | 值域 | 默认 |
 | --- | --- | --- |
@@ -154,6 +166,9 @@ SSE events 通道推送一变，客户端自动重新拉取 `/api/dsh-mcp/config
 - **工作空间隔离（中间层）**：路由以调用方会话当前 cwd 为唯一输入；server
   全名一致性校验（参数声明的 root ≠ 路由 root → 拒绝）防跨空间串台；
   策略 guard（allowTools/denyTools，deny 优先）按 `@<root>/<server>` 全名或裸名配置（全名优先，工作空间隔离）
+- **中间层工具只读边界**：`ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search` 纯读
+  本地目录缓存（不触达远端服务器、不执行工具），不经过策略 guard；`ws_mcp_call`
+  是唯一执行远端工具并受策略约束（deny 优先）的入口
 - **凭据脱敏**：目录摘要与错误路径经 redactor 把 env/headers/URL 用户信息等
   凭据形状替换为 `[REDACTED]`
 - 能力目录注入含来源标注与"不代表当前连接状态"说明
@@ -173,6 +188,8 @@ node test/smoke.mjs
 
 - 不订阅 MCP 的 `tools/list_changed` 通知（无 SSE 长连接）；工具列表变化在
   重连 / 手动刷新时重新同步
+- 中间层目录是「采集边界内的 last-good 快照」（单服务器 ≤512 工具 / ≤256KB 总量），
+  发现失败时 list 透出 `unavailable` 原因
 - 仅桥接工具能力；MCP 的 resources 与 prompts 尚无 harness 消费接口
 - 依赖 Node ≥ 20
 

--- a/packages/dsh-mcp-manager/src/apply.ts
+++ b/packages/dsh-mcp-manager/src/apply.ts
@@ -143,7 +143,8 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
           supervisors as Map<string, SupervisorLite>,
           catalogMaxEntries,
           manager.catalogCache,
-          agent as unknown as CatalogAgent | undefined
+          agent as unknown as CatalogAgent | undefined,
+          middlewareMode,
         ) as unknown as PreStepDecision;
       });
     }

--- a/packages/dsh-mcp-manager/src/apply.ts
+++ b/packages/dsh-mcp-manager/src/apply.ts
@@ -21,7 +21,7 @@ import { makeRoutes, makeEventsRoute, makeHealthRoute, sseData, uiConfigChangedF
 /** 向 Agent 宣告插件（announceToAgent 开启时注入）。能力清单由动态目录
  * （<available_mcp_servers>，见 L1）承担，此处只说明管理界面与使用约束。 */
 export const MCP_GUIDANCE =
-  "本机已安装 dsh-mcp-manager 插件（DSH MCP 管理器）：会话界面右上角浮窗管理 MCP 服务器（全局配置 ~/.dsh/dsh-mcp.json；项目级配置 <项目根>/.dsh/mcp.json，跟随会话切换展示并连接对应项目的服务器；支持 stdio / streamable-http，可粘贴 mcpServers JSON 导入，不预设任何服务器）。已配置服务器的能力清单见会话内的 <available_mcp_servers>（仅描述能力，不代表连接状态）。项目级 MCP 工具经 ws_mcp_search/ws_mcp_call 调用（先用 ws_mcp_search 检索，再 ws_mcp_call 调用）；全局服务器连接后其工具以 mcp__<server>__<tool> 注册可用。限制：MCP 工具在真实服务器上执行，先确认再操作；stdio 服务器的子进程继承宿主权限；工具结果可能含敏感信息。用户提到「MCP / mcp 服务 / 上下文服务器」时即指本插件，请据此协作。";
+  "本机已安装 dsh-mcp-manager 插件（DSH MCP 管理器）：会话界面右上角浮窗管理 MCP 服务器（全局配置 ~/.dsh/dsh-mcp.json；项目级配置 <项目根>/.dsh/mcp.json，跟随会话切换展示并连接对应项目的服务器；支持 stdio / streamable-http，可粘贴 mcpServers JSON 导入，不预设任何服务器）。已配置服务器的能力清单见会话内的 <available_mcp_servers>（仅描述能力，不代表连接状态）。项目级 MCP 工具经 ws_mcp_list/ws_mcp_search 检索（先 ws_mcp_list 完整盘点服务器与工具，再按需 ws_mcp_detail 查完整 inputSchema），经 ws_mcp_call 调用（先用 ws_mcp_search 检索，再 ws_mcp_call 调用；已知 server/tool 时可直呼免搜索）；全局服务器连接后其工具以 mcp__<server>__<tool> 注册可用。限制：MCP 工具在真实服务器上执行，先确认再操作；stdio 服务器的子进程继承宿主权限；工具结果可能含敏感信息。用户提到「MCP / mcp 服务 / 上下文服务器」时即指本插件，请据此协作。";
 
 /**
  * 挂载 MCP 管理器：加载存储、启动已启用服务器、注册路由与提示词。
@@ -117,7 +117,7 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
         }
         return undefined;
       };
-      disposeMiddleware = registerMiddlewareTools(manager.ctx, mw, resolveRoot);
+      disposeMiddleware = registerMiddlewareTools(manager.ctx, mw, resolveRoot, middlewareMode);
       // startAll 在中间层注册前执行（off 语义），此处立即 reconcile：停掉
       // 项目级（all 含全局）supervisor（改由中间层接管），防同一 server 双进程。
       manager.reconcileServers();

--- a/packages/dsh-mcp-manager/src/catalog.ts
+++ b/packages/dsh-mcp-manager/src/catalog.ts
@@ -140,13 +140,14 @@ export function digestCatalogEntries(entries: CatalogEntry[]): string {
 
 /** 渲染能力目录消息（source 标记供定位替换）。
  * 按条目 scope 区分调用引导（#228 双轨迁移）：
- * - 含 project 条目 → 引导经 ws_mcp_search/ws_mcp_call（项目级走中间层）；
+ * - 含 project 条目 → 引导经 ws_mcp_list/ws_mcp_search/ws_mcp_detail/ws_mcp_call
+ *   （项目级走中间层；完整盘点用 ws_mcp_list，查完整 schema 用 ws_mcp_detail）；
  * - 仅 global 条目 → 保持 mcp__ 直呼引导（全局服务器不经中间层检索）。
  */
 export function renderMcpCatalogMessage(entries: CatalogEntry[]): CatalogMessage {
   const hasProject = entries.some((entry) => entry.scope === "project");
   const guidance = hasProject
-    ? "任务匹配某服务器能力时，先用 `ws_mcp_search` 检索当前工作空间的 MCP 工具，再用 `ws_mcp_call` 调用（server/tool 取自检索结果）。**项目级服务器一律经这两个工具访问，不直接调用其 mcp__ 前缀工具**；全局服务器的 `mcp__<server>__<tool>` 工具仍可直接调用（见工具列表）。"
+    ? "任务匹配某服务器能力时，先用 `ws_mcp_search` 检索当前工作空间的 MCP 工具，再用 `ws_mcp_call` 调用（server/tool 取自检索结果）。**项目级服务器一律经这些工具访问，不直接调用其 mcp__ 前缀工具**；完整盘点全部服务器与工具清单用 `ws_mcp_list`，查单个工具的完整 inputSchema 用 `ws_mcp_detail`；全局服务器的 `mcp__<server>__<tool>` 工具仍可直接调用（见工具列表）。"
     : "任务匹配某服务器能力时，直接调用其 `mcp__<server>__<tool>` 工具（具体工具名与参数见工具列表）。";
   const lines = [
     "<system-reminder>",

--- a/packages/dsh-mcp-manager/src/catalog.ts
+++ b/packages/dsh-mcp-manager/src/catalog.ts
@@ -142,12 +142,14 @@ export function digestCatalogEntries(entries: CatalogEntry[]): string {
  * 按条目 scope 区分调用引导（#228 双轨迁移）：
  * - 含 project 条目 → 引导经 ws_mcp_list/ws_mcp_search/ws_mcp_detail/ws_mcp_call
  *   （项目级走中间层；完整盘点用 ws_mcp_list，查完整 schema 用 ws_mcp_detail）；
- * - 仅 global 条目 → 保持 mcp__ 直呼引导（全局服务器不经中间层检索）。
+ * - 仅 global 条目 → 默认保持 mcp__ 直呼引导（全局服务器不经中间层检索）；
+ *   all 模式（mode === "all"）下全局也走中间层 → 同样引导经中间层工具访问。
  */
-export function renderMcpCatalogMessage(entries: CatalogEntry[]): CatalogMessage {
+export function renderMcpCatalogMessage(entries: CatalogEntry[], mode?: string): CatalogMessage {
   const hasProject = entries.some((entry) => entry.scope === "project");
-  const guidance = hasProject
-    ? "任务匹配某服务器能力时，先用 `ws_mcp_search` 检索当前工作空间的 MCP 工具，再用 `ws_mcp_call` 调用（server/tool 取自检索结果）。**项目级服务器一律经这些工具访问，不直接调用其 mcp__ 前缀工具**；完整盘点全部服务器与工具清单用 `ws_mcp_list`，查单个工具的完整 inputSchema 用 `ws_mcp_detail`；全局服务器的 `mcp__<server>__<tool>` 工具仍可直接调用（见工具列表）。"
+  const viaMiddleware = hasProject || mode === "all";
+  const guidance = viaMiddleware
+    ? "任务匹配某服务器能力时，先用 `ws_mcp_search` 检索当前工作空间的 MCP 工具，再用 `ws_mcp_call` 调用（server/tool 取自检索结果）。**服务器一律经这些工具访问，不直接调用其 mcp__ 前缀工具**；完整盘点全部服务器与工具清单用 `ws_mcp_list`，查单个工具的完整 inputSchema 用 `ws_mcp_detail`。"
     : "任务匹配某服务器能力时，直接调用其 `mcp__<server>__<tool>` 工具（具体工具名与参数见工具列表）。";
   const lines = [
     "<system-reminder>",
@@ -227,8 +229,8 @@ export function catalogHistory(agent: CatalogAgent | undefined): CatalogHistoryR
 }
 
 /** 渲染"目录更新"消息（历史旧目录无法删除，新消息声明作废——与 tool-skill 同语义）。 */
-export function renderMcpCatalogUpdate(entries: CatalogEntry[]): CatalogMessage {
-  const body = renderMcpCatalogMessage(entries);
+export function renderMcpCatalogUpdate(entries: CatalogEntry[], mode?: string): CatalogMessage {
+  const body = renderMcpCatalogMessage(entries, mode);
   const inner = body.content![0].text!.split("\n").slice(3).join("\n");
   const text = [
     "<system-reminder>",
@@ -261,7 +263,8 @@ export function resolveCatalogInjection(
   supervisors: Map<string, SupervisorLite>,
   maxEntries = DEFAULT_CATALOG_MAX_ENTRIES,
   cache?: CatalogCache,
-  agent?: CatalogAgent
+  agent?: CatalogAgent,
+  mode?: string,
 ): CatalogDecision {
   if (decision.kind === "reject") return decision;
   const entries = composeCatalogEntries(supervisors, maxEntries, cache);
@@ -286,7 +289,7 @@ export function resolveCatalogInjection(
       messages: decision.messages.filter((message) => message.id !== existing.id),
     };
   }
-  const catalog = history.published ? renderMcpCatalogUpdate(entries) : renderMcpCatalogMessage(entries);
+  const catalog = history.published ? renderMcpCatalogUpdate(entries, mode) : renderMcpCatalogMessage(entries, mode);
   return {
     kind: "enter",
     messages: existing === undefined ? [...decision.messages, catalog] : decision.messages.map((message) => (message.id === existing.id ? catalog : message)),

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -109,7 +109,8 @@ export {
 } from "./catalog.ts";
 // mcpServers JSON 导入
 export { fromClaudeEntry, parseClaudeJson } from "./import.ts";
-// 中间层（工作空间 MCP 路由：连接池 / 目录 / ws_mcp_search / ws_mcp_call）
+// 中间层（工作空间 MCP 路由：连接池 / 目录 / ws_mcp_search / ws_mcp_call /
+// ws_mcp_list / ws_mcp_detail）
 export {
   McpMiddleware,
   normalizeMiddlewareMode,
@@ -125,6 +126,9 @@ export {
   policyDenialReason,
   scoreTool,
   searchCatalog,
+  searchCatalogMulti,
+  listCatalog,
+  findToolDetail,
   withTimeout,
   userStateFile,
   loadUserState,
@@ -138,6 +142,18 @@ export {
   MAX_TOOLS_PER_SERVER,
   MAX_BYTES_PER_TOOL,
   MAX_TOTAL_CATALOG_BYTES,
+  LIST_DEFAULT_TOOLS_PER_SERVER,
+  LIST_MAX_TOOLS_PER_SERVER,
+} from "./middleware.ts";
+export type {
+  MiddlewareMode,
+  MiddlewarePolicy,
+  ProjectUnit,
+  SearchHit,
+  ListToolEntry,
+  ListServerEntry,
+  ListCatalogResult,
+  ToolDetail,
 } from "./middleware.ts";
 // 路由
 export { ROUTES, makeRoutes, makeEventsRoute, makeHealthRoute, sseData, uiConfigChangedFrame, broadcastFrame, SSE_HEARTBEAT_MS, SSE_PING_FRAME } from "./routes.ts";

--- a/packages/dsh-mcp-manager/src/middleware-const.ts
+++ b/packages/dsh-mcp-manager/src/middleware-const.ts
@@ -20,6 +20,10 @@ export const MAX_TOOLS_PER_SERVER = 512;
 export const MAX_BYTES_PER_TOOL = 4096;
 /** 目录安全边界：目录总字节上限。 */
 export const MAX_TOTAL_CATALOG_BYTES = 256 * 1024;
+/** ws_mcp_list 每服务器工具条数默认上限。 */
+export const LIST_DEFAULT_TOOLS_PER_SERVER = 50;
+/** ws_mcp_list 每服务器工具条数硬上限（目录采集边界内）。 */
+export const LIST_MAX_TOOLS_PER_SERVER = 500;
 
 /** 归一化中间层模式（非法值回落 off）。 */
 export function normalizeMiddlewareMode(value: unknown): MiddlewareMode {

--- a/packages/dsh-mcp-manager/src/middleware-register.ts
+++ b/packages/dsh-mcp-manager/src/middleware-register.ts
@@ -65,7 +65,8 @@ export function registerMiddlewareTools(
 
   const search: ToolDefinition = {
     name: "ws_mcp_search",
-    description: "检索当前工作空间的 MCP 工具目录。先用本工具检索，再 ws_mcp_call 调用。空 query 返回能力摘要表。",
+    description:
+      "检索当前工作空间的 MCP 工具目录（关键词命中 server 名/工具名/描述/参数名，返回命中条目）。先用本工具检索，再 ws_mcp_call 调用；完整盘点请用 ws_mcp_list（本工具仅关键词检索）。空 query 返回能力摘要表。",
     parameters: {
       type: "object",
       properties: {
@@ -80,19 +81,21 @@ export function registerMiddlewareTools(
         properties: {
           results: { type: "array", items: {} },
           unavailable: { type: "array", items: {} },
+          truncated: { type: "boolean", description: "结果是否因 limit 截断（results 达到 limit 时为 true，提示模型可能未列全）" },
         },
-        required: ["results", "unavailable"],
+        required: ["results", "unavailable", "truncated"],
         additionalProperties: false,
       },
       render(_args, value: unknown) {
-        const v = (value ?? {}) as { results?: Array<Record<string, unknown>>; unavailable?: Array<Record<string, unknown>> };
+        const v = (value ?? {}) as { results?: Array<Record<string, unknown>>; unavailable?: Array<Record<string, unknown>>; truncated?: unknown };
         const lines = (v.results ?? []).map((hit) => {
           const server = String(hit.server ?? "");
           const tool = String(hit.tool ?? "");
           const description = String(hit.description ?? "");
           return `${server}/${tool}: ${description}`;
         });
-        const body = lines.length > 0 ? lines.join("\n") : "（当前工作空间没有匹配的 MCP 工具）";
+        let body = lines.length > 0 ? lines.join("\n") : "（当前工作空间没有匹配的 MCP 工具）";
+        if (v.truncated === true) body += "\n（结果已达 limit，可能未列全——可调大 limit 或用 ws_mcp_list 完整盘点）";
         const unavailable = (v.unavailable ?? []).map((entry) => `${String(entry.server ?? "")}: ${String(entry.reason ?? "")}`);
         return [{ type: "text", text: unavailable.length > 0 ? `${body}\n\n不可用服务器：\n${unavailable.join("\n")}` : body }];
       },
@@ -120,19 +123,26 @@ export function registerMiddlewareTools(
       }
       const { results, unavailable } = searchCatalogMulti(mw.units, roots, query, limit);
       const filtered = serverFilter === undefined ? results : results.filter((hit) => hit.server === serverFilter);
-      return { results: filtered, unavailable };
+      // truncated：结果达到 limit 即置 true（提示模型可能未列全；可按需调大 limit 或改用 ws_mcp_list）。
+      const truncated = filtered.length >= limit;
+      return { results: filtered, unavailable, truncated };
     },
   };
 
   const call: ToolDefinition = {
     name: "ws_mcp_call",
-    description: "调用当前工作空间的一个 MCP 工具。server/tool 来自 ws_mcp_search 返回（已知时可直呼，免搜索）。",
+    description:
+      "调用当前工作空间的一个 MCP 工具（在真实服务器上执行，先确认再操作）。server/tool 来自 ws_mcp_search 或 ws_mcp_list；参数 schema 用 ws_mcp_detail 查询（已知时可直呼，免搜索）。",
     parameters: {
       type: "object",
       properties: {
-        server: { type: "string", description: "必须：@<root>/<server> 全名（来自 ws_mcp_search）" },
-        tool: { type: "string", description: "必须：远端工具裸名（来自 ws_mcp_search）" },
-        arguments: { type: "object", additionalProperties: true, description: "参数，匹配 ws_mcp_search 返回的 inputSchema" },
+        server: { type: "string", description: "必须：@<root>/<server> 全名（来自 ws_mcp_search / ws_mcp_list）" },
+        tool: { type: "string", description: "必须：远端工具裸名（来自 ws_mcp_search / ws_mcp_list）" },
+        arguments: {
+          type: "object",
+          additionalProperties: true,
+          description: "参数，匹配 ws_mcp_detail 返回的 inputSchema（properties/required/enum/description）；拿不准时先用 ws_mcp_detail 核对",
+        },
       },
       required: ["server", "tool"],
     },
@@ -197,13 +207,13 @@ export function registerMiddlewareTools(
   const list: ToolDefinition = {
     name: "ws_mcp_list",
     description:
-      "完整盘点当前工作空间的 MCP 服务器与每台服务器全部工具（不受关键词/limit 截断；工具数受 perServerLimit 保护）。先 ws_mcp_list 全量盘点，再 ws_mcp_detail 查单工具完整 schema，需要执行时 ws_mcp_call。空返回 message 说明原因（未配置或发现中）。",
+      "列出当前工作空间全部 MCP 服务器与每台服务器的完整工具清单（不受检索 limit 截断）。返回服务器全名、工具名与描述，供盘点与后续 ws_mcp_detail / ws_mcp_call 使用。不返回 inputSchema——查单个工具完整 schema 请用 ws_mcp_detail。all 模式下含全局服务器。",
     parameters: {
       type: "object",
       properties: {
         server: {
           type: "string",
-          description: "可选：@<root>/<server> 全名或裸名过滤（全名 root 不属于当前工作空间 → 抛路由一致性错误）",
+          description: `可选：@<root>/<server> 全名或裸名过滤，只列出该服务器的工具（全名 root 不属于当前工作空间 → 抛路由一致性错误）`,
         },
         perServerLimit: {
           type: "number",
@@ -288,12 +298,12 @@ export function registerMiddlewareTools(
   const detail: ToolDefinition = {
     name: "ws_mcp_detail",
     description:
-      "按 @<root>/<server> + tool 裸名精确查询单个 MCP 工具的完整详情（完整 inputSchema：properties/required/enum/description），不受关键词与 limit 截断。server/tool 来自 ws_mcp_list / ws_mcp_search 返回。错误三分：server 发现失败（附原因）/ server 未连接或未发现 / tool 不存在。",
+      "按 @<root>/<server> 全名 + 工具裸名精确查询单个 MCP 工具的完整参数 schema（inputSchema：properties/required/enum/description）。供 ws_mcp_call 前核对参数。不做关键词检索——找工具用 ws_mcp_list 或 ws_mcp_search。",
     parameters: {
       type: "object",
       properties: {
         server: { type: "string", description: "必须：@<root>/<server> 全名（来自 ws_mcp_list / ws_mcp_search）" },
-        tool: { type: "string", description: "必须：远端工具裸名（兼容 mcp__<server>__<tool> 前缀）" },
+        tool: { type: "string", description: "必须：远端工具裸名（来自 ws_mcp_list / ws_mcp_search；兼容 mcp__<server>__<tool> 前缀）" },
       },
       required: ["server", "tool"],
     },

--- a/packages/dsh-mcp-manager/src/middleware-register.ts
+++ b/packages/dsh-mcp-manager/src/middleware-register.ts
@@ -57,10 +57,11 @@ export function registerMiddlewareTools(
 ): () => void {
   const disposers: Array<() => void> = [];
 
-  /** all 模式可见单元集合：项目 root + @global（评审 A 全局可见性修复）。 */
+  /** all 模式可见单元集合：项目 root + @global（评审 A 全局可见性修复）。
+   * root 本身为 @global 时去重（防 all 模式无项目 cwd 下服务器翻倍）。 */
   const visibleRoots = (root: string | undefined): string[] => {
     if (root === undefined) return [];
-    return mode === "all" ? [root, "@global"] : [root];
+    return mode === "all" ? (root === "@global" ? ["@global"] : [root, "@global"]) : [root];
   };
 
   const search: ToolDefinition = {
@@ -109,22 +110,22 @@ export function registerMiddlewareTools(
       const serverFilter = typeof params.server === "string" ? params.server : undefined;
       const requested = typeof params.limit === "number" ? Math.floor(params.limit) : 5;
       const limit = Math.max(1, Math.min(requested, 10));
+      const roots = visibleRoots(root);
       const unit = await mw.projectUnitFor(root);
       if (unit === undefined) {
-        return { results: [], unavailable: [] };
+        return { results: [], unavailable: [], truncated: false };
       }
-      // 等待 in-flight 连接/发现（预算内），再搜索。
-      await waitForDiscovery(unit);
-      const roots = visibleRoots(root);
-      // all 模式：@global 单元可能尚未触达（无 cwd 会话已由 resolveRoot 触达；
-      // 有 cwd 会话需显式触达一次，保证全局服务器目录可用）。
+      // 等待 in-flight 连接/发现（预算内），再搜索。all 模式对可见全部单元
+      // （含 @global 首次触达）都等待——否则全局目录首次为空（P1-3 修复）。
       for (const visible of roots) {
-        if (visible !== root) await mw.projectUnitFor(visible);
+        const visibleUnit = visible === root ? unit : await mw.projectUnitFor(visible);
+        if (visibleUnit !== undefined) await waitForDiscovery(visibleUnit);
       }
       const { results, unavailable } = searchCatalogMulti(mw.units, roots, query, limit);
+      // truncated 基于过滤前结果判定（serverFilter 过滤后误报的修正，P2-3）：
+      // 过滤前已达 limit 上限即提示可能未列全。
+      const truncated = results.length >= limit;
       const filtered = serverFilter === undefined ? results : results.filter((hit) => hit.server === serverFilter);
-      // truncated：结果达到 limit 即置 true（提示模型可能未列全；可按需调大 limit 或改用 ws_mcp_list）。
-      const truncated = filtered.length >= limit;
       return { results: filtered, unavailable, truncated };
     },
   };
@@ -270,22 +271,30 @@ export function registerMiddlewareTools(
       const serverFilter = typeof params.server === "string" && params.server !== "" ? params.server : undefined;
       const requested = typeof params.perServerLimit === "number" ? Math.floor(params.perServerLimit) : LIST_DEFAULT_TOOLS_PER_SERVER;
       const toolLimit = Math.max(1, Math.min(requested, LIST_MAX_TOOLS_PER_SERVER));
+      const roots = visibleRoots(root);
       const unit = await mw.projectUnitFor(root);
       if (unit === undefined) {
-        return {
-          workspace: root,
-          mode,
-          servers: [],
-          totalServers: 0,
-          totalTools: 0,
-          toolsTruncated: false,
-          message: "当前工作空间没有项目级 MCP 配置（可在 <项目根>/.dsh/mcp.json 添加服务器，或切换工作区）",
-        };
+        // project 模式无项目配置 → 空返回提示；all 模式回退只盘点 @global 单元。
+        if (mode !== "all") {
+          return {
+            workspace: root,
+            mode,
+            servers: [],
+            totalServers: 0,
+            totalTools: 0,
+            toolsTruncated: false,
+            message: "当前工作空间没有项目级 MCP 配置（可在 <项目根>/.dsh/mcp.json 添加服务器，或切换工作区）",
+          };
+        }
+        const globalUnit = await mw.projectUnitFor("@global");
+        if (globalUnit !== undefined) await waitForDiscovery(globalUnit);
+        return listCatalog(mw.units, ["@global"], serverFilter, toolLimit, mode, "当前工作空间没有可用 MCP 服务器（项目级与全局均未发现；若刚添加配置，请稍后重试）");
       }
-      await waitForDiscovery(unit);
-      const roots = visibleRoots(root);
+      // 等待 in-flight 连接/发现（预算内），再搜索。all 模式对可见全部单元
+      // （含 @global 首次触达）都等待——否则全局目录首次为空（P1-3 修复）。
       for (const visible of roots) {
-        if (visible !== root) await mw.projectUnitFor(visible);
+        const visibleUnit = visible === root ? unit : await mw.projectUnitFor(visible);
+        if (visibleUnit !== undefined) await waitForDiscovery(visibleUnit);
       }
       const emptyHint =
         mode === "all"

--- a/packages/dsh-mcp-manager/src/middleware-register.ts
+++ b/packages/dsh-mcp-manager/src/middleware-register.ts
@@ -1,28 +1,67 @@
 /**
- * dsh-mcp-manager — 中间层工具注册（ws_mcp_search / ws_mcp_call + 策略 guard）。
+ * dsh-mcp-manager — 中间层工具注册（ws_mcp_search / ws_mcp_call /
+ * ws_mcp_list / ws_mcp_detail + 策略 guard）。
  *
- * 注册两个中间层工具与策略 guard 层；类型自 middleware-types.ts 取，
+ * 注册四个中间层工具与策略 guard 层；类型自 middleware-types.ts 取，
  * 连接池类（McpMiddleware）自 middleware.ts import type（防运行值环）。
+ * all 模式全局可见性（评审 A）：search/list/detail 合并查询「项目 root 单元 +
+ * @global 单元」；call 放行 @global root。off/project 模式行为不变。
  */
 
 import type { Context } from "@deepseek-ai/cordis";
 import type { ToolDefinition, PreToolDecision } from "@deepseek-ai/dsh-tools";
 import type { McpMiddleware } from "./middleware.ts";
-import { CONNECT_TIMEOUT_MS, DISCOVERY_TIMEOUT_MS, CALL_TIMEOUT_MS } from "./middleware-const.ts";
-import { withTimeout, searchCatalog, parseFullServerName, fullServerName, policyAllows, policyDenialReason } from "./middleware-utils.ts";
+import {
+  CONNECT_TIMEOUT_MS,
+  DISCOVERY_TIMEOUT_MS,
+  CALL_TIMEOUT_MS,
+  LIST_DEFAULT_TOOLS_PER_SERVER,
+  LIST_MAX_TOOLS_PER_SERVER,
+} from "./middleware-const.ts";
+import {
+  withTimeout,
+  searchCatalog,
+  searchCatalogMulti,
+  listCatalog,
+  findToolDetail,
+  parseFullServerName,
+  fullServerName,
+  policyAllows,
+  policyDenialReason,
+} from "./middleware-utils.ts";
+import type { MiddlewareMode } from "./middleware-types.ts";
+
+/** 等待 in-flight 连接/发现（8s 预算，与 search 对齐；超时不阻塞返回已有目录）。 */
+async function waitForDiscovery(unit: NonNullable<Awaited<ReturnType<McpMiddleware["projectUnitFor"]>>>): Promise<void> {
+  const inflight = [...unit.inFlight.values()];
+  if (inflight.length === 0) return;
+  try {
+    await withTimeout(Promise.allSettled(inflight), 8000, "等待连接/发现超时");
+  } catch {
+    // 超时不阻塞（返回已有目录）
+  }
+}
 
 /**
- * 注册 ws_mcp_search / ws_mcp_call 两个中间层工具。
+ * 注册 ws_mcp_search / ws_mcp_call / ws_mcp_list / ws_mcp_detail 四个中间层工具。
  * @param host 中间层宿主。
  * @param mw 中间层实例。
  * @param resolveRoot 路由：exec.agent → 归一化项目根（agent-less → undefined）。
+ * @param mode 中间层模式（all 模式合并查询 @global 单元）。
  */
 export function registerMiddlewareTools(
   ctx: Context,
   mw: McpMiddleware,
   resolveRoot: (agent: unknown) => Promise<string | undefined>,
+  mode: MiddlewareMode = "project",
 ): () => void {
   const disposers: Array<() => void> = [];
+
+  /** all 模式可见单元集合：项目 root + @global（评审 A 全局可见性修复）。 */
+  const visibleRoots = (root: string | undefined): string[] => {
+    if (root === undefined) return [];
+    return mode === "all" ? [root, "@global"] : [root];
+  };
 
   const search: ToolDefinition = {
     name: "ws_mcp_search",
@@ -72,15 +111,14 @@ export function registerMiddlewareTools(
         return { results: [], unavailable: [] };
       }
       // 等待 in-flight 连接/发现（预算内），再搜索。
-      const inflight = [...unit.inFlight.values()];
-      if (inflight.length > 0) {
-        try {
-          await withTimeout(Promise.allSettled(inflight), 8000, "等待连接/发现超时");
-        } catch {
-          // 超时不阻塞搜索（返回已有目录）
-        }
+      await waitForDiscovery(unit);
+      const roots = visibleRoots(root);
+      // all 模式：@global 单元可能尚未触达（无 cwd 会话已由 resolveRoot 触达；
+      // 有 cwd 会话需显式触达一次，保证全局服务器目录可用）。
+      for (const visible of roots) {
+        if (visible !== root) await mw.projectUnitFor(visible);
       }
-      const { results, unavailable } = searchCatalog(mw.units, root, query, limit);
+      const { results, unavailable } = searchCatalogMulti(mw.units, roots, query, limit);
       const filtered = serverFilter === undefined ? results : results.filter((hit) => hit.server === serverFilter);
       return { results: filtered, unavailable };
     },
@@ -141,25 +179,180 @@ export function registerMiddlewareTools(
       const tool = typeof params.tool === "string" ? params.tool : "";
       if (server === "" || tool === "") throw new Error("ws_mcp_call: server 与 tool 均为必填");
       const parsed = parseFullServerName(server);
-      if (parsed === undefined || parsed.root !== root) {
+      // all 模式放行 @global root（全局配置跨工作空间共享，语义成立）；
+      // 仍拒绝非当前 root 的其他项目 root（防跨空间串台）。
+      const allowedRoot = mode === "all" ? "@global" : undefined;
+      if (parsed === undefined || (parsed.root !== root && parsed.root !== allowedRoot)) {
         throw new Error(
           `ws_mcp_call: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`,
         );
       }
-      // 确保连接已建立（等待 in-flight + 单次连接）。
-      const unit = await mw.projectUnitFor(root);
-      if (unit === undefined) throw new Error(`ws_mcp_call: 工作空间 ${JSON.stringify(root)} 无项目级 MCP 配置`);
-      await mw.ensureConnected(root, parsed.server);
+      const unit = await mw.projectUnitFor(parsed.root);
+      if (unit === undefined) throw new Error(`ws_mcp_call: 工作空间 ${JSON.stringify(parsed.root)} 无项目级 MCP 配置`);
+      await mw.ensureConnected(parsed.root, parsed.server);
       return mw.callTool(server, tool, params.arguments, exec.signal);
+    },
+  };
+
+  const list: ToolDefinition = {
+    name: "ws_mcp_list",
+    description:
+      "完整盘点当前工作空间的 MCP 服务器与每台服务器全部工具（不受关键词/limit 截断；工具数受 perServerLimit 保护）。先 ws_mcp_list 全量盘点，再 ws_mcp_detail 查单工具完整 schema，需要执行时 ws_mcp_call。空返回 message 说明原因（未配置或发现中）。",
+    parameters: {
+      type: "object",
+      properties: {
+        server: {
+          type: "string",
+          description: "可选：@<root>/<server> 全名或裸名过滤（全名 root 不属于当前工作空间 → 抛路由一致性错误）",
+        },
+        perServerLimit: {
+          type: "number",
+          description: `可选：每服务器工具条数上限（默认 ${LIST_DEFAULT_TOOLS_PER_SERVER}，上限 ${LIST_MAX_TOOLS_PER_SERVER}；超过置 toolsTruncated=true，模型可按需调大）`,
+        },
+      },
+    },
+    output: {
+      schema: {
+        type: "object",
+        properties: {
+          workspace: { type: "string" },
+          mode: { type: "string" },
+          servers: { type: "array", items: {} },
+          totalServers: { type: "number" },
+          totalTools: { type: "number" },
+          toolsTruncated: { type: "boolean" },
+          message: { type: "string" },
+        },
+        required: ["workspace", "mode", "servers", "totalServers", "totalTools", "toolsTruncated"],
+        additionalProperties: false,
+      },
+      render(_args, value: unknown) {
+        const v = (value ?? {}) as {
+          workspace?: unknown;
+          mode?: unknown;
+          servers?: Array<Record<string, unknown>>;
+          totalServers?: unknown;
+          totalTools?: unknown;
+          toolsTruncated?: unknown;
+          message?: unknown;
+        };
+        const servers = v.servers ?? [];
+        const lines = servers.map((entry) => {
+          const server = String(entry.server ?? "");
+          const tools = Array.isArray(entry.tools) ? (entry.tools as Array<Record<string, unknown>>) : [];
+          const head = tools.length > 0 ? `${server}（${tools.length} 个工具）：\n${tools.map((t) => `  - ${String(t.tool ?? "")}: ${String(t.description ?? "")}`).join("\n")}` : `${server}（0 个工具）`;
+          const disabled = entry.disabled === true ? " [disabled]" : "";
+          const unavailable = typeof entry.unavailable === "string" && entry.unavailable !== "" ? ` [unavailable: ${entry.unavailable}]` : "";
+          const truncated = entry.toolsTruncated === true ? " [toolsTruncated: 工具数已达上限，可调大 perServerLimit 后重试]" : "";
+          return `${head}${disabled}${unavailable}${truncated}`;
+        });
+        const prefix = `工作空间 ${String(v.workspace ?? "")}（mode=${String(v.mode ?? "")}）：共 ${String(v.totalServers ?? 0)} 台服务器 / ${String(v.totalTools ?? 0)} 个工具`;
+        const body = lines.length > 0 ? lines.join("\n\n") : String(v.message ?? "（当前工作空间没有 MCP 服务器）");
+        const truncated = v.toolsTruncated === true ? "\n（部分服务器工具清单被截断，可按需调大 perServerLimit）" : "";
+        return [{ type: "text", text: `${prefix}\n\n${body}${truncated}` }];
+      },
+    },
+    isConcurrencySafe: () => true,
+    async execute(args: unknown, exec: { signal?: AbortSignal; agent?: unknown }) {
+      const root = await resolveRoot(exec.agent);
+      if (root === undefined) throw new Error("ws_mcp_list: 无法确定工作空间，请先选择工作区");
+      const params = (typeof args === "object" && args !== null ? args : {}) as Record<string, unknown>;
+      const serverFilter = typeof params.server === "string" && params.server !== "" ? params.server : undefined;
+      const requested = typeof params.perServerLimit === "number" ? Math.floor(params.perServerLimit) : LIST_DEFAULT_TOOLS_PER_SERVER;
+      const toolLimit = Math.max(1, Math.min(requested, LIST_MAX_TOOLS_PER_SERVER));
+      const unit = await mw.projectUnitFor(root);
+      if (unit === undefined) {
+        return {
+          workspace: root,
+          mode,
+          servers: [],
+          totalServers: 0,
+          totalTools: 0,
+          toolsTruncated: false,
+          message: "当前工作空间没有项目级 MCP 配置（可在 <项目根>/.dsh/mcp.json 添加服务器，或切换工作区）",
+        };
+      }
+      await waitForDiscovery(unit);
+      const roots = visibleRoots(root);
+      for (const visible of roots) {
+        if (visible !== root) await mw.projectUnitFor(visible);
+      }
+      const emptyHint =
+        mode === "all"
+          ? "当前工作空间没有可用 MCP 服务器（项目级与全局均未发现；若刚添加配置，请稍后重试）"
+          : "当前工作空间没有可用 MCP 服务器（未配置项目级服务器；若刚添加配置，请稍后重试）";
+      return listCatalog(mw.units, roots, serverFilter, toolLimit, mode, emptyHint);
+    },
+  };
+
+  const detail: ToolDefinition = {
+    name: "ws_mcp_detail",
+    description:
+      "按 @<root>/<server> + tool 裸名精确查询单个 MCP 工具的完整详情（完整 inputSchema：properties/required/enum/description），不受关键词与 limit 截断。server/tool 来自 ws_mcp_list / ws_mcp_search 返回。错误三分：server 发现失败（附原因）/ server 未连接或未发现 / tool 不存在。",
+    parameters: {
+      type: "object",
+      properties: {
+        server: { type: "string", description: "必须：@<root>/<server> 全名（来自 ws_mcp_list / ws_mcp_search）" },
+        tool: { type: "string", description: "必须：远端工具裸名（兼容 mcp__<server>__<tool> 前缀）" },
+      },
+      required: ["server", "tool"],
+    },
+    output: {
+      schema: {
+        type: "object",
+        properties: {
+          server: { type: "string" },
+          tool: { type: "string" },
+          description: { type: "string" },
+          inputSchema: {},
+          fresh: { type: "boolean" },
+          disabled: { type: "boolean" },
+        },
+        required: ["server", "tool", "description", "inputSchema", "fresh"],
+        additionalProperties: false,
+      },
+      render(_args, value: unknown) {
+        const v = (value ?? {}) as { server?: unknown; tool?: unknown; description?: unknown; inputSchema?: unknown; fresh?: unknown; disabled?: unknown };
+        const server = String(v.server ?? "");
+        const tool = String(v.tool ?? "");
+        const description = typeof v.description === "string" && v.description !== "" ? v.description : "（无描述）";
+        const schema = v.inputSchema === undefined ? "{}" : JSON.stringify(v.inputSchema, null, 2);
+        const fresh = v.fresh === true ? "fresh" : "stale";
+        const disabled = v.disabled === true ? " [disabled]" : "";
+        return [{ type: "text", text: `${server}/${tool}（${fresh}${disabled}）：${description}\n\ninputSchema:\n${schema}` }];
+      },
+    },
+    isConcurrencySafe: () => true,
+    async execute(args: unknown, exec: { signal?: AbortSignal; agent?: unknown }) {
+      const root = await resolveRoot(exec.agent);
+      if (root === undefined) throw new Error("ws_mcp_detail: 无法确定工作空间，请先选择工作区");
+      const params = (typeof args === "object" && args !== null ? args : {}) as Record<string, unknown>;
+      const server = typeof params.server === "string" ? params.server : "";
+      const tool = typeof params.tool === "string" ? params.tool : "";
+      if (server === "" || tool === "") throw new Error("ws_mcp_detail: server 与 tool 均为必填");
+      // all 模式放行 @global root（与 ws_mcp_call 同口径）。
+      const parsed = parseFullServerName(server);
+      const allowedRoot = mode === "all" ? "@global" : undefined;
+      if (parsed === undefined || (parsed.root !== root && parsed.root !== allowedRoot)) {
+        throw new Error(
+          `ws_mcp_detail: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`,
+        );
+      }
+      const unit = await mw.projectUnitFor(parsed.root);
+      if (unit !== undefined) await waitForDiscovery(unit);
+      return findToolDetail(mw.units, parsed.root, server, tool);
     },
   };
 
   disposers.push(ctx.tools.register(search));
   disposers.push(ctx.tools.register(call));
+  disposers.push(ctx.tools.register(list));
+  disposers.push(ctx.tools.register(detail));
 
   // 策略 guard 层（方案 v2）：tools/pre-execute 全局唯一执行点，防其他插件/
   // 入口绕行 ws_mcp_call 直接调用远端工具。对 ws_mcp_call 的调用统一过策略
-  // （deny 优先）；其余工具放行（不干扰 mcp__ 直呼兼容路径）。
+  // （deny 优先）；其余工具放行（不干扰 mcp__ 直呼兼容路径；ws_mcp_list /
+  // ws_mcp_detail 纯读本地目录，与 ws_mcp_search 一致不触达策略 guard）。
   if (typeof ctx.on === "function") {
     const guardDispose = ctx.on(
       "tools/pre-execute",

--- a/packages/dsh-mcp-manager/src/middleware-types.ts
+++ b/packages/dsh-mcp-manager/src/middleware-types.ts
@@ -80,6 +80,54 @@ export interface SearchHit {
   fresh: boolean;
 }
 
+/** ws_mcp_list 的单个工具条目（完整清单只给摘要，防上下文膨胀）。 */
+export interface ListToolEntry {
+  tool: string;
+  description: string;
+}
+
+/** ws_mcp_list 的单个服务器条目。 */
+export interface ListServerEntry {
+  /** @<root>/<server> 全名。 */
+  server: string;
+  /** 用户已禁用（工具来自 last-good 目录缓存，明示）。 */
+  disabled?: boolean;
+  /** 发现失败原因（unavailable 段）。 */
+  unavailable?: string;
+  tools: ListToolEntry[];
+  /** 工具数被 perServerLimit 截断。 */
+  toolsTruncated: boolean;
+}
+
+/** ws_mcp_detail 的单工具详情（完整 inputSchema）。 */
+export interface ToolDetail {
+  /** @<root>/<server> 全名。 */
+  server: string;
+  /** 远端工具裸名（已归一化）。 */
+  tool: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  /** 目录是否新鲜（TTL 内）。 */
+  fresh: boolean;
+  /** 用户已禁用。 */
+  disabled?: boolean;
+}
+
+/** ws_mcp_list 输出（多单元合并的完整盘点）。 */
+export interface ListCatalogResult {
+  /** 当前工作空间 root；all 模式无项目 cwd 时为 "@global"。 */
+  workspace: string;
+  /** 中间层模式（模型据此理解可见范围）。 */
+  mode: string;
+  servers: ListServerEntry[];
+  totalServers: number;
+  totalTools: number;
+  /** 任一服务器截断即为 true。 */
+  toolsTruncated: boolean;
+  /** 空返回时给模型的明确提示。 */
+  message?: string;
+}
+
 /** 中间层最小面（manager 提供）。 */
 export interface MiddlewareHost {
   ctx: Pick<Context, "tools">;

--- a/packages/dsh-mcp-manager/src/middleware-utils.ts
+++ b/packages/dsh-mcp-manager/src/middleware-utils.ts
@@ -263,13 +263,18 @@ export function searchCatalog(
 }
 
 /** 多单元合并检索（all 模式：项目 root 单元 + @global 单元合并查询）。
- * 与 searchCatalog 同语义，仅数据源扩展为多个 root；off/project 模式行为不变。 */
+ * 与 searchCatalog 同语义，仅数据源扩展为多个 root；off/project 模式行为不变。
+ * 单 root 直接委托 searchCatalog（保持原顺序，不引入跨单元排序变化）；
+ * 多 root 合并后统一排序并按全局 limit 截断。 */
 export function searchCatalogMulti(
   units: Map<string, ProjectUnit>,
   roots: readonly string[],
   query: string,
   limit: number,
 ): { results: SearchHit[]; unavailable: Array<{ server: string; reason: string }> } {
+  if (roots.length === 1) {
+    return searchCatalog(units, roots[0] as string, query, limit);
+  }
   const results: SearchHit[] = [];
   const unavailable: Array<{ server: string; reason: string }> = [];
   for (const root of roots) {
@@ -279,7 +284,8 @@ export function searchCatalogMulti(
   }
   // 跨单元排序（评分降序，工具名升序）——与单单元检索同序。
   results.sort((a, b) => b.score - a.score || a.tool.localeCompare(b.tool));
-  return { results, unavailable };
+  // 合并后统一截断（limit 为全局上限，而非每 root 上限）。
+  return { results: results.slice(0, limit), unavailable };
 }
 
 /**

--- a/packages/dsh-mcp-manager/src/middleware-utils.ts
+++ b/packages/dsh-mcp-manager/src/middleware-utils.ts
@@ -5,8 +5,17 @@
  * ts 取；被连接池类、工具注册与 manager 共享。
  */
 
-import { CATALOG_TTL_MS } from "./middleware-const.ts";
-import type { CatalogTool, MiddlewarePolicy, ProjectUnit, SearchHit } from "./middleware-types.ts";
+import { CATALOG_TTL_MS, LIST_DEFAULT_TOOLS_PER_SERVER } from "./middleware-const.ts";
+import type {
+  CatalogTool,
+  ListCatalogResult,
+  ListServerEntry,
+  ListToolEntry,
+  MiddlewarePolicy,
+  ProjectUnit,
+  SearchHit,
+  ToolDetail,
+} from "./middleware-types.ts";
 import type { ServerConfig } from "./types.ts";
 
 // ------------------------------------------------------------ 命名与容错
@@ -25,15 +34,16 @@ export function parseFullServerName(name: string): { root: string; server: strin
   return { root: name.slice(1, slash), server: name.slice(slash + 1) };
 }
 
-/** 归一化 ws_mcp_call 的 tool 参数（模型可能传 mcp__<server>__<tool> 全名）。 */
-export function normalizeToolName(serverName: string, toolName: string): string {
+/** 归一化中间层工具的 tool 参数（模型可能传 mcp__<server>__<tool> 全名）。
+ * @param caller 调用方工具名（错误文案前缀；ws_mcp_call / ws_mcp_detail 复用）。 */
+export function normalizeToolName(serverName: string, toolName: string, caller = "ws_mcp_call"): string {
   const prefix = `mcp__${serverName}__`;
   let name = toolName;
   if (name.startsWith("mcp__")) {
     while (name.startsWith(prefix)) name = name.slice(prefix.length);
     if (name.startsWith("mcp__")) {
       throw new Error(
-        `ws_mcp_call: tool 参数疑似其他 MCP server 的注册全名（${JSON.stringify(toolName)}，server="${serverName}"）；请传该 server 上的裸名`,
+        `${caller}: tool 参数疑似其他 MCP server 的注册全名（${JSON.stringify(toolName)}，server="${serverName}"）；请传该 server 上的裸名`,
       );
     }
   }
@@ -212,7 +222,8 @@ export function scoreTool(query: string, server: string, toolName: string, tool:
   return { score, matchedTerms };
 }
 
-/** 检索目录：query 为空 → 能力摘要表（每服务器前 N 个工具）。 */
+/** 检索目录：query 为空 → 能力摘要表（每服务器前 N 个工具）。
+ * 单 root 实现（searchCatalogMulti 循环调用；兼容既有测试）。 */
 export function searchCatalog(
   units: Map<string, ProjectUnit>,
   root: string,
@@ -249,6 +260,170 @@ export function searchCatalog(
     }
   }
   return { results, unavailable };
+}
+
+/** 多单元合并检索（all 模式：项目 root 单元 + @global 单元合并查询）。
+ * 与 searchCatalog 同语义，仅数据源扩展为多个 root；off/project 模式行为不变。 */
+export function searchCatalogMulti(
+  units: Map<string, ProjectUnit>,
+  roots: readonly string[],
+  query: string,
+  limit: number,
+): { results: SearchHit[]; unavailable: Array<{ server: string; reason: string }> } {
+  const results: SearchHit[] = [];
+  const unavailable: Array<{ server: string; reason: string }> = [];
+  for (const root of roots) {
+    const single = searchCatalog(units, root, query, limit);
+    results.push(...single.results);
+    unavailable.push(...single.unavailable);
+  }
+  // 跨单元排序（评分降序，工具名升序）——与单单元检索同序。
+  results.sort((a, b) => b.score - a.score || a.tool.localeCompare(b.tool));
+  return { results, unavailable };
+}
+
+/**
+ * 完整盘点：列出当前工作空间全部服务器 + 每台完整工具清单（不受关键词/limit
+ * 截断服务器，工具数受 perServerLimit 保护）。
+ * @param units 连接池单元集合。
+ * @param roots 参与盘点的 root 列表（all 模式含 @global）。
+ * @param serverFilter 可选：@<root>/<server> 全名或裸名过滤。
+ * @param toolLimit 每服务器工具条数上限（>0；超过置 toolsTruncated）。
+ * @param emptyHint 空返回时的 message（按模式区分场景）。
+ * @throws 全名 root 不属于当前 roots → 路由一致性错误（与 ws_mcp_call 口径一致）。
+ */
+export function listCatalog(
+  units: Map<string, ProjectUnit>,
+  roots: readonly string[],
+  serverFilter: string | undefined,
+  toolLimit: number,
+  mode: string,
+  emptyHint: string,
+): ListCatalogResult {
+  const safeLimit = Number.isFinite(toolLimit) && toolLimit > 0 ? Math.floor(toolLimit) : LIST_DEFAULT_TOOLS_PER_SERVER;
+  let rootSet: Set<string> | undefined;
+  if (serverFilter !== undefined && serverFilter.startsWith("@")) {
+    const parsed = parseFullServerName(serverFilter);
+    if (parsed === undefined || !roots.includes(parsed.root)) {
+      throw new Error(
+        `ws_mcp_list: server ${JSON.stringify(serverFilter)} 不属于当前工作空间（${JSON.stringify(roots)}）；路由一致性校验失败（防跨空间串台）`,
+      );
+    }
+    rootSet = new Set([parsed.root]);
+  }
+  const servers: ListServerEntry[] = [];
+  let totalTools = 0;
+  let anyTruncated = false;
+  for (const root of roots) {
+    if (rootSet !== undefined && !rootSet.has(root)) continue;
+    const unit = units.get(root);
+    if (unit === undefined) continue;
+    for (const [serverName, catalog] of unit.catalog) {
+      if (serverFilter !== undefined && serverName !== serverFilter && fullServerName(root, serverName) !== serverFilter) continue;
+      const entry: ListServerEntry = {
+        server: fullServerName(root, serverName),
+        tools: [],
+        toolsTruncated: false,
+      };
+      if (unit.userDisabled.has(serverName)) entry.disabled = true;
+      if (catalog.unavailable !== undefined) {
+        entry.unavailable = catalog.unavailable;
+      } else {
+        const tools: ListToolEntry[] = [];
+        let truncated = false;
+        let index = 0;
+        for (const [toolName, tool] of catalog.tools) {
+          if (index >= safeLimit) {
+            truncated = true;
+            break;
+          }
+          tools.push({ tool: toolName, description: tool.description });
+          index += 1;
+        }
+        entry.tools = tools;
+        entry.toolsTruncated = truncated;
+        if (truncated) anyTruncated = true;
+        totalTools += tools.length;
+      }
+      servers.push(entry);
+    }
+  }
+  // 稳定排序（root 出现序 + 服务器名）：跨单元合并不依赖 Map 插入序。
+  const rootIndex = new Map(roots.map((root, index) => [root, index]));
+  servers.sort((a, b) => {
+    const ra = parseFullServerName(a.server)?.root ?? "";
+    const rb = parseFullServerName(b.server)?.root ?? "";
+    const oa = rootIndex.get(ra) ?? Number.MAX_SAFE_INTEGER;
+    const ob = rootIndex.get(rb) ?? Number.MAX_SAFE_INTEGER;
+    if (oa !== ob) return oa - ob;
+    const sa = parseFullServerName(a.server)?.server ?? a.server;
+    const sb = parseFullServerName(b.server)?.server ?? b.server;
+    return sa.localeCompare(sb);
+  });
+  const result: ListCatalogResult = {
+    workspace: roots[0] ?? "@global",
+    mode,
+    servers,
+    totalServers: servers.length,
+    totalTools,
+    toolsTruncated: anyTruncated,
+  };
+  if (servers.length === 0) result.message = emptyHint;
+  return result;
+}
+
+/**
+ * 单工具详情：按 @<root>/<server> + tool 裸名精确命中，返回完整 inputSchema。
+ * 错误三分：
+ * 1. server 发现失败（catalog.unavailable）→ 附原因；
+ * 2. 单元/服务器未发现 → 「server 未连接或未发现」；
+ * 3. 工具不存在 → 「tool 不存在」。
+ * @param units 连接池单元集合。
+ * @param root 目标 root（all 模式可为 @global）。
+ * @param server @<root>/<server> 全名。
+ * @param tool 远端工具裸名（兼容 mcp__ 前缀，复用 normalizeToolName）。
+ */
+export function findToolDetail(
+  units: Map<string, ProjectUnit>,
+  root: string,
+  server: string,
+  tool: string,
+): ToolDetail {
+  const parsed = parseFullServerName(server);
+  if (parsed === undefined || parsed.root !== root) {
+    throw new Error(
+      `ws_mcp_detail: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`,
+    );
+  }
+  const unit = units.get(root);
+  if (unit === undefined) {
+    throw new Error(`ws_mcp_detail: server 未连接或未发现：${JSON.stringify(server)}`);
+  }
+  const catalog = unit.catalog.get(parsed.server);
+  if (catalog === undefined || catalog.tools.size === 0) {
+    if (catalog?.unavailable !== undefined) {
+      throw new Error(`ws_mcp_detail: server 发现失败：${JSON.stringify(server)}（${catalog.unavailable}）`);
+    }
+    if (unit.userDisabled.has(parsed.server)) {
+      throw new Error(`ws_mcp_detail: server 未连接或未发现：${JSON.stringify(server)}（已被用户禁用）`);
+    }
+    throw new Error(`ws_mcp_detail: server 未连接或未发现：${JSON.stringify(server)}`);
+  }
+  const toolName = normalizeToolName(parsed.server, tool, "ws_mcp_detail");
+  const found = catalog.tools.get(toolName);
+  if (found === undefined) {
+    throw new Error(`ws_mcp_detail: tool 不存在：${JSON.stringify(`${server}/${toolName}`)}`);
+  }
+  const fresh = Date.now() - catalog.discoveredAt <= CATALOG_TTL_MS;
+  const detail: ToolDetail = {
+    server,
+    tool: toolName,
+    description: found.description,
+    inputSchema: found.inputSchema,
+    fresh,
+  };
+  if (unit.userDisabled.has(parsed.server)) detail.disabled = true;
+  return detail;
 }
 
 /** 等待带超时（race 兜底）。 */

--- a/packages/dsh-mcp-manager/src/middleware.ts
+++ b/packages/dsh-mcp-manager/src/middleware.ts
@@ -352,24 +352,24 @@ export class McpMiddleware {
     }
     const unit = this.units.get(parsed.root);
     if (unit === undefined) {
-      throw new Error(`ws_mcp_call: 工作空间 ${JSON.stringify(parsed.root)} 未激活；请先 ws_mcp_search`);
+      throw new Error(`ws_mcp_call: 工作空间 ${JSON.stringify(parsed.root)} 未激活；请先 ws_mcp_search 或 ws_mcp_list`);
     }
     const entry = unit.connections.get(parsed.server);
     if (entry === undefined || entry.status === "failed") {
       if (unit.userDisabled.has(parsed.server)) {
-        throw new Error(`ws_mcp_call: server ${JSON.stringify(fullName)} 已被用户禁用`);
+        throw new Error(`ws_mcp_call: server ${JSON.stringify(fullName)} 已被用户禁用；可先在 GUI「MCP」浮窗中重新连接`);
       }
-      throw new Error(`ws_mcp_call: server ${JSON.stringify(fullName)} 未连接或连接失败，请先 ws_mcp_search`);
+      throw new Error(`ws_mcp_call: server ${JSON.stringify(fullName)} 未连接或连接失败，请先 ws_mcp_search 或 ws_mcp_list 确认 server 已连接`);
     }
     if (entry.status === "connecting") {
-      throw new Error(`ws_mcp_call: server ${JSON.stringify(fullName)} 连接仍在进行，请稍后重试`);
+      throw new Error(`ws_mcp_call: server ${JSON.stringify(fullName)} 连接仍在进行，请稍后重试；连接完成后再调用`);
     }
     const tool = normalizeToolName(parsed.server, toolRaw);
     // 策略键支持全名（@root/server，工作空间隔离）或裸名（跨空间共用）。
     const policyKey = fullServerName(parsed.root, parsed.server);
     if (!policyAllows(this.policy, policyKey, tool)) {
       const reason = policyDenialReason(this.policy, policyKey, tool);
-      throw new Error(reason ?? `ws_mcp_call: 工具 ${JSON.stringify(`${policyKey}/${tool}`)} 被策略拒绝`);
+      throw new Error(`${reason ?? `ws_mcp_call: 工具 ${JSON.stringify(`${policyKey}/${tool}`)} 被策略拒绝`}；如需放行请调整 middlewarePolicy 配置`);
     }
     const catalog = unit.catalog.get(parsed.server);
     const stale =
@@ -378,7 +378,7 @@ export class McpMiddleware {
       // stale：仍可调用（目录只是提示），但 schema 可能过期——在结果前置提示。
     }
     if (entry.client === undefined) {
-      throw new Error(`ws_mcp_call: server ${JSON.stringify(fullName)} 未就绪（client 缺失）`);
+      throw new Error(`ws_mcp_call: server ${JSON.stringify(fullName)} 未就绪（client 缺失）；请稍后重试或重新连接`);
     }
     const args = normalizeArguments(rawArgs);
     try {
@@ -388,12 +388,12 @@ export class McpMiddleware {
           timeoutMs: CALL_TIMEOUT_MS,
         }),
         CALL_TIMEOUT_MS + 2000,
-        `ws_mcp_call: 调用超时（${CALL_TIMEOUT_MS}ms），可重试`,
+        `ws_mcp_call: 调用超时（${CALL_TIMEOUT_MS}ms），可重试；若反复超时请用 ws_mcp_detail 核对参数或检查服务器状态`,
         signal,
       );
       const resultObj = result as { content?: unknown; isError?: unknown; structuredContent?: unknown } | undefined;
       if (resultObj?.isError === true) {
-        throw new Error(this.hostRedact(`ws_mcp_call: 远端工具返回错误：${msgOf(resultObj.content)}`));
+        throw new Error(this.hostRedact(`ws_mcp_call: 远端工具返回错误：${msgOf(resultObj.content)}；可先用 ws_mcp_detail 核对参数 schema 后重试`));
       }
       if (stale) {
         // schema 可能已过期：结果前置提示（不改变调用结果结构）。
@@ -404,7 +404,7 @@ export class McpMiddleware {
       return resultObj;
     } catch (error) {
       if (signal?.aborted === true) throw signal.reason;
-      throw new Error(this.hostRedact(`ws_mcp_call: ${JSON.stringify(`${parsed.server}/${tool}`)} 调用失败：${msgOf(error)}`));
+      throw new Error(this.hostRedact(`ws_mcp_call: ${JSON.stringify(`${parsed.server}/${tool}`)} 调用失败：${msgOf(error)}；可先用 ws_mcp_detail 核对参数 schema，或确认服务器已连接后重试`));
     }
   }
 

--- a/packages/dsh-mcp-manager/src/middleware.ts
+++ b/packages/dsh-mcp-manager/src/middleware.ts
@@ -475,6 +475,8 @@ export {
   MAX_TOOLS_PER_SERVER,
   MAX_BYTES_PER_TOOL,
   MAX_TOTAL_CATALOG_BYTES,
+  LIST_DEFAULT_TOOLS_PER_SERVER,
+  LIST_MAX_TOOLS_PER_SERVER,
   normalizeMiddlewareMode,
 } from "./middleware-const.ts";
 // 纯函数与目录检索
@@ -492,6 +494,9 @@ export {
   policyDenialReason,
   scoreTool,
   searchCatalog,
+  searchCatalogMulti,
+  listCatalog,
+  findToolDetail,
 } from "./middleware-utils.ts";
 // 状态持久化
 export { userStateFile, loadUserState, saveUserState, catalogCacheFileFor } from "./middleware-state.ts";
@@ -506,6 +511,10 @@ export type {
   CatalogServer,
   CatalogTool,
   SearchHit,
+  ListToolEntry,
+  ListServerEntry,
+  ListCatalogResult,
+  ToolDetail,
   MiddlewareHost,
 } from "./middleware-types.ts";
 

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -214,13 +214,31 @@ const main = async () => {
     const names = registered.map((def) => def.name).sort();
     assert.deepEqual(names, ["ws_mcp_call", "ws_mcp_detail", "ws_mcp_list", "ws_mcp_search"], "四个中间层工具注册");
     assert.match(registered.find((d) => d.name === "ws_mcp_search").description, /ws_mcp_call/, "search 描述引导先搜后调");
-    assert.match(registered.find((d) => d.name === "ws_mcp_list").description, /ws_mcp_detail/, "list 描述引导两级发现");
+    assert.match(registered.find((d) => d.name === "ws_mcp_search").description, /ws_mcp_list/, "search 描述互引完整盘点");
+    assert.match(registered.find((d) => d.name === "ws_mcp_call").description, /ws_mcp_detail/, "call 描述互引参数 schema 查询");
+    assert.match(registered.find((d) => d.name === "ws_mcp_list").description, /ws_mcp_detail/, "list 描述互引 detail");
+    assert.match(registered.find((d) => d.name === "ws_mcp_list").description, /不返回 inputSchema/, "list 描述写明不做什么");
     assert.match(registered.find((d) => d.name === "ws_mcp_detail").description, /inputSchema/, "detail 描述说明完整 schema");
+    assert.match(registered.find((d) => d.name === "ws_mcp_detail").description, /不做关键词检索/, "detail 描述写明不做什么");
+    // Anthropic 规范：parameters 每个字段都带 description。
+    for (const def of registered) {
+      const props = def.parameters?.properties ?? {};
+      for (const [key, prop] of Object.entries(props)) {
+        assert.ok(typeof prop.description === "string" && prop.description !== "", `参数 ${def.name}.${key} 带 description`);
+      }
+    }
+    // search 输出 schema 含 truncated 字段。
+    const searchSchemaProps = registered.find((d) => d.name === "ws_mcp_search").output.schema.properties;
+    assert.equal(typeof searchSchemaProps.truncated, "object", "search 输出含 truncated 字段");
     // 路由：agent-less → 显式失败
     const searchDef = registered.find((d) => d.name === "ws_mcp_search");
     const callDef = registered.find((d) => d.name === "ws_mcp_call");
     const listDef = registered.find((d) => d.name === "ws_mcp_list");
     const detailDef = registered.find((d) => d.name === "ws_mcp_detail");
+    // search 输出补 truncated 字段：空目录 → false。
+    const emptySearch = await searchDef.execute({}, { agent: { session: { header: { cwd: "/proj" } } } });
+    assert.equal(emptySearch.truncated, false, "空目录 truncated=false");
+    assert.deepEqual(emptySearch.unavailable, []);
     await assert.rejects(() => searchDef.execute({}, { agent: undefined }), /无法确定工作空间/);
     await assert.rejects(() => listDef.execute({}, { agent: undefined }), /无法确定工作空间/);
     await assert.rejects(() => detailDef.execute({}, { agent: undefined }), /无法确定工作空间/);
@@ -300,6 +318,7 @@ const main = async () => {
     // search：合并查询命中 @global 工具
     const found = await searchDef.execute({ query: "全局" }, { agent });
     assert.ok(found.results.some((hit) => hit.server === fullServerName(MIDDLEWARE_GLOBAL_ROOT, "gctx")), "all 模式 search 含 @global 命中");
+    assert.equal(found.truncated, false, "all 模式 search 未达 limit → truncated=false");
     // detail：@global 可查
     const detail = await detailDef.execute({ server: fullServerName(MIDDLEWARE_GLOBAL_ROOT, "gctx"), tool: "use_g" }, { agent });
     assert.equal(detail.server, fullServerName(MIDDLEWARE_GLOBAL_ROOT, "gctx"));

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -192,7 +192,7 @@ const main = async () => {
   });
   check("client source contract（load id/IIFE/use strict/load once）", () => assertClientSourceContract(pkgDir));
   check("client product contract（执行断言：arrive 可解析/apply/inject）", () => assertClientProductContract(pkgDir));
-  await checkAsync("中间层工具注册（ws_mcp_search / ws_mcp_call + 路由一致性）", async () => {
+  await checkAsync("中间层工具注册（ws_mcp_search / ws_mcp_call / ws_mcp_list / ws_mcp_detail + 路由一致性）", async () => {
     const { registerMiddlewareTools, McpMiddleware, fullServerName, parseFullServerName } = await import("../lib/index.js");
     const registered = [];
     const ctx = { tools: { register: (def) => { registered.push(def); return () => {}; } } };
@@ -212,17 +212,109 @@ const main = async () => {
       return cwd === "/proj" ? "/proj" : undefined;
     });
     const names = registered.map((def) => def.name).sort();
-    assert.deepEqual(names, ["ws_mcp_call", "ws_mcp_search"], "两个中间层工具注册");
+    assert.deepEqual(names, ["ws_mcp_call", "ws_mcp_detail", "ws_mcp_list", "ws_mcp_search"], "四个中间层工具注册");
     assert.match(registered.find((d) => d.name === "ws_mcp_search").description, /ws_mcp_call/, "search 描述引导先搜后调");
+    assert.match(registered.find((d) => d.name === "ws_mcp_list").description, /ws_mcp_detail/, "list 描述引导两级发现");
+    assert.match(registered.find((d) => d.name === "ws_mcp_detail").description, /inputSchema/, "detail 描述说明完整 schema");
     // 路由：agent-less → 显式失败
     const searchDef = registered.find((d) => d.name === "ws_mcp_search");
     const callDef = registered.find((d) => d.name === "ws_mcp_call");
+    const listDef = registered.find((d) => d.name === "ws_mcp_list");
+    const detailDef = registered.find((d) => d.name === "ws_mcp_detail");
     await assert.rejects(() => searchDef.execute({}, { agent: undefined }), /无法确定工作空间/);
+    await assert.rejects(() => listDef.execute({}, { agent: undefined }), /无法确定工作空间/);
+    await assert.rejects(() => detailDef.execute({}, { agent: undefined }), /无法确定工作空间/);
     // 路由：有 agent 但 cwd 无项目 → 显式失败（ws_mcp_call 缺 server 参数先报必填）
     await assert.rejects(() => callDef.execute({}, { agent: { session: { header: { cwd: "/other" } } } }), /无法确定工作空间|server 与 tool 均为必填/);
+    // 空返回提示：无项目配置 → list 返回 message
+    const emptyList = await listDef.execute({}, { agent: { session: { header: { cwd: "/proj" } } } });
+    assert.equal(emptyList.totalServers, 0);
+    assert.equal(emptyList.totalTools, 0);
+    assert.match(emptyList.message, /没有可用 MCP 服务器|没有项目级 MCP 配置/, "空返回明确提示");
+    // detail 必填校验
+    await assert.rejects(() => detailDef.execute({}, { agent: { session: { header: { cwd: "/proj" } } } }), /server 与 tool 均为必填/);
     // server 全名解析往返
     const full = fullServerName("/proj", "ctx");
     assert.deepEqual(parseFullServerName(full), { root: "/proj", server: "ctx" });
+    dispose();
+  });
+  await checkAsync("中间层 all 模式：@global 覆盖（list/search 可见全局，call 放行 @global）", async () => {
+    const { registerMiddlewareTools, McpMiddleware, fullServerName, MIDDLEWARE_GLOBAL_ROOT } = await import("../lib/index.js");
+    const registered = [];
+    const ctx = { tools: { register: (def) => { registered.push(def); return () => {}; } } };
+    const host = {
+      ctx,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      projectServersFor: async (root) => {
+        if (root === MIDDLEWARE_GLOBAL_ROOT) return [{ name: "gctx", transport: "stdio", command: "npx", enabled: true }];
+        return [{ name: "ctx", transport: "stdio", command: "npx", enabled: true }];
+      },
+      globalServers: () => [{ name: "gctx", transport: "stdio", command: "npx", enabled: true }],
+      normalizedProjectRoot: async (cwd) => (cwd === "/proj" ? "/proj" : undefined),
+      saveUserState: async () => {},
+      emitStatus: () => {},
+      catalogCachePath: () => "/tmp/cache.json",
+    };
+    const mw = new McpMiddleware(host, {});
+    // 预置目录（模拟 last-good 已发现；不 spawn 子进程）。
+    const projUnit = {
+      root: "/proj",
+      connections: new Map(),
+      catalog: new Map([["ctx", {
+        discoveredAt: Date.now(),
+        tools: new Map([["use_ctx", { description: "项目工具", inputSchema: {} }]]),
+      }]]),
+      userDisabled: new Set(),
+      lastTouchedAt: Date.now(),
+      inFlight: new Map(),
+    };
+    const globalUnit = {
+      root: MIDDLEWARE_GLOBAL_ROOT,
+      connections: new Map(),
+      catalog: new Map([["gctx", {
+        discoveredAt: Date.now(),
+        tools: new Map([["use_g", { description: "全局工具", inputSchema: {} }]]),
+      }]]),
+      userDisabled: new Set(),
+      lastTouchedAt: Date.now(),
+      inFlight: new Map(),
+    };
+    mw.units.set("/proj", projUnit);
+    mw.units.set(MIDDLEWARE_GLOBAL_ROOT, globalUnit);
+    const dispose = registerMiddlewareTools(ctx, mw, async (agent) => {
+      const cwd = agent?.session?.header?.cwd;
+      return cwd === "/proj" ? "/proj" : undefined;
+    }, "all");
+    const names = registered.map((def) => def.name).sort();
+    assert.deepEqual(names, ["ws_mcp_call", "ws_mcp_detail", "ws_mcp_list", "ws_mcp_search"], "all 模式注册四个工具");
+    const searchDef = registered.find((d) => d.name === "ws_mcp_search");
+    const callDef = registered.find((d) => d.name === "ws_mcp_call");
+    const listDef = registered.find((d) => d.name === "ws_mcp_list");
+    const detailDef = registered.find((d) => d.name === "ws_mcp_detail");
+    const agent = { session: { header: { cwd: "/proj" } } };
+    // list：项目 root + @global 合并可见
+    const listed = await listDef.execute({}, { agent });
+    assert.ok(listed.servers.some((s) => s.server === fullServerName("/proj", "ctx")), "list 含项目服务器");
+    assert.ok(listed.servers.some((s) => s.server === fullServerName(MIDDLEWARE_GLOBAL_ROOT, "gctx")), "all 模式 list 含 @global 服务器");
+    assert.equal(listed.mode, "all");
+    // search：合并查询命中 @global 工具
+    const found = await searchDef.execute({ query: "全局" }, { agent });
+    assert.ok(found.results.some((hit) => hit.server === fullServerName(MIDDLEWARE_GLOBAL_ROOT, "gctx")), "all 模式 search 含 @global 命中");
+    // detail：@global 可查
+    const detail = await detailDef.execute({ server: fullServerName(MIDDLEWARE_GLOBAL_ROOT, "gctx"), tool: "use_g" }, { agent });
+    assert.equal(detail.server, fullServerName(MIDDLEWARE_GLOBAL_ROOT, "gctx"));
+    assert.equal(detail.tool, "use_g");
+    // call：all 模式放行 @global root（预置 client 无法调用——此处断言路由放行后
+    // 落到连接/调用错误而非「不属于当前工作空间」路由拒绝）。
+    await assert.rejects(
+      () => callDef.execute({ server: fullServerName(MIDDLEWARE_GLOBAL_ROOT, "gctx"), tool: "use_g" }, { agent }),
+      /未连接|未就绪|连接失败|已禁用/,
+    );
+    // call：非当前 root 的项目 root 仍拒绝（防跨空间串台）。
+    await assert.rejects(
+      () => callDef.execute({ server: fullServerName("/other", "ctx"), tool: "use_ctx" }, { agent }),
+      /不属于当前工作空间/,
+    );
     dispose();
   });
   check("client 注册 settings.plugin.item 卡（id/key = 宿主命名空间 dsh-mcp-manager）", () => {

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -256,6 +256,30 @@ const main = async () => {
     assert.deepEqual(parseFullServerName(full), { root: "/proj", server: "ctx" });
     dispose();
   });
+  await checkAsync("search 早退分支（unit undefined）返回 truncated=false（P1-1）", async () => {
+    const { registerMiddlewareTools, McpMiddleware } = await import("../lib/index.js");
+    const registered = [];
+    const ctx = { tools: { register: (def) => { registered.push(def); return () => {}; } } };
+    const host = {
+      ctx,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      projectServersFor: async () => undefined, // 无项目标记 → projectUnitFor 返回 undefined
+      globalServers: () => [],
+      normalizedProjectRoot: async (cwd) => (cwd === "/proj" ? "/proj" : undefined),
+      saveUserState: async () => {},
+      emitStatus: () => {},
+      catalogCachePath: () => "/tmp/cache.json",
+    };
+    const mw = new McpMiddleware(host, {});
+    const dispose = registerMiddlewareTools(ctx, mw, async (agent) => {
+      const cwd = agent?.session?.header?.cwd;
+      return cwd === "/proj" ? "/proj" : undefined;
+    });
+    const searchDef = registered.find((d) => d.name === "ws_mcp_search");
+    const out = await searchDef.execute({}, { agent: { session: { header: { cwd: "/proj" } } } });
+    assert.deepEqual(out, { results: [], unavailable: [], truncated: false }, "早退分支补 truncated=false（output.schema required）");
+    dispose();
+  });
   await checkAsync("中间层 all 模式：@global 覆盖（list/search 可见全局，call 放行 @global）", async () => {
     const { registerMiddlewareTools, McpMiddleware, fullServerName, MIDDLEWARE_GLOBAL_ROOT } = await import("../lib/index.js");
     const registered = [];
@@ -301,6 +325,8 @@ const main = async () => {
     mw.units.set(MIDDLEWARE_GLOBAL_ROOT, globalUnit);
     const dispose = registerMiddlewareTools(ctx, mw, async (agent) => {
       const cwd = agent?.session?.header?.cwd;
+      // 模拟 apply.ts 的 all 模式 fallback：cwd 无项目 → @global（全局服务器存在时）。
+      if (cwd === "/no-project") return MIDDLEWARE_GLOBAL_ROOT;
       return cwd === "/proj" ? "/proj" : undefined;
     }, "all");
     const names = registered.map((def) => def.name).sort();
@@ -334,6 +360,36 @@ const main = async () => {
       () => callDef.execute({ server: fullServerName("/other", "ctx"), tool: "use_ctx" }, { agent }),
       /不属于当前工作空间/,
     );
+    // P1-2：all 模式无项目 cwd（root 本身为 @global）→ visibleRoots 去重不翻倍。
+    const gAgent = { session: { header: { cwd: "/no-project" } } };
+    const listedGlobalOnly = await listDef.execute({}, { agent: gAgent });
+    const globalNames = listedGlobalOnly.servers.map((s) => s.server);
+    assert.equal(listedGlobalOnly.totalServers, 1, "@global 去重：totalServers 不翻倍");
+    assert.equal(globalNames.filter((n) => n === fullServerName(MIDDLEWARE_GLOBAL_ROOT, "gctx")).length, 1, "gctx 只出现一次");
+    // P1-3：@global 单元首次触达（无预置目录 + in-flight 发现进行中）→
+    // list/search 等待 in-flight 后全局可见（8s 预算内）。
+    const freshGlobal = {
+      root: MIDDLEWARE_GLOBAL_ROOT,
+      connections: new Map(),
+      catalog: new Map(),
+      userDisabled: new Set(),
+      lastTouchedAt: Date.now(),
+      inFlight: new Map([["gctx", new Promise((resolve) => setTimeout(() => {
+        // 发现完成后填充目录（模拟 ensureConnected/discover 完成）。
+        freshGlobal.catalog.set("gctx", {
+          discoveredAt: Date.now(),
+          tools: new Map([["use_g", { description: "全局工具（发现完成）", inputSchema: {} }]]),
+        });
+        resolve();
+      }, 100))]]),
+    };
+    mw.units.set(MIDDLEWARE_GLOBAL_ROOT, freshGlobal);
+    const listedAfterWait = await listDef.execute({}, { agent: gAgent });
+    const freshEntry = listedAfterWait.servers.find((s) => s.server === fullServerName(MIDDLEWARE_GLOBAL_ROOT, "gctx"));
+    assert.ok(freshEntry !== undefined, "@global 首次触达等待 in-flight 后可见");
+    assert.equal(freshEntry.tools.length, 1, "发现完成的工具列出");
+    const foundAfterWait = await searchDef.execute({ query: "发现完成" }, { agent: gAgent });
+    assert.ok(foundAfterWait.results.some((hit) => hit.server === fullServerName(MIDDLEWARE_GLOBAL_ROOT, "gctx")), "search 等待 in-flight 后命中 @global");
     dispose();
   });
   check("client 注册 settings.plugin.item 卡（id/key = 宿主命名空间 dsh-mcp-manager）", () => {
@@ -1518,6 +1574,10 @@ const main = async () => {
     const onlyGlobal = renderMcpCatalogMessage([{ name: "ctx", scope: "global" }]);
     assert.match(onlyGlobal.content[0].text, /mcp__<server>__<tool>/);
     assert.doesNotMatch(onlyGlobal.content[0].text, /ws_mcp_search/);
+    // P2-4：all 模式下纯 global 条目也引导经中间层（全局走中间层，不再 mcp__ 直呼）
+    const onlyGlobalAll = renderMcpCatalogMessage([{ name: "ctx", scope: "global" }], "all");
+    assert.match(onlyGlobalAll.content[0].text, /ws_mcp_search/, "all 模式纯 global 引导经中间层");
+    assert.doesNotMatch(onlyGlobalAll.content[0].text, /mcp__<server>__<tool>/, "all 模式不再 mcp__ 直呼引导");
 
     // #192 AC-3：双缺省行仅渲染名字（无冒号描述），带描述条目渲染不变
     const mixed = renderMcpCatalogMessage([{ name: "bare-x" }, { name: "code-graph", text: "代码图谱" }]);

--- a/packages/dsh-mcp-manager/test/unit-middleware.src.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.src.test.ts
@@ -312,9 +312,12 @@ function makeHost(serversByRoot = new Map()) {
   // 空查询能力摘要同样合并。
   const summary = searchCatalogMulti(units, [ROOT, "@global"], "", 10);
   assert.equal(summary.results.length, 4, "合并摘要含全部工具");
-  // 单 root 包装与 multi 单元素等价。
+  // 单 root 包装与 multi 单元素等价（且顺序一致——multi 单 root 委托 searchCatalog，P2-2）。
   const single = searchCatalog(units, ROOT, "文档", 10);
   assert.deepEqual(single.results, searchCatalogMulti(units, [ROOT], "文档", 10).results);
+  // 多 root 合并后统一按全局 limit 截断（P2-3：limit 为全局上限）。
+  const capped = searchCatalogMulti(units, [ROOT, "@global"], "", 2);
+  assert.equal(capped.results.length, 2, "多 root 合并后按全局 limit 截断");
   // 无此单元 → 空。
   const none = searchCatalogMulti(units, ["/no/such"], "x", 10);
   assert.equal(none.results.length, 0);

--- a/packages/dsh-mcp-manager/test/unit-middleware.src.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.src.test.ts
@@ -29,8 +29,13 @@ const {
   policyDenialReason,
   scoreTool,
   searchCatalog,
+  searchCatalogMulti,
+  listCatalog,
+  findToolDetail,
   McpMiddleware,
   CATALOG_TTL_MS,
+  LIST_DEFAULT_TOOLS_PER_SERVER,
+  LIST_MAX_TOOLS_PER_SERVER,
   userStateFile,
   loadUserState,
   saveUserState,
@@ -257,4 +262,215 @@ function makeHost(serversByRoot = new Map()) {
   await mw.persistCatalog(ROOT);
   assert.equal(readFileSync(file, "utf8"), before, "空采集不覆盖已有缓存（保留 last-good）");
   await mw.dispose();
+}
+
+// ---- searchCatalogMulti：多单元合并检索（all 模式） ----
+{
+  const unit = {
+    root: ROOT,
+    connections: new Map(),
+    catalog: new Map([
+      ["ctx", {
+        discoveredAt: Date.now(),
+        tools: new Map([
+          ["use_ctx", { description: "查询 context7 文档", inputSchema: {} }],
+          ["search", { description: "search tool", inputSchema: {} }],
+        ]),
+      }],
+    ]),
+    userDisabled: new Set(),
+    lastTouchedAt: Date.now(),
+    inFlight: new Map(),
+  };
+  const globalUnit = {
+    ...unit,
+    root: "@global",
+    catalog: new Map([
+      ["gctx", {
+        discoveredAt: Date.now(),
+        tools: new Map([
+          ["use_g", { description: "全局工具", inputSchema: {} }],
+          ["other", { description: "无关", inputSchema: {} }],
+        ]),
+      }],
+    ]),
+  };
+  const units = new Map([[ROOT, unit], ["@global", globalUnit]]);
+  // 合并查询命中两个单元（项目 root + @global）。
+  const multi = searchCatalogMulti(units, [ROOT, "@global"], "use", 10);
+  assert.ok(multi.results.some((hit) => hit.server === fullServerName(ROOT, "ctx")), "命中项目单元");
+  assert.ok(multi.results.some((hit) => hit.server === fullServerName("@global", "gctx")), "命中 @global 单元");
+  // 空查询能力摘要同样合并。
+  const summary = searchCatalogMulti(units, [ROOT, "@global"], "", 10);
+  assert.equal(summary.results.length, 4, "合并摘要含全部工具");
+  // 单 root 包装与 multi 单元素等价。
+  const single = searchCatalog(units, ROOT, "文档", 10);
+  assert.deepEqual(single.results, searchCatalogMulti(units, [ROOT], "文档", 10).results);
+  // 无此单元 → 空。
+  const none = searchCatalogMulti(units, ["/no/such"], "x", 10);
+  assert.equal(none.results.length, 0);
+  assert.equal(none.unavailable.length, 0);
+}
+
+// ---- listCatalog：完整清单 / 过滤 / 空返回 / 截断 / unavailable / disabled ----
+{
+  const mkTools = (count) => {
+    const tools = new Map();
+    for (let i = 0; i < count; i += 1) tools.set(`t${i}`, { description: `desc${i}`, inputSchema: {} });
+    return tools;
+  };
+  const unit = {
+    root: ROOT,
+    connections: new Map(),
+    catalog: new Map([
+      // 2 个工具（无截断）
+      ["ctx", { discoveredAt: Date.now(), tools: mkTools(2) }],
+      // 用户已禁用（工具来自 last-good 目录）
+      ["off", { discoveredAt: Date.now(), tools: mkTools(1) }],
+      // 发现失败
+      ["down", { discoveredAt: 0, tools: new Map(), unavailable: "连接失败" }],
+    ]),
+    userDisabled: new Set(["off"]),
+    lastTouchedAt: Date.now(),
+    inFlight: new Map(),
+  };
+  const globalUnit = {
+    ...unit,
+    root: "@global",
+    catalog: new Map([["gctx", { discoveredAt: Date.now(), tools: mkTools(3) }]]),
+    userDisabled: new Set(),
+  };
+  const units = new Map([[ROOT, unit], ["@global", globalUnit]]);
+
+  // 完整清单（project 模式：单 root）
+  const listed = listCatalog(units, [ROOT], undefined, 50, "project", "empty");
+  assert.equal(listed.workspace, ROOT);
+  assert.equal(listed.mode, "project");
+  assert.equal(listed.totalServers, 3, "全部服务器（含 disabled/unavailable）");
+  assert.equal(listed.totalTools, 3, "工具数不含 unavailable 服务器");
+  assert.equal(listed.toolsTruncated, false);
+  const ctxEntry = listed.servers.find((s) => s.server === fullServerName(ROOT, "ctx"));
+  assert.deepEqual(ctxEntry.tools.map((t) => t.tool), ["t0", "t1"]);
+  assert.equal(ctxEntry.toolsTruncated, false);
+  assert.equal(ctxEntry.disabled, undefined);
+  const offEntry = listed.servers.find((s) => s.server === fullServerName(ROOT, "off"));
+  assert.equal(offEntry.disabled, true, "userDisabled → disabled: true");
+  const downEntry = listed.servers.find((s) => s.server === fullServerName(ROOT, "down"));
+  assert.equal(downEntry.unavailable, "连接失败", "发现失败附原因");
+  assert.deepEqual(downEntry.tools, []);
+  assert.equal(listed.message, undefined, "非空返回无 message");
+
+  // server 过滤（裸名）
+  const filteredBare = listCatalog(units, [ROOT], "ctx", 50, "project", "empty");
+  assert.equal(filteredBare.totalServers, 1);
+  assert.equal(filteredBare.servers[0].server, fullServerName(ROOT, "ctx"));
+  // server 过滤（全名）
+  const filteredFull = listCatalog(units, [ROOT], fullServerName(ROOT, "ctx"), 50, "project", "empty");
+  assert.equal(filteredFull.totalServers, 1);
+  // 全名 root 不属于当前 roots → 路由一致性错误
+  assert.throws(() => listCatalog(units, [ROOT], "@/other/root/ctx", 50, "project", "empty"), /不属于当前工作空间/);
+
+  // all 模式：合并 @global 单元
+  const all = listCatalog(units, [ROOT, "@global"], undefined, 50, "all", "empty");
+  assert.equal(all.mode, "all");
+  assert.equal(all.totalServers, 4, "项目 root + @global 合并");
+  assert.equal(all.workspace, ROOT);
+  assert.ok(all.servers.some((s) => s.server === fullServerName("@global", "gctx")), "含 @global 服务器");
+  assert.equal(all.totalTools, 6);
+
+  // perServerLimit 截断 → toolsTruncated（per-server + 全局汇总）
+  const truncated = listCatalog(units, [ROOT], undefined, 1, "project", "empty");
+  const ctxT = truncated.servers.find((s) => s.server === fullServerName(ROOT, "ctx"));
+  assert.equal(ctxT.tools.length, 1, "截断到 1 条");
+  assert.equal(ctxT.toolsTruncated, true, "per-server toolsTruncated");
+  assert.equal(truncated.toolsTruncated, true, "全局 toolsTruncated");
+  const offT = truncated.servers.find((s) => s.server === fullServerName(ROOT, "off"));
+  assert.equal(offT.toolsTruncated, false, "未超限不置位");
+
+  // 空返回 → message（project / all 区分）
+  const empty = listCatalog(new Map(), [ROOT], undefined, 50, "project", "无项目级 MCP 配置提示");
+  assert.equal(empty.totalServers, 0);
+  assert.equal(empty.totalTools, 0);
+  assert.equal(empty.message, "无项目级 MCP 配置提示");
+  assert.equal(empty.toolsTruncated, false);
+  // 常量值
+  assert.equal(LIST_DEFAULT_TOOLS_PER_SERVER, 50);
+  assert.equal(LIST_MAX_TOOLS_PER_SERVER, 500);
+}
+
+// ---- findToolDetail：精确命中 / 完整 schema / 错误三分 / tool 归一化 ----
+{
+  const schema = { type: "object", properties: { query: { type: "string" }, mode: { type: "string", enum: ["a", "b"] } }, required: ["query"] };
+  const unit = {
+    root: ROOT,
+    connections: new Map(),
+    catalog: new Map([
+      ["ctx", {
+        discoveredAt: Date.now(),
+        tools: new Map([
+          ["use_ctx", { description: "查询 context7 文档", inputSchema: schema }],
+        ]),
+      }],
+      ["down", { discoveredAt: 0, tools: new Map(), unavailable: "连接失败" }],
+    ]),
+    userDisabled: new Set(),
+    lastTouchedAt: Date.now(),
+    inFlight: new Map(),
+  };
+  const units = new Map([[ROOT, unit]]);
+  // 精确命中：完整 schema + fresh + server/tool 原样
+  const detail = findToolDetail(units, ROOT, fullServerName(ROOT, "ctx"), "use_ctx");
+  assert.equal(detail.server, fullServerName(ROOT, "ctx"));
+  assert.equal(detail.tool, "use_ctx");
+  assert.equal(detail.description, "查询 context7 文档");
+  assert.deepEqual(detail.inputSchema, schema, "完整 inputSchema（含 enum/required）");
+  assert.equal(detail.fresh, true);
+  assert.equal(detail.disabled, undefined);
+  // tool 归一化（mcp__ 前缀剥离）
+  const normalized = findToolDetail(units, ROOT, fullServerName(ROOT, "ctx"), "mcp__ctx__use_ctx");
+  assert.equal(normalized.tool, "use_ctx");
+  assert.deepEqual(normalized.inputSchema, schema);
+  // 跨 server 前缀 → 疑似其他
+  assert.throws(() => findToolDetail(units, ROOT, fullServerName(ROOT, "ctx"), "mcp__other__tool"), /疑似其他/);
+  // 错误三分 1：server 发现失败（附原因）
+  assert.throws(
+    () => findToolDetail(units, ROOT, fullServerName(ROOT, "down"), "x"),
+    /发现失败.*连接失败/,
+  );
+  // 错误三分 2：服务器未发现
+  assert.throws(
+    () => findToolDetail(units, ROOT, fullServerName(ROOT, "nope"), "x"),
+    /未连接或未发现/,
+  );
+  // 错误三分 2b：单元未激活
+  assert.throws(
+    () => findToolDetail(units, "/no/such", fullServerName("/no/such", "ctx"), "x"),
+    /未连接或未发现/,
+  );
+  // 错误三分 3：工具不存在
+  assert.throws(
+    () => findToolDetail(units, ROOT, fullServerName(ROOT, "ctx"), "nope"),
+    /tool 不存在/,
+  );
+  // 路由一致性：参数 root ≠ 路由 root → 拒绝
+  assert.throws(
+    () => findToolDetail(units, ROOT, fullServerName("@global", "ctx"), "x"),
+    /不属于当前工作空间/,
+  );
+  // 用户禁用 → detail 标注 disabled
+  const disabledUnit = {
+    ...unit,
+    userDisabled: new Set(["ctx"]),
+  };
+  const disabledDetail = findToolDetail(new Map([[ROOT, disabledUnit]]), ROOT, fullServerName(ROOT, "ctx"), "use_ctx");
+  assert.equal(disabledDetail.disabled, true, "用户禁用标注 disabled");
+  // 禁用且目录空 → 未连接（附禁用说明）
+  const disabledEmpty = {
+    ...disabledUnit,
+    catalog: new Map([["ctx", { discoveredAt: 0, tools: new Map() }]]),
+  };
+  assert.throws(
+    () => findToolDetail(new Map([[ROOT, disabledEmpty]]), ROOT, fullServerName(ROOT, "ctx"), "x"),
+    /已被用户禁用/,
+  );
 }

--- a/packages/dsh-mcp-manager/test/unit-middleware.src.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.src.test.ts
@@ -176,11 +176,20 @@ function makeHost(serversByRoot = new Map()) {
   );
   // 未知 server 形态
   await assert.rejects(() => mw.callTool("ctx", "use_ctx", {}, undefined), /格式应为/);
-  // 未连接（enabled:false 不触发连接）
+  // 未连接（enabled:false 不触发连接）→ 错误含下一步提示（ws_mcp_search 或 ws_mcp_list）
   await assert.rejects(
     () => mw.callTool(fullServerName(ROOT, "ctx"), "use_ctx", {}, undefined),
-    /未连接|连接失败/,
+    /未连接或连接失败，请先 ws_mcp_search 或 ws_mcp_list 确认 server 已连接/,
   );
+  // userDisabled → 错误含下一步提示
+  mw.disabledByRoot.set(ROOT, new Set(["ctx"]));
+  const disabledUnit = await mw.projectUnitFor(ROOT);
+  disabledUnit.userDisabled.add("ctx");
+  await assert.rejects(
+    () => mw.callTool(fullServerName(ROOT, "ctx"), "use_ctx", {}, undefined),
+    /已被用户禁用；可先在 GUI「MCP」浮窗中重新连接/,
+  );
+  disabledUnit.userDisabled.delete("ctx");
   await mw.dispose();
 }
 

--- a/packages/dsh-mcp-manager/test/unit-middleware.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.test.ts
@@ -312,9 +312,12 @@ function makeHost(serversByRoot = new Map()) {
   // 空查询能力摘要同样合并。
   const summary = searchCatalogMulti(units, [ROOT, "@global"], "", 10);
   assert.equal(summary.results.length, 4, "合并摘要含全部工具");
-  // 单 root 包装与 multi 单元素等价。
+  // 单 root 包装与 multi 单元素等价（且顺序一致——multi 单 root 委托 searchCatalog，P2-2）。
   const single = searchCatalog(units, ROOT, "文档", 10);
   assert.deepEqual(single.results, searchCatalogMulti(units, [ROOT], "文档", 10).results);
+  // 多 root 合并后统一按全局 limit 截断（P2-3：limit 为全局上限）。
+  const capped = searchCatalogMulti(units, [ROOT, "@global"], "", 2);
+  assert.equal(capped.results.length, 2, "多 root 合并后按全局 limit 截断");
   // 无此单元 → 空。
   const none = searchCatalogMulti(units, ["/no/such"], "x", 10);
   assert.equal(none.results.length, 0);

--- a/packages/dsh-mcp-manager/test/unit-middleware.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.test.ts
@@ -29,8 +29,13 @@ const {
   policyDenialReason,
   scoreTool,
   searchCatalog,
+  searchCatalogMulti,
+  listCatalog,
+  findToolDetail,
   McpMiddleware,
   CATALOG_TTL_MS,
+  LIST_DEFAULT_TOOLS_PER_SERVER,
+  LIST_MAX_TOOLS_PER_SERVER,
   userStateFile,
   loadUserState,
   saveUserState,
@@ -257,4 +262,215 @@ function makeHost(serversByRoot = new Map()) {
   await mw.persistCatalog(ROOT);
   assert.equal(readFileSync(file, "utf8"), before, "空采集不覆盖已有缓存（保留 last-good）");
   await mw.dispose();
+}
+
+// ---- searchCatalogMulti：多单元合并检索（all 模式） ----
+{
+  const unit = {
+    root: ROOT,
+    connections: new Map(),
+    catalog: new Map([
+      ["ctx", {
+        discoveredAt: Date.now(),
+        tools: new Map([
+          ["use_ctx", { description: "查询 context7 文档", inputSchema: {} }],
+          ["search", { description: "search tool", inputSchema: {} }],
+        ]),
+      }],
+    ]),
+    userDisabled: new Set(),
+    lastTouchedAt: Date.now(),
+    inFlight: new Map(),
+  };
+  const globalUnit = {
+    ...unit,
+    root: "@global",
+    catalog: new Map([
+      ["gctx", {
+        discoveredAt: Date.now(),
+        tools: new Map([
+          ["use_g", { description: "全局工具", inputSchema: {} }],
+          ["other", { description: "无关", inputSchema: {} }],
+        ]),
+      }],
+    ]),
+  };
+  const units = new Map([[ROOT, unit], ["@global", globalUnit]]);
+  // 合并查询命中两个单元（项目 root + @global）。
+  const multi = searchCatalogMulti(units, [ROOT, "@global"], "use", 10);
+  assert.ok(multi.results.some((hit) => hit.server === fullServerName(ROOT, "ctx")), "命中项目单元");
+  assert.ok(multi.results.some((hit) => hit.server === fullServerName("@global", "gctx")), "命中 @global 单元");
+  // 空查询能力摘要同样合并。
+  const summary = searchCatalogMulti(units, [ROOT, "@global"], "", 10);
+  assert.equal(summary.results.length, 4, "合并摘要含全部工具");
+  // 单 root 包装与 multi 单元素等价。
+  const single = searchCatalog(units, ROOT, "文档", 10);
+  assert.deepEqual(single.results, searchCatalogMulti(units, [ROOT], "文档", 10).results);
+  // 无此单元 → 空。
+  const none = searchCatalogMulti(units, ["/no/such"], "x", 10);
+  assert.equal(none.results.length, 0);
+  assert.equal(none.unavailable.length, 0);
+}
+
+// ---- listCatalog：完整清单 / 过滤 / 空返回 / 截断 / unavailable / disabled ----
+{
+  const mkTools = (count) => {
+    const tools = new Map();
+    for (let i = 0; i < count; i += 1) tools.set(`t${i}`, { description: `desc${i}`, inputSchema: {} });
+    return tools;
+  };
+  const unit = {
+    root: ROOT,
+    connections: new Map(),
+    catalog: new Map([
+      // 2 个工具（无截断）
+      ["ctx", { discoveredAt: Date.now(), tools: mkTools(2) }],
+      // 用户已禁用（工具来自 last-good 目录）
+      ["off", { discoveredAt: Date.now(), tools: mkTools(1) }],
+      // 发现失败
+      ["down", { discoveredAt: 0, tools: new Map(), unavailable: "连接失败" }],
+    ]),
+    userDisabled: new Set(["off"]),
+    lastTouchedAt: Date.now(),
+    inFlight: new Map(),
+  };
+  const globalUnit = {
+    ...unit,
+    root: "@global",
+    catalog: new Map([["gctx", { discoveredAt: Date.now(), tools: mkTools(3) }]]),
+    userDisabled: new Set(),
+  };
+  const units = new Map([[ROOT, unit], ["@global", globalUnit]]);
+
+  // 完整清单（project 模式：单 root）
+  const listed = listCatalog(units, [ROOT], undefined, 50, "project", "empty");
+  assert.equal(listed.workspace, ROOT);
+  assert.equal(listed.mode, "project");
+  assert.equal(listed.totalServers, 3, "全部服务器（含 disabled/unavailable）");
+  assert.equal(listed.totalTools, 3, "工具数不含 unavailable 服务器");
+  assert.equal(listed.toolsTruncated, false);
+  const ctxEntry = listed.servers.find((s) => s.server === fullServerName(ROOT, "ctx"));
+  assert.deepEqual(ctxEntry.tools.map((t) => t.tool), ["t0", "t1"]);
+  assert.equal(ctxEntry.toolsTruncated, false);
+  assert.equal(ctxEntry.disabled, undefined);
+  const offEntry = listed.servers.find((s) => s.server === fullServerName(ROOT, "off"));
+  assert.equal(offEntry.disabled, true, "userDisabled → disabled: true");
+  const downEntry = listed.servers.find((s) => s.server === fullServerName(ROOT, "down"));
+  assert.equal(downEntry.unavailable, "连接失败", "发现失败附原因");
+  assert.deepEqual(downEntry.tools, []);
+  assert.equal(listed.message, undefined, "非空返回无 message");
+
+  // server 过滤（裸名）
+  const filteredBare = listCatalog(units, [ROOT], "ctx", 50, "project", "empty");
+  assert.equal(filteredBare.totalServers, 1);
+  assert.equal(filteredBare.servers[0].server, fullServerName(ROOT, "ctx"));
+  // server 过滤（全名）
+  const filteredFull = listCatalog(units, [ROOT], fullServerName(ROOT, "ctx"), 50, "project", "empty");
+  assert.equal(filteredFull.totalServers, 1);
+  // 全名 root 不属于当前 roots → 路由一致性错误
+  assert.throws(() => listCatalog(units, [ROOT], "@/other/root/ctx", 50, "project", "empty"), /不属于当前工作空间/);
+
+  // all 模式：合并 @global 单元
+  const all = listCatalog(units, [ROOT, "@global"], undefined, 50, "all", "empty");
+  assert.equal(all.mode, "all");
+  assert.equal(all.totalServers, 4, "项目 root + @global 合并");
+  assert.equal(all.workspace, ROOT);
+  assert.ok(all.servers.some((s) => s.server === fullServerName("@global", "gctx")), "含 @global 服务器");
+  assert.equal(all.totalTools, 6);
+
+  // perServerLimit 截断 → toolsTruncated（per-server + 全局汇总）
+  const truncated = listCatalog(units, [ROOT], undefined, 1, "project", "empty");
+  const ctxT = truncated.servers.find((s) => s.server === fullServerName(ROOT, "ctx"));
+  assert.equal(ctxT.tools.length, 1, "截断到 1 条");
+  assert.equal(ctxT.toolsTruncated, true, "per-server toolsTruncated");
+  assert.equal(truncated.toolsTruncated, true, "全局 toolsTruncated");
+  const offT = truncated.servers.find((s) => s.server === fullServerName(ROOT, "off"));
+  assert.equal(offT.toolsTruncated, false, "未超限不置位");
+
+  // 空返回 → message（project / all 区分）
+  const empty = listCatalog(new Map(), [ROOT], undefined, 50, "project", "无项目级 MCP 配置提示");
+  assert.equal(empty.totalServers, 0);
+  assert.equal(empty.totalTools, 0);
+  assert.equal(empty.message, "无项目级 MCP 配置提示");
+  assert.equal(empty.toolsTruncated, false);
+  // 常量值
+  assert.equal(LIST_DEFAULT_TOOLS_PER_SERVER, 50);
+  assert.equal(LIST_MAX_TOOLS_PER_SERVER, 500);
+}
+
+// ---- findToolDetail：精确命中 / 完整 schema / 错误三分 / tool 归一化 ----
+{
+  const schema = { type: "object", properties: { query: { type: "string" }, mode: { type: "string", enum: ["a", "b"] } }, required: ["query"] };
+  const unit = {
+    root: ROOT,
+    connections: new Map(),
+    catalog: new Map([
+      ["ctx", {
+        discoveredAt: Date.now(),
+        tools: new Map([
+          ["use_ctx", { description: "查询 context7 文档", inputSchema: schema }],
+        ]),
+      }],
+      ["down", { discoveredAt: 0, tools: new Map(), unavailable: "连接失败" }],
+    ]),
+    userDisabled: new Set(),
+    lastTouchedAt: Date.now(),
+    inFlight: new Map(),
+  };
+  const units = new Map([[ROOT, unit]]);
+  // 精确命中：完整 schema + fresh + server/tool 原样
+  const detail = findToolDetail(units, ROOT, fullServerName(ROOT, "ctx"), "use_ctx");
+  assert.equal(detail.server, fullServerName(ROOT, "ctx"));
+  assert.equal(detail.tool, "use_ctx");
+  assert.equal(detail.description, "查询 context7 文档");
+  assert.deepEqual(detail.inputSchema, schema, "完整 inputSchema（含 enum/required）");
+  assert.equal(detail.fresh, true);
+  assert.equal(detail.disabled, undefined);
+  // tool 归一化（mcp__ 前缀剥离）
+  const normalized = findToolDetail(units, ROOT, fullServerName(ROOT, "ctx"), "mcp__ctx__use_ctx");
+  assert.equal(normalized.tool, "use_ctx");
+  assert.deepEqual(normalized.inputSchema, schema);
+  // 跨 server 前缀 → 疑似其他
+  assert.throws(() => findToolDetail(units, ROOT, fullServerName(ROOT, "ctx"), "mcp__other__tool"), /疑似其他/);
+  // 错误三分 1：server 发现失败（附原因）
+  assert.throws(
+    () => findToolDetail(units, ROOT, fullServerName(ROOT, "down"), "x"),
+    /发现失败.*连接失败/,
+  );
+  // 错误三分 2：服务器未发现
+  assert.throws(
+    () => findToolDetail(units, ROOT, fullServerName(ROOT, "nope"), "x"),
+    /未连接或未发现/,
+  );
+  // 错误三分 2b：单元未激活
+  assert.throws(
+    () => findToolDetail(units, "/no/such", fullServerName("/no/such", "ctx"), "x"),
+    /未连接或未发现/,
+  );
+  // 错误三分 3：工具不存在
+  assert.throws(
+    () => findToolDetail(units, ROOT, fullServerName(ROOT, "ctx"), "nope"),
+    /tool 不存在/,
+  );
+  // 路由一致性：参数 root ≠ 路由 root → 拒绝
+  assert.throws(
+    () => findToolDetail(units, ROOT, fullServerName("@global", "ctx"), "x"),
+    /不属于当前工作空间/,
+  );
+  // 用户禁用 → detail 标注 disabled
+  const disabledUnit = {
+    ...unit,
+    userDisabled: new Set(["ctx"]),
+  };
+  const disabledDetail = findToolDetail(new Map([[ROOT, disabledUnit]]), ROOT, fullServerName(ROOT, "ctx"), "use_ctx");
+  assert.equal(disabledDetail.disabled, true, "用户禁用标注 disabled");
+  // 禁用且目录空 → 未连接（附禁用说明）
+  const disabledEmpty = {
+    ...disabledUnit,
+    catalog: new Map([["ctx", { discoveredAt: 0, tools: new Map() }]]),
+  };
+  assert.throws(
+    () => findToolDetail(new Map([[ROOT, disabledEmpty]]), ROOT, fullServerName(ROOT, "ctx"), "x"),
+    /已被用户禁用/,
+  );
 }

--- a/packages/dsh-mcp-manager/test/unit-middleware.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.test.ts
@@ -176,11 +176,20 @@ function makeHost(serversByRoot = new Map()) {
   );
   // 未知 server 形态
   await assert.rejects(() => mw.callTool("ctx", "use_ctx", {}, undefined), /格式应为/);
-  // 未连接（enabled:false 不触发连接）
+  // 未连接（enabled:false 不触发连接）→ 错误含下一步提示（ws_mcp_search 或 ws_mcp_list）
   await assert.rejects(
     () => mw.callTool(fullServerName(ROOT, "ctx"), "use_ctx", {}, undefined),
-    /未连接|连接失败/,
+    /未连接或连接失败，请先 ws_mcp_search 或 ws_mcp_list 确认 server 已连接/,
   );
+  // userDisabled → 错误含下一步提示
+  mw.disabledByRoot.set(ROOT, new Set(["ctx"]));
+  const disabledUnit = await mw.projectUnitFor(ROOT);
+  disabledUnit.userDisabled.add("ctx");
+  await assert.rejects(
+    () => mw.callTool(fullServerName(ROOT, "ctx"), "use_ctx", {}, undefined),
+    /已被用户禁用；可先在 GUI「MCP」浮窗中重新连接/,
+  );
+  disabledUnit.userDisabled.delete("ctx");
   await mw.dispose();
 }
 


### PR DESCRIPTION
## 关联 issue
Fixes #312

## 背景
中间层模型面恒定 ws_mcp_search / ws_mcp_call，存在两个能力缺口：
1. 无法完整列出工作空间全部 MCP 服务器与工具（search 空 query 受 limit 截断）；
2. 无法查询单工具完整 inputSchema（无精确命中入口）。

## 方案（对抗评审修订版 v2 + 业界实践调研固化）
完整方案见 docs/proposals/issue-312-ws-mcp-list-detail.md；业界实践调研（两级工具发现 / Anthropic 工具描述规范 / 错误显式化）见 docs/proposals/issue-312-tool-design-standards.md。

### 新增工具
- **ws_mcp_list**：列出工作空间全部服务器 + 每台完整工具清单（server/tool/description），支持 server 过滤（全名/裸名，跨 root 抛路由一致性错误）、perServerLimit（默认 50/上限 500，超限 toolsTruncated）、空返回 message 区分场景。
- **ws_mcp_detail**：按 @<root>/<server> + tool 裸名精确查询完整 inputSchema（properties/required/enum/description），错误三分（发现失败/未连接/工具不存在），兼容 mcp__ 前缀。

### 关键决策
1. **修复 all 模式全局可见性**（维护者「用户级 mcp 也要考虑」）：findProjectRoot 恒返回非 undefined → resolveRoot 的 @global fallback 仅无 cwd 时触发；all 模式全局 supervisor 已停、mcp__ 不注册 → 有 cwd 会话中全局服务器不可见（既有缺陷）。本 PR 修复：search/list/detail 在 all 模式合并查询「项目 root + @global」单元；call 放行 @global root。off/project 模式行为不变。
2. **业界实践落地**（Anthropic 工具描述规范）：新工具描述写明做什么/返回什么/不做什么/兄弟互引；参数全 describe；错误显式 + 下一步；search 补 truncated 信号 + 「盘点用 list」引导；call 错误补「先 list 确认连接 + detail 查 schema」。
3. 策略 guard：新工具纯读目录不触达策略（与 search 一致）；call 仍唯一受策略约束。

## 兼容性
- off/project 模式：search/call 行为完全不变；新增工具纯增量。
- all 模式：search/call 修复全局可见性（既有缺陷修复，非破坏）。
- 无新增依赖；无 Config 变更；inject / ROUTES / 契约不变。

## 验收断言（smoke 覆盖）
- [x] 4 工具注册（search/call/list/detail）
- [x] agent-less → 显式失败
- [x] list 空返回 message / detail 必填校验
- [x] all 模式 @global 覆盖（list/search 可见全局、call 放行 @global、跨空间拒绝）
- [x] 纯函数单测：完整清单/过滤/空返回/截断/unavailable/disabled/detail 三分错误/tool 归一化

## 门禁
本地五连门禁全绿（pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck）。
