### PR TITLE
ci(meta): path-filter 补 stryker 段配置映射——改段配置即触发对应包 mutation（#322）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,18 +80,28 @@ jobs:
               - 'AGENTS.md'
             dsh-notifier:
               - 'packages/dsh-notifier/**'
+              # #322：stryker 段配置变更须命中本包面（段配置是 mutation 单一事实源，
+              # 不映射则配置类 PR 的 mutation 矩阵全 skip、无法自证）。模式遵循
+              # 包级 <pkg>.json 与段级 <pkg>-<n>.json 两种形态的通配覆盖
+              - 'stryker.conf.d/dsh-notifier*.json'
             dsh-idle-archive:
               - 'packages/dsh-idle-archive/**'
+              - 'stryker.conf.d/dsh-idle-archive*.json'
             dsh-web-file-preview:
               - 'packages/dsh-web-file-preview/**'
+              - 'stryker.conf.d/dsh-web-file-preview*.json'
             dsh-mcp-manager:
               - 'packages/dsh-mcp-manager/**'
+              - 'stryker.conf.d/dsh-mcp-manager-*.json'
             dsh-provider-usage:
               - 'packages/dsh-provider-usage/**'
+              - 'stryker.conf.d/dsh-provider-usage-*.json'
             dsh-lan-proxy:
               - 'packages/dsh-lan-proxy/**'
+              - 'stryker.conf.d/dsh-lan-proxy-*.json'
             dsh-subagent-model-inherit:
               - 'packages/dsh-subagent-model-inherit/**'
+              - 'stryker.conf.d/dsh-subagent-model-inherit*.json'
             dsh-codegraph:
               - 'packages/dsh-codegraph/**'
             dsh-verify-isolated:

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -139,6 +139,33 @@ test('#220: docs 不在 ci.yml global 过滤面——文档 PR 不触发变异�
     '过滤面旁必须保留理由注释（防后人「好心」加回）')
 })
 
+test('#322: 每个带 stryker 配置的包在 path-filter 均有段配置通配映射（防回归）', () => {
+  // 有 stryker 配置的包 = stryker.conf.d 文件集归并出的基础包名（段级 <pkg>-<n>.json
+  // 归并到 <pkg>），与 #220 段式三方一致测试同一口径
+  const confDir = join(ROOT, 'stryker.conf.d')
+  const confFiles = readdirSync(confDir).filter((f) => f.endsWith('.json'))
+  const basePkgs = [...new Set(confFiles.map((f) => f.replace(/\.json$/, '').replace(/-\d+$/, '')))].sort()
+
+  const filtersBlock = CI.slice(CI.indexOf('filters: |'), CI.indexOf('- name: Compute hit packages'))
+  for (const pkg of basePkgs) {
+    // 定位包面条目：从 `<pkg>:` 到下一个 `            dsh-` 条目（filters 缩进 12 空格）
+    const start = filtersBlock.indexOf(`            ${pkg}:`)
+    assert.ok(start > 0, `ci.yml path-filter 缺包面条目 ${pkg}（#322：段配置变更需命中该包面）`)
+    const after = filtersBlock.indexOf('\n            dsh-', start + pkg.length)
+    const entry = filtersBlock.slice(start, after > 0 ? after : undefined)
+    // 现有 packages/<pkg>/** 映射必须保留（本断言只追加 stryker 段配置通配，不动 case 结构）
+    assert.ok(entry.includes(`- 'packages/${pkg}/**'`),
+      `${pkg} 包面必须保留 packages/${pkg}/** 行（#322 只追加不替换）`)
+    // stryker.conf.d 通配：包级 <pkg>.json 与段级 <pkg>-<n>.json 均以 <pkg> 前缀被覆盖
+    const hasGlob = entry.split('\n').some((l) => {
+      const m = /-\s'(stryker\.conf\.d\/[^']+)'/.exec(l.trim())
+      return !!m && m[1].startsWith(`stryker.conf.d/${pkg}`)
+    })
+    assert.ok(hasGlob,
+      `${pkg} 包面缺 stryker.conf.d 段配置通配映射（#322：改段配置必须触发该包 mutation，不得全 skip）`)
+  }
+})
+
 test('#276 方案 A: observe 四班次全量——定时触发、无 push 裁剪、快照 PR 日期闸', () => {
   assert.ok(OBSERVE.includes("'0 1,4,8,12 * * *'"),
     '每日四班次（UTC 01/04/08/12 = 北京 09/12/16/20）全量变异')


### PR DESCRIPTION
## 改动说明

修复 CI path-filter 盲区（#322）：`stryker.conf.d/**` 段配置变更无法触发对应包 mutation。

在 `.github/workflows/ci.yml` path-filter 的 `filters: |` 区块，为 **7 个有 stryker 配置的包**追加段配置路径映射（**保留现有 `packages/<pkg>/**` 行不变**）：

| 包 | 追加映射 | 实际配置形态 |
|---|---|---|
| dsh-notifier | `stryker.conf.d/dsh-notifier*.json` | 包级 `<pkg>.json` |
| dsh-idle-archive | `stryker.conf.d/dsh-idle-archive*.json` | 包级 `<pkg>.json` |
| dsh-web-file-preview | `stryker.conf.d/dsh-web-file-preview*.json` | 包级 `<pkg>.json` |
| dsh-mcp-manager | `stryker.conf.d/dsh-mcp-manager-*.json` | 段级 `<pkg>-<n>.json`（3 段） |
| dsh-provider-usage | `stryker.conf.d/dsh-provider-usage-*.json` | 段级 `<pkg>-<n>.json`（4 段） |
| dsh-lan-proxy | `stryker.conf.d/dsh-lan-proxy-*.json` | 段级 `<pkg>-<n>.json`（4 段） |
| dsh-subagent-model-inherit | `stryker.conf.d/dsh-subagent-model-inherit*.json` | 包级 `<pkg>.json` |

边界（与 issue 一致）：dsh-verify-isolated / dsh-plugins-all 无 stryker 配置，不映射。

`scripts/test/workflow-assert.test.ts` 新增 **#322 防回归契约断言**：每个带 stryker 配置的包（以 stryker.conf.d 文件集为单一事实源归并），其 filters 面必含对应 `stryker.conf.d/<pkg>` 通配，且 `packages/<pkg>/**` 行必须保留——防止未来新增 stryker 配置包时漏加映射、或有人替换掉现有包面。

## 拆段评估（维护者指示实测复核）

对 stryker.conf.d 全部 **15 个段配置**本地实测**全量**（`--force`，即最坏情形=基线缺失降级全量变异）耗时：

| 段配置 | 实测耗时 | 段配置 | 实测耗时 |
|---|---|---|---|
| dsh-idle-archive | 7s | dsh-provider-usage-1 | 123s |
| dsh-lan-proxy-1 | 158s | dsh-provider-usage-2 | 7s |
| dsh-lan-proxy-2 | 86s | dsh-provider-usage-3 | **182s（最长）** |
| dsh-lan-proxy-3 | 78s | dsh-provider-usage-4 | 54s |
| dsh-lan-proxy-4 | 19s | dsh-subagent-model-inherit | 4s |
| dsh-mcp-manager-1 | 148s | dsh-web-file-preview | 21s |
| dsh-mcp-manager-2 | 122s | dsh-notifier | 157s |
| dsh-mcp-manager-3 | 126s | — | — |

**结论**：
- 全部 15 个段配置全量实测均 ≤ **3 分钟**（最长 dsh-provider-usage-3 约 182s）；CI mutation-gate 单实例预算 **30 分钟**（含 install + 全量 build + stryker），余量充足，**无任何单段变异测试过长**；
- 三个拆分包（lan-proxy 4 段 / mcp-manager 3 段 / provider-usage 4 段）段粒度均衡（最重段 2-3 分钟全量），**暂无需继续拆段**；
- 未拆分包（idle-archive / notifier / subagent-model-inherit / web-file-preview）全量 4s~157s，均远低于预算，同样**无需拆段**；
- **评估结论：维持现状，不调整段划分**（仅记录，不改任何配置）。

## 断言表（对照 issue 验收）

| 验收条目 | 结论 | 证据 |
|---|---|---|
| [硬性] 改任一包段配置的 PR，CI mutation-gate 展开该包全段并跑完（含 verdict） | **PASS（静态可断言）** | 新增 #322 断言锁死「每个 stryker 配置包的 filters 面必含 stryker.conf.d 通配」；test:scripts 全绿证明映射在位。端到端「真实配置类 PR 触发」属 CI 运行证据，需后续配置类 PR 实证（见下「关闭语义」） |
| [硬性] 该 PR 其余包不触发 mutation（增量不变） | **PASS（静态可断言）** | 映射为**包级精确**追加（每条只进对应包面、不进 global），A 包段配置变更只命中 A 包面；case 结构未改，F7/#306 契约全绿 |
| [硬性] pnpm test:scripts（含 workflow-assert）全绿 | **PASS** | 54/54 pass（含新增 #322 断言）；#220/#306/F7 三条既有契约保持全绿 |
| [量级] 后续配置类 PR 无需依赖下一个代码 PR 自然验证 | **PASS（结构达成）** | 映射为静态路径声明，配置类 PR 只要改 stryker.conf.d/<pkg>*.json 即命中对应包面，天然自证；不依赖任何未来代码 PR |

## 门禁结果（本地五连门禁全绿）

```
pnpm build       PASS（9/10 包全量构建，第三方 license 归集完整）
pnpm test        PASS（全包 smoke + 契约 + 围栏用例）
pnpm contract    PASS（客户端契约：@deepseek-ai 仅类型导入等）
pnpm pack:check  PASS（9 包 + 聚合 tarball 完整）
pnpm typecheck   PASS（9 包 --noEmit）
```

改动文件仅两处：`.github/workflows/ci.yml`（+10 行映射 + 注释）与 `scripts/test/workflow-assert.test.ts`（+27 行断言），`git diff` 自证无其他改动。

## 红线核对

- ✅ 只改 `.github/workflows/ci.yml` path-filter 区块 + workflow-assert.test.ts（test 面增强，与既有断言风格一致）
- ✅ 不动 mutation-gate.mjs / observe 基线 / package.json / pnpm-lock.yaml / shared/ 契约层
- ✅ 不新增包名、不改 case 结构

Refs #322
