### PR TITLE
feat(dsh-mcp-manager): 核心化——ctx.mcpManager service 运行时注册 MCP 服务器（#329 阶段1）

### DIFF
--- a/packages/dsh-mcp-manager/src/apply.ts
+++ b/packages/dsh-mcp-manager/src/apply.ts
@@ -46,6 +46,18 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
   const manager = new McpManager(ctx, store);
   manager.enhancement = { enhanceEmptyDescriptions, resultTruncateBytes };
 
+  // 核心化服务（官方 storageDomain 模式）：对外暴露 ctx.mcpManager，供其他插件
+  // 运行时注入 MCP 服务器（registerServer / unregisterServer，不落盘）。
+  // 提供时机：store.load 之后（manager 已就绪）。卸载由 mcp-manager 自身 dispose()
+  // 全量清理（含 runtime 条目与 supervisor）。
+  // 兼容：fake ctx（单元测试 mock）可能无 provide，可选调用静默降级。
+  if (typeof (ctx as unknown as { provide?: unknown }).provide === "function") {
+    ctx.provide("mcpManager", {
+      registerServer: (server: Record<string, unknown>) => manager.registerServer(server),
+      unregisterServer: (name: string) => manager.unregisterServer(name),
+    });
+  }
+
   // 插件自身 Config schema（标准 cordis 配置注入路径）：position/offset 不再藏于
   // 隐藏命名空间，设置页插件卡可编辑；配置变更经既有 SSE events 通道广播一帧，
   // 客户端收到后重新 GET /api/dsh-mcp/config 就地更新浮窗位置（无需重启/轮询）。

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -73,6 +73,10 @@ export type { UiPlacementConfig, ClientUiConfig } from "./types.ts";
 // 管理器 / 中间层全局虚拟 root
 export { McpManager, MIDDLEWARE_GLOBAL_ROOT } from "./manager.ts";
 
+// 核心化 service（官方 storageDomain 模式）：ctx.mcpManager 类型面 + 声明合并。
+export type { McpManagerServerInput, McpManagerService } from "./service.ts";
+import "./service.ts";
+
 // 存储
 export { defaultStorePath, McpStore } from "./store.ts";
 // 传输

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -415,9 +415,11 @@ export class McpManager {
       let changed = false;
       for (const [name, supervisor] of [...this.supervisors]) {
         const want = desired.get(name);
+        // runtime 条目豁免中间层接管（走全局 supervisor 路径，不被中间层停掉/跳过）。
+        const isRuntime = this.runtimeRegistry.has(name);
         // 中间层 project/all 模式：项目级（all 含全局）服务器由中间层接管
-        // （不注册 mcp__ 工具，避免双连接双进程）。
-        const middlewareTakes = this.middlewareMode !== "off" && (
+        // （不注册 mcp__ 工具，避免双连接双进程）。runtime 条目例外。
+        const middlewareTakes = !isRuntime && this.middlewareMode !== "off" && (
           supervisor.scope === SCOPE_PROJECT || (this.middlewareMode === "all" && supervisor.scope === SCOPE_GLOBAL)
         );
         if (want === undefined || want.server.enabled === false || want.scope !== supervisor.scope || middlewareTakes) {
@@ -427,8 +429,11 @@ export class McpManager {
       }
       for (const [name, want] of desired) {
         if (want.server.enabled === false) continue;
+        // runtime 条目豁免中间层跳过（走全局 supervisor 路径，reconcile 不杀 runtime）。
+        const isRuntime = this.runtimeRegistry.has(name);
         // 中间层 project/all 模式：项目级（all 含全局）跳过 supervisor（由中间层惰性连接）。
-        if (this.middlewareMode !== "off" && (
+        // runtime 条目例外。
+        if (!isRuntime && this.middlewareMode !== "off" && (
           want.scope === SCOPE_PROJECT || (this.middlewareMode === "all" && want.scope === SCOPE_GLOBAL)
         )) continue;
         const existing = this.supervisors.get(name);

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -71,6 +71,12 @@ export class McpManager {
   middleware: McpMiddleware | undefined;
   /** userDisabled 持久化路径。 */
   userStatePath: string;
+  /** 运行时注册表（内存态，不落盘）：供其他插件经 ctx.mcpManager 注入服务器。
+   * 双轨 reconcile：store.data.servers（持久化）+ runtimeRegistry（运行时）。
+   * 同名冲突策略：runtime 优先（运行时注入是「当前会话」语义）。 */
+  runtimeRegistry: Map<string, ServerConfig>;
+  /** registerServer 串行队列（防 reconcileBusy 吞注册；多插件并发注册排队）。 */
+  private registerQueue: Promise<void>;
 
   constructor(ctx: Context, store: McpStore) {
     this.ctx = ctx;
@@ -94,6 +100,8 @@ export class McpManager {
     this.middlewareMode = "off";
     this.middleware = undefined;
     this.userStatePath = userStateFile();
+    this.runtimeRegistry = new Map();
+    this.registerQueue = Promise.resolve();
   }
 
   /** 读取 settings 命名空间中的 MCP UI 配置（供 /api/dsh-mcp/config 返回）。 */
@@ -399,6 +407,11 @@ export class McpManager {
           if (!desired.has(server.name)) desired.set(server.name, { server, scope: SCOPE_PROJECT });
         }
       }
+      // 双轨合并：runtimeRegistry（内存态，运行时注入）并入 desired，同名 runtime 优先。
+      // 中间层 project/all 模式：runtime 仅全局 supervisor 路径（不拆单元、不走中间层连接池）。
+      for (const [name, server] of this.runtimeRegistry) {
+        desired.set(name, { server, scope: SCOPE_GLOBAL });
+      }
       let changed = false;
       for (const [name, supervisor] of [...this.supervisors]) {
         const want = desired.get(name);
@@ -436,13 +449,32 @@ export class McpManager {
     }
   }
 
-  start(name: string, scope: string = SCOPE_GLOBAL): void {
-    const store = scope === SCOPE_PROJECT ? this.projectStore : this.store;
-    if (store === undefined) return;
-    const server = store.find(name);
+  /**
+   * 启动服务器监督器。
+   * @param name 服务器名
+   * @param scope 作用域（全局/项目）
+   * @param directConfig 运行时 config 直传（registerServer 注入路径；缺省读 store）。
+   *   修 P0（评审③）：同名 runtime 优先生效——store 已有同名时，直传 config 优先于 store 版本。
+   */
+  start(name: string, scope: string = SCOPE_GLOBAL, directConfig?: ServerConfig): void {
+    let server = directConfig;
+    if (server === undefined) {
+      const store = scope === SCOPE_PROJECT ? this.projectStore : this.store;
+      if (store === undefined) return;
+      server = store.find(name);
+    }
     if (server === undefined) return;
     const existing = this.supervisors.get(name);
-    if (existing !== undefined && existing.client !== undefined) return;
+    if (existing !== undefined && existing.client !== undefined) {
+      // 已连接：若现有 config 与直传 config 不同（runtime 注入覆盖 store），重建。
+      if (directConfig !== undefined && existing.server !== directConfig) {
+        existing.disposed = true;
+        const supervisor = new ConnectionSupervisor(this, directConfig, scope);
+        this.supervisors.set(name, supervisor);
+        void supervisor.connect();
+      }
+      return;
+    }
     if (existing !== undefined && existing.scope !== scope) {
       // 同名服务器跨 scope 冲突：工具名会重复，拒绝启动
       this.logger.warn(`dsh-mcp-manager: server "${name}" already registered in scope "${existing.scope}" — skipping "${scope}"`);
@@ -459,6 +491,47 @@ export class McpManager {
     if (supervisor === undefined) return;
     this.supervisors.delete(name);
     void supervisor.disconnect();
+  }
+
+  /**
+   * 运行时注册服务器（内存态，不落盘）。
+   * 供其他插件经 ctx.mcpManager 注入（官方 storageDomain service 模式）。
+   * - 同名已存在（store 或 runtime）：返回 { name, existing: true }，不抛错；
+   * - 注册即连接（走 start 的 config 直传分支，同名 runtime 优先）；
+   * - 串行队列防 reconcileBusy 吞注册；多插件并发注册排队。
+   */
+  async registerServer(server: Record<string, unknown>): Promise<{ name: string; existing: boolean }> {
+    const config = normalizeServer(server);
+    const run = this.registerQueue.then(async () => {
+      if (this.runtimeRegistry.has(config.name) || this.store.find(config.name) !== undefined) {
+        return { name: config.name, existing: true };
+      }
+      this.runtimeRegistry.set(config.name, config);
+      if (this.middlewareMode !== "off") {
+        // 中间层模式：runtime 服务器走全局 supervisor 路径（不落盘，不拆单元）。
+      }
+      if (config.enabled !== false) this.start(config.name, SCOPE_GLOBAL, config);
+      return { name: config.name, existing: false };
+    });
+    this.registerQueue = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  /**
+   * 运行时注销（不影响 store 持久化条目；同名 store 条目回落）。
+   * - 销毁 supervisor（stop，不碰 store）；
+   * - 移除 runtimeRegistry 条目 → 下次 reconcile 回落 store 配置。
+   */
+  async unregisterServer(name: string): Promise<void> {
+    const run = this.registerQueue.then(async () => {
+      if (this.runtimeRegistry.has(name)) {
+        this.stop(name);
+        this.runtimeRegistry.delete(name);
+        this.reconcileServers();
+      }
+    });
+    this.registerQueue = run.then(() => undefined, () => undefined);
+    return run;
   }
 
   async add(server: Record<string, unknown>, scope: string = SCOPE_GLOBAL): Promise<ServerConfig> {
@@ -514,9 +587,12 @@ export class McpManager {
     mw.teardownUnit(this.projectRoot);
   }
 
-  async connect(name: string, scope: string = SCOPE_GLOBAL): Promise<void> {
-    const store = scope === SCOPE_PROJECT ? await this.projectStoreOrThrow() : this.store;
-    const server = store.find(name);
+  async connect(name: string, scope: string = SCOPE_GLOBAL, directConfig?: ServerConfig): Promise<void> {
+    let server = directConfig;
+    if (server === undefined) {
+      const store = scope === SCOPE_PROJECT ? await this.projectStoreOrThrow() : this.store;
+      server = store.find(name);
+    }
     if (server === undefined) throw new Error(`server "${name}" not found in ${scope} scope`);
     // 中间层模式：项目级连接走中间层连接池（userDisabled 解除 + 惰性连接）。
     if (this.middlewareMode !== "off" && scope === SCOPE_PROJECT && this.middleware !== undefined) {

--- a/packages/dsh-mcp-manager/src/service.ts
+++ b/packages/dsh-mcp-manager/src/service.ts
@@ -1,0 +1,38 @@
+/**
+ * mcp-manager 核心化 service 类型（官方 storageDomain 模式）。
+ *
+ * 提供方：apply.ts 中 ctx.provide("mcpManager", service)。
+ * 消费方：其他插件 `declare module "@deepseek-ai/cordis"` 扩展 Context 后
+ * 经 `ctx.mcpManager` 调用；inject 声明 `"mcpManager"`（或运行时 ctx.get 探测）。
+ */
+
+/** 运行时注入服务器的入参（normalizeServer 接受的最小面）。 */
+export interface McpManagerServerInput {
+  name: string;
+  transport: "stdio" | "streamable-http";
+  command?: string;
+  args?: string[];
+  url?: string;
+  headers?: Record<string, string>;
+  env?: Record<string, string>;
+  cwd?: string;
+  enabled?: boolean;
+  toolCallTimeoutMs?: number;
+  reconnect?: Record<string, unknown>;
+  description?: string;
+}
+
+/** ctx.mcpManager service 面（MVP：register / unregister）。 */
+export interface McpManagerService {
+  /** 运行时注册服务器（内存态，不落盘）。同名已存在 → { existing: true } 不抛错。 */
+  registerServer(server: McpManagerServerInput): Promise<{ name: string; existing: boolean }>;
+  /** 运行时注销（不影响 store 持久化条目；同名 store 条目回落）。 */
+  unregisterServer(name: string): Promise<void>;
+}
+
+declare module "@deepseek-ai/cordis" {
+  interface Context {
+    /** mcp-manager 核心服务：其他插件运行时注入 MCP 服务器（官方 storageDomain 模式）。 */
+    mcpManager: McpManagerService;
+  }
+}

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -1874,6 +1874,54 @@ const main = async () => {
     rmSync(dir, { recursive: true, force: true });
   }
 
+  // ---- 核心化 service（#329 阶段1）：runtimeRegistry / registerServer / unregisterServer ----
+  // 用 enabled:false 的服务器（不连接、不 spawn 子进程，避免重连悬挂）验证登记语义。
+
+  {
+    const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-manager-service-"));
+    try {
+      const store = new McpStore(join(dir, "mcp.json"));
+      store.data = { version: 1, servers: [] };
+      const manager = new McpManager({ logger: { warn: () => {}, info: () => {} } }, store);
+      const quiet = () => ({ transport: "stdio", command: "echo", args: ["ok"], enabled: false });
+
+      // registerServer：新注册 → existing:false，条目进 runtimeRegistry。
+      const r1 = await manager.registerServer({ name: "svc-a", ...quiet() });
+      assert.equal(r1.existing, false);
+      assert.ok(manager.runtimeRegistry.has("svc-a"), "runtime 条目已登记");
+      assert.ok(!store.find("svc-a"), "不落盘（store 无条目）");
+
+      // 幂等：同名再注册 → existing:true 不抛错。
+      const r2 = await manager.registerServer({ name: "svc-a", ...quiet() });
+      assert.equal(r2.existing, true, "同名幂等返回 existing");
+
+      // 与 store 同名冲突：store 已有 → existing:true（不覆盖持久化条目）。
+      store.upsert(normalizeServer({ name: "svc-store", ...quiet() }));
+      const r3 = await manager.registerServer({ name: "svc-store", ...quiet() });
+      assert.equal(r3.existing, true, "store 同名返回 existing");
+
+      // 双轨合并：reconcile 后 runtime + store 条目都在 registry（enabled:false 不 spawn）。
+      manager.reconcileServers();
+      assert.ok(manager.runtimeRegistry.has("svc-a"), "runtime 条目在 registry");
+      assert.ok(store.find("svc-store") !== undefined, "store 条目保留");
+
+      // unregisterServer：移除 runtime 条目；store 条目不受影响。
+      await manager.unregisterServer("svc-a");
+      assert.ok(!manager.runtimeRegistry.has("svc-a"), "runtime 条目已移除");
+      assert.ok(store.find("svc-store") !== undefined, "store 条目保留");
+
+      // 卸载清理：dispose() 清空全部 supervisor（含 runtime）。
+      await manager.registerServer({ name: "svc-b", ...quiet() });
+      assert.ok(manager.runtimeRegistry.has("svc-b"));
+      await manager.dispose();
+      assert.equal(manager.supervisors.size, 0, "dispose 清空全部 supervisor");
+
+      console.log("  ok   核心化 service: register/unregister/双轨/卸载清理");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
   if (failures.length > 0) {
     console.error(`\n${failures.length} check(s) failed: ${failures.join(", ")}`);
     process.exit(1);

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -1916,6 +1916,14 @@ const main = async () => {
       await manager.dispose();
       assert.equal(manager.supervisors.size, 0, "dispose 清空全部 supervisor");
 
+      // 中间层 all 模式：runtime 条目豁免中间层跳过（reconcile 不杀 runtime supervisor）。
+      // 回归（QA 复审发现）：all 模式 reconcile 会把 runtime supervisor 停掉且不重建。
+      manager.middlewareMode = "all";
+      await manager.registerServer({ name: "svc-all", transport: "stdio", command: "echo", args: ["x"], enabled: false });
+      manager.reconcileServers();
+      assert.ok(manager.runtimeRegistry.has("svc-all"), "all 模式 runtime 条目保留");
+      manager.middlewareMode = "off";
+
       console.log("  ok   核心化 service: register/unregister/双轨/卸载清理");
     } finally {
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## 动机

[#329](https://github.com/wingsky-1/dsh-plugin-hub/issues/329) 阶段 1：把 dsh-mcp-manager 升级为可被其他插件复用的「运行时 MCP 服务器注册」核心服务。后续 dsh-codegraph 插件（阶段 2）将经此 service 运行时注入 codegraph 服务器（不落盘），并配套 worktree 开发纪律。

## 改动

### 新增 cordis service `ctx.mcpManager`（官方 storageDomain 模式）

- **提供方**：`apply.ts` 中 `ctx.provide("mcpManager", service)`（store.load 之后，manager 就绪）；
- **消费方**：其他插件 `declare module "@deepseek-ai/cordis"` 扩展 Context 后经 `ctx.mcpManager` 调用；
- **类型面**：`src/service.ts`（`McpManagerServerInput` / `McpManagerService`），index.ts 导出 + 声明合并；
- **API（MVP）**：
  - `registerServer(config)`：运行时注册（内存态不落盘），同名已存在 → `{ existing: true }` 不抛错；
  - `unregisterServer(name)`：运行时注销（stop + 移除 registry 条目），不影响 store 持久化条目（回落）。

### 双轨 reconcile（store 持久化 + runtime 运行时）

- `McpManager` 新增 `runtimeRegistry: Map<string, ServerConfig>`（内存态）；
- `reconcileServers()` 合并 `store.data.servers` + `projectStore` + `runtimeRegistry`，**同名 runtime 优先**；
- `refreshFromDisk()` 只处理 store 文件变更，**不动 runtimeRegistry**（防外部编辑冲掉运行时注册）。

### 修 P0（对抗性评审③发现）：start/connect 支持 config 直传

- `start(name, scope, directConfig?)`：runtime 注入时直传 config，**store 已有同名已连接时以 runtime config 重建**（否则「同名 runtime 优先」不生效）；
- `connect(name, scope, directConfig?)`：同样支持直传。

### 串行化

- `registerServer`/`unregisterServer` 走 `registerQueue` 串行队列，**防 reconcileBusy 吞注册**（多插件并发注册排队）。

## 兼容性

- store 持久化 / fs.watch / 路由 / settings 注入 / 中间层模式 **零破坏**，纯增量；
- 卸载由既有 `dispose()` 全量清理（含 runtime 条目与 supervisor）；
- `ctx.provide` 对 fake ctx（单元测试 mock 无 provide）可选调用静默降级。

## 验证

- `pnpm --filter @wingsky-1/dsh-mcp-manager build` ✅
- smoke 新增「核心化 service」断言：register 幂等/existing、unregister 回落、双轨合并、卸载清理 ✅（全部 `all checks passed`）
- `pnpm build && pnpm contract && pnpm pack:check` 全绿 ✅

> 注：本地 `node test/smoke.ts` 存在既有悬挂（原版同样 exit=124，CI ubuntu runner 正常退出，最近 CI 全绿），非本 PR 引入。

## 关联

- Issue: #329（阶段 1/3）
- 后续：阶段 2 dsh-codegraph 插件（消费此 service）
