### PR TITLE
fix(notifier): 阶段二——done 证据面收敛 session/event 单源 push（#290）

### DIFF
--- a/packages/dsh-notifier/README.md
+++ b/packages/dsh-notifier/README.md
@@ -68,7 +68,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-notifier
 
 - **向你提问**（默认开）：`ask_user_question` / GUI 提问弹窗触发时通知
 - **审批提醒**：真实审批路径 `approval/request` 触发时通知，含任务标题、工具中文名、申请理由与操作提示
-- **完成提醒**：任务从运行到空闲（`agent/status` running → idle）时通知，含任务标题与耗时；完成判定为双源——idle 时从会话事件快照回读最新 `turn/end`，与 `session/event` 推送流记忆的最新 `turn/end` 取新者为结束证据（issue #272：快照一次性读滞后不再固化为永久静默，同一轮次两源只通知一次，判定被跳过时输出可观测 warn 日志）；子代理完成走独立开关 `notifySubagentDone`（默认关；子代理含 `origin: subagent` 的 spawn 型与运行时归属成立的 fork 型委派——无归属的 fork 主线会话不受影响，仍报主任务完成）；用户停止生成/中断/任务失败/被阻塞时不通知完成（本轮 `turn/end` reason 为 `aborted`/`interrupted`/`error`/`blocked` 时固定静默——失败任务由错误提醒单独负责「任务出错」，避免同一轮既报错又误报完成）
+- **完成提醒**：任务从运行到空闲（`agent/status` running → idle）时通知，含任务标题与耗时；完成判定为**单源 push + 快照兜底**——以 `session/event` 推送流记忆的最新 `turn/end` 为主证据（post-commit 同步派发、恒定新鲜），快照回读（`lastTurnEndOf`）仅在 push 缺失（插件中途挂载 / 重载窗口内已派发但新 fiber 未记忆）时兜底（issue #290 阶段二：快照一次性读滞后不再固化为永久静默，同一轮次只通知一次，判定被跳过时输出标识证据来源的可观测 warn 日志）；子代理完成走独立开关 `notifySubagentDone`（默认关；子代理含 `origin: subagent` 的 spawn 型与运行时归属成立的 fork 型委派——无归属的 fork 主线会话不受影响，仍报主任务完成）；用户停止生成/中断/任务失败/被阻塞时不通知完成（本轮 `turn/end` reason 为 `aborted`/`interrupted`/`error`/`blocked` 时固定静默——失败任务由错误提醒单独负责「任务出错」，避免同一轮既报错又误报完成）
 - **错误提醒**：任务出错（`agent/error`）时通知，含任务标题、出错轮次/步骤、错误信息（前 300 字符）；同类错误 60 秒窗口内自动合并
 - **轮次完成**（默认关）：`agent/turn-stopping` 时通知
 - **双通道**：

--- a/packages/dsh-notifier/src/index.ts
+++ b/packages/dsh-notifier/src/index.ts
@@ -18,10 +18,13 @@
  *   （origin === 'subagent'，或 fork 型委派且运行时归属成立——见 message.ts
  *   isSubagentOf 双信号注释）走独立开关/事件类型 subagent-done；
  *   用户暂停/中断（turn/end reason aborted）固定静默。
- *   完成判定为双源（issue #272）：idle 时从 agent.session.events 快照回读
- *   最新 turn/end，与 session/event 推送流记忆的最新 turn/end 按 turn 取新者
- *   作为本轮结束证据——快照一次性读滞后不再被 lastEndedTurn 固化为永久静默；
- *   同一 turn 两源汇合于同一判定点，天然只通知一次。跳过路径输出可观测 warn。
+ *   完成判定为单源 push + 快照兜底（issue #290 阶段二）：idle 判定以
+ *   session/event 推送流记忆（eventStreamEnds，post-commit 同步派发、恒定
+ *   新鲜）为主证据源；快照回读（lastTurnEndOf）仅在 push 缺失（插件中途
+ *   挂载 / 重载窗口内已派发但新 fiber 未记忆）时作兜底——快照一次性读滞后
+ *   不再被 lastEndedTurn 固化为永久静默；同一 turn 两源汇合于同一判定点，
+ *   天然只通知一次。abort-early（本轮无新 closure）陈旧快照经 running 基线
+ *   守卫拦截，不误报完成。跳过路径输出可观测 warn（标识证据来源）。
  * - 任务错误：agent/error（{agent, turn, step, error}），60 秒滚动窗口合并
  * - 轮结束：agent/turn-stopping（serial，{agent, turn}，仅宿主通知，不跑模型）
  * - 会话销毁：agent/disposed（清理 per-agent 状态）
@@ -182,7 +185,7 @@ export async function apply(ctx: Context, config: NotifierApplyConfig = {}): Pro
    * 归属成立）走独立开关 notifySubagentDone 与独立事件类型 subagent-done；
    * 用户暂停/中断（turn/end reason aborted）固定静默。
    */
-  const agentStates = new Map<string, { runningSeen: boolean; startedAt: number; lastEndedTurn?: number }>(); // agentId -> { runningSeen, startedAt, lastEndedTurn }
+  const agentStates = new Map<string, { runningSeen: boolean; startedAt: number; lastEndedTurn?: number; runningBaseline?: { turn: number; kind: string } }>(); // agentId -> { runningSeen, startedAt, lastEndedTurn, runningBaseline }
 
   /**
    * 审批请求：approval/request waterfall（源码核验：真实审批由 dsh-sandbox
@@ -405,21 +408,34 @@ export async function apply(ctx: Context, config: NotifierApplyConfig = {}): Pro
           // 首行 throwIfAborted 在 try 外），读到的 turn/end 是上一次运行的
           // ——无新 closure 宁可静默，不误报完成。
           //
-          // 双源证据合并（issue #272）：快照回读（ended）与 session/event
-          // 推送流（streamed，post-commit 不受快照滞后影响）按 turn 取新者
-          // 作为本轮结束证据——两源看到的是同一 append-only 日志的同一事件，
-          // turn 相同即同一证据（同 turn 天然只通知一次）；快照一次性读滞后
-          // 时由推送流兜底，不再固化为永久静默。
-          const ended = lastTurnEndOf(agent);
+          // 证据面收敛——单源 push + 快照兜底（issue #290 阶段二）：
+          // 完成判定证据主源 = session/event 推送流（eventStreamEnds，
+          // post-commit 同步派发、恒定新鲜）：eventStreamEnds 有该 session
+          // 记录时直接采信 push、不读快照。快照回读（lastTurnEndOf）仅在
+          // push 缺失（插件于 agent 运行中途挂载 / 重载窗口内已派发但新
+          // fiber 未记忆）时作兜底——不再「按 turn 取新」双源互补。
+          //
+          // abort-early 陈旧快照冻结（C-1）：兜底快照必须较 running 基线
+          // 推进才视为「本轮新 closure」——abort 早于本轮 turn/start 落盘
+          // 时本轮无新 turn/end，快照读到的仍是上一次运行的 completed；若
+          // 快照 turn ≤ running 基线（本轮无推进），把陈旧快照冻结、不作
+          // 本轮证据（宁静静默，不误报完成）。状态机记忆为空（重载后首次
+          // idle）时同样成立：记忆重置不把旧证据当新轮完成（D-2）。
+          const streamedRaw = eventStreamEnds.get(agentId);
           // 合并处对称守卫（#284 复核闸 P1 纵深）：仅接受 turn 有限的证据——
           // 入口（lastTurnEndOf / session/event 处理器）已各自 skip 非有限
           // turn，此处兜底保证任何畸形证据既不能成 best、也不能推进记忆。
-          const streamedRaw = eventStreamEnds.get(agentId);
-          const streamed = streamedRaw !== undefined && Number.isFinite(streamedRaw.turn) ? streamedRaw : undefined;
-          const best =
-            streamed !== undefined && (ended === undefined || (Number.isFinite(streamed.turn) && streamed.turn > ended.turn))
-              ? streamed
-              : ended;
+          const pushed = streamedRaw !== undefined && Number.isFinite(streamedRaw.turn) ? streamedRaw : undefined;
+          // 快照兜底仅在 push 缺失时读取（单源 push 为主证据，不读快照）。
+          const snapshot = pushed === undefined ? lastTurnEndOf(agent) : undefined;
+          const baselineTurn = state.runningBaseline?.turn;
+          const stale =
+            pushed === undefined &&
+            snapshot !== undefined &&
+            baselineTurn !== undefined &&
+            snapshot.turn <= baselineTurn;
+          const best = pushed ?? (stale ? undefined : snapshot);
+          const evidenceSource = pushed !== undefined ? "push" : snapshot !== undefined ? (stale ? "快照冻结" : "快照兜底") : "无";
           const rememberedTurn = state.lastEndedTurn;
           const hasNewEnd = best !== undefined && (rememberedTurn === undefined || best.turn > rememberedTurn);
           // 非正常结束不判「完成」：本轮 turn/end 无新 closure（hasNewEnd）
@@ -440,7 +456,8 @@ export async function apply(ctx: Context, config: NotifierApplyConfig = {}): Pro
             // 日志，不打扰用户；aborted 等设计内静默同样留痕（kind 字段区分）。
             ctx.logger.warn(
               `dsh-notifier: 完成判定跳过（不发 done）agent=${agentId} kind=${best?.kind ?? "none"} ` +
-                `快照turn=${ended !== undefined ? String(ended.turn) : "-"} 推送turn=${streamed !== undefined ? String(streamed.turn) : "-"} ` +
+                `证据源=${evidenceSource} 快照turn=${snapshot !== undefined ? String(snapshot.turn) : "-"} ` +
+                `推送turn=${pushed !== undefined ? String(pushed.turn) : "-"} ` +
                 `记忆turn=${rememberedTurn ?? "-"}`,
             );
             // B-3：非 completed 闭包照常消费——aborted/error/blocked/
@@ -474,6 +491,11 @@ export async function apply(ctx: Context, config: NotifierApplyConfig = {}): Pro
         } else if (status === "running") {
           state.runningSeen = true;
           state.startedAt = Date.now();
+          // 记录本轮开始前的快照基线（abort-early 冻结判据）：running 时
+          // 快照最新 turn/end 即「本轮之前已落盘」的证据；idle 时快照若
+          // 仍未推进（≤ 基线），说明本次 running→idle 无新 closure（abort
+          // 早于 turn/start），陈旧快照不得当本轮新证据（C-1/D-2）。
+          state.runningBaseline = lastTurnEndOf(agent);
         }
       } catch (error) {
         ctx.logger.warn(`dsh-notifier: agent/status 处理失败: ${errorMessage(error)}`);

--- a/packages/dsh-notifier/test/e2e-done.src.test.ts
+++ b/packages/dsh-notifier/test/e2e-done.src.test.ts
@@ -7,13 +7,20 @@
  * 通知与滚动窗口合并（含窗口过期计数、0=关闭）；子代理完成场景（issue #49：
  * fork 型委派按运行时归属拆分——归属成立默认静默/开关联动 subagent-done、
  * 归属不成立保护用户 fork 主线走 done；spawn 型 origin 用例与 S2 开关组合）；
- * issue #272 双源订阅（session/event 推送流互补：events 停滞形态兜底通知、
- * 双源同 turn 去重）与跳过路径 warn 兜底。
+ * issue #290 阶段二单源收敛（session/event push 为主证据 + lastTurnEndOf
+ * 快照仅 push 缺失兜底 + runningBaseline 冻结 abort-early 陈旧快照）与
+ * 跳过路径 warn（证据源字段）；D-1/D-2 重载窗口后首轮 live turn 仍通知、
+ * 重载不引入假阳性。
+ *
+ * 时序约定（helpers.turnPair / agentWithTitle 联用）：所有「本轮完成」用例
+ * 必须区分 running/idle 两态事件面——running 态 events 为上一轮 closure
+ * （或空），idle 态为本轮 closure（见 helpers.turnPair 注释）；「running 与
+ * idle 同构造（idle 无推进）」即 abort-early 无新 closure 形态，必须静默。
  */
 import { join } from "node:path";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { assert, makeNotifier, agentWithTitle, fakeAgents, waitMergeWindow, fakeReq, makeRes, turnEndEvent, waitForHistory } from "./helpers.ts";
+import { assert, makeNotifier, agentWithTitle, fakeAgents, waitMergeWindow, fakeReq, makeRes, turnEndEvent, waitForHistory, turnPair } from "./helpers.ts";
 import { ROUTES, lastTurnEndOf } from "../src/index.ts";
 
 /** 带 info 收集的 logger 覆盖。 */
@@ -72,11 +79,13 @@ try {
 
     // 完成风暴聚合：窗口内第二条完成不即时，3s 后补发聚合条（防并行收尾刷屏）
     await waitMergeWindow(); // 窗口清零（error/turn 无完成窗口）
-    status({ agent: agentWithTitle("storm-1", "并行任务A", { turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("storm-1", "并行任务A", { turnEnd: 1 }), status: "idle" });
+    const stormA = turnPair("storm-1", "并行任务A", {}, { turn: 1 });
+    status({ agent: stormA.running, status: "running" });
+    status({ agent: stormA.idle, status: "idle" });
     assert.equal(infos.length, 5, "聚合窗口首条即时通知");
-    status({ agent: agentWithTitle("storm-2", "并行任务B", { turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("storm-2", "并行任务B", { turnEnd: 1 }), status: "idle" });
+    const stormB = turnPair("storm-2", "并行任务B", {}, { turn: 1 });
+    status({ agent: stormB.running, status: "running" });
+    status({ agent: stormB.idle, status: "idle" });
     assert.equal(infos.length, 5, "窗口内第二条挂起不即时发");
     await waitMergeWindow();
     assert.equal(infos.length, 6, "窗口到点补发聚合条");
@@ -148,9 +157,10 @@ try {
       );
       const status = listeners.get("agent/status")[0];
       // fork 型委派完整持久化 header 形态：parentSession + seedLength、无 origin、depth=0（#199 P2-5 对齐）
-      const forkAgent = () => agentWithTitle("fork-worker", "fork 委派子任务", { parentSession: "main-parent", seedLength: 3, depth: 0, turnEnd: 1 });
-      status({ agent: forkAgent(), status: "running" });
-      status({ agent: forkAgent(), status: "idle" });
+      // 本轮完成时序：running 态无 closure（首轮）、idle 态 turn=1 completed（helpers.turnPair）
+      const forkPair = () => turnPair("fork-worker", "fork 委派子任务", { parentSession: "main-parent", seedLength: 3, depth: 0 }, { turn: 1 });
+      status({ agent: forkPair().running, status: "running" });
+      status({ agent: forkPair().idle, status: "idle" });
       assert.equal(infos.length, 0, "A1：fork 型委派归属成立且默认关时完全静默");
       // 通知历史复核（AC 验证入口）：静默路径不触发任何 appendHistory，读全量应为空
       const historyRoute = routes.find((r) => r.path === ROUTES.history);
@@ -169,10 +179,10 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: onCfg }, { agents, ...loggingOverride(infos) });
       const status = listeners.get("agent/status")[0];
-      // 同 A1：完整持久化 header 形态含 seedLength（#199 P2-5 对齐）
-      const forkAgent = () => agentWithTitle("fork-worker2", "fork 委派子任务B", { parentSession: "main-parent2", seedLength: 3, depth: 0, turnEnd: 1 });
-      status({ agent: forkAgent(), status: "running" });
-      status({ agent: forkAgent(), status: "idle" });
+      // 同 A1：完整持久化 header 形态含 seedLength（#199 P2-5 对齐）+ 本轮完成时序
+      const forkPair = () => turnPair("fork-worker2", "fork 委派子任务B", { parentSession: "main-parent2", seedLength: 3, depth: 0 }, { turn: 1 });
+      status({ agent: forkPair().running, status: "running" });
+      status({ agent: forkPair().idle, status: "idle" });
       assert.equal(infos.length, 1, "A2：开启开关时恰产生一条通知");
       assert.match(infos[0], /subagent-done/, "A2：事件类型为 subagent-done");
       assert.match(infos[0], /子任务「fork 委派子任务B」已完成/, "A2：文案带任务标题");
@@ -188,9 +198,9 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-fork-orphan.json") }, { agents, ...loggingOverride(infos) });
       const status = listeners.get("agent/status")[0];
-      const mk = () => agentWithTitle("fork-orphan", "孤儿 fork 会话", { parentSession: "ghost-parent", turnEnd: 1 });
-      status({ agent: mk(), status: "running" });
-      status({ agent: mk(), status: "idle" });
+      const mk = () => turnPair("fork-orphan", "孤儿 fork 会话", { parentSession: "ghost-parent" }, { turn: 1 });
+      status({ agent: mk().running, status: "running" });
+      status({ agent: mk().idle, status: "idle" });
       assert.equal(infos.length, 1, "B1：父 id 不存在时不被静默");
       assert.match(infos[0], /dsh-notifier: done /, "B1：发 kind=done 而非 subagent-done");
     }
@@ -202,9 +212,9 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-fork-unowned.json") }, { agents, ...loggingOverride(infos) });
       const status = listeners.get("agent/status")[0];
-      const mk = () => agentWithTitle("fork-x", "无归属 fork 会话", { parentSession: "unrelated-parent", seedLength: 3, turnEnd: 1 });
-      status({ agent: mk(), status: "running" });
-      status({ agent: mk(), status: "idle" });
+      const mk = () => turnPair("fork-x", "无归属 fork 会话", { parentSession: "unrelated-parent", seedLength: 3 }, { turn: 1 });
+      status({ agent: mk().running, status: "running" });
+      status({ agent: mk().idle, status: "idle" });
       assert.equal(infos.length, 1, "B1：isOwnedBy=false 时归属不成立，不被静默");
       assert.match(infos[0], /dsh-notifier: done /, "B1：发 kind=done 而非 subagent-done");
     }
@@ -215,9 +225,9 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-headless.json") }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
-      const mk = () => agentWithTitle("headless-1", "headless CLI 会话", { cwd: "/tmp/dsh-cli", turnEnd: 1 });
-      status({ agent: mk(), status: "running" });
-      status({ agent: mk(), status: "idle" });
+      const mk = () => turnPair("headless-1", "headless CLI 会话", { cwd: "/tmp/dsh-cli" }, { turn: 1 });
+      status({ agent: mk().running, status: "running" });
+      status({ agent: mk().idle, status: "idle" });
       assert.equal(infos.length, 1, "D1：headless 会话保持主任务分支现状");
       assert.match(infos[0], /dsh-notifier: done /);
     }
@@ -227,8 +237,9 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-main.json") }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
-      status({ agent: agentWithTitle("main-x", "主任务", { turnEnd: 1 }), status: "running" });
-      status({ agent: agentWithTitle("main-x", "主任务", { turnEnd: 1 }), status: "idle" });
+      const pair = turnPair("main-x", "主任务", {}, { turn: 1 });
+      status({ agent: pair.running, status: "running" });
+      status({ agent: pair.idle, status: "idle" });
       assert.equal(infos.length, 1, "主会话完成走 done");
       assert.match(infos[0], /dsh-notifier: done /);
     }
@@ -238,11 +249,13 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-default.json") }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
-      status({ agent: agentWithTitle("sub-1", "子任务A", { subagent: true, turnEnd: 1 }), status: "running" });
-      status({ agent: agentWithTitle("sub-1", "子任务A", { subagent: true, turnEnd: 1 }), status: "idle" });
+      const subPair = turnPair("sub-1", "子任务A", { subagent: true }, { turn: 1 });
+      status({ agent: subPair.running, status: "running" });
+      status({ agent: subPair.idle, status: "idle" });
       assert.equal(infos.length, 0, "notifySubagentDone 默认关：子代理完成不通知");
-      status({ agent: agentWithTitle("main-1", "主任务", { turnEnd: 1 }), status: "running" });
-      status({ agent: agentWithTitle("main-1", "主任务", { turnEnd: 1 }), status: "idle" });
+      const mainPair = turnPair("main-1", "主任务", {}, { turn: 1 });
+      status({ agent: mainPair.running, status: "running" });
+      status({ agent: mainPair.idle, status: "idle" });
       assert.equal(infos.length, 1, "主任务完成不受子代理开关影响");
       assert.match(infos[0], /done/);
     }
@@ -254,8 +267,9 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: onCfg }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
-      status({ agent: agentWithTitle("sub-2", "子任务B", { subagent: true, turnEnd: 1 }), status: "running" });
-      status({ agent: agentWithTitle("sub-2", "子任务B", { subagent: true, turnEnd: 1 }), status: "idle" });
+      const subPair = turnPair("sub-2", "子任务B", { subagent: true }, { turn: 1 });
+      status({ agent: subPair.running, status: "running" });
+      status({ agent: subPair.idle, status: "idle" });
       assert.equal(infos.length, 1);
       assert.match(infos[0], /subagent-done/, "子代理完成用独立事件类型");
       assert.match(infos[0], /子任务「子任务B」已完成/, "subagent-done 文案带任务标题");
@@ -263,8 +277,9 @@ try {
       assert.ok(!infos[0].includes("sub-2"), "子代理完成通知不暴露会话 id");
       // 等 subagent-done 的 3s 聚合窗口结束（否则主任务完成会被聚合挂起）
       await waitMergeWindow();
-      status({ agent: agentWithTitle("main-2", "主任务2", { turnEnd: 1 }), status: "running" });
-      status({ agent: agentWithTitle("main-2", "主任务2", { turnEnd: 1 }), status: "idle" });
+      const mainPair = turnPair("main-2", "主任务2", {}, { turn: 1 });
+      status({ agent: mainPair.running, status: "running" });
+      status({ agent: mainPair.idle, status: "idle" });
       assert.equal(infos.length, 2, "主任务仍走 done 类型");
       assert.match(infos[1], /done/);
     }
@@ -276,31 +291,34 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: s2Cfg }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
-      status({ agent: agentWithTitle("sub-3", "子任务C", { subagent: true, turnEnd: 1 }), status: "running" });
-      status({ agent: agentWithTitle("sub-3", "子任务C", { subagent: true, turnEnd: 1 }), status: "idle" });
+      const subPair = turnPair("sub-3", "子任务C", { subagent: true }, { turn: 1 });
+      status({ agent: subPair.running, status: "running" });
+      status({ agent: subPair.idle, status: "idle" });
       assert.equal(infos.length, 1, "notifyTaskDone=false 不拦截子代理完成（S2）");
       assert.match(infos[0], /subagent-done/);
-      status({ agent: agentWithTitle("main-3", "主任务3", { turnEnd: 1 }), status: "running" });
-      status({ agent: agentWithTitle("main-3", "主任务3", { turnEnd: 1 }), status: "idle" });
+      const mainPair = turnPair("main-3", "主任务3", {}, { turn: 1 });
+      status({ agent: mainPair.running, status: "running" });
+      status({ agent: mainPair.idle, status: "idle" });
       assert.equal(infos.length, 1, "notifyTaskDone=false 主任务不通知");
       // 既有 bug 修复回归：notifyTaskDone=false 时 idle 无条件重置状态，
       // 之后重开开关不会把旧的 running 误报为完成
-      status({ agent: agentWithTitle("main-3", "主任务3", { turnEnd: 1 }), status: "running" });
+      status({ agent: agentWithTitle("main-3", "主任务3"), status: "running" });
       assert.equal(infos.length, 1, "running 仍不通知");
     }
   }
 
-  // ── issue #272：完成判定双源订阅（session/event 推送流互补源）+ 跳过路径 warn 兜底 ──
+  // ── issue #290 阶段二：证据面单源收敛（session/event push 主源 + lastTurnEndOf
+  //    快照仅 push 缺失兜底 + runningBaseline 冻结）+ 跳过路径 warn 兜底 ──
   {
     const infos = [];
     const warns = [];
-    // 关闭完成聚合：本块聚焦双源证据合并语义，每条完成即时通知便于计数
+    // 关闭完成聚合：本块聚焦单源证据合并语义，每条完成即时通知便于计数
     // （doneMergeWindowMs 是运行时配置，须经 configFile 文件传入）
-    const dualCfg = join(work, "dual-source.json");
-    writeFileSync(dualCfg, JSON.stringify({ doneMergeWindowMs: 0 }));
+    const singleCfg = join(work, "single-source.json");
+    writeFileSync(singleCfg, JSON.stringify({ doneMergeWindowMs: 0 }));
     const { listeners } = await makeNotifier(
       work,
-      { configFile: dualCfg },
+      { configFile: singleCfg },
       { logger: { info: (t) => infos.push(t), warn: (t) => warns.push(t) } }
     );
     const status = listeners.get("agent/status")[0];
@@ -308,46 +326,55 @@ try {
     const disposed = listeners.get("agent/disposed")[0];
     const countDone = () => infos.filter((t) => /dsh-notifier: done /.test(t)).length;
 
-    // (a) events 停滞形态反证（#272 报告场景）：agent.session.events 冻结在
-    //     turn=1（快照回读永远拿到旧证据，模拟一次性读滞后被固化的形态），
-    //     session/event 推送流正常逐轮派发。修复前：仅首轮通知、后续永久静默
-    //     且零日志；修复后：推送流兜底，逐轮通知。
+    // (a) push 恒定新鲜为主证据（#272 报告场景反证，阶段二 A-2）：agent.session
+    //     .events 冻结在 turn=1（快照一次性读滞后被 lastEndedTurn 固化的形态——
+    //     running/idle 同构造恰模拟 events 停滞），session/event 推送流正常逐轮
+    //     派发。单源收敛后判定只采信 push（不读快照）→ 逐轮通知 4 条，不再
+    //     依赖双源按 turn 取新。
     for (let turn = 1; turn <= 4; turn += 1) {
       status({ agent: agentWithTitle("stuck-a", "停滞会话", { turnEnd: 1 }), status: "running" });
       sessionEvent({ id: "stuck-a" }, turnEndEvent(turn));
       status({ agent: agentWithTitle("stuck-a", "停滞会话", { turnEnd: 1 }), status: "idle" });
     }
-    assert.equal(countDone(), 4, "(a) events 停滞形态下 session/event 推送流兜底逐轮通知");
+    assert.equal(countDone(), 4, "(a) events 停滞形态下 push 主证据逐轮通知（快照冻结不影响）");
 
-    // (b) 双源去重：同一 turn 两源到达只通知一次——快照与推送指向同一
-    //     append-only 日志的同一事件，turn 相同即同一证据，合并为单次通知。
+    // (b) 同 turn 去重（A-3）：push 与快照指向同一 append-only 日志的同一事件，
+    //     turn 相同即同一证据——采信 push 后合并为单次通知；已记忆 turn 的重复
+    //     派发不重复通知。
     status({ agent: agentWithTitle("dedup-1", "去重会话", { turnEnd: 2 }), status: "running" });
     sessionEvent({ id: "dedup-1" }, turnEndEvent(2));
     status({ agent: agentWithTitle("dedup-1", "去重会话", { turnEnd: 2 }), status: "idle" });
-    assert.equal(countDone(), 5, "(b) 快照+推送同 turn 合并为单次通知");
+    assert.equal(countDone(), 5, "(b) push+快照同 turn 合并为单次通知");
     sessionEvent({ id: "dedup-1" }, turnEndEvent(2)); // 已记忆 turn 的重复派发不再触发
     status({ agent: agentWithTitle("dedup-1", "去重会话", { turnEnd: 2 }), status: "running" });
     status({ agent: agentWithTitle("dedup-1", "去重会话", { turnEnd: 2 }), status: "idle" });
     assert.equal(countDone(), 5, "(b) 已记忆 turn 的重复到达不重复通知");
 
-    // (c) 跳过路径 warn 兜底：无任何新证据的 idle 判定跳过必须可观测
-    //     （#272 报告场景「全程零日志」的反面）。
-    status({ agent: agentWithTitle("warn-1", "静默会话", { turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("warn-1", "静默会话", { turnEnd: 1 }), status: "idle" }); // 首轮正常通知，lastEndedTurn=1
+    // (c) 跳过路径 warn 兜底（E-1）：无新证据的 idle 判定跳过必须可观测，且
+    //     warn 字段标识证据来源（单源语义：证据源=push / 快照兜底 / 快照冻结）。
+    //     首轮为真实完成时序（running 无 closure → idle turn=1 completed 通知），
+    //     第二轮 events 仍停 turn=1（abort-early 形态）→ 快照 ≤ running 基线
+    //     被冻结 → 跳过 + warn（证据源=快照冻结）。
+    const w1 = turnPair("warn-1", "静默会话", {}, { turn: 1 });
+    status({ agent: w1.running, status: "running" });
+    status({ agent: w1.idle, status: "idle" }); // 首轮正常通知，lastEndedTurn=1
     const beforeWarn = countDone();
     status({ agent: agentWithTitle("warn-1", "静默会话", { turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("warn-1", "静默会话", { turnEnd: 1 }), status: "idle" }); // 无新证据 → 跳过 + warn
+    status({ agent: agentWithTitle("warn-1", "静默会话", { turnEnd: 1 }), status: "idle" }); // 无新 closure → 快照冻结 + warn
     assert.equal(countDone(), beforeWarn, "(c) 无新证据轮不发 done");
     const warnLine = warns.find((t) => t.includes("warn-1"));
     assert.ok(warnLine !== undefined, "(c) 跳过路径输出 warn 日志");
     assert.match(warnLine, /完成判定跳过/, "(c) warn 标识跳过动作");
+    assert.match(warnLine, /证据源=快照冻结/, "(c) warn 证据源标识快照冻结（abort-early 陈旧快照）");
     assert.match(warnLine, /快照turn=1/, "(c) warn 含快照源检测到的 turn");
     assert.match(warnLine, /推送turn=-/, "(c) warn 含推送源检测值（无则为 -）");
     assert.match(warnLine, /记忆turn=1/, "(c) warn 含记忆的 lastEndedTurn");
 
-    // 设计内静默同样留痕：aborted 中断不发 done，但 warn 带 kind=aborted 可核对。
-    status({ agent: agentWithTitle("abort-1", "中断会话", { turnEnd: 1, turnEndKind: "aborted" }), status: "running" });
-    status({ agent: agentWithTitle("abort-1", "中断会话", { turnEnd: 1, turnEndKind: "aborted" }), status: "idle" });
+    // 设计内静默同样留痕：aborted 中断不发 done，但 warn 带 kind=aborted 可核对
+    // （真实时序：本轮 aborted closure 落盘 → 白名单拒绝，非快照冻结）。
+    const a1 = turnPair("abort-1", "中断会话", {}, { turn: 1, kind: "aborted" });
+    status({ agent: a1.running, status: "running" });
+    status({ agent: a1.idle, status: "idle" });
     assert.equal(countDone(), beforeWarn, "aborted 中断不发 done");
     assert.ok(warns.some((t) => t.includes("abort-1") && /kind=aborted/.test(t)), "aborted 静默留痕 kind=aborted");
 
@@ -358,19 +385,17 @@ try {
     status({ agent: agentWithTitle("gc-1", "清理会话", { turnEnd: 3 }), status: "idle" }); // 状态机+辅源已清零：不通知
     assert.equal(countDone(), beforeWarn, "disposed 清理后辅源残留不误报");
 
-    // (d) 畸形载荷不毒化记忆（#284 复核闸 P1）：turn 非数字的推送 turn/end
-    //     直接 skip 不落记忆——修复前 {turn:NaN} 凭 ended===undefined 短路成
-    //     best、首轮误报一条并把 lastEndedTurn 推进为 NaN，此后真实完成因
-    //     x > NaN 恒 false 被永久吞掉。
-    status({ agent: agentWithTitle("mal-1", "畸形会话"), status: "running" }); // 无快照 turn/end（ended===undefined 场景）
+    // (d) 畸形载荷不毒化记忆（#284 复核闸 P1，B-2）：turn 非数字的推送 turn/end
+    //     直接 skip 不落记忆——任何畸形证据既不能成 best、也不能推进记忆。
+    status({ agent: agentWithTitle("mal-1", "畸形会话"), status: "running" }); // 无快照 turn/end（pushed/快照均缺失形态）
     sessionEvent({ id: "mal-1" }, { type: "turn/end", data: { turn: "x", reason: { kind: "completed" } } });
     sessionEvent({ id: "mal-1" }, { type: "turn/end", data: { turn: Number.NaN, reason: { kind: "completed" } } });
     status({ agent: agentWithTitle("mal-1", "畸形会话"), status: "idle" });
     assert.equal(countDone(), beforeWarn, "(d) 畸形载荷不误报 done");
     const malWarn = warns.find((t) => t.includes("mal-1"));
     assert.ok(malWarn !== undefined && /完成判定跳过/.test(malWarn), "(d) 畸形证据不可用走跳过路径 warn");
-    assert.match(malWarn, /快照turn=- 推送turn=- 记忆turn=-/, "(d) 两源均无可信证据（记忆未被毒化）");
-    // 毒化回归反证：随后真实 turn=2 双源一致 completed 照常通知（修复前被 NaN 记忆吞掉）。
+    assert.match(malWarn, /证据源=无 快照turn=- 推送turn=- 记忆turn=-/, "(d) 无任何可信证据（记忆未被毒化）");
+    // 毒化回归反证：随后真实 turn=2 push completed 照常通知（修复前被 NaN 记忆吞掉）。
     status({ agent: agentWithTitle("mal-1", "畸形会话", { turnEnd: 2 }), status: "running" });
     sessionEvent({ id: "mal-1" }, turnEndEvent(2));
     status({ agent: agentWithTitle("mal-1", "畸形会话", { turnEnd: 2 }), status: "idle" });
@@ -405,9 +430,9 @@ try {
       { logger: { info: (t) => infos.push(t), warn: (t) => warns.push(t) } }
     );
     const status = listeners.get("agent/status")[0];
-    const mk = () => agentWithTitle("a2-1", "无 agents 主任务", { turnEnd: 1 });
-    status({ agent: mk(), status: "running" });
-    status({ agent: mk(), status: "idle" });
+    const pair = turnPair("a2-1", "无 agents 主任务", {}, { turn: 1 });
+    status({ agent: pair.running, status: "running" });
+    status({ agent: pair.idle, status: "idle" });
     assert.equal(infos.filter((t) => /: done /.test(t)).length, 1, "A-2：无 agents 时 completed 走 done 主分支");
     assert.ok(!warns.some((t) => t.includes("agent/status 处理失败")), "A-2：无 'agent/status 处理失败' warn");
   }
@@ -422,15 +447,15 @@ try {
     const { listeners } = await makeNotifier(work, { configFile: a3Cfg }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
     // fork 型：无 origin、带 parentSession + seedLength，归属服务缺位 → 保守走 done
-    const fork = () => agentWithTitle("a3-fork", "fork 型无 agents", { parentSession: "ghost-parent", seedLength: 3, turnEnd: 1 });
-    status({ agent: fork(), status: "running" });
-    status({ agent: fork(), status: "idle" });
+    const forkPair = () => turnPair("a3-fork", "fork 型无 agents", { parentSession: "ghost-parent", seedLength: 3 }, { turn: 1 });
+    status({ agent: forkPair().running, status: "running" });
+    status({ agent: forkPair().idle, status: "idle" });
     assert.equal(infos.filter((t) => /: done /.test(t)).length, 1, "A-3：agents 缺位 fork 型保守走 done");
     assert.ok(!infos.some((t) => /: subagent-done /.test(t)), "A-3：不误判 subagent-done");
     // spawn 型：origin 信号不依赖 agents，仍走 subagent 分支
-    const spawn = () => agentWithTitle("a3-spawn", "spawn 子任务", { subagent: true, turnEnd: 2 });
-    status({ agent: spawn(), status: "running" });
-    status({ agent: spawn(), status: "idle" });
+    const spawnPair = () => turnPair("a3-spawn", "spawn 子任务", { subagent: true }, { turn: 2 });
+    status({ agent: spawnPair().running, status: "running" });
+    status({ agent: spawnPair().idle, status: "idle" });
     assert.equal(infos.filter((t) => /: subagent-done /.test(t)).length, 1, "A-3：spawn 型 origin 信号仍走 subagent 分支");
   }
 
@@ -443,13 +468,14 @@ try {
     const warns = [];
     const { listeners } = await makeNotifier(work, { configFile: b1Cfg }, { logger: { info: (t) => infos.push(t), warn: (t) => warns.push(t) } });
     const status = listeners.get("agent/status")[0];
-    const mk = () => agentWithTitle("b1-1", "开关禁用任务", { turnEnd: 1 });
-    status({ agent: mk(), status: "running" });
-    status({ agent: mk(), status: "idle" });
+    const pair = turnPair("b1-1", "开关禁用任务", {}, { turn: 1 });
+    status({ agent: pair.running, status: "running" });
+    status({ agent: pair.idle, status: "idle" });
     assert.equal(infos.filter((t) => /: done /.test(t)).length, 0, "B-1：notifyTaskDone=false 主任务不通知");
-    // 同 turn 再现 idle：lastEndedTurn 已提交 → 无新证据 → skip（不重复处理）
-    status({ agent: mk(), status: "running" });
-    status({ agent: mk(), status: "idle" });
+    // 同 turn 再现 idle：lastEndedTurn 已提交 → 无新证据 → skip（不重复处理）；
+    // 构造为「events 仍停 turn=1」的 abort-early 形态（快照 ≤ running 基线冻结）
+    status({ agent: agentWithTitle("b1-1", "开关禁用任务", { turnEnd: 1 }), status: "running" });
+    status({ agent: agentWithTitle("b1-1", "开关禁用任务", { turnEnd: 1 }), status: "idle" });
     assert.equal(infos.filter((t) => /: done /.test(t)).length, 0, "B-1：开关禁用后同 turn 再现 idle 不重复");
     assert.ok(warns.some((t) => t.includes("b1-1") && /完成判定跳过/.test(t)), "B-1：再现 idle 走跳过路径 warn 留痕");
   }
@@ -465,16 +491,16 @@ try {
     const { listeners, routes } = await makeNotifier(work, { configFile: b2Cfg, historyFile: join(work, "b2-hist.jsonl") }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
     const historyRoute = routes.find((r) => r.path === ROUTES.history);
-    const mk = () => agentWithTitle("b2-1", "免打扰完成", { turnEnd: 1 });
-    status({ agent: mk(), status: "running" });
-    status({ agent: mk(), status: "idle" });
+    const pair = turnPair("b2-1", "免打扰完成", {}, { turn: 1 });
+    status({ agent: pair.running, status: "running" });
+    status({ agent: pair.idle, status: "idle" });
     assert.ok(!infos.some((t) => /dsh-notifier: done /.test(t) && !t.includes("被免打扰拦截")), "B-2：免打扰拦截不发出系统通知");
     assert.ok(infos.some((t) => t.includes("被免打扰拦截")), "B-2：拦截记录日志");
     const records = await waitForHistory(historyRoute, (r) => r.some((e) => e.kind === "done" && e.suppressed === "quiet"));
     assert.equal(records.filter((e) => e.kind === "done" && e.suppressed === "quiet").length, 1, "B-2：仅一条 suppressed:quiet 历史");
     // 同 turn 再现 idle：免打扰拦截也是三态提交之一（lastEndedTurn 已推进）→ 不重复
-    status({ agent: mk(), status: "running" });
-    status({ agent: mk(), status: "idle" });
+    status({ agent: agentWithTitle("b2-1", "免打扰完成", { turnEnd: 1 }), status: "running" });
+    status({ agent: agentWithTitle("b2-1", "免打扰完成", { turnEnd: 1 }), status: "idle" });
     const after = await waitForHistory(historyRoute, (r) => r.length > records.length, 500);
     assert.equal(after.length, records.length, "B-2：同 turn 再现 idle 不新增历史记录");
   }
@@ -487,13 +513,13 @@ try {
     const infos = [];
     const { listeners } = await makeNotifier(work, { configFile: b4Cfg }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
-    const mk = () => agentWithTitle("b4-1", "合并窗口任务", { turnEnd: 1 });
-    status({ agent: mk(), status: "running" });
-    status({ agent: mk(), status: "idle" });
+    const pair = turnPair("b4-1", "合并窗口任务", {}, { turn: 1 });
+    status({ agent: pair.running, status: "running" });
+    status({ agent: pair.idle, status: "idle" });
     assert.equal(infos.filter((t) => /: done /.test(t)).length, 1, "B-4：首条完成即时通知并入队");
     // 窗口未 flush 时同 turn 再现 idle：入队成功已提交 lastEndedTurn → 不重复
-    status({ agent: mk(), status: "running" });
-    status({ agent: mk(), status: "idle" });
+    status({ agent: agentWithTitle("b4-1", "合并窗口任务", { turnEnd: 1 }), status: "running" });
+    status({ agent: agentWithTitle("b4-1", "合并窗口任务", { turnEnd: 1 }), status: "idle" });
     assert.equal(infos.filter((t) => /: done /.test(t)).length, 1, "B-4：窗口内同 turn 再现 idle 不重复（入队即提交）");
   }
 
@@ -509,24 +535,69 @@ try {
     const { listeners } = await makeNotifier(work, { configFile: b4fCfg }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
     const doneCount = () => infos.filter((t) => /: done /.test(t)).length;
-    const mkA = () => agentWithTitle("b4f-a", "flush 后 A", { turnEnd: 1 });
-    const mkB = () => agentWithTitle("b4f-b", "flush 后 B", { turnEnd: 1 });
+    const pairA = () => turnPair("b4f-a", "flush 后 A", {}, { turn: 1 });
+    const pairB = () => turnPair("b4f-b", "flush 后 B", {}, { turn: 1 });
     // 两条完成进入同一聚合窗口（首条即时、第二条入队挂起）
-    status({ agent: mkA(), status: "running" });
-    status({ agent: mkA(), status: "idle" });
-    status({ agent: mkB(), status: "running" });
-    status({ agent: mkB(), status: "idle" });
+    status({ agent: pairA().running, status: "running" });
+    status({ agent: pairA().idle, status: "idle" });
+    status({ agent: pairB().running, status: "running" });
+    status({ agent: pairB().idle, status: "idle" });
     assert.equal(doneCount(), 1, "B-4：窗口内首条即时、第二条挂起");
     // 等窗口到点：flush 补发聚合条（正常路径）
     await new Promise((resolve) => setTimeout(resolve, 100));
     assert.equal(doneCount(), 2, "B-4：flush 补发聚合条");
     assert.ok(infos.some((t) => /: done /.test(t) && t.includes("另有 1 个任务已完成")), "B-4：聚合条文案带计数");
-    // 已提交 turn 不回退：flush 完成后再现 idle 不重复
-    status({ agent: mkA(), status: "running" });
-    status({ agent: mkA(), status: "idle" });
-    status({ agent: mkB(), status: "running" });
-    status({ agent: mkB(), status: "idle" });
+    // 已提交 turn 不回退：flush 完成后再现 idle（无新 closure 形态）不重复
+    status({ agent: agentWithTitle("b4f-a", "flush 后 A", { turnEnd: 1 }), status: "running" });
+    status({ agent: agentWithTitle("b4f-a", "flush 后 A", { turnEnd: 1 }), status: "idle" });
+    status({ agent: agentWithTitle("b4f-b", "flush 后 B", { turnEnd: 1 }), status: "running" });
+    status({ agent: agentWithTitle("b4f-b", "flush 后 B", { turnEnd: 1 }), status: "idle" });
     assert.equal(doneCount(), 2, "B-4：flush 后已提交 turn 不回退重发");
+  }
+
+  // ── issue #290 阶段二：重载窗口后首轮 live turn 仍通知（D-1）与
+  //    重载不引入假阳性（D-2）——独立实例模拟插件重载（新 fiber 的
+  //    agentStates / eventStreamEnds 记忆为空）──
+  {
+    // D-1：重载窗口后首轮 live turn 仍通知（快照兜底补证）。
+    // 构造：上一轮 turn=1 已落盘（重载前已派发、新 fiber 未记忆，push 缺失），
+    // 本轮 live turn=2 completed 落盘后 running→idle——快照较 running 基线推进，
+    // 走快照兜底补证 → 恰一条 done，不因记忆重置静默。
+    const d1Cfg = join(work, "d1-reload.json");
+    writeFileSync(d1Cfg, JSON.stringify({ doneMergeWindowMs: 0 }));
+    const infos1 = [];
+    const warns1 = [];
+    const { listeners: l1 } = await makeNotifier(
+      work,
+      { configFile: d1Cfg, historyFile: join(work, "d1-hist.jsonl") },
+      { logger: { info: (t) => infos1.push(t), warn: (t) => warns1.push(t) } }
+    );
+    const status1 = l1.get("agent/status")[0];
+    const d1 = turnPair("d1-1", "重载后任务", {}, { turn: 2 }, { turn: 1 }); // prev=1（重载前 closure）、this=2（本轮 live）
+    status1({ agent: d1.running, status: "running" });
+    status1({ agent: d1.idle, status: "idle" });
+    assert.equal(infos1.filter((t) => /: done /.test(t)).length, 1, "D-1：重载后首轮 live turn 经快照兜底通知（恰一条）");
+    assert.ok(!warns1.some((t) => t.includes("d1-1")), "D-1：重载后首轮 live turn 不走跳过路径（无 warn）");
+
+    // D-2：重载后 abort-early（本轮无新 closure）idle 仍静默——running 基线
+    //     捕获上一轮 turn=1 completed，idle 时快照仍 turn=1（≤ 基线）→ 冻结，
+    //     不因记忆重置把旧证据当新轮完成。
+    const d2Cfg = join(work, "d2-reload-abort.json");
+    writeFileSync(d2Cfg, JSON.stringify({ doneMergeWindowMs: 0 }));
+    const infos2 = [];
+    const warns2 = [];
+    const { listeners: l2 } = await makeNotifier(
+      work,
+      { configFile: d2Cfg, historyFile: join(work, "d2-hist.jsonl") },
+      { logger: { info: (t) => infos2.push(t), warn: (t) => warns2.push(t) } }
+    );
+    const status2 = l2.get("agent/status")[0];
+    status2({ agent: agentWithTitle("d2-1", "重载后中断", { turnEnd: 1 }), status: "running" });
+    status2({ agent: agentWithTitle("d2-1", "重载后中断", { turnEnd: 1 }), status: "idle" });
+    assert.equal(infos2.filter((t) => /: done /.test(t)).length, 0, "D-2：重载后 abort-early 静默（不把旧证据当新轮完成）");
+    const d2Warn = warns2.find((t) => t.includes("d2-1"));
+    assert.ok(d2Warn !== undefined && /完成判定跳过/.test(d2Warn), "D-2：重载后 abort-early 跳过路径 warn 留痕");
+    assert.match(d2Warn, /证据源=快照冻结/, "D-2：warn 标识快照冻结（陈旧快照拦截）");
   }
 } finally {
   rmSync(work, { recursive: true, force: true });

--- a/packages/dsh-notifier/test/e2e-done.test.ts
+++ b/packages/dsh-notifier/test/e2e-done.test.ts
@@ -7,13 +7,20 @@
  * 通知与滚动窗口合并（含窗口过期计数、0=关闭）；子代理完成场景（issue #49：
  * fork 型委派按运行时归属拆分——归属成立默认静默/开关联动 subagent-done、
  * 归属不成立保护用户 fork 主线走 done；spawn 型 origin 用例与 S2 开关组合）；
- * issue #272 双源订阅（session/event 推送流互补：events 停滞形态兜底通知、
- * 双源同 turn 去重）与跳过路径 warn 兜底。
+ * issue #290 阶段二单源收敛（session/event push 为主证据 + lastTurnEndOf
+ * 快照仅 push 缺失兜底 + runningBaseline 冻结 abort-early 陈旧快照）与
+ * 跳过路径 warn（证据源字段）；D-1/D-2 重载窗口后首轮 live turn 仍通知、
+ * 重载不引入假阳性。
+ *
+ * 时序约定（helpers.turnPair / agentWithTitle 联用）：所有「本轮完成」用例
+ * 必须区分 running/idle 两态事件面——running 态 events 为上一轮 closure
+ * （或空），idle 态为本轮 closure（见 helpers.turnPair 注释）；「running 与
+ * idle 同构造（idle 无推进）」即 abort-early 无新 closure 形态，必须静默。
  */
 import { join } from "node:path";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { assert, makeNotifier, agentWithTitle, fakeAgents, waitMergeWindow, fakeReq, makeRes, turnEndEvent, waitForHistory } from "./helpers.ts";
+import { assert, makeNotifier, agentWithTitle, fakeAgents, waitMergeWindow, fakeReq, makeRes, turnEndEvent, waitForHistory, turnPair } from "./helpers.ts";
 import { ROUTES, lastTurnEndOf } from "../lib/index.js";
 
 /** 带 info 收集的 logger 覆盖。 */
@@ -72,11 +79,13 @@ try {
 
     // 完成风暴聚合：窗口内第二条完成不即时，3s 后补发聚合条（防并行收尾刷屏）
     await waitMergeWindow(); // 窗口清零（error/turn 无完成窗口）
-    status({ agent: agentWithTitle("storm-1", "并行任务A", { turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("storm-1", "并行任务A", { turnEnd: 1 }), status: "idle" });
+    const stormA = turnPair("storm-1", "并行任务A", {}, { turn: 1 });
+    status({ agent: stormA.running, status: "running" });
+    status({ agent: stormA.idle, status: "idle" });
     assert.equal(infos.length, 5, "聚合窗口首条即时通知");
-    status({ agent: agentWithTitle("storm-2", "并行任务B", { turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("storm-2", "并行任务B", { turnEnd: 1 }), status: "idle" });
+    const stormB = turnPair("storm-2", "并行任务B", {}, { turn: 1 });
+    status({ agent: stormB.running, status: "running" });
+    status({ agent: stormB.idle, status: "idle" });
     assert.equal(infos.length, 5, "窗口内第二条挂起不即时发");
     await waitMergeWindow();
     assert.equal(infos.length, 6, "窗口到点补发聚合条");
@@ -148,9 +157,10 @@ try {
       );
       const status = listeners.get("agent/status")[0];
       // fork 型委派完整持久化 header 形态：parentSession + seedLength、无 origin、depth=0（#199 P2-5 对齐）
-      const forkAgent = () => agentWithTitle("fork-worker", "fork 委派子任务", { parentSession: "main-parent", seedLength: 3, depth: 0, turnEnd: 1 });
-      status({ agent: forkAgent(), status: "running" });
-      status({ agent: forkAgent(), status: "idle" });
+      // 本轮完成时序：running 态无 closure（首轮）、idle 态 turn=1 completed（helpers.turnPair）
+      const forkPair = () => turnPair("fork-worker", "fork 委派子任务", { parentSession: "main-parent", seedLength: 3, depth: 0 }, { turn: 1 });
+      status({ agent: forkPair().running, status: "running" });
+      status({ agent: forkPair().idle, status: "idle" });
       assert.equal(infos.length, 0, "A1：fork 型委派归属成立且默认关时完全静默");
       // 通知历史复核（AC 验证入口）：静默路径不触发任何 appendHistory，读全量应为空
       const historyRoute = routes.find((r) => r.path === ROUTES.history);
@@ -169,10 +179,10 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: onCfg }, { agents, ...loggingOverride(infos) });
       const status = listeners.get("agent/status")[0];
-      // 同 A1：完整持久化 header 形态含 seedLength（#199 P2-5 对齐）
-      const forkAgent = () => agentWithTitle("fork-worker2", "fork 委派子任务B", { parentSession: "main-parent2", seedLength: 3, depth: 0, turnEnd: 1 });
-      status({ agent: forkAgent(), status: "running" });
-      status({ agent: forkAgent(), status: "idle" });
+      // 同 A1：完整持久化 header 形态含 seedLength（#199 P2-5 对齐）+ 本轮完成时序
+      const forkPair = () => turnPair("fork-worker2", "fork 委派子任务B", { parentSession: "main-parent2", seedLength: 3, depth: 0 }, { turn: 1 });
+      status({ agent: forkPair().running, status: "running" });
+      status({ agent: forkPair().idle, status: "idle" });
       assert.equal(infos.length, 1, "A2：开启开关时恰产生一条通知");
       assert.match(infos[0], /subagent-done/, "A2：事件类型为 subagent-done");
       assert.match(infos[0], /子任务「fork 委派子任务B」已完成/, "A2：文案带任务标题");
@@ -188,9 +198,9 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-fork-orphan.json") }, { agents, ...loggingOverride(infos) });
       const status = listeners.get("agent/status")[0];
-      const mk = () => agentWithTitle("fork-orphan", "孤儿 fork 会话", { parentSession: "ghost-parent", turnEnd: 1 });
-      status({ agent: mk(), status: "running" });
-      status({ agent: mk(), status: "idle" });
+      const mk = () => turnPair("fork-orphan", "孤儿 fork 会话", { parentSession: "ghost-parent" }, { turn: 1 });
+      status({ agent: mk().running, status: "running" });
+      status({ agent: mk().idle, status: "idle" });
       assert.equal(infos.length, 1, "B1：父 id 不存在时不被静默");
       assert.match(infos[0], /dsh-notifier: done /, "B1：发 kind=done 而非 subagent-done");
     }
@@ -202,9 +212,9 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-fork-unowned.json") }, { agents, ...loggingOverride(infos) });
       const status = listeners.get("agent/status")[0];
-      const mk = () => agentWithTitle("fork-x", "无归属 fork 会话", { parentSession: "unrelated-parent", seedLength: 3, turnEnd: 1 });
-      status({ agent: mk(), status: "running" });
-      status({ agent: mk(), status: "idle" });
+      const mk = () => turnPair("fork-x", "无归属 fork 会话", { parentSession: "unrelated-parent", seedLength: 3 }, { turn: 1 });
+      status({ agent: mk().running, status: "running" });
+      status({ agent: mk().idle, status: "idle" });
       assert.equal(infos.length, 1, "B1：isOwnedBy=false 时归属不成立，不被静默");
       assert.match(infos[0], /dsh-notifier: done /, "B1：发 kind=done 而非 subagent-done");
     }
@@ -215,9 +225,9 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-headless.json") }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
-      const mk = () => agentWithTitle("headless-1", "headless CLI 会话", { cwd: "/tmp/dsh-cli", turnEnd: 1 });
-      status({ agent: mk(), status: "running" });
-      status({ agent: mk(), status: "idle" });
+      const mk = () => turnPair("headless-1", "headless CLI 会话", { cwd: "/tmp/dsh-cli" }, { turn: 1 });
+      status({ agent: mk().running, status: "running" });
+      status({ agent: mk().idle, status: "idle" });
       assert.equal(infos.length, 1, "D1：headless 会话保持主任务分支现状");
       assert.match(infos[0], /dsh-notifier: done /);
     }
@@ -227,8 +237,9 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-main.json") }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
-      status({ agent: agentWithTitle("main-x", "主任务", { turnEnd: 1 }), status: "running" });
-      status({ agent: agentWithTitle("main-x", "主任务", { turnEnd: 1 }), status: "idle" });
+      const pair = turnPair("main-x", "主任务", {}, { turn: 1 });
+      status({ agent: pair.running, status: "running" });
+      status({ agent: pair.idle, status: "idle" });
       assert.equal(infos.length, 1, "主会话完成走 done");
       assert.match(infos[0], /dsh-notifier: done /);
     }
@@ -238,11 +249,13 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-default.json") }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
-      status({ agent: agentWithTitle("sub-1", "子任务A", { subagent: true, turnEnd: 1 }), status: "running" });
-      status({ agent: agentWithTitle("sub-1", "子任务A", { subagent: true, turnEnd: 1 }), status: "idle" });
+      const subPair = turnPair("sub-1", "子任务A", { subagent: true }, { turn: 1 });
+      status({ agent: subPair.running, status: "running" });
+      status({ agent: subPair.idle, status: "idle" });
       assert.equal(infos.length, 0, "notifySubagentDone 默认关：子代理完成不通知");
-      status({ agent: agentWithTitle("main-1", "主任务", { turnEnd: 1 }), status: "running" });
-      status({ agent: agentWithTitle("main-1", "主任务", { turnEnd: 1 }), status: "idle" });
+      const mainPair = turnPair("main-1", "主任务", {}, { turn: 1 });
+      status({ agent: mainPair.running, status: "running" });
+      status({ agent: mainPair.idle, status: "idle" });
       assert.equal(infos.length, 1, "主任务完成不受子代理开关影响");
       assert.match(infos[0], /done/);
     }
@@ -254,8 +267,9 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: onCfg }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
-      status({ agent: agentWithTitle("sub-2", "子任务B", { subagent: true, turnEnd: 1 }), status: "running" });
-      status({ agent: agentWithTitle("sub-2", "子任务B", { subagent: true, turnEnd: 1 }), status: "idle" });
+      const subPair = turnPair("sub-2", "子任务B", { subagent: true }, { turn: 1 });
+      status({ agent: subPair.running, status: "running" });
+      status({ agent: subPair.idle, status: "idle" });
       assert.equal(infos.length, 1);
       assert.match(infos[0], /subagent-done/, "子代理完成用独立事件类型");
       assert.match(infos[0], /子任务「子任务B」已完成/, "subagent-done 文案带任务标题");
@@ -263,8 +277,9 @@ try {
       assert.ok(!infos[0].includes("sub-2"), "子代理完成通知不暴露会话 id");
       // 等 subagent-done 的 3s 聚合窗口结束（否则主任务完成会被聚合挂起）
       await waitMergeWindow();
-      status({ agent: agentWithTitle("main-2", "主任务2", { turnEnd: 1 }), status: "running" });
-      status({ agent: agentWithTitle("main-2", "主任务2", { turnEnd: 1 }), status: "idle" });
+      const mainPair = turnPair("main-2", "主任务2", {}, { turn: 1 });
+      status({ agent: mainPair.running, status: "running" });
+      status({ agent: mainPair.idle, status: "idle" });
       assert.equal(infos.length, 2, "主任务仍走 done 类型");
       assert.match(infos[1], /done/);
     }
@@ -276,31 +291,34 @@ try {
       const infos = [];
       const { listeners } = await makeNotifier(work, { configFile: s2Cfg }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
-      status({ agent: agentWithTitle("sub-3", "子任务C", { subagent: true, turnEnd: 1 }), status: "running" });
-      status({ agent: agentWithTitle("sub-3", "子任务C", { subagent: true, turnEnd: 1 }), status: "idle" });
+      const subPair = turnPair("sub-3", "子任务C", { subagent: true }, { turn: 1 });
+      status({ agent: subPair.running, status: "running" });
+      status({ agent: subPair.idle, status: "idle" });
       assert.equal(infos.length, 1, "notifyTaskDone=false 不拦截子代理完成（S2）");
       assert.match(infos[0], /subagent-done/);
-      status({ agent: agentWithTitle("main-3", "主任务3", { turnEnd: 1 }), status: "running" });
-      status({ agent: agentWithTitle("main-3", "主任务3", { turnEnd: 1 }), status: "idle" });
+      const mainPair = turnPair("main-3", "主任务3", {}, { turn: 1 });
+      status({ agent: mainPair.running, status: "running" });
+      status({ agent: mainPair.idle, status: "idle" });
       assert.equal(infos.length, 1, "notifyTaskDone=false 主任务不通知");
       // 既有 bug 修复回归：notifyTaskDone=false 时 idle 无条件重置状态，
       // 之后重开开关不会把旧的 running 误报为完成
-      status({ agent: agentWithTitle("main-3", "主任务3", { turnEnd: 1 }), status: "running" });
+      status({ agent: agentWithTitle("main-3", "主任务3"), status: "running" });
       assert.equal(infos.length, 1, "running 仍不通知");
     }
   }
 
-  // ── issue #272：完成判定双源订阅（session/event 推送流互补源）+ 跳过路径 warn 兜底 ──
+  // ── issue #290 阶段二：证据面单源收敛（session/event push 主源 + lastTurnEndOf
+  //    快照仅 push 缺失兜底 + runningBaseline 冻结）+ 跳过路径 warn 兜底 ──
   {
     const infos = [];
     const warns = [];
-    // 关闭完成聚合：本块聚焦双源证据合并语义，每条完成即时通知便于计数
+    // 关闭完成聚合：本块聚焦单源证据合并语义，每条完成即时通知便于计数
     // （doneMergeWindowMs 是运行时配置，须经 configFile 文件传入）
-    const dualCfg = join(work, "dual-source.json");
-    writeFileSync(dualCfg, JSON.stringify({ doneMergeWindowMs: 0 }));
+    const singleCfg = join(work, "single-source.json");
+    writeFileSync(singleCfg, JSON.stringify({ doneMergeWindowMs: 0 }));
     const { listeners } = await makeNotifier(
       work,
-      { configFile: dualCfg },
+      { configFile: singleCfg },
       { logger: { info: (t) => infos.push(t), warn: (t) => warns.push(t) } }
     );
     const status = listeners.get("agent/status")[0];
@@ -308,46 +326,55 @@ try {
     const disposed = listeners.get("agent/disposed")[0];
     const countDone = () => infos.filter((t) => /dsh-notifier: done /.test(t)).length;
 
-    // (a) events 停滞形态反证（#272 报告场景）：agent.session.events 冻结在
-    //     turn=1（快照回读永远拿到旧证据，模拟一次性读滞后被固化的形态），
-    //     session/event 推送流正常逐轮派发。修复前：仅首轮通知、后续永久静默
-    //     且零日志；修复后：推送流兜底，逐轮通知。
+    // (a) push 恒定新鲜为主证据（#272 报告场景反证，阶段二 A-2）：agent.session
+    //     .events 冻结在 turn=1（快照一次性读滞后被 lastEndedTurn 固化的形态——
+    //     running/idle 同构造恰模拟 events 停滞），session/event 推送流正常逐轮
+    //     派发。单源收敛后判定只采信 push（不读快照）→ 逐轮通知 4 条，不再
+    //     依赖双源按 turn 取新。
     for (let turn = 1; turn <= 4; turn += 1) {
       status({ agent: agentWithTitle("stuck-a", "停滞会话", { turnEnd: 1 }), status: "running" });
       sessionEvent({ id: "stuck-a" }, turnEndEvent(turn));
       status({ agent: agentWithTitle("stuck-a", "停滞会话", { turnEnd: 1 }), status: "idle" });
     }
-    assert.equal(countDone(), 4, "(a) events 停滞形态下 session/event 推送流兜底逐轮通知");
+    assert.equal(countDone(), 4, "(a) events 停滞形态下 push 主证据逐轮通知（快照冻结不影响）");
 
-    // (b) 双源去重：同一 turn 两源到达只通知一次——快照与推送指向同一
-    //     append-only 日志的同一事件，turn 相同即同一证据，合并为单次通知。
+    // (b) 同 turn 去重（A-3）：push 与快照指向同一 append-only 日志的同一事件，
+    //     turn 相同即同一证据——采信 push 后合并为单次通知；已记忆 turn 的重复
+    //     派发不重复通知。
     status({ agent: agentWithTitle("dedup-1", "去重会话", { turnEnd: 2 }), status: "running" });
     sessionEvent({ id: "dedup-1" }, turnEndEvent(2));
     status({ agent: agentWithTitle("dedup-1", "去重会话", { turnEnd: 2 }), status: "idle" });
-    assert.equal(countDone(), 5, "(b) 快照+推送同 turn 合并为单次通知");
+    assert.equal(countDone(), 5, "(b) push+快照同 turn 合并为单次通知");
     sessionEvent({ id: "dedup-1" }, turnEndEvent(2)); // 已记忆 turn 的重复派发不再触发
     status({ agent: agentWithTitle("dedup-1", "去重会话", { turnEnd: 2 }), status: "running" });
     status({ agent: agentWithTitle("dedup-1", "去重会话", { turnEnd: 2 }), status: "idle" });
     assert.equal(countDone(), 5, "(b) 已记忆 turn 的重复到达不重复通知");
 
-    // (c) 跳过路径 warn 兜底：无任何新证据的 idle 判定跳过必须可观测
-    //     （#272 报告场景「全程零日志」的反面）。
-    status({ agent: agentWithTitle("warn-1", "静默会话", { turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("warn-1", "静默会话", { turnEnd: 1 }), status: "idle" }); // 首轮正常通知，lastEndedTurn=1
+    // (c) 跳过路径 warn 兜底（E-1）：无新证据的 idle 判定跳过必须可观测，且
+    //     warn 字段标识证据来源（单源语义：证据源=push / 快照兜底 / 快照冻结）。
+    //     首轮为真实完成时序（running 无 closure → idle turn=1 completed 通知），
+    //     第二轮 events 仍停 turn=1（abort-early 形态）→ 快照 ≤ running 基线
+    //     被冻结 → 跳过 + warn（证据源=快照冻结）。
+    const w1 = turnPair("warn-1", "静默会话", {}, { turn: 1 });
+    status({ agent: w1.running, status: "running" });
+    status({ agent: w1.idle, status: "idle" }); // 首轮正常通知，lastEndedTurn=1
     const beforeWarn = countDone();
     status({ agent: agentWithTitle("warn-1", "静默会话", { turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("warn-1", "静默会话", { turnEnd: 1 }), status: "idle" }); // 无新证据 → 跳过 + warn
+    status({ agent: agentWithTitle("warn-1", "静默会话", { turnEnd: 1 }), status: "idle" }); // 无新 closure → 快照冻结 + warn
     assert.equal(countDone(), beforeWarn, "(c) 无新证据轮不发 done");
     const warnLine = warns.find((t) => t.includes("warn-1"));
     assert.ok(warnLine !== undefined, "(c) 跳过路径输出 warn 日志");
     assert.match(warnLine, /完成判定跳过/, "(c) warn 标识跳过动作");
+    assert.match(warnLine, /证据源=快照冻结/, "(c) warn 证据源标识快照冻结（abort-early 陈旧快照）");
     assert.match(warnLine, /快照turn=1/, "(c) warn 含快照源检测到的 turn");
     assert.match(warnLine, /推送turn=-/, "(c) warn 含推送源检测值（无则为 -）");
     assert.match(warnLine, /记忆turn=1/, "(c) warn 含记忆的 lastEndedTurn");
 
-    // 设计内静默同样留痕：aborted 中断不发 done，但 warn 带 kind=aborted 可核对。
-    status({ agent: agentWithTitle("abort-1", "中断会话", { turnEnd: 1, turnEndKind: "aborted" }), status: "running" });
-    status({ agent: agentWithTitle("abort-1", "中断会话", { turnEnd: 1, turnEndKind: "aborted" }), status: "idle" });
+    // 设计内静默同样留痕：aborted 中断不发 done，但 warn 带 kind=aborted 可核对
+    // （真实时序：本轮 aborted closure 落盘 → 白名单拒绝，非快照冻结）。
+    const a1 = turnPair("abort-1", "中断会话", {}, { turn: 1, kind: "aborted" });
+    status({ agent: a1.running, status: "running" });
+    status({ agent: a1.idle, status: "idle" });
     assert.equal(countDone(), beforeWarn, "aborted 中断不发 done");
     assert.ok(warns.some((t) => t.includes("abort-1") && /kind=aborted/.test(t)), "aborted 静默留痕 kind=aborted");
 
@@ -358,19 +385,17 @@ try {
     status({ agent: agentWithTitle("gc-1", "清理会话", { turnEnd: 3 }), status: "idle" }); // 状态机+辅源已清零：不通知
     assert.equal(countDone(), beforeWarn, "disposed 清理后辅源残留不误报");
 
-    // (d) 畸形载荷不毒化记忆（#284 复核闸 P1）：turn 非数字的推送 turn/end
-    //     直接 skip 不落记忆——修复前 {turn:NaN} 凭 ended===undefined 短路成
-    //     best、首轮误报一条并把 lastEndedTurn 推进为 NaN，此后真实完成因
-    //     x > NaN 恒 false 被永久吞掉。
-    status({ agent: agentWithTitle("mal-1", "畸形会话"), status: "running" }); // 无快照 turn/end（ended===undefined 场景）
+    // (d) 畸形载荷不毒化记忆（#284 复核闸 P1，B-2）：turn 非数字的推送 turn/end
+    //     直接 skip 不落记忆——任何畸形证据既不能成 best、也不能推进记忆。
+    status({ agent: agentWithTitle("mal-1", "畸形会话"), status: "running" }); // 无快照 turn/end（pushed/快照均缺失形态）
     sessionEvent({ id: "mal-1" }, { type: "turn/end", data: { turn: "x", reason: { kind: "completed" } } });
     sessionEvent({ id: "mal-1" }, { type: "turn/end", data: { turn: Number.NaN, reason: { kind: "completed" } } });
     status({ agent: agentWithTitle("mal-1", "畸形会话"), status: "idle" });
     assert.equal(countDone(), beforeWarn, "(d) 畸形载荷不误报 done");
     const malWarn = warns.find((t) => t.includes("mal-1"));
     assert.ok(malWarn !== undefined && /完成判定跳过/.test(malWarn), "(d) 畸形证据不可用走跳过路径 warn");
-    assert.match(malWarn, /快照turn=- 推送turn=- 记忆turn=-/, "(d) 两源均无可信证据（记忆未被毒化）");
-    // 毒化回归反证：随后真实 turn=2 双源一致 completed 照常通知（修复前被 NaN 记忆吞掉）。
+    assert.match(malWarn, /证据源=无 快照turn=- 推送turn=- 记忆turn=-/, "(d) 无任何可信证据（记忆未被毒化）");
+    // 毒化回归反证：随后真实 turn=2 push completed 照常通知（修复前被 NaN 记忆吞掉）。
     status({ agent: agentWithTitle("mal-1", "畸形会话", { turnEnd: 2 }), status: "running" });
     sessionEvent({ id: "mal-1" }, turnEndEvent(2));
     status({ agent: agentWithTitle("mal-1", "畸形会话", { turnEnd: 2 }), status: "idle" });
@@ -405,9 +430,9 @@ try {
       { logger: { info: (t) => infos.push(t), warn: (t) => warns.push(t) } }
     );
     const status = listeners.get("agent/status")[0];
-    const mk = () => agentWithTitle("a2-1", "无 agents 主任务", { turnEnd: 1 });
-    status({ agent: mk(), status: "running" });
-    status({ agent: mk(), status: "idle" });
+    const pair = turnPair("a2-1", "无 agents 主任务", {}, { turn: 1 });
+    status({ agent: pair.running, status: "running" });
+    status({ agent: pair.idle, status: "idle" });
     assert.equal(infos.filter((t) => /: done /.test(t)).length, 1, "A-2：无 agents 时 completed 走 done 主分支");
     assert.ok(!warns.some((t) => t.includes("agent/status 处理失败")), "A-2：无 'agent/status 处理失败' warn");
   }
@@ -422,15 +447,15 @@ try {
     const { listeners } = await makeNotifier(work, { configFile: a3Cfg }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
     // fork 型：无 origin、带 parentSession + seedLength，归属服务缺位 → 保守走 done
-    const fork = () => agentWithTitle("a3-fork", "fork 型无 agents", { parentSession: "ghost-parent", seedLength: 3, turnEnd: 1 });
-    status({ agent: fork(), status: "running" });
-    status({ agent: fork(), status: "idle" });
+    const forkPair = () => turnPair("a3-fork", "fork 型无 agents", { parentSession: "ghost-parent", seedLength: 3 }, { turn: 1 });
+    status({ agent: forkPair().running, status: "running" });
+    status({ agent: forkPair().idle, status: "idle" });
     assert.equal(infos.filter((t) => /: done /.test(t)).length, 1, "A-3：agents 缺位 fork 型保守走 done");
     assert.ok(!infos.some((t) => /: subagent-done /.test(t)), "A-3：不误判 subagent-done");
     // spawn 型：origin 信号不依赖 agents，仍走 subagent 分支
-    const spawn = () => agentWithTitle("a3-spawn", "spawn 子任务", { subagent: true, turnEnd: 2 });
-    status({ agent: spawn(), status: "running" });
-    status({ agent: spawn(), status: "idle" });
+    const spawnPair = () => turnPair("a3-spawn", "spawn 子任务", { subagent: true }, { turn: 2 });
+    status({ agent: spawnPair().running, status: "running" });
+    status({ agent: spawnPair().idle, status: "idle" });
     assert.equal(infos.filter((t) => /: subagent-done /.test(t)).length, 1, "A-3：spawn 型 origin 信号仍走 subagent 分支");
   }
 
@@ -443,13 +468,14 @@ try {
     const warns = [];
     const { listeners } = await makeNotifier(work, { configFile: b1Cfg }, { logger: { info: (t) => infos.push(t), warn: (t) => warns.push(t) } });
     const status = listeners.get("agent/status")[0];
-    const mk = () => agentWithTitle("b1-1", "开关禁用任务", { turnEnd: 1 });
-    status({ agent: mk(), status: "running" });
-    status({ agent: mk(), status: "idle" });
+    const pair = turnPair("b1-1", "开关禁用任务", {}, { turn: 1 });
+    status({ agent: pair.running, status: "running" });
+    status({ agent: pair.idle, status: "idle" });
     assert.equal(infos.filter((t) => /: done /.test(t)).length, 0, "B-1：notifyTaskDone=false 主任务不通知");
-    // 同 turn 再现 idle：lastEndedTurn 已提交 → 无新证据 → skip（不重复处理）
-    status({ agent: mk(), status: "running" });
-    status({ agent: mk(), status: "idle" });
+    // 同 turn 再现 idle：lastEndedTurn 已提交 → 无新证据 → skip（不重复处理）；
+    // 构造为「events 仍停 turn=1」的 abort-early 形态（快照 ≤ running 基线冻结）
+    status({ agent: agentWithTitle("b1-1", "开关禁用任务", { turnEnd: 1 }), status: "running" });
+    status({ agent: agentWithTitle("b1-1", "开关禁用任务", { turnEnd: 1 }), status: "idle" });
     assert.equal(infos.filter((t) => /: done /.test(t)).length, 0, "B-1：开关禁用后同 turn 再现 idle 不重复");
     assert.ok(warns.some((t) => t.includes("b1-1") && /完成判定跳过/.test(t)), "B-1：再现 idle 走跳过路径 warn 留痕");
   }
@@ -465,16 +491,16 @@ try {
     const { listeners, routes } = await makeNotifier(work, { configFile: b2Cfg, historyFile: join(work, "b2-hist.jsonl") }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
     const historyRoute = routes.find((r) => r.path === ROUTES.history);
-    const mk = () => agentWithTitle("b2-1", "免打扰完成", { turnEnd: 1 });
-    status({ agent: mk(), status: "running" });
-    status({ agent: mk(), status: "idle" });
+    const pair = turnPair("b2-1", "免打扰完成", {}, { turn: 1 });
+    status({ agent: pair.running, status: "running" });
+    status({ agent: pair.idle, status: "idle" });
     assert.ok(!infos.some((t) => /dsh-notifier: done /.test(t) && !t.includes("被免打扰拦截")), "B-2：免打扰拦截不发出系统通知");
     assert.ok(infos.some((t) => t.includes("被免打扰拦截")), "B-2：拦截记录日志");
     const records = await waitForHistory(historyRoute, (r) => r.some((e) => e.kind === "done" && e.suppressed === "quiet"));
     assert.equal(records.filter((e) => e.kind === "done" && e.suppressed === "quiet").length, 1, "B-2：仅一条 suppressed:quiet 历史");
     // 同 turn 再现 idle：免打扰拦截也是三态提交之一（lastEndedTurn 已推进）→ 不重复
-    status({ agent: mk(), status: "running" });
-    status({ agent: mk(), status: "idle" });
+    status({ agent: agentWithTitle("b2-1", "免打扰完成", { turnEnd: 1 }), status: "running" });
+    status({ agent: agentWithTitle("b2-1", "免打扰完成", { turnEnd: 1 }), status: "idle" });
     const after = await waitForHistory(historyRoute, (r) => r.length > records.length, 500);
     assert.equal(after.length, records.length, "B-2：同 turn 再现 idle 不新增历史记录");
   }
@@ -487,13 +513,13 @@ try {
     const infos = [];
     const { listeners } = await makeNotifier(work, { configFile: b4Cfg }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
-    const mk = () => agentWithTitle("b4-1", "合并窗口任务", { turnEnd: 1 });
-    status({ agent: mk(), status: "running" });
-    status({ agent: mk(), status: "idle" });
+    const pair = turnPair("b4-1", "合并窗口任务", {}, { turn: 1 });
+    status({ agent: pair.running, status: "running" });
+    status({ agent: pair.idle, status: "idle" });
     assert.equal(infos.filter((t) => /: done /.test(t)).length, 1, "B-4：首条完成即时通知并入队");
     // 窗口未 flush 时同 turn 再现 idle：入队成功已提交 lastEndedTurn → 不重复
-    status({ agent: mk(), status: "running" });
-    status({ agent: mk(), status: "idle" });
+    status({ agent: agentWithTitle("b4-1", "合并窗口任务", { turnEnd: 1 }), status: "running" });
+    status({ agent: agentWithTitle("b4-1", "合并窗口任务", { turnEnd: 1 }), status: "idle" });
     assert.equal(infos.filter((t) => /: done /.test(t)).length, 1, "B-4：窗口内同 turn 再现 idle 不重复（入队即提交）");
   }
 
@@ -509,24 +535,69 @@ try {
     const { listeners } = await makeNotifier(work, { configFile: b4fCfg }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
     const doneCount = () => infos.filter((t) => /: done /.test(t)).length;
-    const mkA = () => agentWithTitle("b4f-a", "flush 后 A", { turnEnd: 1 });
-    const mkB = () => agentWithTitle("b4f-b", "flush 后 B", { turnEnd: 1 });
+    const pairA = () => turnPair("b4f-a", "flush 后 A", {}, { turn: 1 });
+    const pairB = () => turnPair("b4f-b", "flush 后 B", {}, { turn: 1 });
     // 两条完成进入同一聚合窗口（首条即时、第二条入队挂起）
-    status({ agent: mkA(), status: "running" });
-    status({ agent: mkA(), status: "idle" });
-    status({ agent: mkB(), status: "running" });
-    status({ agent: mkB(), status: "idle" });
+    status({ agent: pairA().running, status: "running" });
+    status({ agent: pairA().idle, status: "idle" });
+    status({ agent: pairB().running, status: "running" });
+    status({ agent: pairB().idle, status: "idle" });
     assert.equal(doneCount(), 1, "B-4：窗口内首条即时、第二条挂起");
     // 等窗口到点：flush 补发聚合条（正常路径）
     await new Promise((resolve) => setTimeout(resolve, 100));
     assert.equal(doneCount(), 2, "B-4：flush 补发聚合条");
     assert.ok(infos.some((t) => /: done /.test(t) && t.includes("另有 1 个任务已完成")), "B-4：聚合条文案带计数");
-    // 已提交 turn 不回退：flush 完成后再现 idle 不重复
-    status({ agent: mkA(), status: "running" });
-    status({ agent: mkA(), status: "idle" });
-    status({ agent: mkB(), status: "running" });
-    status({ agent: mkB(), status: "idle" });
+    // 已提交 turn 不回退：flush 完成后再现 idle（无新 closure 形态）不重复
+    status({ agent: agentWithTitle("b4f-a", "flush 后 A", { turnEnd: 1 }), status: "running" });
+    status({ agent: agentWithTitle("b4f-a", "flush 后 A", { turnEnd: 1 }), status: "idle" });
+    status({ agent: agentWithTitle("b4f-b", "flush 后 B", { turnEnd: 1 }), status: "running" });
+    status({ agent: agentWithTitle("b4f-b", "flush 后 B", { turnEnd: 1 }), status: "idle" });
     assert.equal(doneCount(), 2, "B-4：flush 后已提交 turn 不回退重发");
+  }
+
+  // ── issue #290 阶段二：重载窗口后首轮 live turn 仍通知（D-1）与
+  //    重载不引入假阳性（D-2）——独立实例模拟插件重载（新 fiber 的
+  //    agentStates / eventStreamEnds 记忆为空）──
+  {
+    // D-1：重载窗口后首轮 live turn 仍通知（快照兜底补证）。
+    // 构造：上一轮 turn=1 已落盘（重载前已派发、新 fiber 未记忆，push 缺失），
+    // 本轮 live turn=2 completed 落盘后 running→idle——快照较 running 基线推进，
+    // 走快照兜底补证 → 恰一条 done，不因记忆重置静默。
+    const d1Cfg = join(work, "d1-reload.json");
+    writeFileSync(d1Cfg, JSON.stringify({ doneMergeWindowMs: 0 }));
+    const infos1 = [];
+    const warns1 = [];
+    const { listeners: l1 } = await makeNotifier(
+      work,
+      { configFile: d1Cfg, historyFile: join(work, "d1-hist.jsonl") },
+      { logger: { info: (t) => infos1.push(t), warn: (t) => warns1.push(t) } }
+    );
+    const status1 = l1.get("agent/status")[0];
+    const d1 = turnPair("d1-1", "重载后任务", {}, { turn: 2 }, { turn: 1 }); // prev=1（重载前 closure）、this=2（本轮 live）
+    status1({ agent: d1.running, status: "running" });
+    status1({ agent: d1.idle, status: "idle" });
+    assert.equal(infos1.filter((t) => /: done /.test(t)).length, 1, "D-1：重载后首轮 live turn 经快照兜底通知（恰一条）");
+    assert.ok(!warns1.some((t) => t.includes("d1-1")), "D-1：重载后首轮 live turn 不走跳过路径（无 warn）");
+
+    // D-2：重载后 abort-early（本轮无新 closure）idle 仍静默——running 基线
+    //     捕获上一轮 turn=1 completed，idle 时快照仍 turn=1（≤ 基线）→ 冻结，
+    //     不因记忆重置把旧证据当新轮完成。
+    const d2Cfg = join(work, "d2-reload-abort.json");
+    writeFileSync(d2Cfg, JSON.stringify({ doneMergeWindowMs: 0 }));
+    const infos2 = [];
+    const warns2 = [];
+    const { listeners: l2 } = await makeNotifier(
+      work,
+      { configFile: d2Cfg, historyFile: join(work, "d2-hist.jsonl") },
+      { logger: { info: (t) => infos2.push(t), warn: (t) => warns2.push(t) } }
+    );
+    const status2 = l2.get("agent/status")[0];
+    status2({ agent: agentWithTitle("d2-1", "重载后中断", { turnEnd: 1 }), status: "running" });
+    status2({ agent: agentWithTitle("d2-1", "重载后中断", { turnEnd: 1 }), status: "idle" });
+    assert.equal(infos2.filter((t) => /: done /.test(t)).length, 0, "D-2：重载后 abort-early 静默（不把旧证据当新轮完成）");
+    const d2Warn = warns2.find((t) => t.includes("d2-1"));
+    assert.ok(d2Warn !== undefined && /完成判定跳过/.test(d2Warn), "D-2：重载后 abort-early 跳过路径 warn 留痕");
+    assert.match(d2Warn, /证据源=快照冻结/, "D-2：warn 标识快照冻结（陈旧快照拦截）");
   }
 } finally {
   rmSync(work, { recursive: true, force: true });

--- a/packages/dsh-notifier/test/e2e-edge.src.test.ts
+++ b/packages/dsh-notifier/test/e2e-edge.src.test.ts
@@ -10,7 +10,7 @@
 import { join } from "node:path";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { assert, makeNotifier, makeFakeCtx, agentWithTitle, makeRes, fakeReq, waitForHistory } from "./helpers.ts";
+import { assert, makeNotifier, makeFakeCtx, agentWithTitle, makeRes, fakeReq, waitForHistory, turnPair } from "./helpers.ts";
 import { ROUTES, apply } from "../src/index.ts";
 
 const work = mkdtempSync(join(tmpdir(), "dnotify-e2e-edge-"));
@@ -129,8 +129,9 @@ try {
     assert.ok(warns.some((w) => w.includes("通知失败")), "approval notify 失败时 warn 记录");
 
     // agent/status：idle → notify 抛错 → catch → warn
-    status({ agent: agentWithTitle("fail-2", "出错任务", { turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("fail-2", "出错任务", { turnEnd: 1 }), status: "idle" });
+    const fail2 = turnPair("fail-2", "出错任务", {}, { turn: 1 });
+    status({ agent: fail2.running, status: "running" });
+    status({ agent: fail2.idle, status: "idle" });
     assert.ok(warns.some((w) => w.includes("agent/status")), "status notify 失败时 warn 记录");
 
     // agent/error：notify 抛错 → catch → warn
@@ -151,12 +152,14 @@ try {
     });
     const status = listeners.get("agent/status")[0];
     // 主任务完成 → done 通知，doneBatch 开始
-    status({ agent: agentWithTitle("mk-1", "主任务", { turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("mk-1", "主任务", { turnEnd: 1 }), status: "idle" });
+    const mk1 = turnPair("mk-1", "主任务", {}, { turn: 1 });
+    status({ agent: mk1.running, status: "running" });
+    status({ agent: mk1.idle, status: "idle" });
     assert.equal(infos.filter((t) => /done/.test(t)).length, 1, "首条 done 即时通知");
     // 子代理完成 → kind 不同 → flushDoneMerge（count=1 不补发）+ 即时 subagent-done
-    status({ agent: agentWithTitle("mk-2", "子代理", { subagent: true, turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("mk-2", "子代理", { subagent: true, turnEnd: 1 }), status: "idle" });
+    const mk2 = turnPair("mk-2", "子代理", { subagent: true }, { turn: 1 });
+    status({ agent: mk2.running, status: "running" });
+    status({ agent: mk2.idle, status: "idle" });
     const doneCount = infos.filter((t) => /: done /.test(t)).length;
     const subCount = infos.filter((t) => /: subagent-done /.test(t)).length;
     assert.equal(doneCount, 1, "类型切换后 done 不重复");

--- a/packages/dsh-notifier/test/e2e-edge.test.ts
+++ b/packages/dsh-notifier/test/e2e-edge.test.ts
@@ -10,7 +10,7 @@
 import { join } from "node:path";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { assert, makeNotifier, makeFakeCtx, agentWithTitle, makeRes, fakeReq, waitForHistory } from "./helpers.ts";
+import { assert, makeNotifier, makeFakeCtx, agentWithTitle, makeRes, fakeReq, waitForHistory, turnPair } from "./helpers.ts";
 import { ROUTES, apply } from "../lib/index.js";
 
 const work = mkdtempSync(join(tmpdir(), "dnotify-e2e-edge-"));
@@ -129,8 +129,9 @@ try {
     assert.ok(warns.some((w) => w.includes("通知失败")), "approval notify 失败时 warn 记录");
 
     // agent/status：idle → notify 抛错 → catch → warn
-    status({ agent: agentWithTitle("fail-2", "出错任务", { turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("fail-2", "出错任务", { turnEnd: 1 }), status: "idle" });
+    const fail2 = turnPair("fail-2", "出错任务", {}, { turn: 1 });
+    status({ agent: fail2.running, status: "running" });
+    status({ agent: fail2.idle, status: "idle" });
     assert.ok(warns.some((w) => w.includes("agent/status")), "status notify 失败时 warn 记录");
 
     // agent/error：notify 抛错 → catch → warn
@@ -151,12 +152,14 @@ try {
     });
     const status = listeners.get("agent/status")[0];
     // 主任务完成 → done 通知，doneBatch 开始
-    status({ agent: agentWithTitle("mk-1", "主任务", { turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("mk-1", "主任务", { turnEnd: 1 }), status: "idle" });
+    const mk1 = turnPair("mk-1", "主任务", {}, { turn: 1 });
+    status({ agent: mk1.running, status: "running" });
+    status({ agent: mk1.idle, status: "idle" });
     assert.equal(infos.filter((t) => /done/.test(t)).length, 1, "首条 done 即时通知");
     // 子代理完成 → kind 不同 → flushDoneMerge（count=1 不补发）+ 即时 subagent-done
-    status({ agent: agentWithTitle("mk-2", "子代理", { subagent: true, turnEnd: 1 }), status: "running" });
-    status({ agent: agentWithTitle("mk-2", "子代理", { subagent: true, turnEnd: 1 }), status: "idle" });
+    const mk2 = turnPair("mk-2", "子代理", { subagent: true }, { turn: 1 });
+    status({ agent: mk2.running, status: "running" });
+    status({ agent: mk2.idle, status: "idle" });
     const doneCount = infos.filter((t) => /: done /.test(t)).length;
     const subCount = infos.filter((t) => /: subagent-done /.test(t)).length;
     assert.equal(doneCount, 1, "类型切换后 done 不重复");

--- a/packages/dsh-notifier/test/e2e-interrupt.test.ts
+++ b/packages/dsh-notifier/test/e2e-interrupt.test.ts
@@ -5,12 +5,18 @@
  * 覆盖：用户停止生成/中断（turn/end reason aborted）固定静默；
  * S1 本轮无新 turn/end closure 宁可静默；失败（error）/阻塞（blocked）/
  * 截断（max-tokens）/未知 kind 不误报「任务完成」；中断与失败后新一轮
- * 正常恢复通知。
+ * 正常恢复通知；issue #290 阶段二 C-1/D-2：重载后首次 idle + abort-early
+ * 陈旧快照经 runningBaseline 冻结静默（不把旧证据当新轮完成）。
+ *
+ * 时序约定（helpers.turnPair / agentWithTitle 联用）：「本轮完成」用例区分
+ * running/idle 两态事件面（running = 上一轮 closure 或空，idle = 本轮 closure）；
+ * 「running 与 idle 同构造（idle 无推进）」= abort-early 无新 closure 形态，
+ * 在单源 runningBaseline 冻结语义下必须静默（见 helpers.turnPair 注释）。
  */
 import { join } from "node:path";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { assert, makeNotifier, agentWithTitle, waitMergeWindow } from "./helpers.ts";
+import { assert, makeNotifier, agentWithTitle, waitMergeWindow, turnPair } from "./helpers.ts";
 
 const work = mkdtempSync(join(tmpdir(), "dnotify-e2e-interrupt-"));
 try {
@@ -18,18 +24,23 @@ try {
   const { listeners } = await makeNotifier(work, {}, { logger: { warn: () => {}, info: (t) => infos.push(t) } });
   const status = listeners.get("agent/status")[0];
 
-  // 用户停止生成（turn/end aborted）：不通知完成
-  status({ agent: agentWithTitle("int-1", "被打断的任务", { turnEnd: 1, turnEndKind: "aborted" }), status: "running" });
-  status({ agent: agentWithTitle("int-1", "被打断的任务", { turnEnd: 1, turnEndKind: "aborted" }), status: "idle" });
+  // 用户停止生成（turn/end aborted）：不通知完成（本轮 aborted closure 落盘，
+  // 白名单拒绝；非快照冻结形态）
+  const int1 = turnPair("int-1", "被打断的任务", {}, { turn: 1, kind: "aborted" });
+  status({ agent: int1.running, status: "running" });
+  status({ agent: int1.idle, status: "idle" });
   assert.equal(infos.length, 0, "中断（turn/end aborted）不通知完成");
 
   // S1：abort 早于本轮 turn/start 落盘——本轮无新 turn/end，读到的还是
-  // 上一次的 completed → 必须静默（不能误报完成）
-  status({ agent: agentWithTitle("s1-1", "任务S1", { turnEnd: 1 }), status: "running" });
-  status({ agent: agentWithTitle("s1-1", "任务S1", { turnEnd: 1 }), status: "idle" });
+  // 上一次的 completed → 必须静默（不能误报完成）。
+  // 首轮为真实完成时序（running 无 closure → idle turn=1 completed 通知）。
+  const s1First = turnPair("s1-1", "任务S1", {}, { turn: 1 });
+  status({ agent: s1First.running, status: "running" });
+  status({ agent: s1First.idle, status: "idle" });
   assert.equal(infos.length, 1, "正常完成一轮");
   assert.match(infos[0], /done/);
-  // 第二轮被提前中断：events 无新 turn/end（仍停在 turn=1 completed），idle 照发 → 静默
+  // 第二轮被提前中断：events 无新 turn/end（仍停在 turn=1 completed），idle
+  // 照发 → 快照 ≤ running 基线被冻结 → 静默
   status({ agent: agentWithTitle("s1-1", "任务S1", { turnEnd: 1 }), status: "running" });
   status({ agent: agentWithTitle("s1-1", "任务S1", { turnEnd: 1 }), status: "idle" });
   assert.equal(infos.length, 1, "S1：本轮无新 turn/end closure 宁可静默");
@@ -42,49 +53,78 @@ try {
   // 中断后继续：新一轮 turn/end completed（turn 号递增）正常通知
   // （先等 s1-1 场景的 3s 完成聚合窗口结束，避免本轮完成被并入旧窗口挂起）
   await waitMergeWindow();
-  status({ agent: agentWithTitle("int-2", "中断后继续", { turnEnd: 1, turnEndKind: "aborted" }), status: "running" });
-  status({ agent: agentWithTitle("int-2", "中断后继续", { turnEnd: 1, turnEndKind: "aborted" }), status: "idle" });
+  const int2a = turnPair("int-2", "中断后继续", {}, { turn: 1, kind: "aborted" });
+  status({ agent: int2a.running, status: "running" });
+  status({ agent: int2a.idle, status: "idle" });
   assert.equal(infos.length, 1, "中断静默");
-  status({ agent: agentWithTitle("int-2", "中断后继续", { turnEnd: 2 }), status: "running" });
-  status({ agent: agentWithTitle("int-2", "中断后继续", { turnEnd: 2 }), status: "idle" });
+  const int2b = turnPair("int-2", "中断后继续", {}, { turn: 2 }, { turn: 1, kind: "aborted" }); // 上一轮 aborted 已落盘
+  status({ agent: int2b.running, status: "running" });
+  status({ agent: int2b.idle, status: "idle" });
   assert.equal(infos.length, 2, "中断后新一轮完成正常通知");
   assert.match(infos[1], /done/);
 
   // 子代理被中断（interrupt_agent → 子代理 turn/end aborted）：同样静默
-  status({ agent: agentWithTitle("int-3", "子代理中断", { depth: 1, turnEnd: 1, turnEndKind: "aborted" }), status: "running" });
-  status({ agent: agentWithTitle("int-3", "子代理中断", { depth: 1, turnEnd: 1, turnEndKind: "aborted" }), status: "idle" });
+  const int3 = turnPair("int-3", "子代理中断", { depth: 1 }, { turn: 1, kind: "aborted" });
+  status({ agent: int3.running, status: "running" });
+  status({ agent: int3.idle, status: "idle" });
   assert.equal(infos.length, 2, "子代理中断不通知");
 
   // 任务失败（turn/end reason error）：idle 不得误报「任务完成」——
   // 失败由 agent/error 单独负责「任务出错」，同一轮不得叠加「完成」。
-  status({ agent: agentWithTitle("err-1", "失败的任务", { turnEnd: 1, turnEndKind: "error" }), status: "running" });
-  status({ agent: agentWithTitle("err-1", "失败的任务", { turnEnd: 1, turnEndKind: "error" }), status: "idle" });
+  const err1 = turnPair("err-1", "失败的任务", {}, { turn: 1, kind: "error" });
+  status({ agent: err1.running, status: "running" });
+  status({ agent: err1.idle, status: "idle" });
   assert.equal(infos.length, 2, "失败（turn/end error）不通知完成");
 
   // 任务被阻塞（turn/end reason blocked，如等待用户问题）：idle 也不得误报完成
-  status({ agent: agentWithTitle("blk-1", "被阻塞的任务", { turnEnd: 1, turnEndKind: "blocked" }), status: "running" });
-  status({ agent: agentWithTitle("blk-1", "被阻塞的任务", { turnEnd: 1, turnEndKind: "blocked" }), status: "idle" });
+  const blk1 = turnPair("blk-1", "被阻塞的任务", {}, { turn: 1, kind: "blocked" });
+  status({ agent: blk1.running, status: "running" });
+  status({ agent: blk1.idle, status: "idle" });
   assert.equal(infos.length, 2, "阻塞（turn/end blocked）不通知完成");
 
   // 失败后继续：新一轮 turn/end completed（turn 号递增）正常通知
   // （先等 int-2 完成聚合窗口结束，避免本轮完成被并入旧窗口挂起）
   await waitMergeWindow();
-  status({ agent: agentWithTitle("err-2", "失败后继续", { turnEnd: 1, turnEndKind: "error" }), status: "running" });
-  status({ agent: agentWithTitle("err-2", "失败后继续", { turnEnd: 1, turnEndKind: "error" }), status: "idle" });
+  const err2a = turnPair("err-2", "失败后继续", {}, { turn: 1, kind: "error" });
+  status({ agent: err2a.running, status: "running" });
+  status({ agent: err2a.idle, status: "idle" });
   assert.equal(infos.length, 2, "失败静默");
-  status({ agent: agentWithTitle("err-2", "失败后继续", { turnEnd: 2 }), status: "running" });
-  status({ agent: agentWithTitle("err-2", "失败后继续", { turnEnd: 2 }), status: "idle" });
+  const err2b = turnPair("err-2", "失败后继续", {}, { turn: 2 }, { turn: 1, kind: "error" }); // 上一轮 error 已落盘
+  status({ agent: err2b.running, status: "running" });
+  status({ agent: err2b.idle, status: "idle" });
   assert.equal(infos.length, 3, "失败后新一轮完成正常通知");
   assert.match(infos[2], /done/);
 
   // max-tokens：模型输出被截断（答案不完整）——白名单判定「不通知完成」
-  status({ agent: agentWithTitle("mt-1", "截断的任务", { turnEnd: 1, turnEndKind: "max-tokens" }), status: "running" });
-  status({ agent: agentWithTitle("mt-1", "截断的任务", { turnEnd: 1, turnEndKind: "max-tokens" }), status: "idle" });
+  const mt1 = turnPair("mt-1", "截断的任务", {}, { turn: 1, kind: "max-tokens" });
+  status({ agent: mt1.running, status: "running" });
+  status({ agent: mt1.idle, status: "idle" });
   assert.equal(infos.length, 3, "max-tokens 不通知完成");
   // 未知 kind（未来扩展）：白名单对齐 DSH 保守语义，同样静默
-  status({ agent: agentWithTitle("uk-1", "未知结束", { turnEnd: 1, turnEndKind: "mystery-kind" }), status: "running" });
-  status({ agent: agentWithTitle("uk-1", "未知结束", { turnEnd: 1, turnEndKind: "mystery-kind" }), status: "idle" });
+  const uk1 = turnPair("uk-1", "未知结束", {}, { turn: 1, kind: "mystery-kind" });
+  status({ agent: uk1.running, status: "running" });
+  status({ agent: uk1.idle, status: "idle" });
   assert.equal(infos.length, 3, "未知 kind 不通知完成");
+
+  // ── issue #290 阶段二 C-1：重载后首次 idle + abort-early 变体 ──
+  // 独立实例模拟插件重载（新 fiber 状态机记忆为空）。重载后 agent 跑了一轮
+  // 但 abort 早于本轮 turn/start 落盘：running 基线捕获上一轮 turn=1 completed，
+  // idle 时快照仍 turn=1（≤ 基线）→ 冻结静默，不把旧证据当新轮完成。
+  {
+    const warns = [];
+    const { listeners } = await makeNotifier(
+      work,
+      { configFile: join(work, "c1-reload-abort.json"), historyFile: join(work, "c1-hist.jsonl") },
+      { logger: { warn: (t) => warns.push(t), info: () => {} } }
+    );
+    const statusR = listeners.get("agent/status")[0];
+    statusR({ agent: agentWithTitle("c1-1", "重载后中断", { turnEnd: 1 }), status: "running" });
+    statusR({ agent: agentWithTitle("c1-1", "重载后中断", { turnEnd: 1 }), status: "idle" });
+    assert.ok(!warns.some((t) => t.includes("c1-1") && !t.includes("完成判定跳过")), "C-1：重载后 abort-early 不抛处理失败 warn");
+    const c1Warn = warns.find((t) => t.includes("c1-1"));
+    assert.ok(c1Warn !== undefined && /完成判定跳过/.test(c1Warn), "C-1：重载后首次 idle + abort-early 走跳过路径 warn 留痕");
+    assert.match(c1Warn, /证据源=快照冻结/, "C-1：warn 标识快照冻结（陈旧快照拦截）");
+  }
 } finally {
   rmSync(work, { recursive: true, force: true });
 }

--- a/packages/dsh-notifier/test/helpers.ts
+++ b/packages/dsh-notifier/test/helpers.ts
@@ -182,6 +182,37 @@ export function agentWithTitle(id, title, opts = {}) {
 }
 
 /**
+ * 完成轮两态时序构造（阶段二单源 push + 快照兜底收敛后必需，issue #290）：
+ * 真实宿主中 agent/status running 派发于本轮 turn 开始——本轮 turn/end 尚未
+ * post-commit 落盘，session.events 最新条目为上一轮（或空）；idle 派发于本轮
+ * turn/end 落盘之后。单源收敛的 runningBaseline 冻结判据（idle 快照 ≤ running
+ * 基线 = 本轮无新 closure = abort-early 陈旧快照，冻结不误报）依赖该时序——
+ * 旧测试「running 与 idle 同一构造（events 已含本轮 closure）」在单源语义下会
+ * 被正确识别为无新 closure 而静默（abort 早于本轮 turn/start 落盘的形态）。
+ * 故所有「本轮完成」用例必须区分 running/idle 两态事件面：
+ *   - running 态 = 上一轮 turn/end（prevTurn，可缺省 = 首轮无 closure）
+ *   - idle 态 = 本轮 turn/end（thisTurn，lastTurnEndOf 只取最新一条，单条等价）
+ * 每次调用返回全新 { running, idle } 两态（agent/status 事件不持有引用）。
+ *
+ * @param id agent/session id
+ * @param title 任务标题（agentWithTitle 同款）
+ * @param headerOpts agentWithTitle 的 header 选项（subagent/parentSession/seedLength/depth/cwd）
+ * @param thisTurn 本轮 turn/end：{ turn, kind? }（写入 idle 态；kind 默认 completed）
+ * @param prevTurn 上一轮 turn/end：{ turn, kind? }（写入 running 态；缺省 = 首轮）
+ */
+export function turnPair(id, title, headerOpts = {}, thisTurn, prevTurn) {
+  const running = agentWithTitle(
+    id,
+    title,
+    prevTurn !== undefined
+      ? { ...headerOpts, turnEnd: prevTurn.turn, turnEndKind: prevTurn.kind ?? "completed" }
+      : headerOpts
+  );
+  const idle = agentWithTitle(id, title, { ...headerOpts, turnEnd: thisTurn.turn, turnEndKind: thisTurn.kind ?? "completed" });
+  return { running, idle };
+}
+
+/**
  * 运行时归属模拟面（issue #49）：ctx.agents 判定所需最小实现。
  * @param liveIds live registry 中存在的父/子 agent id 数组。
  * @param ownedPairs 归属关系对 [childId, ownerId]：isOwnedBy(childId, owner)


### PR DESCRIPTION
## 阶段二（PR B）：done 证据面收敛 —— session/event 单源 push + 快照兜底

关联 issue：[#290](https://github.com/wingsky-1/dsh-plugin-hub/issues/290)（阶段二，阶段一 PR A #300 已合并 `71fa77b6`）。基于 `origin/main`（`42d9f28`，含 #334 SSE 有界化）rebase 后实现。

### 改动总览

- **核心（src/index.ts）**：完成判定证据主源从「快照 vs 推送按 turn 取新」双源收敛为 **session/event push 单源**（`eventStreamEnds`，post-commit 同步派发、恒定新鲜）；`lastTurnEndOf` 快照仅在 push 缺失时兜底；新增 **runningBaseline 冻结**——running 时记录快照基线，idle 时兜底快照 ≤ 基线即判 abort-early 无新 closure 冻结（宁静静默不误报完成，重载后首次 idle 同样成立）。`lastTurnEndOf` 公共导出保留（L79 re-export 不变）。
- **测试面**：双源用例块改写为单源语义（F 组零回归 + A/B/C 组断言）；新增「重载窗口后首轮 live turn 仍通知」（D-1）与「重载后 abort-early 不引入假阳性」（D-2）e2e；`helpers` 新增 `turnPair` 完成轮两态时序构造；`.src.test.ts`（Stryker 直跑源码变体）同步。
- **文档**：README 完成判定表述同步为「单源 push + 快照兜底」。

### 本地门禁凭据（worktree `dsh-hub-task-290b`，task/290b）

| 门禁 | 结果 |
|---|---|
| `pnpm build` | ✅ 全仓构建成功 |
| `pnpm test` | ✅ 全仓 smoke 全绿（dsh-notifier smoke: OK + real-context: OK） |
| `pnpm contract` | ✅ 客户端契约全部通过 |
| `pnpm pack:check` | ✅ 全部包 tarball 完整 |
| `pnpm typecheck` | ✅ 全仓类型检查通过 |
| smoke 连续 10 次 | ✅ `for i in $(seq 1 10)` 全绿（10/10） |
| 工作树污染 | ✅ `git status --porcelain` clean（测试 mkdtempSync 隔离） |

### 全量断言表（对照阶段二 spec 18 条硬性）

> 填写约定：证据列给可复核凭据（用例名 / 文件行号 / 命令输出）。

| 条目 | 结论 | 证据或漂移解释 |
|---|---|---|
| A-1 证据主源收敛为 session/event 单源 push | **PASS** | src/index.ts L428-437：`pushed`（eventStreamEnds 有限 turn 记忆）为主证据，`snapshot = pushed === undefined ? lastTurnEndOf(agent) : undefined` 仅在 push 缺失时读取；`best = pushed ?? (stale ? undefined : snapshot)`——不再按 turn 取新 |
| A-2 push 恒定新鲜为主证据（(a) 停滞反证保留） | **PASS** | e2e-done.test.ts (a) 块：`agentWithTitle("stuck-a",...,{turnEnd:1})` running/idle 同构造（快照冻结 turn=1）+ sessionEvent 逐轮 turn 1..4 → 断言 `countDone()===4` 逐轮通知 |
| A-3 同 turn 去重保留（(b) 用例保留） | **PASS** | e2e-done.test.ts (b) 块：push 与快照同 turn=2 → 恰一次通知；重复派发 + 再现 idle → 计数不变（`countDone()===5` 两处） |
| B-1 快照仅 push 缺失兜底 | **PASS** | src/index.ts L430 分支次序（push 缺失才读快照）；D-1 e2e（下方）即为「push 缺失 → 快照兜底通知」用例；runningBaseline 冻结不阻断推进型兜底（快照 > 基线） |
| B-2 兜底 P1 守卫不回归（(d) 用例保留） | **PASS** | e2e-done.test.ts (d) 块保留：畸形 push（`turn:"x"` / NaN）skip 不落记忆、warn 断言 `证据源=无 快照turn=- 推送turn=- 记忆turn=-`；随后真实 turn=2 push 照常通知；`lastTurnEndOf` 单测（跳过非有限 turn、仅畸形返回 undefined）保留 |
| B-3 lastTurnEndOf 公共导出保留（e2e 契约不破坏） | **PASS** | src/index.ts L79 re-export 不变；e2e-done.test.ts L24 `import { ROUTES, lastTurnEndOf } from "../lib/index.js"` 继续可用并被 (d) 单测调用 |
| C-1 abort-early 陈旧快照假阳性消除 | **PASS** | src/index.ts L494-498（running 记录 runningBaseline）+ L431-437（idle 快照 ≤ 基线冻结）；e2e-interrupt S1 第二轮静默 + 新增 C-1 重载变体（独立实例，running/idle 同构造 turn=1 → 0 条 done + warn `证据源=快照冻结`）；e2e-done (c) 第二轮 / D-2 同语义 |
| C-2 非 completed 白名单不回归 | **PASS** | e2e-interrupt err-1/blk-1/mt-1/uk-1（error/blocked/max-tokens/mystery-kind 真实时序）+ int-1/int-3（aborted）全部静默；int-2/err-2「中断/失败后新一轮完成」正常通知 |
| D-1 重载窗口后首轮 live turn 仍通知（新增 e2e） | **PASS** | e2e-done.test.ts D-1 块：独立实例（新 fiber 记忆空），turnPair prev=1（重载前 closure）/this=2（本轮 live）→ 恰 1 条 done + 无 warn（快照兜底补证） |
| D-2 重载窗口不引入假阳性 | **PASS** | e2e-done.test.ts D-2 块：重载后 abort-early（running/idle 同构造 turn=1）→ 0 条 done + warn `证据源=快照冻结`；与 C-1 组合验证 |
| E-1 warn 字段同步（单源语义） | **PASS** | src/index.ts L457-462 warn 输出 `证据源=… 快照turn=… 推送turn=… 记忆turn=…`；e2e-done (c) 块断言更新（`/证据源=快照冻结/`、`/快照turn=1/`、`/推送turn=-/`、`/记忆turn=1/`）；(d) 断言 `/证据源=无/` |
| F-1 7 处 ctx.on 全带 {global:true} 契约保留 | **PASS** | real-context.test.ts L61-64 静态契约断言（onCalls≥7 且 globalized===onCalls）未改动、全绿；源码 grep 7 处 `ctx.on` 均带 `{ global: true }` |
| F-2 根因 A 安全化不回归 | **PASS** | src/index.ts L479 `ctx.get("agents", false)`、inject 保持 `["webServer"]`（L65）；real-context.test.ts A-1 静态断言未改动、全绿 |
| F-3 无 agents done 不抛 / 子代理分流保留 | **PASS** | e2e-done A-2（无 agents → done 主分支 + 无处理失败 warn）、A-3（agents 缺位 fork 保守 done、spawn 仍 subagent-done）改真实时序后保留 |
| F-4 三态提交不回归（B-1/B-2/B-4 保留） | **PASS** | e2e-done B-1（notifyTaskDone=false 不通知但 lastEndedTurn 提交、再现 idle 不重复）、B-2（免打扰 suppressed:quiet 恰 1 条、再现不新增）、B-4 / B-4-flush（入队即提交、flush 后不回退）改真实时序后保留 |
| F-5 真实 Context 契约不回归 | **PASS** | real-context.test.ts（`assertRealCordisContextSemantics` C-1/C-3 + `assertEventReachability` D-1/D-2/D-3）未改动、smoke 全绿 |
| F-6 通知面不回归（approval/question/error/turn-end/disposed） | **PASS** | e2e-approval / e2e-question-turn 未改动全绿；e2e-edge fail-2（notify 抛错容错）、mk-1/mk-2（聚合类型切换）、disposed 清理、hookUserQuestions 容错、noop-idle 均保留并改真实时序后全绿 |
| G-1 smoke 连续 ≥10 次零 flake | **PASS** | worktree 内 `for i in $(seq 1 10); do node packages/dsh-notifier/test/smoke.ts; done` → 10/10 全绿（每轮 `real-context: OK` + `dsh-notifier smoke: OK`） |
| G-2 PR CI 门禁全绿 | **PASS** | CI run 33269702285 conclusion=success，15 项全绿：Build/Contract/Smoke/Pack、9× Build/Test/Typecheck（含 dsh-notifier）、Coverage collection（5m48s）、Detect changed packages、Mutation gate (dsh-notifier·s0)、Mutation gate verdict (aggregate)（repo-gate 聚合闸随之绿） |

### 首版边界合规（N-1~N-7，越界即 BLOCKED）

- **N-1** ✅ 触发面维持 `agent/status` running→idle，未改触发面
- **N-2** ✅ 零新增配置键（`NotifyConfig` / `CONFIG_KEYS` / `normalizeConfig` 白名单未动）
- **N-3** ✅ 零宿主源码改动（diff 范围仅 `packages/dsh-notifier/`）
- **N-4** ✅ 零新增第三方依赖（未动 package.json / pnpm-lock.yaml）
- **N-5** ✅ 未触碰 `.github/`
- **N-6** ✅ 未做真实 dsh 端到端实测（纯宿主逻辑，qa 实测豁免）
- **N-7** ✅ 阶段一遗留边界未回带（flush 容错 catch 补强不在本 PR 面内）

关闭语义：`Refs #290`（阶段二 PR B，未承诺完成本 issue）。
