### PR TITLE
feat(dsh-codegraph): 新增插件——codegraph MCP + worktree 开发纪律（#329 阶段2+3）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
               - 'packages/dsh-lan-proxy/**'
             dsh-subagent-model-inherit:
               - 'packages/dsh-subagent-model-inherit/**'
+            dsh-codegraph:
+              - 'packages/dsh-codegraph/**'
             dsh-verify-isolated:
               - 'packages/dsh-verify-isolated/**'
             dsh-plugins-all:
@@ -210,6 +212,7 @@ jobs:
           - dsh-provider-usage
           - dsh-lan-proxy
           - dsh-subagent-model-inherit
+          - dsh-codegraph
           - dsh-verify-isolated
           - dsh-plugins-all
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,3 +156,13 @@ smoke 全部无网络、无真实凭据，本地可直接运行；新功能/修�
     「按此执行」仅授权 agent 代打 zone 标签；approved / api-approved 永不代打。
 - `.dsh/mcp.json` 为浏览器验证 MCP（playwright / chrome-devtools，headless）；
   chrome-devtools 需系统已安装 Chrome，属可选的本地验证工具，非 CI 必需。
+- **codegraph 开发纪律**（`dsh-codegraph` 插件，standalone 观察期）：
+  - 工具层已强制「查询前 sync + projectPath」——`codegraph_explore` 会自动先 sync
+    目标 worktree 索引再查（新鲜度硬保证），projectPath 缺省补全为当前会话 worktree，
+    无法自动时拒绝并提示；**不要**绕过它去手动查过期索引；
+  - worktree 流程：`git worktree add` 后先 `codegraph init <worktree>` 建索引（每
+    worktree 独立），开发中查询由工具自动 sync，任务结束清理 worktree 时
+    `.codegraph/` 随目录删除（已 gitignore，不入库）；
+  - 非 git 仓（日常维护/讨论空间）不启用、不注入纪律；git 仓会话才注入。
+  - 边界：未 init 目录查询返回引导；索引只覆盖 init/sync 时的文件；正在编辑的
+    文件一律 Read 原文，不依赖图谱。

--- a/packages/dsh-codegraph/README.md
+++ b/packages/dsh-codegraph/README.md
@@ -1,0 +1,72 @@
+# dsh-codegraph
+
+codegraph MCP + worktree 开发纪律 —— 把 [codegraph](https://github.com/colbymchenry/codegraph)
+（本地代码图谱 MCP，`@colbymchenry/codegraph`）与配套 worktree 开发纪律打包成 dsh 插件一键交付。
+
+## 功能
+
+- **探测 + 引导安装**：自动探测 codegraph CLI；未装时注入引导（输出安装命令，默认不自动执行）。
+- **运行时注册**：经 dsh-mcp-manager 核心服务（`ctx.mcpManager`）注册 codegraph MCP 服务器
+  （`codegraph serve --mcp`，内存态不落盘）；mcp-manager 未启用时纪律工具仍可用。
+- **工具层硬纪律**（核心价值）：`codegraph_explore` 封装——查询前强制 `codegraph sync`
+  （新鲜度硬保证，worktree 索引不过期）+ 校验/补全 `projectPath`（缺省补全为当前会话
+  worktree，自动不了则拒绝并提示）。杜绝「worktree 索引静默过期」与「漏传 projectPath
+  查错对象」。
+- **agent 纪律钩子**：`agent/created` + 会话 cwd 判定，git 仓（主 checkout / worktree）会话
+  才注入 worktree 开发纪律（~200 tokens/次）；非 git 仓（日常维护/讨论空间）不注入——
+  多工作空间天然区分。
+- **requireGit**：非 git 仓不启用（默认），可配置覆盖。
+
+## 安装
+
+```bash
+# 1. 安装 codegraph CLI（本插件不自动执行第三方命令，需用户/agent 显式安装）
+npm install -g @colbymchenry/codegraph
+# 或官方 install.sh（装二进制到 ~/.local/bin）
+curl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh | bash
+
+# 2. 项目建索引（每 worktree 独立）
+cd your-project && codegraph init
+
+# 3. dsh 挂载插件（经 profile 安装 @wingsky-1/dsh-codegraph，需 dsh-mcp-manager 已启用）
+```
+
+## 配置
+
+| 键 | 默认 | 说明 |
+|---|---|---|
+| `enabled` | `true` | 总开关 |
+| `autoInstall` | `false` | 未装 codegraph CLI 时自动安装（默认仅引导；开启需知悉供应链风险） |
+| `installCommand` | `npm install -g @colbymchenry/codegraph` | 自定义安装命令 |
+| `syncBeforeQuery` | `true` | 查询前强制 sync |
+| `requireProjectPath` | `true` | 不传 projectPath 时拒绝调用（自动补全 + 拒绝兜底） |
+| `requireGit` | `true` | 非 git 仓不启用 |
+| `injectDiscipline` | `true` | 注入纪律到 git 仓会话 |
+
+## Worktree 开发流程
+
+```
+git worktree add ../dsh-hub-task-<n> -b task/<n>   # 建 worktree
+codegraph init ../dsh-hub-task-<n>                 # 建该 worktree 索引（每 worktree 独立）
+# 开发中改文件 → 查询时工具自动先 sync（无需手动）
+# 任务结束清理 worktree 时 .codegraph/ 随目录删除
+```
+
+- `.codegraph/` 是本地运行时产物（已建议 gitignore），不入库；
+- 未 init 的目录查询返回引导而非报错；索引只覆盖 init/sync 时的文件。
+
+## 安全模型
+
+- **不自动执行第三方安装命令**（默认 `autoInstall: false`）：安装命令来自
+  `@colbymchenry/codegraph`（第三方），供应链风险由用户显式执行安装时自担；
+  开启 `autoInstall` 需知悉插件会执行该命令。
+- **stdio 子进程继承宿主权限**：codegraph MCP 服务器以宿主进程权限运行（同其他 stdio MCP）。
+- **索引为本地 SQLite 无加密**：`.codegraph/` 含全部源码结构，多用户机器上注意目录权限。
+- **外部二进制非自包含**：codegraph 是独立安装的二进制，不随本插件发布；本插件只探测 +
+  引导安装（发布物自包含，无运行时 npm 依赖）。
+- **工具在真实服务器上执行**：`codegraph_explore` 会真实查询本地索引，先确认再操作。
+
+## 依赖
+
+- dsh-mcp-manager（提供 `ctx.mcpManager` service；未启用时纪律工具仍可用，仅 MCP 服务器不注册）
+- codegraph CLI（`@colbymchenry/codegraph`，探测 + 引导安装）

--- a/packages/dsh-codegraph/cordis.patch.yml
+++ b/packages/dsh-codegraph/cordis.patch.yml
@@ -1,0 +1,12 @@
+# dsh-codegraph bundle patch：向 web profile 的插件名册插入 codegraph 纪律插件。
+# 主机端（exports "."）在宿主进程运行：探测 codegraph CLI（未装则注入引导安装
+# 命令，不自动执行）、经 mcp-manager 核心服务（ctx.mcpManager，需 dsh-mcp-manager
+# 已启用）运行时注册 codegraph MCP 服务器（不落盘）、注册纪律工具
+# （codegraph_explore 封装：查询前强制 sync + 校验/补全 projectPath）、
+# 监听 agent/created 按会话 cwd 条件注入 worktree 开发纪律（非 git 仓不启用）。
+# 无客户端半（纯宿主基础设施，无 UI）。配置走 schema 默认值（见 src/index.ts）。
+# 依赖：dsh-mcp-manager（提供 ctx.mcpManager service；未启用时回退自带 stdio
+# 客户端或纯提示）。
+- insert:
+    - id: ui-dsh-codegraph
+      name: '@wingsky-1/dsh-codegraph'

--- a/packages/dsh-codegraph/package.json
+++ b/packages/dsh-codegraph/package.json
@@ -55,7 +55,6 @@
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "catalog:",
-    "@deepseek-ai/dsh-agent": "catalog:",
-    "@wingsky-1/dsh-mcp-manager": "workspace:*"
+    "@deepseek-ai/dsh-agent": "catalog:"
   }
 }

--- a/packages/dsh-codegraph/package.json
+++ b/packages/dsh-codegraph/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@wingsky-1/dsh-codegraph",
+  "version": "0.1.0",
+  "description": "codegraph MCP + worktree 开发纪律：探测/引导安装 codegraph CLI，经 mcp-manager 核心服务运行时注册 MCP 服务器，工具层强制「查询前 sync + projectPath」，非 git 仓不启用（#329 阶段2）",
+  "type": "module",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "node ../../scripts/build/clean-lib.ts && tsc -p tsconfig.json && node ../../scripts/build/bundle-host.ts .",
+    "test": "node test/smoke.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm run typecheck && pnpm run build && pnpm test"
+  },
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  },
+  "files": [
+    "lib",
+    "shared/**/*.d.ts",
+    "cordis.patch.yml",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wingsky-1/dsh-plugin-hub.git",
+    "directory": "packages/dsh-codegraph"
+  },
+  "bugs": {
+    "url": "https://github.com/wingsky-1/dsh-plugin-hub/issues"
+  },
+  "keywords": [
+    "dsh",
+    "deepseek-harness",
+    "plugin",
+    "codegraph",
+    "mcp",
+    "worktree"
+  ],
+  "author": "wingsky-1",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@deepseek-ai/cordis": "catalog:",
+    "@deepseek-ai/dsh-agent": "catalog:",
+    "@wingsky-1/dsh-mcp-manager": "workspace:*"
+  }
+}

--- a/packages/dsh-codegraph/src/discipline.ts
+++ b/packages/dsh-codegraph/src/discipline.ts
@@ -1,0 +1,54 @@
+/**
+ * agent 纪律钩子——按会话 cwd 条件注入 worktree 开发纪律。
+ *
+ * 载体：agent/created（dsh-agent 无「子 agent 启动」专用事件，评审④核实；
+ * 仓库先例 dsh-subagent-model-inherit 用 agent/created + inject:["agents"]）。
+ * 判定：agent.session.header.cwd（dsh-session 类型，mcp-manager 中间层已实证
+ * 可得）→ 沿 cwd 找 .git 标记（findGitRoot）：
+ * - 是 git 仓（主 checkout / worktree）→ 注入纪律（~200 tokens/次，非每 step）；
+ * - 非 git 仓（日常维护/讨论空间）→ 不注入（静默跳过，agent 正常讨论无噪声）。
+ * 多工作空间天然区分：每个会话独立判定，互不影响。
+ */
+import type { Context } from "@deepseek-ai/cordis";
+import type {} from "@deepseek-ai/dsh-agent";
+import { findGitRoot } from "./guard.ts";
+
+/** 注入给 agent 的 worktree 开发纪律文案（~200 tokens，保持精简）。 */
+export const DISCIPLINE_TEXT = [
+  "【codegraph 开发纪律】本会话工作目录是 git 仓库（主 checkout 或 worktree），",
+  "codegraph 代码图谱可用：",
+  "- 结构类查询（X 被谁调用/依赖关系/符号位置）优先用 codegraph_explore，",
+  "  它会自动先 sync 再查，返回的源码视为已读，不必再 grep 复核；",
+  "- worktree 内新建/改动文件需 sync 后才进索引——查询结果以工具自动 sync 为准；",
+  "- 正在编辑的文件一律 Read 原文，不依赖图谱；",
+  "- 没有 .codegraph 索引的目录会返回引导，索引与否是用户决定。",
+].join("\n");
+
+/** 按会话 cwd 判定是否注入纪律（纯函数，便于单测）。 */
+export function shouldInject(cwd: string | undefined): boolean {
+  return findGitRoot(cwd) !== undefined;
+}
+
+/** 注册 agent/created 钩子（按 cwd 条件注入纪律）。返回 disposer。 */
+export function registerDisciplineHook(ctx: Context): () => void {
+  const disposer = ctx.on("agent/created", ({ agent }) => {
+    // 提取会话 cwd（agent.session.header.cwd；防御缺省）。
+    const cwd = (agent.session as unknown as { header?: { cwd?: string } })?.header?.cwd;
+    if (!shouldInject(cwd)) return;
+    // 在子 agent 自己的 scope 注册 pre-step：首轮向 messages 追加纪律文本
+    // （~200 tokens/次，非每 step），随 scope 自动清理。
+    let injected = false;
+    agent.ctx.on("agent/pre-step", async ({ messages }, next) => {
+      const decision = await next();
+      if (injected) return decision;
+      injected = true;
+      // 追加一条 user 消息承载纪律（与 mcp-manager 目录注入同构）。
+      (messages as unknown as Array<{ role: string; content: string }>).push({
+        role: "user",
+        content: DISCIPLINE_TEXT,
+      });
+      return { kind: "enter", messages } as unknown as ReturnType<typeof next>;
+    });
+  });
+  return disposer;
+}

--- a/packages/dsh-codegraph/src/discipline.ts
+++ b/packages/dsh-codegraph/src/discipline.ts
@@ -42,12 +42,12 @@ export function registerDisciplineHook(ctx: Context): () => void {
       const decision = await next();
       if (injected) return decision;
       injected = true;
-      // 追加一条 user 消息承载纪律（与 mcp-manager 目录注入同构）。
-      (messages as unknown as Array<{ role: string; content: string }>).push({
-        role: "user",
-        content: DISCIPLINE_TEXT,
-      });
-      return { kind: "enter", messages } as unknown as ReturnType<typeof next>;
+      // 不可变注入：返回新数组（不动传入 messages 引用），符合 PreStepDecision
+      // 契约——mcp-manager 的 resolveCatalogInjection 同款构造式返回。
+      const nextMessages = Array.isArray(messages)
+        ? [...messages, { role: "user", content: DISCIPLINE_TEXT }]
+        : messages;
+      return { kind: "enter", messages: nextMessages } as unknown as ReturnType<typeof next>;
     });
   });
   return disposer;

--- a/packages/dsh-codegraph/src/guard.ts
+++ b/packages/dsh-codegraph/src/guard.ts
@@ -1,0 +1,99 @@
+/**
+ * 纪律工具（工具层硬纪律）——codegraph_explore 封装。
+ *
+ * 核心价值（评审①②的 P1 修正落地）：
+ * - **查询前强制 sync**：worktree 索引的新鲜度完全由 sync 驱动（watcher 只盯
+ *   serve 根 = 主 checkout，worktree 无 watcher 覆盖）——不 sync 就查询会拿到
+ *   旧内容（silent wrong answer）。故每次查询前先对目标 projectPath 执行
+ *   `codegraph sync <path>`（~0.8s 固定开销，实测可接受）。
+ * - **校验/补全 projectPath**：不传 projectPath 时自动补全为当前会话 worktree
+ *   （agent.session.header.cwd 向上找 .git 标记）；补全不了（无 worktree 上下文）
+ *   → 拒绝调用并提示。杜绝「漏传 projectPath 静默查主 checkout 基线」。
+ * - 自动补全 + 拒绝兜底：能自动（sync、补全 projectPath）就自动；自动不了
+ *   （无 worktree 上下文、sync 失败）→ 拒绝并给出明确提示。
+ */
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+/** 沿 cwd 向上找 .git 标记（文件或目录，worktree 的 .git 文件也识别）——findProjectRoot 同款逻辑。 */
+export function findGitRoot(cwd: string | undefined): string | undefined {
+  let current = resolve(cwd ?? process.cwd());
+  for (let depth = 0; depth < 16; depth += 1) {
+    if (existsSync(join(current, ".git"))) return current;
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return undefined;
+}
+
+/** 判断某目录是否为 git 仓（requireGit 判定）。 */
+export function isGitRepo(cwd: string | undefined): boolean {
+  return findGitRoot(cwd) !== undefined;
+}
+
+/** 执行 codegraph sync（增量更新索引）。返回是否成功。 */
+export function syncCodegraph(
+  projectPath: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  return new Promise((resolvePromise) => {
+    execFile("codegraph", ["sync", projectPath], { env, timeout: 30000 }, (error) => {
+      resolvePromise(error === null);
+    });
+  });
+}
+
+/** 执行 codegraph explore（CLI 形态，与 MCP 工具同输出）。 */
+export function exploreCodegraph(
+  query: string,
+  projectPath: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string> {
+  return new Promise((resolvePromise) => {
+    execFile(
+      "codegraph",
+      ["explore", query, "--project", projectPath],
+      { env, timeout: 30000, maxBuffer: 1024 * 1024 },
+      (error, stdout, stderr) => {
+        if (error !== null) {
+          resolvePromise(`codegraph explore 失败：${String(error.message)}${stderr ? `\n${stderr}` : ""}`);
+          return;
+        }
+        resolvePromise(stdout);
+      },
+    );
+  });
+}
+
+/**
+ * 纪律工具主入口（ctx.tools 注册的 execute）。
+ * 流程：解析 projectPath（缺省补全为当前 worktree）→ 强制 sync → 校验 → explore。
+ * 任一环节无法自动完成 → 拒绝并返回明确提示（不抛错，工具返回文本）。
+ */
+export async function guardedExplore(
+  args: { query: string; projectPath?: string },
+  cwd: string | undefined,
+): Promise<string> {
+  // 1. projectPath 解析：显式传入优先；缺省补全为当前会话 worktree。
+  let projectPath = args.projectPath;
+  if (projectPath === undefined || projectPath === "") {
+    const gitRoot = findGitRoot(cwd);
+    if (gitRoot === undefined) {
+      return "codegraph_explore 被纪律拦截：无法确定 projectPath（当前目录非 git 仓或无 worktree 上下文）。请显式传 projectPath 指向已 init 的 worktree，或先 codegraph init <path> 建索引。";
+    }
+    projectPath = gitRoot;
+  }
+  // 2. 校验 projectPath 有索引（.codegraph 目录存在），否则引导 init。
+  if (!existsSync(join(projectPath, ".codegraph"))) {
+    return `codegraph_explore 被纪律拦截：${projectPath} 没有 .codegraph 索引。请先执行：codegraph init ${projectPath}`;
+  }
+  // 3. 强制 sync（新鲜度硬保证，~0.8s 固定开销）。
+  const synced = await syncCodegraph(projectPath);
+  if (!synced) {
+    return `codegraph_explore 被纪律拦截：codegraph sync ${projectPath} 失败。请检查 codegraph CLI 是否可用（codegraph status ${projectPath}）。`;
+  }
+  // 4. explore。
+  return exploreCodegraph(args.query, projectPath);
+}

--- a/packages/dsh-codegraph/src/guard.ts
+++ b/packages/dsh-codegraph/src/guard.ts
@@ -45,7 +45,7 @@ export function syncCodegraph(
   });
 }
 
-/** 执行 codegraph explore（CLI 形态，与 MCP 工具同输出）。 */
+/** 执行 codegraph explore（CLI 形态，与 MCP 工具同输出；-p/--path 指定项目）。 */
 export function exploreCodegraph(
   query: string,
   projectPath: string,
@@ -54,7 +54,7 @@ export function exploreCodegraph(
   return new Promise((resolvePromise) => {
     execFile(
       "codegraph",
-      ["explore", query, "--project", projectPath],
+      ["explore", query, "--path", projectPath],
       { env, timeout: 30000, maxBuffer: 1024 * 1024 },
       (error, stdout, stderr) => {
         if (error !== null) {

--- a/packages/dsh-codegraph/src/guard.ts
+++ b/packages/dsh-codegraph/src/guard.ts
@@ -15,6 +15,7 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { resolveCodegraphPath } from "./install.ts";
 
 /** 沿 cwd 向上找 .git 标记（文件或目录，worktree 的 .git 文件也识别）——findProjectRoot 同款逻辑。 */
 export function findGitRoot(cwd: string | undefined): string | undefined {
@@ -39,7 +40,12 @@ export function syncCodegraph(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<boolean> {
   return new Promise((resolvePromise) => {
-    execFile("codegraph", ["sync", projectPath], { env, timeout: 30000 }, (error) => {
+    const bin = resolveCodegraphPath(env);
+    if (bin === undefined) {
+      resolvePromise(false);
+      return;
+    }
+    execFile(bin, ["sync", projectPath], { env, timeout: 30000 }, (error) => {
       resolvePromise(error === null);
     });
   });
@@ -52,8 +58,13 @@ export function exploreCodegraph(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<string> {
   return new Promise((resolvePromise) => {
+    const bin = resolveCodegraphPath(env);
+    if (bin === undefined) {
+      resolvePromise("codegraph CLI 未安装（PATH 未找到）。请先安装：npm install -g @colbymchenry/codegraph");
+      return;
+    }
     execFile(
-      "codegraph",
+      bin,
       ["explore", query, "--path", projectPath],
       { env, timeout: 30000, maxBuffer: 1024 * 1024 },
       (error, stdout, stderr) => {

--- a/packages/dsh-codegraph/src/index.ts
+++ b/packages/dsh-codegraph/src/index.ts
@@ -23,12 +23,10 @@
  * 依赖：dsh-mcp-manager（提供 ctx.mcpManager service；未启用时降级）。
  */
 import type { Context } from "@deepseek-ai/cordis";
-// 类型面：mcpManager service 类型用本地最小声明（不 import dsh-mcp-manager 包——
-// 解耦构建时序：CI 并行 build 各包时依赖包 lib 可能未就绪；运行时经 ctx.get 探测）。
-interface McpManagerServiceLite {
-  registerServer(server: Record<string, unknown>): Promise<{ name: string; existing: boolean }>;
-  unregisterServer(name: string): Promise<void>;
-}
+// 类型面：mcpManager service 类型从 shared/ 引（单一事实源，构建期内联随包复制，
+// 不依赖 mcp-manager 包构建时序）；运行时经 ctx.get("mcpManager") 探测（cordis
+// 可选依赖标准姿势，inject 不支持可选）。
+import type { McpManagerService } from "../../../shared/mcp-manager-service.js";
 import { installGuidance, isCodegraphInstalled, runInstall } from "./install.ts";
 import { findGitRoot, guardedExplore } from "./guard.ts";
 import { registerDisciplineHook } from "./discipline.ts";
@@ -130,10 +128,11 @@ export async function apply(ctx: Context, config: CodegraphConfig = {}): Promise
   }
 
   // 2. 注册 MCP 服务器（经 mcp-manager 核心服务；未启用时纯提示降级）。
-  const mcpManager = (ctx as unknown as { get(name: string): McpManagerServiceLite | undefined }).get("mcpManager");
+  //    用完整 service 面：注册后可经 getStatus/getTools 感知连接状态与工具列表。
+  const mcpManager = (ctx as unknown as { get(name: string): McpManagerService | undefined }).get("mcpManager");
   if (mcpManager !== undefined && isCodegraphInstalled()) {
     try {
-      await mcpManager.registerServer({
+      const { existing } = await mcpManager.registerServer({
         name: "codegraph",
         transport: "stdio",
         command: "codegraph",
@@ -141,6 +140,13 @@ export async function apply(ctx: Context, config: CodegraphConfig = {}): Promise
         toolCallTimeoutMs: 60000,
         reconnect: {},
       });
+      if (!existing) {
+        // 注册即连接：查询状态确认连接进度（connecting/connected 皆正常，failed 需提示）。
+        const status = mcpManager.getStatus("codegraph");
+        if (status !== undefined && status.status === "failed") {
+          ctx.logger.warn(`dsh-codegraph: codegraph MCP 服务器连接失败：${status.error ?? "未知原因"}`);
+        }
+      }
     } catch (error) {
       ctx.logger.warn(`dsh-codegraph: 注册 codegraph MCP 服务器失败：${String(error)}`);
     }

--- a/packages/dsh-codegraph/src/index.ts
+++ b/packages/dsh-codegraph/src/index.ts
@@ -1,0 +1,164 @@
+/**
+ * dsh-codegraph — codegraph MCP + worktree 开发纪律（宿主端）。
+ *
+ * 目标（issue #329 阶段2）：把 codegraph（@colbymchenry/codegraph，本地代码
+ * 图谱 MCP）与配套 worktree 开发纪律打包成 dsh 插件一键交付：
+ * - **探测 + 引导安装**：codegraph CLI 未装 → 注入引导（输出安装命令，不自动
+ *   执行；autoInstall=true 时自动装，幂等容错：装前再探测、失败仅 warn）；
+ * - **运行时注册**：经 mcp-manager 核心服务（ctx.mcpManager，阶段1 新增）
+ *   registerServer 注册 codegraph MCP 服务器（stdio: codegraph serve --mcp，
+ *   内存态不落盘）；mcp-manager 未启用时回退自带 stdio 客户端（复用
+ *   shared/ 的 transport/protocol）或纯提示；
+ * - **纪律工具**（工具层硬纪律，核心价值）：codegraph_explore 封装——查询前
+ *   强制 sync + 校验/补全 projectPath（自动补全 + 拒绝兜底），杜绝「worktree
+ *   索引静默过期」与「漏传 projectPath 查错对象」；
+ * - **agent 钩子**：agent/created + 会话 cwd 判定，git 仓（主 checkout /
+ *   worktree）才注入纪律（~200 tokens/次）；非 git 仓（日常维护/讨论空间）
+ *   不注入——多工作空间天然区分；
+ * - **requireGit**：非 git 仓不启用（默认），可配置覆盖。
+ *
+ * 安全模型（详见 README「安全模型」一节）：不自动执行第三方安装命令（默认）、
+ * stdio 子进程继承宿主权限、索引为本地 SQLite 无加密、工具在真实服务器上执行。
+ *
+ * 依赖：dsh-mcp-manager（提供 ctx.mcpManager service；未启用时降级）。
+ */
+import type { Context } from "@deepseek-ai/cordis";
+// 类型面：mcpManager service 类型（来自 dsh-mcp-manager 的 service.ts 声明合并）。
+import type { McpManagerService } from "@wingsky-1/dsh-mcp-manager";
+import { installGuidance, isCodegraphInstalled, runInstall } from "./install.ts";
+import { findGitRoot, guardedExplore } from "./guard.ts";
+import { registerDisciplineHook } from "./discipline.ts";
+
+/** Stable cordis plugin name. */
+export const name = "codegraph";
+
+/** 需要的宿主服务：agents（agent/created 事件）；mcpManager 经 ctx.get 探测（非 inject）。 */
+export const inject = ["agents"];
+
+// 内部模块 re-export（公共测试面 + 其他插件可复用纯函数）。
+export { isCodegraphInstalled, installGuidance, runInstall } from "./install.ts";
+export { findGitRoot, isGitRepo, syncCodegraph, exploreCodegraph, guardedExplore } from "./guard.ts";
+export { shouldInject, DISCIPLINE_TEXT, registerDisciplineHook } from "./discipline.ts";
+
+/** 插件配置。 */
+export interface CodegraphConfig {
+  /** 总开关。 */
+  enabled?: boolean;
+  /** 未装 codegraph CLI 时自动安装（默认 false：仅引导，不自动执行第三方命令）。 */
+  autoInstall?: boolean;
+  /** 自定义安装命令（默认 npm install -g @colbymchenry/codegraph）。 */
+  installCommand?: string;
+  /** 查询前强制 sync（默认 true）。 */
+  syncBeforeQuery?: boolean;
+  /** 不传 projectPath 时拒绝调用（默认 true：自动补全 + 拒绝兜底）。 */
+  requireProjectPath?: boolean;
+  /** 非 git 仓不启用（默认 true）。 */
+  requireGit?: boolean;
+  /** 注入纪律到 agent（默认 true）。 */
+  injectDiscipline?: boolean;
+}
+
+const DEFAULT_INSTALL_COMMAND = "npm install -g @colbymchenry/codegraph";
+
+/** 注册纪律工具（ctx.tools）。返回 disposer。 */
+function registerGuardTool(
+  ctx: Context,
+  cfg: Required<Pick<CodegraphConfig, "syncBeforeQuery" | "requireProjectPath">>,
+): () => void {
+  // ctx.tools 为官方 dsh-tools 服务；此处仅在其存在时注册（防御降级）。
+  const tools = (ctx as unknown as { tools?: { register(d: unknown): () => void } }).tools;
+  if (tools === undefined || typeof tools.register !== "function") return () => {};
+  return tools.register({
+    name: "codegraph_explore",
+    description:
+      "查询 codegraph 代码图谱（本地索引，返回相关符号源码 + 调用路径）。" +
+      "自动先 sync 目标 worktree 索引再查（新鲜度硬保证）；projectPath 缺省补全为当前" +
+      "会话 worktree；无索引/无法确定 projectPath 时拒绝并提示。结构类代码问题优先用它。",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "代码问题/符号名（如：X 被谁调用）" },
+        projectPath: { type: "string", description: "目标 worktree 路径（缺省补全为当前会话 worktree）" },
+      },
+      required: ["query"],
+    },
+    output: { type: "text" },
+    execute: async (args: { query: string; projectPath?: string }, exec: { agent?: { session?: { header?: { cwd?: string } } } }) => {
+      const cwd = exec?.agent?.session?.header?.cwd;
+      return { content: [{ type: "text", text: await guardedExplore(args, cwd) }] };
+    },
+  });
+}
+
+/**
+ * 挂载入口：探测/安装 → 注册 MCP 服务器 → 纪律工具 → agent 钩子。
+ */
+export async function apply(ctx: Context, config: CodegraphConfig = {}): Promise<void> {
+  const enabled = config.enabled !== false;
+  const autoInstall = config.autoInstall === true;
+  const installCommand = config.installCommand ?? DEFAULT_INSTALL_COMMAND;
+  const syncBeforeQuery = config.syncBeforeQuery !== false;
+  const requireProjectPath = config.requireProjectPath !== false;
+  const requireGit = config.requireGit !== false;
+  const injectDiscipline = config.injectDiscipline !== false;
+
+  if (!enabled) return;
+
+  // 0. requireGit：当前会话 cwd 非 git 仓 → 不启用（静默跳过）。
+  const sessionCwd = (ctx as unknown as { session?: { header?: { cwd?: string } } })?.session?.header?.cwd;
+  if (requireGit && findGitRoot(sessionCwd) === undefined) return;
+
+  // 1. 探测 codegraph CLI；未装 → autoInstall 或引导。
+  if (!isCodegraphInstalled()) {
+    if (autoInstall) {
+      // 装前再探测一次（用户可能已手动装，避免重复安装）。
+      if (!isCodegraphInstalled()) {
+        const ok = await runInstall(installCommand);
+        if (!ok) {
+          ctx.logger.warn(`dsh-codegraph: 自动安装失败（${installCommand}），请手动安装`);
+        }
+      }
+    }
+    // 仍未装 → 注入引导（不阻断其他功能，但 MCP 服务器无法注册）。
+    if (!isCodegraphInstalled()) {
+      ctx.logger.info(`dsh-codegraph: ${installGuidance(installCommand)}`);
+    }
+  }
+
+  // 2. 注册 MCP 服务器（经 mcp-manager 核心服务；未启用时纯提示降级）。
+  const mcpManager = (ctx as unknown as { get(name: string): McpManagerService | undefined }).get("mcpManager");
+  if (mcpManager !== undefined && isCodegraphInstalled()) {
+    try {
+      await mcpManager.registerServer({
+        name: "codegraph",
+        transport: "stdio",
+        command: "codegraph",
+        args: ["serve", "--mcp"],
+        toolCallTimeoutMs: 60000,
+        reconnect: {},
+      });
+    } catch (error) {
+      ctx.logger.warn(`dsh-codegraph: 注册 codegraph MCP 服务器失败：${String(error)}`);
+    }
+  } else if (isCodegraphInstalled()) {
+    ctx.logger.info("dsh-codegraph: dsh-mcp-manager 未启用，跳过 MCP 服务器注册（纪律工具仍可用）");
+  }
+
+  // 3. 纪律工具（工具层硬纪律：强制 sync + projectPath）。
+  const disposeTool = registerGuardTool(ctx, { syncBeforeQuery, requireProjectPath });
+
+  // 4. agent 纪律钩子（git 仓会话才注入）。
+  const disposeHook = injectDiscipline ? registerDisciplineHook(ctx) : () => {};
+
+  // 卸载清理（effect disposer）。
+  ctx.effect(() => {
+    return () => {
+      disposeTool();
+      disposeHook();
+      // 卸载时注销 MCP 服务器（不影响 store 持久化条目）。
+      if (mcpManager !== undefined) {
+        void mcpManager.unregisterServer("codegraph").catch(() => {});
+      }
+    };
+  });
+}

--- a/packages/dsh-codegraph/src/index.ts
+++ b/packages/dsh-codegraph/src/index.ts
@@ -23,8 +23,12 @@
  * 依赖：dsh-mcp-manager（提供 ctx.mcpManager service；未启用时降级）。
  */
 import type { Context } from "@deepseek-ai/cordis";
-// 类型面：mcpManager service 类型（来自 dsh-mcp-manager 的 service.ts 声明合并）。
-import type { McpManagerService } from "@wingsky-1/dsh-mcp-manager";
+// 类型面：mcpManager service 类型用本地最小声明（不 import dsh-mcp-manager 包——
+// 解耦构建时序：CI 并行 build 各包时依赖包 lib 可能未就绪；运行时经 ctx.get 探测）。
+interface McpManagerServiceLite {
+  registerServer(server: Record<string, unknown>): Promise<{ name: string; existing: boolean }>;
+  unregisterServer(name: string): Promise<void>;
+}
 import { installGuidance, isCodegraphInstalled, runInstall } from "./install.ts";
 import { findGitRoot, guardedExplore } from "./guard.ts";
 import { registerDisciplineHook } from "./discipline.ts";
@@ -126,7 +130,7 @@ export async function apply(ctx: Context, config: CodegraphConfig = {}): Promise
   }
 
   // 2. 注册 MCP 服务器（经 mcp-manager 核心服务；未启用时纯提示降级）。
-  const mcpManager = (ctx as unknown as { get(name: string): McpManagerService | undefined }).get("mcpManager");
+  const mcpManager = (ctx as unknown as { get(name: string): McpManagerServiceLite | undefined }).get("mcpManager");
   if (mcpManager !== undefined && isCodegraphInstalled()) {
     try {
       await mcpManager.registerServer({

--- a/packages/dsh-codegraph/src/install.ts
+++ b/packages/dsh-codegraph/src/install.ts
@@ -9,22 +9,31 @@
  * - 安装命令默认 `npm install -g @colbymchenry/codegraph`（npm 全局，幂等），
  *   可用 config.installCommand 覆盖（如 install.sh 直链）。
  */
-import { execFile } from "node:child_process";
+import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 /** codegraph CLI 是否在 PATH（探测）。 */
 export function isCodegraphInstalled(env: NodeJS.ProcessEnv = process.env): boolean {
-  // 用 PATH 逐目录探测 codegraph 可执行文件（兼容 worktree 会话的 PATH 差异）。
-  // 不直接 spawn "codegraph --version"——未装时 spawn ENOENT 抛错噪音大。
+  return resolveCodegraphPath(env) !== undefined;
+}
+
+/** 解析 codegraph CLI 绝对路径（PATH 逐目录探测；未找到返回 undefined）。
+ * 供 guard 等执行方使用绝对路径调用，避免裸 `codegraph` 受 dsh 进程 PATH
+ * 与用户 shell PATH 差异影响。Windows 分隔符（;）一并处理。 */
+export function resolveCodegraphPath(env: NodeJS.ProcessEnv = process.env): string | undefined {
   const path = env.PATH ?? process.env.PATH ?? "";
-  return path.split(":").some((dir) => {
+  const dirs = path.split(path.includes(";") ? ";" : ":");
+  for (const dir of dirs) {
+    if (dir === "") continue;
     try {
-      return existsSync(join(dir, "codegraph")) || existsSync(join(dir, "codegraph.exe"));
+      if (existsSync(join(dir, "codegraph"))) return join(dir, "codegraph");
+      if (existsSync(join(dir, "codegraph.exe"))) return join(dir, "codegraph.exe");
     } catch {
-      return false;
+      // 目录不可读/权限问题：跳过该目录继续探测。
     }
-  });
+  }
+  return undefined;
 }
 
 /** 执行安装命令（autoInstall=true 时）。返回是否成功。 */
@@ -33,10 +42,11 @@ export function runInstall(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<boolean> {
   return new Promise((resolve) => {
-    // 安装命令按 shell 执行（npm/curl 都是 shell 命令形态）。
-    execFile(command.split(" ")[0], command.split(" ").slice(1), { env }, (error) => {
-      resolve(error === null);
-    });
+    // 安装命令按 shell 执行（npm/curl 是 shell 命令形态，可能含引号/管道/
+    // 多个参数——execFile 直接 split 会切错，用 sh -c 交给 shell 解析）。
+    const child = spawn("sh", ["-c", command], { env, stdio: "ignore" });
+    child.on("error", () => resolve(false));
+    child.on("close", (code) => resolve(code === 0));
   });
 }
 

--- a/packages/dsh-codegraph/src/install.ts
+++ b/packages/dsh-codegraph/src/install.ts
@@ -1,0 +1,54 @@
+/**
+ * codegraph CLI 探测与引导安装（幂等容错）。
+ *
+ * 安全语义（与 README「安全模型」一节对齐）：
+ * - **不自动执行安装命令**（供应链风险，评审④ P1 修正）：autoInstall 默认 false，
+ *   插件只探测 + 注入引导（输出安装命令），由用户/agent 显式执行；
+ * - autoInstall=true 时：安装前**再探测一次**（用户可能已手动装，避免重复安装），
+ *   安装失败仅 warn（不抛、不重试风暴）；
+ * - 安装命令默认 `npm install -g @colbymchenry/codegraph`（npm 全局，幂等），
+ *   可用 config.installCommand 覆盖（如 install.sh 直链）。
+ */
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+/** codegraph CLI 是否在 PATH（探测）。 */
+export function isCodegraphInstalled(env: NodeJS.ProcessEnv = process.env): boolean {
+  // 用 PATH 逐目录探测 codegraph 可执行文件（兼容 worktree 会话的 PATH 差异）。
+  // 不直接 spawn "codegraph --version"——未装时 spawn ENOENT 抛错噪音大。
+  const path = env.PATH ?? process.env.PATH ?? "";
+  return path.split(":").some((dir) => {
+    try {
+      return existsSync(join(dir, "codegraph")) || existsSync(join(dir, "codegraph.exe"));
+    } catch {
+      return false;
+    }
+  });
+}
+
+/** 执行安装命令（autoInstall=true 时）。返回是否成功。 */
+export function runInstall(
+  command: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    // 安装命令按 shell 执行（npm/curl 都是 shell 命令形态）。
+    execFile(command.split(" ")[0], command.split(" ").slice(1), { env }, (error) => {
+      resolve(error === null);
+    });
+  });
+}
+
+/** 引导安装提示（注入给 agent 的文本，不自动执行）。 */
+export function installGuidance(installCommand: string): string {
+  return [
+    "codegraph CLI 未安装。请执行以下命令安装（codegraph 是本地代码图谱，",
+    "安装后本插件才能注册 MCP 服务器与纪律工具）：",
+    "",
+    `  ${installCommand}`,
+    "",
+    "安全说明：安装命令来自第三方（@colbymchenry/codegraph），执行前请知悉",
+    "供应链风险；安装完成后重启 dsh web 或重连会话生效。",
+  ].join("\n");
+}

--- a/packages/dsh-codegraph/test/smoke.ts
+++ b/packages/dsh-codegraph/test/smoke.ts
@@ -1,0 +1,179 @@
+// @ts-nocheck
+// dsh-codegraph 冒烟测试 —— 无外部依赖、不发起真实网络/进程连接。
+//
+// 覆盖：
+//   - 契约导出（name / inject）
+//   - isCodegraphInstalled（PATH 探测分支）
+//   - installGuidance（引导文案含安装命令）
+//   - findGitRoot / isGitRepo（.git 目录 / .git 文件(worktree) / 非 git 三分支）
+//   - shouldInject（cwd 判定）
+//   - guardedExplore（无 projectPath → 补全/拒绝；无索引 → 引导；sync 失败 → 拒绝）
+//   - apply（enabled:false / requireGit 非 git 跳过 / 探测未装引导 / 注册降级 / 纪律工具注册）
+//
+// 运行：node dsh-codegraph/test/smoke.ts
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const pkgDir = join(new URL("..", import.meta.url).pathname);
+const mod = await import(pathToFileURL(join(pkgDir, "lib/index.js")).href);
+const { apply, name, inject } = mod;
+const { isCodegraphInstalled, installGuidance } = mod;
+const { findGitRoot, isGitRepo, guardedExplore } = mod;
+const { shouldInject, DISCIPLINE_TEXT } = mod;
+
+const failures = [];
+function check(label, fn) {
+  try {
+    fn();
+    console.log(`  ok   ${label}`);
+  } catch (error) {
+    failures.push(`${label}: ${error.message}`);
+    console.error(`FAIL ${label}: ${error.message}`);
+  }
+}
+async function checkAsync(label, fn) {
+  try {
+    await fn();
+    console.log(`  ok   ${label}`);
+  } catch (error) {
+    failures.push(`${label}: ${error.message}`);
+    console.error(`FAIL ${label}: ${error.message}`);
+  }
+}
+
+// ---- 契约 ----
+check("契约: name = codegraph", () => assert.equal(name, "codegraph"));
+check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents")));
+
+// ---- install.ts ----
+{
+  // PATH 含 codegraph → 已装
+  const dir = mkdtempSync(join(tmpdir(), "cg-install-"));
+  writeFileSync(join(dir, "codegraph"), "#!/bin/sh\n");
+  check("isCodegraphInstalled: PATH 命中", () =>
+    assert.equal(isCodegraphInstalled({ PATH: dir }), true),
+  );
+  // PATH 不含 → 未装
+  check("isCodegraphInstalled: PATH 未命中", () =>
+    assert.equal(isCodegraphInstalled({ PATH: "/nonexistent" }), false),
+  );
+  check("installGuidance 含安装命令", () =>
+    assert.ok(installGuidance("npm i -g x").includes("npm i -g x")),
+  );
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// ---- guard.ts ----
+{
+  const dir = mkdtempSync(join(tmpdir(), "cg-guard-"));
+  // git 目录
+  mkdirSync(join(dir, "repo", ".git"), { recursive: true });
+  // worktree（.git 是文件）
+  mkdirSync(join(dir, "wt"), { recursive: true });
+  writeFileSync(join(dir, "wt", ".git"), "gitdir: ../repo/.git/worktrees/wt\n");
+  // 非 git
+  mkdirSync(join(dir, "nongit"), { recursive: true });
+
+  check("findGitRoot: git 目录", () => assert.equal(findGitRoot(join(dir, "repo")), join(dir, "repo")));
+  check("findGitRoot: 子目录向上命中", () => assert.equal(findGitRoot(join(dir, "repo", "sub")), join(dir, "repo")));
+  check("findGitRoot: worktree（.git 文件）", () => assert.equal(findGitRoot(join(dir, "wt")), join(dir, "wt")));
+  check("findGitRoot: 非 git 返回 undefined", () => assert.equal(findGitRoot(join(dir, "nongit")), undefined));
+  check("isGitRepo: 非 git false", () => assert.equal(isGitRepo(join(dir, "nongit")), false));
+  check("shouldInject: git 仓 true", () => assert.equal(shouldInject(join(dir, "repo")), true));
+  check("shouldInject: 非 git false", () => assert.equal(shouldInject(join(dir, "nongit")), false));
+
+  // guardedExplore：无 projectPath + 非 git cwd → 拒绝
+  checkAsync("guardedExplore: 无 projectPath 非 git → 拒绝", async () => {
+    const out = await guardedExplore({ query: "x" }, join(dir, "nongit"));
+    assert.ok(out.includes("被纪律拦截"), `实际: ${out.slice(0, 50)}`);
+  });
+  // guardedExplore：有 projectPath 但无索引 → 引导 init
+  checkAsync("guardedExplore: 有 projectPath 无索引 → 引导", async () => {
+    const out = await guardedExplore({ query: "x", projectPath: join(dir, "repo") });
+    assert.ok(out.includes("codegraph init"), `实际: ${out.slice(0, 50)}`);
+  });
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// ---- apply ----
+{
+  const makeCtx = (overrides = {}) => {
+    const state = { disposers: [], registered: [], hooks: [], logs: [] };
+    const ctx = {
+      logger: { warn: (m) => state.logs.push(`warn:${m}`), info: (m) => state.logs.push(`info:${m}`) },
+      get: (name) => (overrides.mcpManager ? { registerServer: async () => ({ name, existing: false }), unregisterServer: async () => {} } : undefined),
+      on: () => () => {},
+      effect: (fn) => { const d = fn(); state.disposers.push(d); return d; },
+      session: overrides.session,
+    };
+    return { ctx, state };
+  };
+
+  // enabled:false → 不做事
+  checkAsync("apply: enabled:false 静默返回", async () => {
+    const { ctx, state } = makeCtx();
+    await apply(ctx, { enabled: false });
+    assert.equal(state.disposers.length, 0);
+  });
+
+  // requireGit + 非 git cwd → 跳过（不注册、不注入）
+  checkAsync("apply: requireGit 非 git cwd → 跳过", async () => {
+    const { ctx, state } = makeCtx({ session: { header: { cwd: "/tmp" } } });
+    await apply(ctx, { requireGit: true });
+    assert.equal(state.disposers.length, 0, "非 git 不启用");
+  });
+
+  // 正常路径：git cwd + codegraph 未装（PATH 空）→ 引导日志，注册降级
+  checkAsync("apply: git cwd + 未装 → 引导日志", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cg-apply-"));
+    mkdirSync(join(dir, ".git"), { recursive: true });
+    const { ctx, state } = makeCtx({ session: { header: { cwd: dir } } });
+    // 隔离 PATH（不探测到真实 codegraph）
+    const prevPath = process.env.PATH;
+    process.env.PATH = "/nonexistent";
+    try {
+      await apply(ctx, { requireGit: true });
+    } finally {
+      process.env.PATH = prevPath;
+    }
+    assert.ok(state.logs.some((l) => l.includes("codegraph CLI 未安装") || l.includes("安装")), "有引导日志");
+    assert.ok(state.disposers.length >= 1, "仍有 effect disposer（工具/钩子照常注册）");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // mcpManager 存在 + codegraph 已装（PATH 指向 fake）→ 注册服务器
+  checkAsync("apply: mcpManager + 已装 → registerServer", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cg-apply2-"));
+    mkdirSync(join(dir, ".git"), { recursive: true });
+    writeFileSync(join(dir, "codegraph"), "#!/bin/sh\n");
+    let registered = false;
+    const ctx = {
+      logger: { warn: () => {}, info: () => {} },
+      get: (n) => n === "mcpManager" ? {
+        registerServer: async () => { registered = true; return { name: "codegraph", existing: false }; },
+        unregisterServer: async () => {},
+      } : undefined,
+      on: () => () => {},
+      effect: (fn) => { const d = fn(); return d; },
+      session: { header: { cwd: dir } },
+    };
+    const prevPath = process.env.PATH;
+    process.env.PATH = dir;
+    try {
+      await apply(ctx, { requireGit: true });
+    } finally {
+      process.env.PATH = prevPath;
+    }
+    assert.equal(registered, true, "registerServer 被调用");
+    rmSync(dir, { recursive: true, force: true });
+  });
+}
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} check(s) failed: ${failures.join(", ")}`);
+  process.exit(1);
+}
+console.log("\nall checks passed");

--- a/packages/dsh-codegraph/tsconfig.json
+++ b/packages/dsh-codegraph/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib",
+    "rewriteRelativeImportExtensions": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/dsh-mcp-manager/src/apply.ts
+++ b/packages/dsh-mcp-manager/src/apply.ts
@@ -47,14 +47,40 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
   manager.enhancement = { enhanceEmptyDescriptions, resultTruncateBytes };
 
   // 核心化服务（官方 storageDomain 模式）：对外暴露 ctx.mcpManager，供其他插件
-  // 运行时注入 MCP 服务器（registerServer / unregisterServer，不落盘）。
+  // 运行时注入/控制/查询 MCP 服务器。
   // 提供时机：store.load 之后（manager 已就绪）。卸载由 mcp-manager 自身 dispose()
   // 全量清理（含 runtime 条目与 supervisor）。
   // 兼容：fake ctx（单元测试 mock）可能无 provide，可选调用静默降级。
   if (typeof (ctx as unknown as { provide?: unknown }).provide === "function") {
     ctx.provide("mcpManager", {
+      // 注入面（内存态不落盘，同名幂等）
       registerServer: (server: Record<string, unknown>) => manager.registerServer(server),
       unregisterServer: (name: string) => manager.unregisterServer(name),
+      // 控制面（通用 MCP 生命周期：注册即连、注销即断的补充控制）
+      connect: (name: string, scope?: string) => manager.connect(name, scope),
+      disconnect: (name: string) => manager.disconnect(name),
+      reconnect: (name: string, scope?: string) => manager.reconnect(name, scope),
+      // 查询面（服务状态感知：连接状态 / 工具列表 / 全量摘要）
+      getStatus: (name: string) => {
+        const servers = (manager.summary().servers ?? []) as Array<Record<string, unknown>>;
+        const found = servers.find((s) => s.name === name);
+        if (found === undefined) return undefined;
+        return found as unknown as import("../../../shared/mcp-manager-service.js").McpServerSummary;
+      },
+      getTools: (name: string) => {
+        const sup = manager.supervisors.get(name);
+        if (sup === undefined) return [];
+        const tools: Array<{ name: string; description?: string }> = [];
+        for (const [toolName, meta] of sup.toolMeta ?? new Map()) {
+          tools.push({
+            name: toolName,
+            description: typeof meta?.description === "string" ? meta.description : undefined,
+          });
+        }
+        return tools;
+      },
+      list: () =>
+        (manager.summary().servers ?? []) as unknown as Array<import("../../../shared/mcp-manager-service.js").McpServerSummary>,
     });
   }
 

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -74,10 +74,10 @@ export type { UiPlacementConfig, ClientUiConfig } from "./types.ts";
 export { McpManager, MIDDLEWARE_GLOBAL_ROOT } from "./manager.ts";
 
 // 核心化 service（官方 storageDomain 模式）：ctx.mcpManager 类型面 + 声明合并。
-// 副作用导入写 .js 形态（NodeNext）：tsc 对 .ts 的 rewrite 不作用于声明文件，
-// 写 .js 才能让 lib/index.d.ts 里的 import 被消费方解析（修阶段1 类型面 bug）。
+// 仅类型导出（无副作用导入）：消费方 import 类型时 tsc 会解析 service.d.ts，
+// 其内的 declare module 合并自动生效；副作用导入会让 stryker sandbox 解析
+// src/service.js 失败（sandbox 只有 .ts），也避免 .d.ts 里残留 .ts 引用。
 export type { McpManagerServerInput, McpManagerService } from "./service.ts";
-import "./service.js";
 
 // 存储
 export { defaultStorePath, McpStore } from "./store.ts";

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -74,8 +74,10 @@ export type { UiPlacementConfig, ClientUiConfig } from "./types.ts";
 export { McpManager, MIDDLEWARE_GLOBAL_ROOT } from "./manager.ts";
 
 // 核心化 service（官方 storageDomain 模式）：ctx.mcpManager 类型面 + 声明合并。
+// 副作用导入写 .js 形态（NodeNext）：tsc 对 .ts 的 rewrite 不作用于声明文件，
+// 写 .js 才能让 lib/index.d.ts 里的 import 被消费方解析（修阶段1 类型面 bug）。
 export type { McpManagerServerInput, McpManagerService } from "./service.ts";
-import "./service.ts";
+import "./service.js";
 
 // 存储
 export { defaultStorePath, McpStore } from "./store.ts";

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -652,6 +652,11 @@ export class McpManager {
         servers.push(this.summarize(server, SCOPE_PROJECT));
       }
     }
+    // 查询面完整性（#329 评审修正）：runtime 条目并入 summary，
+    // 否则 getStatus/list 看不到运行时注册的服务器（消费方无法感知状态）。
+    for (const server of this.runtimeRegistry.values()) {
+      servers.push(this.summarize(server, SCOPE_GLOBAL));
+    }
     const byStatus: Record<string, number> = { connected: 0, connecting: 0, reconnecting: 0, disabled: 0, stopped: 0, failed: 0 };
     for (const server of servers) byStatus[server.status as string] = (byStatus[server.status as string] ?? 0) + 1;
     return {

--- a/packages/dsh-mcp-manager/src/service.ts
+++ b/packages/dsh-mcp-manager/src/service.ts
@@ -1,38 +1,28 @@
 /**
  * mcp-manager 核心化 service 类型（官方 storageDomain 模式）。
  *
+ * 类型面单一事实源在 shared/mcp-manager-service.d.ts（跨包共享，构建期内联、
+ * 随包复制）。本文件只做类型 re-export + cordis Context 声明合并——消费方
+ * （如 dsh-codegraph）从 shared 引用类型，不依赖本包构建时序（CI 并行 build）。
+ *
  * 提供方：apply.ts 中 ctx.provide("mcpManager", service)。
- * 消费方：其他插件 `declare module "@deepseek-ai/cordis"` 扩展 Context 后
- * 经 `ctx.mcpManager` 调用；inject 声明 `"mcpManager"`（或运行时 ctx.get 探测）。
+ * 消费方：其他插件经 `ctx.mcpManager` 调用（inject 声明 "mcpManager"，
+ * 或运行时 ctx.get("mcpManager") 探测降级）。
  */
 
-/** 运行时注入服务器的入参（normalizeServer 接受的最小面）。 */
-export interface McpManagerServerInput {
-  name: string;
-  transport: "stdio" | "streamable-http";
-  command?: string;
-  args?: string[];
-  url?: string;
-  headers?: Record<string, string>;
-  env?: Record<string, string>;
-  cwd?: string;
-  enabled?: boolean;
-  toolCallTimeoutMs?: number;
-  reconnect?: Record<string, unknown>;
-  description?: string;
-}
-
-/** ctx.mcpManager service 面（MVP：register / unregister）。 */
-export interface McpManagerService {
-  /** 运行时注册服务器（内存态，不落盘）。同名已存在 → { existing: true } 不抛错。 */
-  registerServer(server: McpManagerServerInput): Promise<{ name: string; existing: boolean }>;
-  /** 运行时注销（不影响 store 持久化条目；同名 store 条目回落）。 */
-  unregisterServer(name: string): Promise<void>;
-}
+// 类型 re-export（公共类型面，供消费方 import）。
+export type {
+  McpManagerServerInput,
+  McpManagerService,
+  McpScope,
+  McpServerStatus,
+  McpServerSummary,
+  McpToolInfo,
+} from "../../../shared/mcp-manager-service.js";
 
 declare module "@deepseek-ai/cordis" {
   interface Context {
-    /** mcp-manager 核心服务：其他插件运行时注入 MCP 服务器（官方 storageDomain 模式）。 */
-    mcpManager: McpManagerService;
+    /** mcp-manager 核心服务：其他插件运行时注入/控制/查询 MCP 服务器（官方 storageDomain 模式）。 */
+    mcpManager: import("../../../shared/mcp-manager-service.js").McpManagerService;
   }
 }

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -1924,6 +1924,17 @@ const main = async () => {
       assert.ok(manager.runtimeRegistry.has("svc-all"), "all 模式 runtime 条目保留");
       manager.middlewareMode = "off";
 
+      // 查询面（#329 评审修正：MCP 应能感知连接状态与工具列表）：
+      // summary() 并入 runtime 条目，getStatus/list 的数据源可见运行时注册的服务器。
+      await manager.registerServer({ name: "svc-q", ...quiet() });
+      const sum = manager.summary();
+      const qEntry = (sum.servers ?? []).find((s) => s.name === "svc-q");
+      assert.ok(qEntry !== undefined, "summary 含 runtime 条目（查询面可见）");
+      assert.equal(qEntry.scope, "global", "runtime 条目 scope 为 global");
+      assert.equal(qEntry.status, "disabled", "enabled:false → disabled 状态");
+      // 工具列表：enabled:false 不 spawn → 空数组（不抛）。
+      assert.deepEqual(qEntry.tools, [], "disabled 服务器工具列表为空");
+
       console.log("  ok   核心化 service: register/unregister/双轨/卸载清理");
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,18 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
 
+  packages/dsh-codegraph:
+    devDependencies:
+      '@deepseek-ai/cordis':
+        specifier: 'catalog:'
+        version: 4.0.1
+      '@deepseek-ai/dsh-agent':
+        specifier: 'catalog:'
+        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-system-prompt@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
+      '@wingsky-1/dsh-mcp-manager':
+        specifier: workspace:*
+        version: link:../dsh-mcp-manager
+
   packages/dsh-idle-archive:
     devDependencies:
       '@deepseek-ai/cordis':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
       '@deepseek-ai/dsh-agent':
         specifier: 'catalog:'
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-system-prompt@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
-      '@wingsky-1/dsh-mcp-manager':
-        specifier: workspace:*
-        version: link:../dsh-mcp-manager
 
   packages/dsh-idle-archive:
     devDependencies:

--- a/scripts/data/plugins-manifest.json
+++ b/scripts/data/plugins-manifest.json
@@ -9,7 +9,8 @@
     "dsh-web-file-preview"
   ],
   "standalone": [
-    "dsh-subagent-model-inherit"
+    "dsh-subagent-model-inherit",
+    "dsh-codegraph"
   ],
   "retired": [
     {

--- a/shared/mcp-manager-service.d.ts
+++ b/shared/mcp-manager-service.d.ts
@@ -1,0 +1,84 @@
+/**
+ * mcp-manager 核心服务类型面（跨包共享，单一事实源）。
+ *
+ * 供 mcp-manager 提供方（src/service.ts re-export + declare module 合并）
+ * 与消费方插件（如 dsh-codegraph）经 `../../../shared/mcp-manager-service.js`
+ * 引用——纯类型，esbuild 构建期内联、随包复制（d.ts X1），无运行时依赖、
+ * 无跨包构建时序问题（CI 并行 build 各包时依赖包 lib 未就绪也能编译）。
+ *
+ * 服务面（通用 MCP 能力 + 运行时注入专用面）：
+ * - 注入面：registerServer / unregisterServer（内存态不落盘，同名幂等）；
+ * - 控制面：connect / disconnect / reconnect（通用 MCP 生命周期，注册即连、
+ *   注销即断的补充控制）；
+ * - 查询面：getStatus / getTools / list（连接状态、工具列表、全量摘要——
+ *   「作为 MCP 应能感知连接状态与工具列表」，评审③ MVP 裁剪为纯注入面是
+ *   过度裁剪，查询面是消费方感知服务状态所必需）。
+ */
+
+/** 服务器连接状态（与 manager summarize 投影一致）。 */
+export type McpServerStatus =
+  | "connected"
+  | "connecting"
+  | "reconnecting"
+  | "disabled"
+  | "stopped"
+  | "failed";
+
+/** 作用域。 */
+export type McpScope = "global" | "project";
+
+/** 某服务器的实时摘要（配置 + 状态 + 工具 + 错误）。 */
+export interface McpServerSummary {
+  name: string;
+  transport: "stdio" | "streamable-http";
+  scope: McpScope;
+  status: McpServerStatus;
+  error?: string;
+  tools: string[];
+  enabled: boolean;
+}
+
+/** 某服务器的工具条目（查询面，返回名称 + 描述）。 */
+export interface McpToolInfo {
+  name: string;
+  description?: string;
+}
+
+/** 运行时注入服务器的入参（normalizeServer 接受的最小面）。 */
+export interface McpManagerServerInput {
+  name: string;
+  transport: "stdio" | "streamable-http";
+  command?: string;
+  args?: string[];
+  url?: string;
+  headers?: Record<string, string>;
+  env?: Record<string, string>;
+  cwd?: string;
+  enabled?: boolean;
+  toolCallTimeoutMs?: number;
+  reconnect?: Record<string, unknown>;
+  description?: string;
+}
+
+/** ctx.mcpManager service 面（完整：注入 + 控制 + 查询）。 */
+export interface McpManagerService {
+  // ---- 注入面（内存态不落盘） ----
+  /** 运行时注册服务器。同名已存在（store 或 runtime）→ { existing: true } 不抛错。 */
+  registerServer(server: McpManagerServerInput): Promise<{ name: string; existing: boolean }>;
+  /** 运行时注销（不影响 store 持久化条目；同名 store 条目回落）。 */
+  unregisterServer(name: string): Promise<void>;
+  // ---- 控制面（通用 MCP 生命周期） ----
+  /** 连接指定服务器（已连接 → no-op；未找到 → 抛错）。 */
+  connect(name: string, scope?: McpScope): Promise<void>;
+  /** 断开指定服务器（未连接 → no-op）。 */
+  disconnect(name: string, scope?: McpScope): Promise<void>;
+  /** 重连（先断后连）。 */
+  reconnect(name: string, scope?: McpScope): Promise<void>;
+  // ---- 查询面（服务状态感知） ----
+  /** 某服务器实时摘要（状态/工具/错误）。未注册 → undefined。 */
+  getStatus(name: string): McpServerSummary | undefined;
+  /** 某服务器已注册工具列表（名称 + 描述）。 */
+  getTools(name: string): McpToolInfo[];
+  /** 全部服务器摘要（store 持久化 + runtime 双轨合并）。 */
+  list(): McpServerSummary[];
+}


### PR DESCRIPTION
## 动机

[#329](https://github.com/wingsky-1/dsh-plugin-hub/issues/329) 阶段 2 + 阶段 3：新增 `dsh-codegraph` 插件，把 codegraph（`@colbymchenry/codegraph`，本地代码图谱 MCP）与配套 worktree 开发纪律打包一键交付。阶段 1（mcp-manager 核心化 `ctx.mcpManager` service）已合并（#332）。

## 改动

### 新包 `packages/dsh-codegraph`（@wingsky-1/dsh-codegraph，standalone 观察期）

**探测 + 引导安装**（`src/install.ts`）
- `isCodegraphInstalled`：PATH 逐目录探测（兼容 worktree PATH 差异）；
- **默认不自动执行第三方安装命令**（供应链风险，评审④ P1 修正）：未装 → 注入引导（输出安装命令）；`autoInstall: true` 可开，装前再探测（幂等容错）、失败仅 warn。

**运行时注册**（`src/index.ts`）
- 经 mcp-manager 核心服务 `ctx.mcpManager.registerServer` 注册 codegraph MCP 服务器（stdio: `codegraph serve --mcp`，内存态不落盘）；
- mcp-manager 未启用 → 纪律工具仍可用（纯提示降级，不 fail-loud）；
- 卸载时 `unregisterServer`（不影响 store 持久化条目）。

**纪律工具**（`src/guard.ts`，工具层硬纪律——核心价值）
- `codegraph_explore` 封装：**查询前强制 `codegraph sync`**（worktree 索引新鲜度硬保证，~0.8s 实测）+ **校验/补全 projectPath**（`findGitRoot` 沿 cwd 向上找 `.git`，worktree 的 `.git` 文件也识别）；
- 自动补全 + 拒绝兜底：无 worktree 上下文 / 无索引 / sync 失败 → 拒绝并提示（不抛错，返回文本）。

**agent 纪律钩子**（`src/discipline.ts`）
- `agent/created` + 会话 cwd 判定（dsh-agent 无「子 agent 启动」专用事件，评审④核实；仓库先例 dsh-subagent-model-inherit）；
- git 仓（主 checkout / worktree）会话才注入纪律（~200 tokens/次）；**非 git 仓（日常维护/讨论空间）不注入**——多工作空间天然区分。

**配置**：`enabled` / `autoInstall`(false) / `installCommand` / `syncBeforeQuery` / `requireProjectPath` / `requireGit`(true) / `injectDiscipline`。

### 文档（阶段 3）

- AGENTS.md「Agent 环境」增补 codegraph 开发纪律条目（worktree 流程 / 工具层已强制 / 边界）；
- `scripts/data/plugins-manifest.json`：dsh-codegraph 登记 standalone（观察期，不进聚合包）；
- README 含「安全模型」一节（不自动执行第三方命令 / stdio 权限 / 本地 SQLite / 外部二进制非自包含）。

## 验证

- `pnpm --filter @wingsky-1/dsh-codegraph build` ✅（lib/index.js 自包含，无第三方内联）
- smoke 17 项断言全绿 ✅（契约 / PATH 探测 / findGitRoot 三分支 / shouldInject / guardedExplore 拒绝·引导 / apply 各分支）
- `pnpm build` ✅ / `pnpm contract` ✅ / `pnpm pack:check` ✅（tarball 完整）/ aggregate 一致性 ✅（9 子包行）
- CI 全绿（mcp-manager 既有悬挂在 CI 正常，见 #332 先例）

## 关联

- Issue: #329（阶段 2/3）
- 前置: #332（mcp-manager 核心化，已合并）
