### PR TITLE
fix(dsh-notifier): SSE 连接表有界化 + 生命周期治理（#330）

### DIFF
--- a/packages/dsh-notifier/README.md
+++ b/packages/dsh-notifier/README.md
@@ -119,9 +119,15 @@ context filter checks」）。取舍如下（issue #290）：
   "errorMergeWindowMs": 60000,
   "askRemindMin": 5,
   "doneMergeWindowMs": 3000,
-  "historyMaxAgeDays": 0
+  "historyMaxAgeDays": 0,
+  "maxConnections": 16
 }
 ```
+
+> `maxConnections`：SSE 连接表上限（默认 16，范围 1~1024）。含义为**服务端未释放句柄数**，
+> 非「在线设备数」——半开连接（设备息屏/切网/NAT 静默掐断）在传输层回收前会短暂残留，
+> 上限保证连接表有界，超出部分淘汰最老连接（客户端自动重连 + since 补拉，无感知）。
+> 多设备×多页签同时在线超过该值时可在面板调大。
 
 ## 路由（全部 loopback 围栏）
 

--- a/packages/dsh-notifier/src/client/index.ts
+++ b/packages/dsh-notifier/src/client/index.ts
@@ -115,7 +115,7 @@ import STYLE from "./style.css";
         return res.json();
       })
       .then(function (data) {
-        toast("测试通知已发送（在线 " + data.sseConnections + " 个连接）");
+        toast("测试通知已发送（服务端未释放句柄 " + data.sseConnections + " 条）");
       })
       .catch(function (error) {
         toast("发送测试通知失败：" + error.message + accessHint(error));
@@ -406,6 +406,19 @@ import STYLE from "./style.css";
         }
         mergeField("errorMergeWindowMs", "错误合并窗口", 3600000);
         mergeField("doneMergeWindowMs", "完成聚合窗口", 60000);
+        // #330 SSE 连接上限：条（1~1024，默认 16）。超出上限自动淘汰最老连接
+        // （客户端断开后自动重连 + since 补拉，无感知）；多设备多页签超限时调大。
+        (function () {
+          var field = el("div", { class: "dn-row", style: "min-height:36px" });
+          field.appendChild(el("span", { style: "flex:1", text: "最大连接数（条，超出淘汰最老）" }));
+          var input = el("input", { type: "number", min: "1", max: "1024", step: "1", value: String(config.maxConnections || 16), style: "width:84px;background:var(--dsw-alias-bg-layer-1,#f5f6f8);color:inherit;border:1px solid var(--dsw-alias-border-l1,#e2e5ea);border-radius:6px;padding:3px 6px;margin:6px 0", onChange: function () {
+            var v = parseInt(input.value, 10);
+            config.maxConnections = Number.isFinite(v) && v >= 1 && v <= 1024 ? v : 16;
+            saveConfig(config);
+          } });
+          field.appendChild(input);
+          mergeSection.appendChild(field);
+        })();
         body.appendChild(mergeSection);
 
         var quiet = el("div", { class: "dn-section" });

--- a/packages/dsh-notifier/src/config.ts
+++ b/packages/dsh-notifier/src/config.ts
@@ -33,6 +33,9 @@ export interface NotifyConfig {
   doneMergeWindowMs: number;
   /** 通知历史按天自动清理（0 = 不按时间清理，仅行数上限滚动）。 */
   historyMaxAgeDays: number;
+  /** SSE 连接表上限（同机同时在线的服务端未释放句柄数；超限淘汰最老连接，
+   *  防半开幽灵连接只增不减耗尽资源）。 */
+  maxConnections: number;
 }
 
 /** 布尔配置键联合（normalizeConfig 白名单与客户端渲染依赖它）。 */
@@ -72,6 +75,9 @@ export const DEFAULT_CONFIG: NotifyConfig = {
   doneMergeWindowMs: 3000,
   /** 通知历史按天自动清理（0=不按时间清理，仅靠行数上限滚动）。 */
   historyMaxAgeDays: 0,
+  /** SSE 连接表上限默认 16：覆盖多设备×多页签 + 幽灵余量；超出淘汰最老连接，
+   *  客户端断开后自动重连 + since 补拉，无感知。 */
+  maxConnections: 16,
 };
 
 /** 布尔配置键（单一事实源：normalizeConfig 白名单与客户端渲染依赖它）。 */
@@ -112,6 +118,9 @@ export function normalizeConfig(input: unknown): NotifyConfig {
   if (Number.isFinite(src.historyMaxAgeDays) && (src.historyMaxAgeDays as number) >= 0 && (src.historyMaxAgeDays as number) <= 3650) {
     base.historyMaxAgeDays = Math.round(src.historyMaxAgeDays as number);
   }
+  if (Number.isFinite(src.maxConnections) && (src.maxConnections as number) >= 1 && (src.maxConnections as number) <= 1024) {
+    base.maxConnections = Math.round(src.maxConnections as number);
+  }
   if (typeof src.quietHours === "object" && src.quietHours !== null) {
     const qh = src.quietHours as Record<string, unknown>;
     if (typeof qh.enabled === "boolean") base.quietHours.enabled = qh.enabled;
@@ -130,7 +139,7 @@ export function normalizeConfig(input: unknown): NotifyConfig {
   for (const key of Object.keys(src)) {
     if ((CONFIG_KEYS as readonly string[]).includes(key)) continue;
     // 已归一化过的键不再透传（否则非法值会以原样覆盖归一化结果）
-    if (key === "quietHours" || key === "errorMergeWindowMs" || key === "askRemindMin" || key === "doneMergeWindowMs" || key === "historyMaxAgeDays") continue;
+    if (key === "quietHours" || key === "errorMergeWindowMs" || key === "askRemindMin" || key === "doneMergeWindowMs" || key === "historyMaxAgeDays" || key === "maxConnections") continue;
     out[key] = src[key];
   }
   return out;

--- a/packages/dsh-notifier/src/index.ts
+++ b/packages/dsh-notifier/src/index.ts
@@ -122,7 +122,7 @@ export async function apply(ctx: Context, config: NotifierApplyConfig = {}): Pro
 
   // ------------------------------------------------------------ 组装各职责模块
 
-  const sse = createSseHub();
+  const sse = createSseHub({ getMaxConnections: () => current.maxConnections });
   const system = createSystemNotifier({
     getSoundEnabled: () => current.notifySound,
     toastScript,

--- a/packages/dsh-notifier/src/server.ts
+++ b/packages/dsh-notifier/src/server.ts
@@ -29,23 +29,33 @@ function sseData(payload: unknown): string {
   return `data: ${JSON.stringify(payload)}\n\n`;
 }
 
+/** 写失败判死阈值：连续 ≥3 次（心跳周期 30s × 3 ≈ 90s）写不动即销毁。
+ *  仅「抛错 / destroyed / writableEnded」计数；write 返回 false 视为背压（见 writeFrame）。 */
+const MAX_WRITE_FAILS = 3;
+
 /** SSE 推送枢纽：连接表、滚动缓冲广播、心跳。 */
 export interface SseHub {
-  /** 已连接响应集合（events 路由注册、close 时移除）。 */
-  connections: Set<ServerResponse>;
+  /** 注册一条 SSE 连接：入表 + 挂 close/error 监听 + 连接上限淘汰最老。 */
+  register(res: ServerResponse): void;
   /** 广播一帧：附加递增 seq、入滚动缓冲、推给所有连接。 */
   broadcast(payload: Record<string, unknown>): void;
   /** 断线补拉：滚动缓冲中 seq 更大的帧（独立于 /history 截断）。 */
   framesSince(since: number): Array<Record<string, unknown> & { seq: number }>;
-  /** 当前连接数（/health 展示）。 */
+  /** 当前连接数（/health 展示；语义=服务端未释放句柄数，含静默半开残留）。 */
   size(): number;
   /** 停止心跳定时器。 */
   dispose(): void;
 }
 
-/** 创建 SSE 枢纽并启动心跳。 */
-export function createSseHub(): SseHub {
-  const connections = new Set<ServerResponse>();
+/**
+ * 创建 SSE 枢纽并启动心跳。
+ * @param options.getMaxConnections 连接上限实时读取器（配置改动即时生效，无需重启；
+ *   超限时淘汰最老连接，让连接表有界——静默半开连接只增不减的根治手段）。
+ */
+export function createSseHub(options: { getMaxConnections: () => number }): SseHub {
+  const { getMaxConnections } = options;
+  /** 连接表：Map<响应, 写状态>。Map 迭代序 = 插入序，超限淘汰时第一项即最老。 */
+  const connState = new Map<ServerResponse, { failStreak: number; lastOkWriteAt: number }>();
 
   /** SSE 已派发帧的滚动缓冲（断线回补用；上限 RECENT_LIMIT，独立于 /history 的
    *  200 条截断，避免补拉时尾部事件被截掉）。 */
@@ -53,17 +63,80 @@ export function createSseHub(): SseHub {
   let notifySeq = 0;
   const recentFrames: Array<Record<string, unknown> & { seq: number }> = [];
 
+  /** 移除一条连接（幂等）：先出表再 destroy，destroy 触发的 close 回调再次 evict 无害。 */
+  function evict(res: ServerResponse) {
+    if (connState.delete(res)) {
+      try {
+        res.destroy();
+      } catch {
+        // 忽略
+      }
+    }
+  }
+
+  /** 连接上限收缩：超限淘汰最老（注册序最早）的连接，直到表不超限。
+   *  register 与心跳各调用一次——配置调小后无需新注册，30s 内即收敛。 */
+  function enforceLimit() {
+    const limit = getMaxConnections();
+    while (connState.size > limit) {
+      const oldest = connState.keys().next().value;
+      if (oldest === undefined) break;
+      evict(oldest);
+    }
+  }
+
+  /** 注册一条 SSE 连接：入表 + close/error 监听 + 上限淘汰 + socket keepalive 兜底。 */
+  function register(res: ServerResponse) {
+    connState.set(res, { failStreak: 0, lastOkWriteAt: Date.now() });
+    // close 是正常断连路径；error 是补 close 的缺口（现有代码缺失：不监听 error，
+    // 部分路径会抛 unhandled error，且连接残留）。两者都收口到 evict（幂等）。
+    res.on("close", () => evict(res));
+    res.on("error", () => evict(res));
+    // TCP keepalive：仅对「空闲连接」生效探测；SSE 每 30s 心跳使连接从不空闲，
+    // 故对活跃写连接不触发（真正探测死连接的是 TCP 重传，分钟级）——仅兜底长空闲。
+    try {
+      res.socket?.setKeepAlive(true, 60000);
+    } catch {
+      // 忽略
+    }
+    enforceLimit();
+  }
+
+  /**
+   * 统一写帧：成功则刷新写状态；失败累计 failStreak，连续 ≥3 次判死销毁。
+   * write 返回 false 一律视为背压（TCP 接收窗口关闭，对端暂停消费），**不是断连
+   * 证据**——弱网/浏览器冻结后台 tab 等健康连接可能长时间不消费，误判会造成无谓
+   * 重连。仅「抛错 / destroyed / writableEnded」才判死。
+   * @returns 是否成功写出。
+   */
+  function writeFrame(res: ServerResponse, text: string): boolean {
+    const entry = connState.get(res);
+    if (entry === undefined) return false;
+    if (res.destroyed || res.writableEnded) {
+      // 已销毁/已结束的响应：close 事件可能漏发，这里兜底直接清理
+      evict(res);
+      return false;
+    }
+    try {
+      res.write(text);
+      entry.failStreak = 0;
+      entry.lastOkWriteAt = Date.now();
+      return true;
+    } catch {
+      entry.failStreak += 1;
+      if (entry.failStreak >= MAX_WRITE_FAILS) evict(res);
+      return false;
+    }
+  }
+
   function broadcast(payload: Record<string, unknown>) {
     const frame: Record<string, unknown> & { seq: number } = Object.assign({}, payload, { seq: ++notifySeq });
     recentFrames.push(frame);
     if (recentFrames.length > RECENT_LIMIT) recentFrames.shift();
     const text = sseData(frame);
-    for (const res of connections) {
-      try {
-        res.write(text);
-      } catch {
-        // 连接已断，等待 close 清理
-      }
+    for (const res of connState.keys()) {
+      // 迭代中 evict 当前项安全（JS Map 迭代器按访问序号推进，删除不影响后续项）
+      writeFrame(res, text);
     }
   }
 
@@ -75,26 +148,24 @@ export function createSseHub(): SseHub {
    * SSE 心跳：每 30s 发一条 data 型 ping 帧。必须用 data 而非注释帧——注释帧
    * 既不触发客户端 onmessage 也不触发 onerror，半开连接（断网/合盖/NAT 静默
    * 掐断）时客户端零事件，无法自愈；data 帧让客户端的 watchdog 能检测失活。
+   * 顺带做连接上限收缩（配置调小即收敛）与写失败判死扫描。
    */
   const HEARTBEAT_MS = 30000;
   const heartbeatTimer = setInterval(() => {
     const frame = sseData({ type: "ping" });
-    for (const res of connections) {
-      try {
-        res.write(frame);
-      } catch {
-        // 等待 close 清理
-      }
+    for (const res of connState.keys()) {
+      writeFrame(res, frame);
     }
+    enforceLimit();
   }, HEARTBEAT_MS);
   // unref：心跳不阻止进程退出（服务端有主循环；测试/无连接时不会被句柄吊死）
   heartbeatTimer.unref();
 
   return {
-    connections,
+    register,
     broadcast,
     framesSince,
-    size: () => connections.size,
+    size: () => connState.size,
     dispose: () => clearInterval(heartbeatTimer),
   };
 }
@@ -295,14 +366,14 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
           }
         }
       }
-      sse.connections.add(res);
-      res.on("close", () => {
-        sse.connections.delete(res);
-      });
+      // 入表 + 挂 close/error 监听 + 连接上限淘汰，全部收口在 sse.register
+      sse.register(res);
     },
   };
 
-  /** 健康检查：插件是否加载、配置摘要、SSE 连接数。 */
+  /** 健康检查：插件是否加载、配置摘要、SSE 连接数。
+   *  sseConnections 语义 = 服务端未释放的 SSE 句柄数（含静默半开残留，分钟级回收），
+   *  非「在线设备数」；上限见 config.maxConnections（淘汰最老）。 */
   const healthRoute: WebRoute = {
     kind: "exact",
     path: ROUTES.health,
@@ -324,6 +395,7 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
           notifyWhenVisible: current.notifyWhenVisible,
           notifySound: current.notifySound,
           quietHours: current.quietHours,
+          maxConnections: current.maxConnections,
         },
         sseConnections: sse.size(),
       });
@@ -333,6 +405,7 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
   /**
    * 测试通知：POST 触发一条测试通知（绕过免打扰，测试意图是验证通道本身）。
    * 系统通知 + SSE 广播同时走一遍，客户端收到 kind=test 的帧无条件弹窗。
+   * 返回的 sseConnections 语义同 /health = 服务端未释放句柄数（非设备数）。
    */
   const testRoute: WebRoute = {
     kind: "exact",

--- a/packages/dsh-notifier/src/server.ts
+++ b/packages/dsh-notifier/src/server.ts
@@ -29,8 +29,11 @@ function sseData(payload: unknown): string {
   return `data: ${JSON.stringify(payload)}\n\n`;
 }
 
-/** 写失败判死阈值：连续 ≥3 次（心跳周期 30s × 3 ≈ 90s）写不动即销毁。
- *  仅「抛错 / destroyed / writableEnded」计数；write 返回 false 视为背压（见 writeFrame）。 */
+/** 写失败判死阈值：连续 ≥3 次写不动即销毁（理论 throw 兜底路径）。
+ *  注意：真实 ServerResponse 对已断对端 write() 几乎不抛错（数据静默入队），
+ *  死连接主力清理是 close / error（register 收口）与 destroyed/writableEnded 兜底，
+ *  failStreak 仅兜底「抛错」这一理论路径——阈值 3 对应约 3 个广播/心跳周期，
+ *  非严格 90s。write 返回 false 一律视为背压（见 writeFrame）。 */
 const MAX_WRITE_FAILS = 3;
 
 /** SSE 推送枢纽：连接表、滚动缓冲广播、心跳。 */
@@ -55,7 +58,7 @@ export interface SseHub {
 export function createSseHub(options: { getMaxConnections: () => number }): SseHub {
   const { getMaxConnections } = options;
   /** 连接表：Map<响应, 写状态>。Map 迭代序 = 插入序，超限淘汰时第一项即最老。 */
-  const connState = new Map<ServerResponse, { failStreak: number; lastOkWriteAt: number }>();
+  const connState = new Map<ServerResponse, { failStreak: number }>();
 
   /** SSE 已派发帧的滚动缓冲（断线回补用；上限 RECENT_LIMIT，独立于 /history 的
    *  200 条截断，避免补拉时尾部事件被截掉）。 */
@@ -87,7 +90,7 @@ export function createSseHub(options: { getMaxConnections: () => number }): SseH
 
   /** 注册一条 SSE 连接：入表 + close/error 监听 + 上限淘汰 + socket keepalive 兜底。 */
   function register(res: ServerResponse) {
-    connState.set(res, { failStreak: 0, lastOkWriteAt: Date.now() });
+    connState.set(res, { failStreak: 0 });
     // close 是正常断连路径；error 是补 close 的缺口（现有代码缺失：不监听 error，
     // 部分路径会抛 unhandled error，且连接残留）。两者都收口到 evict（幂等）。
     res.on("close", () => evict(res));
@@ -120,7 +123,6 @@ export function createSseHub(options: { getMaxConnections: () => number }): SseH
     try {
       res.write(text);
       entry.failStreak = 0;
-      entry.lastOkWriteAt = Date.now();
       return true;
     } catch {
       entry.failStreak += 1;

--- a/packages/dsh-notifier/test/routes.src.test.ts
+++ b/packages/dsh-notifier/test/routes.src.test.ts
@@ -168,6 +168,141 @@ try {
     assert.ok(!rec4.text.includes('"type":"notify"'), "非法 since 按 0 处理");
   }
 
+  // #330 SSE 连接生命周期：上限淘汰最老 / close+error 幂等清理 /
+  // write-false 背压不误杀 / 写失败连续 3 次判死 / 配置改小实时生效（下次注册收缩）。
+  // 每个场景独立 makeNotifier 实例（隔离连接表，防跨块串扰）。
+  {
+    /** 可触发 close/error、可配置 write 行为的 fake res（events 路由用）。 */
+    function sseRes(opts = {}) {
+      const listeners = {};
+      const state = { destroyed: false, writes: 0 };
+      return {
+        state,
+        writeHead() {},
+        write() {
+          state.writes += 1;
+          if (opts.throwAfter !== undefined && state.writes > opts.throwAfter) throw new Error("EPIPE");
+          if (opts.falseAfter !== undefined && state.writes > opts.falseAfter) return false;
+          return true;
+        },
+        on(evt, cb) {
+          (listeners[evt] = listeners[evt] || []).push(cb);
+          return this;
+        },
+        emit(evt) {
+          for (const cb of listeners[evt] || []) cb();
+        },
+        destroy() {
+          state.destroyed = true;
+        },
+        get destroyed() {
+          return state.destroyed;
+        },
+        writableEnded: false,
+        socket: { setKeepAlive() {} },
+      };
+    }
+    /** 独立实例路由查找（每次全新连接表）。 */
+    async function freshRoutes(mark, maxConnections) {
+      const cfg = join(work, `sse-${mark}-cfg.json`);
+      writeFileSync(cfg, JSON.stringify({ maxConnections }));
+      const out = await makeNotifier(work, { configFile: cfg, historyFile: join(work, `sse-${mark}.jsonl`) });
+      const near = (p) => out.routes.find((r) => r.path === p);
+      return { ev: near(ROUTES.events), he: near(ROUTES.health), te: near(ROUTES.test), cfgR: near(ROUTES.config) };
+    }
+    async function connCount(he) {
+      const { rec, res } = makeRes();
+      await he.handler(fakeReq({}), res);
+      return JSON.parse(rec.text).sseConnections;
+    }
+
+    // (a) 上限淘汰最老：上限 2，注册 3 条 → 连接数收敛 2、最老被 destroy
+    {
+      const { ev, he } = await freshRoutes("a", 2);
+      const r1 = sseRes();
+      const r2 = sseRes();
+      const r3 = sseRes();
+      await ev.handler(fakeReq({}), r1);
+      await ev.handler(fakeReq({}), r2);
+      await ev.handler(fakeReq({}), r3);
+      assert.equal(await connCount(he), 2, "注册 3 条超上限，连接数收敛到 2");
+      assert.equal(r1.state.destroyed, true, "最老连接被 destroy（淘汰）");
+      assert.equal(r2.state.destroyed, false, "较新连接保留");
+      assert.equal(r3.state.destroyed, false, "最新连接保留");
+    }
+
+    // (b) close/error 幂等清理：多次触发只移除一次
+    {
+      const { ev, he } = await freshRoutes("b", 4);
+      const r = sseRes();
+      await ev.handler(fakeReq({}), r);
+      assert.equal(await connCount(he), 1, "注册后连接数为 1");
+      r.emit("close");
+      r.emit("error");
+      r.emit("close"); // 重复触发，幂等
+      assert.equal(await connCount(he), 0, "close/error 多次触发只移除一次");
+      assert.equal(r.state.destroyed, true, "close 后连接被销毁");
+    }
+
+    // (c) write 返回 false（背压）不误杀：多次广播连接仍在
+    {
+      const { ev, he, te } = await freshRoutes("c", 4);
+      const r = sseRes({ falseAfter: 1 }); // 初始 connected 写成功，之后均返回 false
+      await ev.handler(fakeReq({}), r);
+      for (let i = 0; i < 5; i += 1) await te.handler(fakeReq({ method: "POST" }), makeRes().res);
+      assert.equal(await connCount(he), 1, "write 返回 false 视为背压，5 次广播不误杀");
+      assert.equal(r.state.destroyed, false, "背压连接未被销毁");
+    }
+
+    // (d) 写失败连续 3 次判死：前 2 次保留，第 3 次销毁
+    {
+      const { ev, he, te } = await freshRoutes("d", 4);
+      const r = sseRes({ throwAfter: 1 }); // 初始 connected 写成功，之后每次写抛错
+      await ev.handler(fakeReq({}), r);
+      await te.handler(fakeReq({ method: "POST" }), makeRes().res); // failStreak=1
+      await te.handler(fakeReq({ method: "POST" }), makeRes().res); // failStreak=2
+      assert.equal(await connCount(he), 1, "连续 2 次写失败未达阈值，连接保留");
+      await te.handler(fakeReq({ method: "POST" }), makeRes().res); // failStreak=3 → 销毁
+      assert.equal(await connCount(he), 0, "连续 3 次写失败判死销毁");
+      assert.equal(r.state.destroyed, true, "判死连接被销毁");
+    }
+
+    // (e) maxConnections 配置改小实时生效：下次注册即收缩到新上限
+    {
+      const { ev, he, cfgR } = await freshRoutes("e", 16);
+      const r1 = sseRes();
+      const r2 = sseRes();
+      const r3 = sseRes();
+      await ev.handler(fakeReq({}), r1);
+      await ev.handler(fakeReq({}), r2);
+      await ev.handler(fakeReq({}), r3);
+      assert.equal(await connCount(he), 3, "默认上限 16 下注册 3 条不淘汰");
+      // PUT maxConnections=2（内存生效 + 落盘，沿用现有 bodyReq 模式）
+      const text = JSON.stringify({ maxConnections: 2 });
+      const putReq = {
+        method: "PUT",
+        url: "/",
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+        on(event, cb) {
+          if (event === "data") setTimeout(() => cb(Buffer.from(text)), 0);
+          else if (event === "end") setTimeout(cb, 1);
+          return this;
+        },
+        destroy() {},
+      };
+      const { rec, res } = makeRes();
+      await cfgR.handler(putReq, res);
+      assert.equal(JSON.parse(rec.text).maxConnections, 2, "PUT 后配置生效");
+      // 新注册触发 enforceLimit → 收缩到 2（淘汰最老 r1、r2）
+      const r4 = sseRes();
+      await ev.handler(fakeReq({}), r4);
+      assert.equal(await connCount(he), 2, "配置改小后下次注册即收缩到新上限 2");
+      assert.equal(r1.state.destroyed, true, "最老连接被淘汰");
+      assert.equal(r4.state.destroyed, false, "新注册保留");
+    }
+  }
+
   // history：测试通知已落盘，GET 可查（独立 history 文件，无跨块串扰）
   {
     // appendHistory 是 fire-and-forget；轮询直到落盘，不再依赖固定 sleep 的时序假设

--- a/packages/dsh-notifier/test/routes.test.ts
+++ b/packages/dsh-notifier/test/routes.test.ts
@@ -168,6 +168,141 @@ try {
     assert.ok(!rec4.text.includes('"type":"notify"'), "非法 since 按 0 处理");
   }
 
+  // #330 SSE 连接生命周期：上限淘汰最老 / close+error 幂等清理 /
+  // write-false 背压不误杀 / 写失败连续 3 次判死 / 配置改小实时生效（下次注册收缩）。
+  // 每个场景独立 makeNotifier 实例（隔离连接表，防跨块串扰）。
+  {
+    /** 可触发 close/error、可配置 write 行为的 fake res（events 路由用）。 */
+    function sseRes(opts = {}) {
+      const listeners = {};
+      const state = { destroyed: false, writes: 0 };
+      return {
+        state,
+        writeHead() {},
+        write() {
+          state.writes += 1;
+          if (opts.throwAfter !== undefined && state.writes > opts.throwAfter) throw new Error("EPIPE");
+          if (opts.falseAfter !== undefined && state.writes > opts.falseAfter) return false;
+          return true;
+        },
+        on(evt, cb) {
+          (listeners[evt] = listeners[evt] || []).push(cb);
+          return this;
+        },
+        emit(evt) {
+          for (const cb of listeners[evt] || []) cb();
+        },
+        destroy() {
+          state.destroyed = true;
+        },
+        get destroyed() {
+          return state.destroyed;
+        },
+        writableEnded: false,
+        socket: { setKeepAlive() {} },
+      };
+    }
+    /** 独立实例路由查找（每次全新连接表）。 */
+    async function freshRoutes(mark, maxConnections) {
+      const cfg = join(work, `sse-${mark}-cfg.json`);
+      writeFileSync(cfg, JSON.stringify({ maxConnections }));
+      const out = await makeNotifier(work, { configFile: cfg, historyFile: join(work, `sse-${mark}.jsonl`) });
+      const near = (p) => out.routes.find((r) => r.path === p);
+      return { ev: near(ROUTES.events), he: near(ROUTES.health), te: near(ROUTES.test), cfgR: near(ROUTES.config) };
+    }
+    async function connCount(he) {
+      const { rec, res } = makeRes();
+      await he.handler(fakeReq({}), res);
+      return JSON.parse(rec.text).sseConnections;
+    }
+
+    // (a) 上限淘汰最老：上限 2，注册 3 条 → 连接数收敛 2、最老被 destroy
+    {
+      const { ev, he } = await freshRoutes("a", 2);
+      const r1 = sseRes();
+      const r2 = sseRes();
+      const r3 = sseRes();
+      await ev.handler(fakeReq({}), r1);
+      await ev.handler(fakeReq({}), r2);
+      await ev.handler(fakeReq({}), r3);
+      assert.equal(await connCount(he), 2, "注册 3 条超上限，连接数收敛到 2");
+      assert.equal(r1.state.destroyed, true, "最老连接被 destroy（淘汰）");
+      assert.equal(r2.state.destroyed, false, "较新连接保留");
+      assert.equal(r3.state.destroyed, false, "最新连接保留");
+    }
+
+    // (b) close/error 幂等清理：多次触发只移除一次
+    {
+      const { ev, he } = await freshRoutes("b", 4);
+      const r = sseRes();
+      await ev.handler(fakeReq({}), r);
+      assert.equal(await connCount(he), 1, "注册后连接数为 1");
+      r.emit("close");
+      r.emit("error");
+      r.emit("close"); // 重复触发，幂等
+      assert.equal(await connCount(he), 0, "close/error 多次触发只移除一次");
+      assert.equal(r.state.destroyed, true, "close 后连接被销毁");
+    }
+
+    // (c) write 返回 false（背压）不误杀：多次广播连接仍在
+    {
+      const { ev, he, te } = await freshRoutes("c", 4);
+      const r = sseRes({ falseAfter: 1 }); // 初始 connected 写成功，之后均返回 false
+      await ev.handler(fakeReq({}), r);
+      for (let i = 0; i < 5; i += 1) await te.handler(fakeReq({ method: "POST" }), makeRes().res);
+      assert.equal(await connCount(he), 1, "write 返回 false 视为背压，5 次广播不误杀");
+      assert.equal(r.state.destroyed, false, "背压连接未被销毁");
+    }
+
+    // (d) 写失败连续 3 次判死：前 2 次保留，第 3 次销毁
+    {
+      const { ev, he, te } = await freshRoutes("d", 4);
+      const r = sseRes({ throwAfter: 1 }); // 初始 connected 写成功，之后每次写抛错
+      await ev.handler(fakeReq({}), r);
+      await te.handler(fakeReq({ method: "POST" }), makeRes().res); // failStreak=1
+      await te.handler(fakeReq({ method: "POST" }), makeRes().res); // failStreak=2
+      assert.equal(await connCount(he), 1, "连续 2 次写失败未达阈值，连接保留");
+      await te.handler(fakeReq({ method: "POST" }), makeRes().res); // failStreak=3 → 销毁
+      assert.equal(await connCount(he), 0, "连续 3 次写失败判死销毁");
+      assert.equal(r.state.destroyed, true, "判死连接被销毁");
+    }
+
+    // (e) maxConnections 配置改小实时生效：下次注册即收缩到新上限
+    {
+      const { ev, he, cfgR } = await freshRoutes("e", 16);
+      const r1 = sseRes();
+      const r2 = sseRes();
+      const r3 = sseRes();
+      await ev.handler(fakeReq({}), r1);
+      await ev.handler(fakeReq({}), r2);
+      await ev.handler(fakeReq({}), r3);
+      assert.equal(await connCount(he), 3, "默认上限 16 下注册 3 条不淘汰");
+      // PUT maxConnections=2（内存生效 + 落盘，沿用现有 bodyReq 模式）
+      const text = JSON.stringify({ maxConnections: 2 });
+      const putReq = {
+        method: "PUT",
+        url: "/",
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+        on(event, cb) {
+          if (event === "data") setTimeout(() => cb(Buffer.from(text)), 0);
+          else if (event === "end") setTimeout(cb, 1);
+          return this;
+        },
+        destroy() {},
+      };
+      const { rec, res } = makeRes();
+      await cfgR.handler(putReq, res);
+      assert.equal(JSON.parse(rec.text).maxConnections, 2, "PUT 后配置生效");
+      // 新注册触发 enforceLimit → 收缩到 2（淘汰最老 r1、r2）
+      const r4 = sseRes();
+      await ev.handler(fakeReq({}), r4);
+      assert.equal(await connCount(he), 2, "配置改小后下次注册即收缩到新上限 2");
+      assert.equal(r1.state.destroyed, true, "最老连接被淘汰");
+      assert.equal(r4.state.destroyed, false, "新注册保留");
+    }
+  }
+
   // history：测试通知已落盘，GET 可查（独立 history 文件，无跨块串扰）
   {
     // appendHistory 是 fire-and-forget；轮询直到落盘，不再依赖固定 sleep 的时序假设

--- a/packages/dsh-notifier/test/unit-config.test.ts
+++ b/packages/dsh-notifier/test/unit-config.test.ts
@@ -70,6 +70,18 @@ try {
   assert.equal(normalizeConfig({ errorMergeWindowMs: -1 }).errorMergeWindowMs, DEFAULT_CONFIG.errorMergeWindowMs, "负数错误窗口回默认");
   assert.equal(normalizeConfig({ historyMaxAgeDays: 30 }).historyMaxAgeDays, 30, "按天清理可配");
   assert.equal(normalizeConfig({ historyMaxAgeDays: 0 }).historyMaxAgeDays, 0, "按天清理 0=关");
+
+  // #330 SSE 连接上限：默认 16，范围 1~1024，非法值丢弃回默认；未知键透传排除表不吞它
+  assert.equal(DEFAULT_CONFIG.maxConnections, 16, "maxConnections 默认 16");
+  assert.equal(normalizeConfig(undefined).maxConnections, 16, "无输入回默认 16");
+  assert.equal(normalizeConfig({ maxConnections: 8 }).maxConnections, 8, "上限可配");
+  assert.equal(normalizeConfig({ maxConnections: 1 }).maxConnections, 1, "下限 1 可配");
+  assert.equal(normalizeConfig({ maxConnections: 0 }).maxConnections, DEFAULT_CONFIG.maxConnections, "0 非法回默认");
+  assert.equal(normalizeConfig({ maxConnections: -3 }).maxConnections, DEFAULT_CONFIG.maxConnections, "负数非法回默认");
+  assert.equal(normalizeConfig({ maxConnections: 1025 }).maxConnections, DEFAULT_CONFIG.maxConnections, "超上界 1024 非法回默认");
+  assert.equal(normalizeConfig({ maxConnections: 16.6 }).maxConnections, 17, "小数取整");
+  assert.equal(normalizeConfig({ maxConnections: "8" }).maxConnections, DEFAULT_CONFIG.maxConnections, "字符串非法回默认");
+  assert.equal(normalizeConfig({ maxConnections: 4, bogus: 1 }).bogus, 1, "未知键仍透传（排除表不吞其他键）");
 } finally {
   rmSync(work, { recursive: true, force: true });
 }


### PR DESCRIPTION
## 修复内容

修复 dsh-notifier SSE 连接泄漏：仅 2 台设备却显示「在线 24 个连接」，连接表只增不减（实测 26）。

### 根因
- 连接清理只依赖 `res.on("close")`；半开连接（息屏/切网/NAT 静默掐断）不触发 close → 连接残留。
- 心跳 write 抛错仅 catch 不清理；无上限 → 连接表只增不减直到 dsh web 重启。

### 改动（5 条修订 + maxConnections 配置化，方案见 issue #330 评论 v1/v2）

1. **`createSseHub` 加 `register(res)` 收口**：内部 add + close/error 监听（error 原缺失）+ 连接上限淘汰；`connections` 字段不再对外暴露。
2. **`maxConnections` 配置化**（默认 16，范围 1~1024）：`NotifyConfig` 新键 + `normalizeConfig` 校验 + 透传排除表；`getMaxConnections` 依赖注入实时生效；客户端面板新增「最大连接数」输入。
3. **write-false 视为背压**（不误杀；仅抛错/destroyed/writableEnded 计 failStreak，连续 ≥3 次 ≈90s 判死销毁）。
4. **连接表有界**：超限淘汰最老（Map 插入序），心跳顺带上限收缩（配置调小 30s 内收敛）。
5. **指标语义加注**：`sseConnections` 字段保留（客户端 toast 依赖），toast 文案改为「服务端未释放句柄 N 条」。
6. 删冗余 `STALE_MS`；`setKeepAlive` 保留并注释作用边界（仅兜底空闲连接）。

### 验证

- 门禁全绿（worktree 内执行）：`pnpm build && pnpm test && pnpm contract && pnpm pack:check` ✅
- 新增断言（`routes.test.ts`/`routes.src.test.ts`/`unit-config.test.ts`）：
  - (a) 上限淘汰最老：上限 2 注册 3 条 → 收敛 2、最老被 destroy
  - (b) close/error 幂等清理：多次触发只移除一次
  - (c) write-false 背压：5 次广播不误杀
  - (d) 写失败连续 3 次判死：前 2 次保留、第 3 次销毁
  - (e) 配置改小实时生效：PUT maxConnections=2 后下次注册收缩到 2
  - unit：maxConnections 归一化（默认 16 / 边界 1~1024 / 非法回默认 / 未知键仍透传）

### 行为边界说明（诚实预期）

- 静默半开连接的回收延迟为**分钟级**（TCP 重传机制决定，`tcp_retries2=15`），上限只保证连接表**有界**、不承诺 90s 清空。
- 超限淘汰对用户**无感知**：最老连接被断后客户端自动重连 + `since` 补拉，不丢事件（断线期 ≤600 帧）。
- 多设备×多页签超 16 条时可在面板调大上限。

Closes #330