### PR TITLE
feat(notifier): 通知设置整合进官方插件配置页，移除侧边栏浮层（#76）

### DIFF
--- a/packages/dsh-notifier/README.en.md
+++ b/packages/dsh-notifier/README.en.md
@@ -57,7 +57,7 @@ loopback interface (`127.0.0.1` / `localhost`) are accepted. Therefore, when you
 403 and the notification channels do not work — this is the expected behavior of the security
 guardrail, not a plugin fault; the page will show a guidance hint.
 
-Pick one of the following access forms (both the panel and the README surface a hint for each):
+Pick one of the following access forms (both the settings card and the README surface a hint for each):
 
 | Form | How to access | Notes |
 |---|---|---|
@@ -82,10 +82,19 @@ Pick one of the following access forms (both the panel and the README surface a 
 - **Do-not-disturb window**: supports crossing midnight (e.g. 22:00 → 08:00); an **urgent exception** can be set (`allowKinds`: still remind approval / question / error during DND)
 - **Approval timeout re-reminder**: when an approval waits longer than `askRemindMin` minutes (default 5, 0 disables) without being handled, remind again
 - **Completion-storm aggregation**: when multiple tasks / subagents finish at once, auto-aggregate into "N other tasks have completed" to avoid notification spam
-- **Panel diagnostics**: the config panel shows the browser notification permission status and a secure-context hint
-- **Unread badge**: when there are unread notifications, the sidebar "Notifications" entry shows a red dot count, which clears as soon as the panel is opened
+- **Settings-card diagnostics**: the plugin card under Settings → Plugins → dsh-notifier shows the browser notification permission status and a secure-context hint, plus the 10 most recent notification records, a "Send test notification" button, and a "Clear history" entry
 
-## Configuration (~/.dsh/dsh-notifier.json, editable in the GUI "Notifications" panel)
+## Configuration (official settings storage, editable via Settings → Plugins → dsh-notifier)
+
+Configuration is stored in the **official settings store** (`<DSH_HOME>/settings.yaml`,
+namespace `dsh-notifier`), read/written through the plugin card under
+Settings → Plugins → dsh-notifier (issue #76). The legacy self-maintained
+`~/.dsh/dsh-notifier.json` is **migrated once at startup** into the official store;
+the original file is renamed `dsh-notifier.json.migrated.bak` (corrupt files are
+renamed `.corrupted.bak` without being written). The self-maintained read/write path
+is retired.
+
+Example values (defaults):
 
 ```json
 {
@@ -103,19 +112,30 @@ Pick one of the following access forms (both the panel and the README surface a 
   "errorMergeWindowMs": 60000,
   "askRemindMin": 5,
   "doneMergeWindowMs": 3000,
-  "historyMaxAgeDays": 0
+  "historyMaxAgeDays": 0,
+  "maxConnections": 16
 }
 ```
+
+> `maxConnections`: SSE connection-table cap (default 16, range 1–1024). It counts
+> **server-side unreleased handles**, not "online devices" — half-open connections
+> (device screen off / network switch / silent NAT cut) linger briefly until the
+> transport layer reaps them; the cap keeps the connection table bounded, evicting
+> the oldest connection beyond the limit (clients auto-reconnect with `since`
+> replay, transparent). If more devices×tabs are concurrently online, raise it in
+> the card.
 
 ## Routes (all behind the loopback fence)
 
 | Route | Method | Notes |
 |---|---|---|
-| `/api/dsh-notifier/config` | GET/PUT | Read / save config |
-| `/api/dsh-notifier/events` | GET | SSE notification frames (browser EventSource subscription) |
+| `/api/dsh-notifier/config` | GET/PUT | **GET** returns `{ok, user, revision, effective, writable}` (`user` = official settings user layer, `revision` for optimistic concurrency, `effective` = resolved config); **PUT** accepts `{patch, expectedRevision?}` (incremental patch, optional `expectedRevision`), returns `{ok, user, revision}` |
+| `/api/dsh-notifier/events` | GET | SSE notification frames (browser EventSource subscription; `?since=<seq>` replays missed frames after reconnect) |
 | `/api/dsh-notifier/test` | POST | Test notification (bypasses Do-Not-Disturb) |
 | `/api/dsh-notifier/history` | GET / **DELETE** | GET recent notification records (up to 200, filtered by `historyMaxAgeDays`; entries suppressed by DND are flagged `suppressed`); **DELETE clears** |
 | `/api/dsh-notifier/health` | GET | Health check |
+
+Error mapping (PUT /config): invalid config key → 400 (`{ok:false, error:{error:"配置校验失败: <key>", hint}}`); stale `expectedRevision` conflict → 409 (`code:"SETTINGS_CONFLICT"`); settings service unavailable → 503 (`code:"settings-unavailable"`); write failure → 500 (root cause only in server logs).
 
 ## Type dependencies
 
@@ -142,11 +162,11 @@ be able to resolve these official packages (skipping type checking is unaffected
   - Proven false-positive-prone, deliberately not covered: IPv4 (same shape as UA version numbers), phone numbers (same shape as order IDs), credit cards (13-digit millisecond timestamps match at 100%)
 - System notification failures are silent (logs only), and do not affect the main flow; a missing / non-executable native binary (ENOENT etc.) is caught by the `error` event and **never bubbles up as an unhandled error that crashes the host process** (see issue #1)
 - **The two channels are delivered to different machines (don't confuse them)**:
-  - **Browser notifications** are pushed to **the browser client you are actually using** (your Mac / phone both count), and pop a native notification via the browser's Notification API; they require permission and by default only pop when the page is hidden (the panel can enable "also when visible"). No matter which machine dsh web runs on, as long as browser notifications are allowed you receive them on your own Mac.
-  - **System notifications (host toast)** are popped on the desktop of **the machine dsh web runs on**: if dsh web runs on a Linux server (headless, no desktop session) or some other machine, the toast appears on **that server**, not your Mac — the panel / health reflects whether the channel is available. To also get the system toast on your Mac, run dsh web directly on your Mac (it then uses macOS `osascript`); macOS has no `notify-send`, and the system notification is already implemented via `osascript` (zero dependencies, nothing to install)
+  - **Browser notifications** are pushed to **the browser client you are actually using** (your Mac / phone both count), and pop a native notification via the browser's Notification API; they require permission and by default only pop when the page is hidden (the settings card can enable "also when visible"). No matter which machine dsh web runs on, as long as browser notifications are allowed you receive them on your own Mac.
+  - **System notifications (host toast)** are popped on the desktop of **the machine dsh web runs on**: if dsh web runs on a Linux server (headless, no desktop session) or some other machine, the toast appears on **that server**, not your Mac — the settings card / health reflects whether the channel is available. To also get the system toast on your Mac, run dsh web directly on your Mac (it then uses macOS `osascript`); macOS has no `notify-send`, and the system notification is already implemented via `osascript` (zero dependencies, nothing to install)
 - **iOS difference**: Safari's normal tabs have no Web Notifications API (only the "Add to Home Screen" PWA does); on iOS the available channels are "in-page banner + sound when the page is visible" and system notifications after HTTPS + A2HS
 - Browser notifications require a **secure context** (HTTPS or localhost); LAN HTTP access automatically routes through the fallback channel (banner / sound / title reminder)
-- Browser notification permission is requested within a gesture (when clicking the sidebar "Notifications" entry or a panel button)
+- Browser notification permission is requested within a gesture (via the "Request notification permission" button on the Settings → Plugins → dsh-notifier card)
 - Windows system notifications are implemented via a PowerShell WinRT script, with the command passed as a parameter array and title/body packed into a single base64 (UTF-8 JSON) payload argument (no shell concatenation surface, and immune to PS 5.1 command-line argument parsing ambiguities, see issue #238); the script idempotently registers the AppUserModelId `DSH.dsh-notifier` on startup (HKCU, no admin required) — an unregistered AUMID gets toasts silently dropped by Windows 10/11. The AUMID follows the `Company.Product` convention to avoid collisions in the public namespace (`HKCU\SOFTWARE\Classes\AppUserModelId`) where same-named apps overwrite each other's display names; a legacy `DSH` key registered by older versions is harmless leftover (just an empty registry entry, does not affect new toasts) and can be removed manually with `Remove-Item -Path "HKCU:\SOFTWARE\Classes\AppUserModelId\DSH"` if desired
 
 ## Verification

--- a/packages/dsh-notifier/README.md
+++ b/packages/dsh-notifier/README.md
@@ -53,7 +53,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-notifier
 `/api/dsh-notifier/*` 一律返回 403，通知通道不工作**——这是安全护栏的预期行为，
 不是插件故障；此时页面内会给出引导提示。
 
-请选用下列任一形态访问（均在面板与 README 中给出提示）：
+请选用下列任一形态访问（均在设置卡片与 README 中给出提示）：
 
 | 形态 | 访问方式 | 说明 |
 |---|---|---|
@@ -78,8 +78,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-notifier
 - **免打扰时段**：支持跨午夜（如 22:00 → 08:00）；可设**紧急例外**（`allowKinds`：免打扰期间仍提醒审批/提问/出错）
 - **审批超时二次提醒**：审批等待超 `askRemindMin` 分钟（默认 5，0 关闭）未处理时再次提醒
 - **完成风暴聚合**：多任务/子代理同时收尾自动聚合为「另有 N 个任务已完成」，避免刷屏
-- **面板诊断**：配置面板显示浏览器通知授权状态与安全上下文提示
-- **未读角标**：有通知未查看时侧边栏「通知」入口显示红点计数，打开面板即清零
+- **设置卡片诊断**：设置 → 插件 → dsh-notifier 卡片显示浏览器通知授权状态与安全上下文提示，并含最近 10 条通知记录、发送测试通知与清理记录入口
 
 ## 事件订阅与 scope 语义（{global:true} 取舍）
 
@@ -101,7 +100,15 @@ context filter checks」）。取舍如下（issue #290）：
   逐字段运行时校验，非有限 turn 直接 skip），跨 scope 到达只会被过滤后静默，
   不产生错误通知；本阶段**不新增配置键**控制该行为。
 
-## 配置（~/.dsh/dsh-notifier.json，GUI「通知」面板可改）
+## 配置（官方 settings 存储：设置 → 插件 → dsh-notifier 卡片可改）
+
+配置保存在**官方 settings 存储**（`<DSH_HOME>/settings.yaml`，命名空间 `dsh-notifier`），
+经「设置 → 插件 → dsh-notifier」卡片读写（issue #76）；旧版自建
+`~/.dsh/dsh-notifier.json` 在升级后**启动时一次性迁移**进官方存储，原文件改名
+`dsh-notifier.json.migrated.bak`（损坏则改名 `.corrupted.bak`，不写入），
+自建读写链路已废弃。
+
+配置项示例（默认值）：
 
 ```json
 {
@@ -134,11 +141,13 @@ context filter checks」）。取舍如下（issue #290）：
 
 | 路由 | 方法 | 说明 |
 |---|---|---|
-| `/api/dsh-notifier/config` | GET/PUT | 读取/保存配置 |
-| `/api/dsh-notifier/events` | GET | SSE 通知帧（浏览器 EventSource 订阅） |
+| `/api/dsh-notifier/config` | GET/PUT | **GET** 返回 `{ok, user, revision, effective, writable}`（`user` 为官方 settings 用户层、`revision` 供乐观并发、`effective` 为生效配置）；**PUT** 接收 `{patch, expectedRevision?}`（增量 patch，`expectedRevision` 可选做乐观并发），返回 `{ok, user, revision}` |
+| `/api/dsh-notifier/events` | GET | SSE 通知帧（浏览器 EventSource 订阅；`?since=<seq>` 断线补拉） |
 | `/api/dsh-notifier/test` | POST | 测试通知（绕过免打扰） |
 | `/api/dsh-notifier/history` | GET / **DELETE** | GET 最近通知记录（最多 200 条，`historyMaxAgeDays` 过滤 / 被免打扰拦截的标记 `suppressed`）；**DELETE 清空** |
 | `/api/dsh-notifier/health` | GET | 健康检查 |
+
+错误映射（PUT /config）：非法配置键 → 400（`{ok:false, error:{error:"配置校验失败: <键>", hint}}`）；版本冲突（`expectedRevision` 过期）→ 409（`code:"SETTINGS_CONFLICT"`）；settings 服务缺失 → 503（`code:"settings-unavailable"`）；写入异常 → 500（底层原因只进服务端日志）。
 
 ## 类型依赖
 
@@ -164,12 +173,12 @@ context filter checks」）。取舍如下（issue #290）：
 - 系统通知失败静默（仅日志），不影响主流程；原生二进制缺失/不可执行（ENOENT 等）
   会被 `error` 事件接住，**绝不冒泡成 unhandled error 把宿主进程打挂**（见 issue #1）
 - **两个通道到达的机器不同（别混淆）**：
-  - **浏览器通知**推到**你正在用的浏览器客户端**（Mac/手机都算），由浏览器 Notification API 弹出原生通知；需要授权、且默认页面隐藏时才弹（面板可开「页面可见也弹」）。无论 dsh web 跑在哪台机器，只要浏览器通知允许，你都能在自己的 Mac 上收到。
-  - **系统通知（宿主 toast）**弹在 **dsh web 运行的宿主机器**桌面：若 dsh web 跑在 Linux 服务器（headless，无桌面会话）或别的机器上，toast 会出现在**那台服务器**而不是你的 Mac——面板/health 会体现该通道是否可用。想让系统 toast 也出现在你的 Mac 上，需把 dsh web 直接跑在你的 Mac 上（此时走 macOS 的 `osascript`）；macOS 无 `notify-send`，系统通知已用系统自带的 `osascript` 实现（无需安装）
+  - **浏览器通知**推到**你正在用的浏览器客户端**（Mac/手机都算），由浏览器 Notification API 弹出原生通知；需要授权、且默认页面隐藏时才弹（设置卡片可开「页面可见也弹」）。无论 dsh web 跑在哪台机器，只要浏览器通知允许，你都能在自己的 Mac 上收到。
+  - **系统通知（宿主 toast）**弹在 **dsh web 运行的宿主机器**桌面：若 dsh web 跑在 Linux 服务器（headless，无桌面会话）或别的机器上，toast 会出现在**那台服务器**而不是你的 Mac——设置卡片/health 会体现该通道是否可用。想让系统 toast 也出现在你的 Mac 上，需把 dsh web 直接跑在你的 Mac 上（此时走 macOS 的 `osascript`）；macOS 无 `notify-send`，系统通知已用系统自带的 `osascript` 实现（无需安装）
 - **iOS 差异**：Safari 普通标签页无 Web Notifications API（「添加到主屏幕」的 PWA
   才有）；iOS 上可用通道为「页面可见时横幅 + 提示音」及 HTTPS+A2HS 后的系统通知
 - 浏览器通知需要**安全上下文**（HTTPS 或 localhost）；局域网 HTTP 访问自动走降级通道（横幅/提示音/标题提醒）
-- 浏览器通知权限为手势内请求（点击侧边栏「通知」入口或面板按钮时）
+- 浏览器通知权限为手势内请求（设置 → 插件 → dsh-notifier 卡片的「请求通知权限」按钮）
 - Windows 系统通知通过 PowerShell WinRT 脚本实现，命令以参数数组传递、标题/正文打包为 base64(UTF-8 JSON) 经单一 payload 参数传入（无 shell 拼接面，且规避 PS 5.1 命令行参数解析歧义，见 issue #238）；脚本启动时幂等注册 AppUserModelId `DSH.dsh-notifier`（HKCU，无需管理员权限）——未注册的 AUMID 在 Win10/11 上 toast 会被系统静默丢弃。AUMID 采用 `Company.Product` 形态，避免在公共命名空间（`HKCU\SOFTWARE\Classes\AppUserModelId`）与其他同名软件冲突互覆；历史版本注册的旧键 `DSH` 残留无害（仅一个空注册表条目，不影响新 toast），如需清理可手动执行 `Remove-Item -Path "HKCU:\SOFTWARE\Classes\AppUserModelId\DSH"`
 
 ## 验证

--- a/packages/dsh-notifier/src/client/index.ts
+++ b/packages/dsh-notifier/src/client/index.ts
@@ -1,13 +1,23 @@
 /**
- * dsh-notifier — 浏览器端（自包含，无 import）。
- * 自动订阅 /events SSE；页面隐藏时用 Notification API 弹通知；侧边栏「通知」
- * 入口提供配置面板（事件开关/系统通知/浏览器通知/免打扰时段）。
- * 路由常量与宿主端 ROUTES 一致（smoke 断言）。
+ * dsh-notifier — 浏览器端（自包含）。
+ *
+ * 行为（issue #76）：
+ * - 在「设置 → 插件」面板渲染 dsh-notifier 配置卡片（settings.plugin.item 插槽，
+ *   id+key 双写兼容 rc.7 前后两代运行时）——侧边栏「通知」入口/浮层/角标/拖拽
+ *   全部移除（B1-B6）；
+ * - 通知半区（C1-C9）保留并与 DOM 解耦：SSE /events 订阅 + 60s 看门狗 +
+ *   visibilitychange 重建 + 多标签租约 + 音频手势解锁，不依赖任何插件 DOM；
+ * - 历史记录最近 10 条收进卡片（D1-D2）；卡片动作区含清理记录（两段式确认）/
+ *   请求权限/发送测试通知（A6-A7）；三端降级文案迁入卡片（A5/A8）；
+ * - 配置读取走 GET /config 包装体 {ok,user,revision,effective,writable}，保存走
+ *   PUT {patch, expectedRevision}（基线 diff 只提变更键，F3/A4）。
  */
-// 浏览器半区干净模块：只导出 apply/inject，契约外壳（IIFE/load/Symbol.toStringTag 装配）
-// 由 scripts/build/build-client.ts 统一生成——源码不写任何 loader 痕迹。
+// 浏览器半区干净模块：只导出 apply/inject；React 由构建期 external 注入（经 factory
+// 注入的 require("react") 解析，dsh web 不暴露全局 React）。契约外壳（IIFE/load/
+// Symbol.toStringTag 装配）由 scripts/build/build-client.ts 统一生成——源码不写任何 loader。
 // 样式：独立 style.css（见同目录），build-client 的 .css text-loader 构建期内联为字符串
 import STYLE from "./style.css";
+import * as React from "react";
 
   var ROUTES = {
     config: "/api/dsh-notifier/config",
@@ -16,10 +26,8 @@ import STYLE from "./style.css";
     test: "/api/dsh-notifier/test",
     history: "/api/dsh-notifier/history",
   };
-  var ENTRY_SELECTOR = "[data-dsh-notifier-entry]";
-  var PANEL_ID = "dsh-notifier-panel";
   var STYLE_ID = "dsh-notifier-style";
-  var ICON = "🔔";
+  var CSS_VERSION = "76";
   // 浏览器通知图标（内联 SVG data URL，零外部资源；铃铛造型）。
   var NOTIFY_ICON =
     "data:image/svg+xml;utf8," +
@@ -52,16 +60,17 @@ import STYLE from "./style.css";
   };
 
   function injectStyle() {
-    // 每次 apply 直接重建 <style>（无 cssVersion 字符串比对）：行为等价，
-    // 且消除「改 CSS 忘 bump 版本号则热更新不生效」的手动状态漂移。
     var existing = document.getElementById(STYLE_ID);
+    if (existing && existing.dataset.version === CSS_VERSION) return;
     if (existing) existing.remove();
     var style = document.createElement("style");
     style.id = STYLE_ID;
+    style.dataset.version = CSS_VERSION;
     style.textContent = STYLE;
     document.head.appendChild(style);
   }
 
+  /** 页面内短提示（操作反馈）。 */
   function toast(message: any) {
     var el = document.createElement("div");
     el.className = "dn-toast";
@@ -84,7 +93,7 @@ import STYLE from "./style.css";
 
   /**
    * 请求浏览器通知权限（必须在用户手势内调用，Chrome 才接受）。
-   * 完成后回调（无论结果），用于刷新面板权限状态。
+   * 完成后回调（无论结果），用于刷新卡片权限状态。
    */
   function requestPermission(onDone: any) {
     if (!("Notification" in window)) return;
@@ -99,442 +108,13 @@ import STYLE from "./style.css";
     }
   }
 
-  /** 发送测试通知：POST /test 触发宿主端系统通知 + SSE 广播（绕过免打扰）。
-   *  防抖：800ms 内重复点击忽略，防止狂点导致通知风暴。 */
-  var lastTestAt = 0;
-  function sendTestNotification() {
-    var now = Date.now();
-    if (now - lastTestAt < 800) {
-      toast("点击太频繁，稍等片刻");
-      return;
-    }
-    lastTestAt = now;
-    fetch(ROUTES.test, { method: "POST" })
-      .then(function (res) {
-        if (!res.ok) throw new Error("HTTP " + res.status);
-        return res.json();
-      })
-      .then(function (data) {
-        toast("测试通知已发送（服务端未释放句柄 " + data.sseConnections + " 条）");
-      })
-      .catch(function (error) {
-        toast("发送测试通知失败：" + error.message + accessHint(error));
-      });
-  }
-
-  function el(tag: any, attrs: any, children: any = undefined) {
-    var node = document.createElement(tag);
-    if (attrs) {
-      for (var key in attrs) {
-        var value = attrs[key];
-        if (key === "class") node.className = value;
-        else if (key === "text") node.textContent = value;
-        else if (key === "dataset") Object.assign(node.dataset, value);
-        else if (key === "onClick") node.addEventListener("click", value);
-        else if (key === "onChange") node.addEventListener("change", value);
-        else if (key === "style") node.style.cssText = value;
-        else if (key in node && key !== "list") node[key] = value;
-        else node.setAttribute(key, value);
-      }
-    }
-    if (children) {
-      for (var i = 0; i < children.length; i += 1) node.appendChild(children[i]);
-    }
-    return node;
-  }
-
-  /** 面板拖拽：Pointer Events 重写（触屏统一——iOS Safari 兼容鼠标事件不可靠：
-   *  触摸拖动不产生持续 mousemove，旧实现触屏完全拖不动）。配 CSS
-   *  .dn-header{touch-action:none} 防滚动手势抢占；指针捕获避免移出面板丢事件；
-   *  位置 clamp 在视口内（防拖出「失踪」），持久化 localStorage。
-   */
-  function attachDrag(header: any, panel: any) {
-    header.addEventListener("pointerdown", function (e: any) {
-      if (e.button !== undefined && e.button !== 0) return;
-      if (e.target && e.target.closest("button")) return; // 按钮点击不触发拖拽
-      var rect = panel.getBoundingClientRect();
-      var startX = e.clientX;
-      var startY = e.clientY;
-      var startLeft = rect.left;
-      var startTop = rect.top;
-      var moved = false;
-      function clampPos(left: number, top: number) {
-        var pw = panel.offsetWidth || 320;
-        var ph = panel.offsetHeight || 300;
-        return {
-          left: Math.min(Math.max(0, left), Math.max(0, window.innerWidth - pw)),
-          top: Math.min(Math.max(0, top), Math.max(0, window.innerHeight - ph)),
-        };
-      }
-      function onMove(ev: any) {
-        var dx = ev.clientX - startX;
-        var dy = ev.clientY - startY;
-        if (!moved && Math.abs(dx) < 3 && Math.abs(dy) < 3) return; // 位移阈值，区分点击
-        moved = true;
-        var pos = clampPos(startLeft + dx, startTop + dy);
-        panel.style.left = pos.left + "px";
-        panel.style.top = pos.top + "px";
-        panel.style.right = "auto";
-      }
-      function onUp() {
-        panel.removeEventListener("pointermove", onMove);
-        panel.removeEventListener("pointerup", onUp);
-        panel.removeEventListener("pointercancel", onUp);
-        try {
-          panel.releasePointerCapture(e.pointerId);
-        } catch (err) {
-          // 忽略
-        }
-        if (moved) {
-          try {
-            localStorage.setItem(PANEL_ID + ":pos", JSON.stringify({ left: panel.style.left, top: panel.style.top }));
-          } catch (err) {
-            // localStorage 不可用（隐私模式等）仅不持久化
-          }
-        }
-      }
-      try {
-        panel.setPointerCapture(e.pointerId);
-      } catch (err) {
-        // 不支持捕获的浏览器：移出面板时可能丢事件，可接受
-      }
-      panel.addEventListener("pointermove", onMove);
-      panel.addEventListener("pointerup", onUp);
-      panel.addEventListener("pointercancel", onUp);
-      e.preventDefault();
-    });
-  }
-
-  /** 恢复上次拖拽位置（无则用 CSS 默认 left:12px）；越界值 clamp 回视口内。 */
-  function restorePanelPos(panel: any) {
-    try {
-      var saved = JSON.parse(localStorage.getItem(PANEL_ID + ":pos") || "null");
-      if (saved && saved.left) {
-        var pw = panel.offsetWidth || 320;
-        var ph = panel.offsetHeight || 300;
-        var mw = window.innerWidth;
-        var mh = window.innerHeight;
-        var left = Math.min(Math.max(0, parseFloat(saved.left) || 12), Math.max(0, mw - pw));
-        var top = Math.min(Math.max(0, parseFloat(saved.top) || 0), Math.max(0, mh - ph));
-        panel.style.left = left + "px";
-        panel.style.top = top + "px";
-        panel.style.right = "auto";
-      }
-    } catch (err) {
-      // 忽略损坏的存储
-    }
-  }
-
-  function switchEl(key: any, label: any, config: any, onToggle: any) {
-    var row = el("div", { class: "dn-row" });
-    // 整行作为触控目标（≥44px 见 CSS）：文本 label 用 htmlFor 关联 input，
-    // 点文字也能切换（WCAG 2.5.5 目标尺寸）
-    var inputId = "dn-sw-" + key + "-" + Math.random().toString(36).slice(2);
-    var text = el("label", { for: inputId, class: "dn-row-text" });
-    text.appendChild(el("span", { text: label }));
-    row.appendChild(text);
-    var wrap = el("label", { class: "dn-switch" });
-    var input = el("input", { type: "checkbox", id: inputId, checked: config[key] === true, onChange: function () {
-      config[key] = input.checked;
-      onToggle(config);
-    } });
-    var track = el("span", { class: "dn-track" });
-    track.appendChild(el("span", { class: "dn-thumb" }));
-    wrap.appendChild(input);
-    wrap.appendChild(track);
-    row.appendChild(wrap);
-    return row;
-  }
-
-  var configCache: any = null;
-
-  /** 启动时预取配置（不依赖打开面板）：可见性判断要用 notifyWhenVisible。 */
-  function refreshConfig() {
-    fetch(ROUTES.config, { headers: { accept: "application/json" } })
-      .then(function (res) {
-        if (!res.ok) throw new Error("HTTP " + res.status);
-        return res.json();
-      })
-      .then(function (config) {
-        configCache = config;
-      })
-      .catch(function (error) {
-        // 失败静默（打开面板时会再次拉取）；403（局域网直连被回环围栏拒绝）时给引导
-        console.warn("[dsh-notifier] 配置预取失败：", error);
-        if (accessHint(error) !== "") toast("通知通道不可用" + accessHint(error));
-      });
-  }
-
-  function saveConfig(config: any) {
-    fetch(ROUTES.config, {
-      method: "PUT",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(config),
-    })
-      .then(function (res) {
-        if (!res.ok) throw new Error("HTTP " + res.status);
-        return res.json();
-      })
-      .then(function (data) {
-        configCache = data;
-      })
-      .catch(function (error) {
-        toast("保存配置失败：" + error.message + accessHint(error));
-      });
-  }
-
-  function fmtTime(ts: any) {
-    var d = new Date(ts);
-    function pad(n: any) {
-      return n < 10 ? "0" + n : String(n);
-    }
-    return pad(d.getHours()) + ":" + pad(d.getMinutes()) + ":" + pad(d.getSeconds());
-  }
-
-  /** 通知记录列表（最近 10 条，倒序）：日志验证的入口。 */
-  function renderHistory(holder: any) {
-    holder.textContent = "";
-    fetch(ROUTES.history, { headers: { accept: "application/json" } })
-      .then(function (res) {
-        if (!res.ok) throw new Error("HTTP " + res.status);
-        return res.json();
-      })
-      .then(function (data) {
-        holder.textContent = "";
-        var records = data.records || [];
-        if (records.length === 0) {
-          holder.appendChild(el("div", { class: "dn-note", text: "暂无通知记录（点「发送测试通知」可生成一条）" }));
-          return;
-        }
-        var shown = records.slice(-10).reverse();
-        for (var i = 0; i < shown.length; i += 1) {
-          var r = shown[i];
-          var row = el("div", { class: "dn-row", style: "flex-direction:column;align-items:flex-start;gap:2px" });
-          var head = el("div", { style: "display:flex;gap:6px;align-items:center" });
-          head.appendChild(el("span", { text: fmtTime(r.ts), style: "color:var(--dsw-alias-label-tertiary,#8a919c)" }));
-          head.appendChild(el("span", { text: KIND_LABELS[r.kind] || r.kind, style: "font-weight:600" }));
-          if (r.suppressed === "quiet") {
-            // 免打扰拦截未发出：标记，让用户区分「已发」与「被免打扰拦下」
-            head.appendChild(el("span", { text: "免打扰拦截未发出", style: "color:var(--dsw-alias-label-tertiary,#8a919c);font-size:10px;border:1px solid var(--dsw-alias-border-l1,#e2e5ea);border-radius:8px;padding:0 4px" }));
-          }
-          row.appendChild(head);
-          row.appendChild(el("div", { text: r.title + "：" + r.message, style: "color:var(--dsw-alias-label-secondary,#5f6672)" }));
-          holder.appendChild(row);
-        }
-      })
-      .catch(function (error) {
-        holder.appendChild(el("div", { class: "dn-note", text: "加载记录失败：" + error.message + accessHint(error) }));
-      });
-  }
-
-  function renderPanel(panel: any) {
-    var body = panel.querySelector(".dn-body");
-    body.textContent = "";
-    fetch(ROUTES.config, { headers: { accept: "application/json" } })
-      .then(function (res) {
-        if (!res.ok) throw new Error("HTTP " + res.status);
-        return res.json();
-      })
-      .then(function (config) {
-        configCache = config;
-        body.textContent = "";
-
-        var events = el("div", { class: "dn-section" });
-        events.appendChild(el("div", { class: "dn-section-title", text: "通知事件" }));
-        for (var i = 0; i < EVENT_KEYS.length; i += 1) {
-          events.appendChild(switchEl(EVENT_KEYS[i][0], EVENT_KEYS[i][1], config, saveConfig));
-        }
-        body.appendChild(events);
-
-        var channels = el("div", { class: "dn-section" });
-        channels.appendChild(el("div", { class: "dn-section-title", text: "通知通道" }));
-        for (var j = 0; j < CHANNEL_KEYS.length; j += 1) {
-          channels.appendChild(switchEl(CHANNEL_KEYS[j][0], CHANNEL_KEYS[j][1], config, saveConfig));
-        }
-        if ("Notification" in window) {
-          if (!isSecureContext()) {
-            // 非安全上下文（局域网 HTTP）：系统弹窗被浏览器禁止，降级提醒已启用
-            channels.appendChild(el("div", { class: "dn-note", text: "当前为局域网 HTTP 访问（非安全上下文），浏览器禁止系统级弹窗，已启用「页面内横幅 + 提示音 + 标题提醒」降级通道。如需系统弹窗，请改用 dsh-lan-proxy 的 https://<局域网IP>:3443 或 localhost 隧道访问（如 ssh -L 3080:127.0.0.1:3080）后刷新页面。" }));
-          } else {
-            var permText = "";
-            if (Notification.permission === "granted") permText = "浏览器通知权限：已授权 ✓";
-            else if (Notification.permission === "denied") permText = "浏览器通知权限：已拒绝（请在浏览器站点设置中允许本页通知）";
-            else permText = "浏览器通知权限：未授权（点击下方按钮在浏览器弹窗中允许）";
-            channels.appendChild(el("div", { class: "dn-note", text: permText }));
-            if (Notification.permission === "default") {
-              // 请求授权必须在用户手势内（点击按钮），浏览器才会接受
-              channels.appendChild(el("button", {
-                type: "button",
-                text: "请求通知权限",
-                style: "margin:6px 0 0;border:1px solid var(--dsw-alias-border-l1,#e2e5ea);background:var(--dsw-alias-bg-layer-1,#f5f6f8);border-radius:6px;padding:4px 10px;cursor:pointer;color:inherit",
-                onClick: function () {
-                  requestPermission(function () {
-                    renderPanel(panel); // 刷新权限状态显示
-                  });
-                },
-              }));
-            }
-          }
-        } else {
-          // 无 Web Notifications API（iOS Safari 普通标签页等）：渲染设备能力说明，
-          // 避免「通知通道区整个消失」让用户误以为插件坏了。
-          channels.appendChild(el("div", { class: "dn-note", text: "当前设备不支持系统级通知（如 iOS Safari 普通标签页无 Web Notifications）。可用通道：页面可见时的横幅 + 提示音（需保持页面打开），或经 dsh-lan-proxy 的 https://<局域网IP>:3443 访问并「添加到主屏幕」后获得 PWA 级通知能力。" }));
-        }
-        // 测试按钮：端到端验证通知链路（宿主 → SSE → 浏览器提醒）。
-        // 移出 Notification 门：iOS 等无 Notification API 的设备也能自测宿主链路。
-        channels.appendChild(el("button", {
-          type: "button",
-          text: "发送测试通知",
-          style: "margin:6px 0 0;border:1px solid var(--dsw-alias-border-l1,#e2e5ea);background:var(--dsw-alias-bg-layer-1,#f5f6f8);border-radius:6px;padding:4px 10px;cursor:pointer;color:inherit",
-          onClick: sendTestNotification,
-        }));
-        body.appendChild(channels);
-
-        // 合并/去重：错误合并窗口与完成聚合窗口（ms，0=关闭；沿用配置面板）
-        var mergeSection = el("div", { class: "dn-section" });
-        mergeSection.appendChild(el("div", { class: "dn-section-title", text: "合并/去重" }));
-        function mergeField(objKey: any, label: any, max: number) {
-          var field = el("div", { class: "dn-row", style: "min-height:36px" });
-          field.appendChild(el("span", { style: "flex:1", text: label + "（ms，0=关）" }));
-          var input = el("input", { type: "number", min: "0", step: "1000", value: String(config[objKey] || 0), style: "width:84px;background:var(--dsw-alias-bg-layer-1,#f5f6f8);color:inherit;border:1px solid var(--dsw-alias-border-l1,#e2e5ea);border-radius:6px;padding:3px 6px;margin:6px 0", onChange: function () {
-            // Number 而非 parseInt：1e2/0x10 等非十进制写法在 parseInt(v,10) 下解析不精确
-            // （0x10 → 0 回默认），Number 按 JS 字面量语义精确取值；空串→0 与
-            // parseInt 空串→NaN→回退 0 的结果一致（下方校验兜底）。
-            var v = Number(input.value);
-            config[objKey] = Number.isFinite(v) && v >= 0 && v <= max ? v : 0;
-            saveConfig(config);
-          } });
-          field.appendChild(input);
-          mergeSection.appendChild(field);
-        }
-        mergeField("errorMergeWindowMs", "错误合并窗口", 3600000);
-        mergeField("doneMergeWindowMs", "完成聚合窗口", 60000);
-        // #330 SSE 连接上限：条（1~1024，默认 16）。超出上限自动淘汰最老连接
-        // （客户端断开后自动重连 + since 补拉，无感知）；多设备多页签超限时调大。
-        (function () {
-          var field = el("div", { class: "dn-row", style: "min-height:36px" });
-          field.appendChild(el("span", { style: "flex:1", text: "最大连接数（条，超出淘汰最老）" }));
-          var input = el("input", { type: "number", min: "1", max: "1024", step: "1", value: String(config.maxConnections || 16), style: "width:84px;background:var(--dsw-alias-bg-layer-1,#f5f6f8);color:inherit;border:1px solid var(--dsw-alias-border-l1,#e2e5ea);border-radius:6px;padding:3px 6px;margin:6px 0", onChange: function () {
-            // 同上：Number 保 1e2/0x10 精确解析；空串→0 不满足 >=1 校验，回默认 16（同 parseInt 语义）。
-            var v = Number(input.value);
-            config.maxConnections = Number.isFinite(v) && v >= 1 && v <= 1024 ? v : 16;
-            saveConfig(config);
-          } });
-          field.appendChild(input);
-          mergeSection.appendChild(field);
-        })();
-        body.appendChild(mergeSection);
-
-        var quiet = el("div", { class: "dn-section" });
-        quiet.appendChild(el("div", { class: "dn-section-title", text: "免打扰时段" }));
-        var quietRow = el("div", { class: "dn-row" });
-        quietRow.appendChild(el("span", { text: "启用" }));
-        var quietWrap = el("label", { class: "dn-switch" });
-        var quietInput = el("input", { type: "checkbox", checked: config.quietHours.enabled === true, onChange: function () {
-          config.quietHours.enabled = quietInput.checked;
-          saveConfig(config);
-        } });
-        var quietTrack = el("span", { class: "dn-track" });
-        quietTrack.appendChild(el("span", { class: "dn-thumb" }));
-        quietWrap.appendChild(quietInput);
-        quietWrap.appendChild(quietTrack);
-        quietRow.appendChild(quietWrap);
-        quiet.appendChild(quietRow);
-        var times = el("div", { class: "dn-quiet" });
-        var startInput = el("input", { type: "time", value: config.quietHours.start, onChange: function () { config.quietHours.start = startInput.value || "22:00"; saveConfig(config); } });
-        var endInput = el("input", { type: "time", value: config.quietHours.end, onChange: function () { config.quietHours.end = endInput.value || "08:00"; saveConfig(config); } });
-        times.appendChild(el("span", { text: "从" }));
-        times.appendChild(startInput);
-        times.appendChild(el("span", { text: "到" }));
-        times.appendChild(endInput);
-        quiet.appendChild(times);
-        // 免打扰紧急例外：时段内仍放行的通知类型（宿主端 allowKinds 白名单）
-        var allowWrap = el("div", { class: "dn-quiet-allow" });
-        allowWrap.appendChild(el("span", { class: "dn-note", text: "免打扰期间仍提醒：" }));
-        var ALLOW_CHOICES = [["ask", "审批"], ["question", "提问"], ["error", "出错"]];
-        var allows = config.quietHours.allowKinds || (config.quietHours.allowKinds = []);
-        for (var k = 0; k < ALLOW_CHOICES.length; k += 1) {
-          (function (kindText, kindLabel) {
-            var item = el("label", { class: "dn-allow-item" });
-            var input = el("input", { type: "checkbox", checked: allows.indexOf(kindText) !== -1, onChange: function () {
-              var idx = allows.indexOf(kindText);
-              if (input.checked && idx === -1) allows.push(kindText);
-              else if (!input.checked && idx !== -1) allows.splice(idx, 1);
-              saveConfig(config);
-            } });
-            item.appendChild(input);
-            item.appendChild(el("span", { text: kindLabel }));
-            allowWrap.appendChild(item);
-          })(ALLOW_CHOICES[k][0], ALLOW_CHOICES[k][1]);
-        }
-        quiet.appendChild(allowWrap);
-        body.appendChild(quiet);
-
-        var hist = el("div", { class: "dn-section" });
-        var histTitle = el("div", { class: "dn-section-title", text: "通知记录" });
-        histTitle.appendChild(el("button", {
-          type: "button",
-          text: "刷新",
-          style: "float:right;border:1px solid var(--dsw-alias-border-l1,#e2e5ea);background:var(--dsw-alias-bg-layer-1,#f5f6f8);border-radius:6px;padding:1px 8px;cursor:pointer;color:inherit;font-size:11px",
-          onClick: function () {
-            renderHistory(histHolder);
-          },
-        }));
-        // 清空记录（二次确认：首次点击进入「确认清空？」态，3s 内再点才真正清空）
-        var clearArmed = false;
-        var clearTimer: any = null;
-        histTitle.appendChild(el("button", {
-          type: "button",
-          text: "清空",
-          style: "float:right;margin-right:6px;border:1px solid var(--dsw-alias-border-l1,#e2e5ea);background:var(--dsw-alias-bg-layer-1,#f5f6f8);border-radius:6px;padding:1px 8px;cursor:pointer;color:inherit;font-size:11px",
-          onClick: function () {
-            var btn = this;
-            if (!clearArmed) {
-              clearArmed = true;
-              btn.textContent = "确认清空？";
-              if (clearTimer !== null) clearTimeout(clearTimer);
-              clearTimer = setTimeout(function () {
-                clearArmed = false;
-                btn.textContent = "清空";
-              }, 3000);
-              return;
-            }
-            clearArmed = false;
-            if (clearTimer !== null) clearTimeout(clearTimer);
-            fetch(ROUTES.history, { method: "DELETE" })
-              .then(function (res) { if (!res.ok) throw new Error("HTTP " + res.status); return res.json(); })
-              .then(function (data) {
-                toast("已清空 " + data.removed + " 条通知记录");
-                renderHistory(histHolder);
-              })
-              .catch(function (error) {
-                toast("清空失败：" + error.message + accessHint(error));
-              });
-          },
-        }));
-        hist.appendChild(histTitle);
-        var histHolder = el("div", {});
-        hist.appendChild(histHolder);
-        body.appendChild(hist);
-        renderHistory(histHolder);
-
-        body.appendChild(el("div", { class: "dn-note", text: "浏览器通知仅在页面隐藏时弹出（可开「页面可见时也弹」）；系统通知由宿主进程发出（Windows toast / notify-send）。点「发送测试通知」可验证链路。提示音需先点击页面任意位置一次（浏览器策略）。通知内容不含工具参数。" }));
-      })
-      .catch(function (error) {
-        body.appendChild(el("div", { class: "dn-note", text: "加载配置失败：" + error.message + accessHint(error) }));
-      });
-  }
-
-  // ------------------------------------------------------------ 通知显示
+  // ------------------------------------------------------------ 通知显示（半区）
 
   var notified: any = [];
 
   // 多标签主从租约（仅「同 URL 的同浏览器多标签」有效；跨 host/IP、跨浏览器
-  // 的 storage 域互不相交，去重自然失效——已按此口径写入 README）：
-  // 收到通知帧的标签先 checkMaster：有效租约且属于自己 → 续租并展示；
-  // 属于他人 → 静默；无主/已过期 → 抢占（写自己租约）并展示。
-  // 租约 15s：主标签关闭/后台休眠后，下一个帧事件在 ≤15s 窗口内由其他标签接管。
-  // 事件驱动、不依赖后台定时器（浏览器会对后台 setInterval 节流）。
+  // 的 storage 域互不相交，去重自然失效）：收到通知帧的标签先 checkMaster：
+  // 有效租约且属于自己 → 续租并展示；属于他人 → 静默；无主/已过期 → 抢占。
   var TAB_ID = Math.random().toString(36).slice(2);
   var MASTER_KEY = "dsh-notifier:master";
   var MASTER_LEASE_MS = 15000;
@@ -545,17 +125,15 @@ import STYLE from "./style.css";
       var now = Date.now();
       if (lease && typeof lease.id === "string" && typeof lease.ts === "number" && now - lease.ts < MASTER_LEASE_MS) {
         if (lease.id === TAB_ID) {
-          lease.ts = now; // 续租
+          lease.ts = now;
           localStorage.setItem(MASTER_KEY, JSON.stringify(lease));
           return true;
         }
-        return false; // 他标签持有有效租约
+        return false;
       }
-      // 无主/租约已过期：抢占为当前主标签
       localStorage.setItem(MASTER_KEY, JSON.stringify({ id: TAB_ID, ts: now }));
       return true;
     } catch (error) {
-      // localStorage 不可用（隐私模式等）：退化为每标签单独展示（同旧行为）
       return true;
     }
   }
@@ -572,8 +150,6 @@ import STYLE from "./style.css";
     return Notification.permission === "granted";
   }
 
-  // ---- 降级提醒（非安全上下文：系统弹窗被浏览器禁止时使用）----
-
   var audioCtx: any = null;
 
   /** 解锁音频（必须在用户手势内调用）：后台播放提示音需要已解锁的 AudioContext。 */
@@ -585,7 +161,6 @@ import STYLE from "./style.css";
         audioCtx = new AC();
       }
       if (audioCtx.state === "suspended") audioCtx.resume();
-      // 播放一段静音以完成解锁
       var buffer = audioCtx.createBuffer(1, 1, 22050);
       var source = audioCtx.createBufferSource();
       source.buffer = buffer;
@@ -596,9 +171,6 @@ import STYLE from "./style.css";
     }
   }
 
-  /** 播放双音提示音（880Hz→660Hz，短促）。
-   *  节流：1.5 秒内通知连发只响一次，防止频繁通知（如连点测试按钮）
-   *  创建大量振荡器导致音频线程过载、页面卡顿。 */
   var lastChimeAt = 0;
   function playChime() {
     if (audioCtx === null || audioCtx.state !== "running") return;
@@ -626,13 +198,10 @@ import STYLE from "./style.css";
   }
 
   var savedTitle: any = null;
-
-  /** 隐藏时改 document.title 提醒（"🔔 任务完成 …"），可见时还原。 */
   function flashTitle(title: any) {
     if (savedTitle === null) savedTitle = document.title;
     document.title = "🔔 " + String(title).slice(0, 40);
   }
-
   function restoreTitle() {
     if (savedTitle !== null) {
       document.title = savedTitle;
@@ -640,8 +209,27 @@ import STYLE from "./style.css";
     }
   }
 
-  /** 页面内横幅（非安全上下文降级通道；点击聚焦，8 秒自动消失，最多叠 3 条）。
-   *  同类型（如 test 连发）先替换旧横幅，避免抖动堆叠。 */
+  function el(tag: any, attrs: any, children: any = undefined) {
+    var node = document.createElement(tag);
+    if (attrs) {
+      for (var key in attrs) {
+        var value = attrs[key];
+        if (key === "class") node.className = value;
+        else if (key === "text") node.textContent = value;
+        else if (key === "dataset") Object.assign(node.dataset, value);
+        else if (key === "onClick") node.addEventListener("click", value);
+        else if (key === "style") node.style.cssText = value;
+        else if (key in node && key !== "list") node[key] = value;
+        else node.setAttribute(key, value);
+      }
+    }
+    if (children) {
+      for (var i = 0; i < children.length; i += 1) node.appendChild(children[i]);
+    }
+    return node;
+  }
+
+  /** 页面内横幅（非安全上下文降级通道；点击聚焦，8 秒自动消失，最多叠 3 条）。 */
   function showBanner(kind: any, title: any, message: any) {
     var existing = document.querySelector('.dn-banner[data-kind="' + kind + '"]');
     if (existing) existing.remove();
@@ -670,15 +258,12 @@ import STYLE from "./style.css";
    * 通知展示总入口：系统级 Notification 可用 → 弹系统通知；
    * 否则降级（页面内横幅 + 提示音 + 标题提醒）。
    */
-  function showNotification(kind: any, title: any, message: any) {
-    // 多标签去重：仅主标签执行展示（通知/横幅/提示音/标题），副标签静默
+  function showNotification(kind: any, title: any, message: any, soundEnabled: boolean) {
+    // 多标签去重：仅主标签执行展示，副标签静默
     if (!claimMaster()) return;
     if (systemNotificationUsable()) {
       try {
-        // tag 加时间戳+随机后缀：每条通知独立显示，同类连发也互不替换
-        // （固定 tag 时 Chrome 会用新通知替换旧通知，表现为"通知漏掉"）。
-        // 堆积控制靠 notified 数组上限（超过 5 条关闭最早的）。
-        var notification = new Notification(title, { body: message, tag: "dsh-notifier-" + kind + "-" + Date.now() + "-" + Math.random().toString(36).slice(2, 8), icon: NOTIFY_ICON, silent: !!(configCache && configCache.notifySound === false) });
+        var notification = new Notification(title, { body: message, tag: "dsh-notifier-" + kind + "-" + Date.now() + "-" + Math.random().toString(36).slice(2, 8), icon: NOTIFY_ICON, silent: !soundEnabled });
         notification.onclick = function () {
           window.focus();
           notification.close();
@@ -699,21 +284,24 @@ import STYLE from "./style.css";
     playChime();
   }
 
+  // ---- 运行时配置镜像（GET /config 的 effective；SSE 展示与可见性判定用）----
+  var runtimeConfig: any = null;
+
   function handleNotifyFrame(payload: any) {
     // 测试通知：无条件提醒（验证链路是它的目的，与可见性/权限之外的开关无关）。
     if (payload.kind === "test") {
-      showNotification(payload.kind, payload.title, payload.message);
+      showNotification(payload.kind, payload.title, payload.message, runtimeConfig?.notifySound !== false);
       return;
     }
-    // 未读角标：收到非测试通知帧即 +1（打开面板清零）
-    bumpUnread();
     // 页面聚焦时不提醒（用户在界面中）；除非配置了「页面可见时也弹」。
-    if (document.visibilityState !== "hidden" && !(configCache && configCache.notifyWhenVisible === true)) return;
-    showNotification(payload.kind, payload.title, payload.message);
+    if (document.visibilityState !== "hidden" && !(runtimeConfig && runtimeConfig.notifyWhenVisible === true)) return;
+    showNotification(payload.kind, payload.title, payload.message, runtimeConfig?.notifySound !== false);
   }
 
+  // ------------------------------------------------------------ SSE 半区（C1-C9）
+
   // 当前 SSE 句柄（visibilitychange 回前台重建时引用；卸载时置 null）
-  var eventsHandle: any = null;
+  var eventsHandle: { close: () => void; reconnect: () => void } | null = null;
 
   // 页面重新可见时：还原标题 + 强制重建 SSE（iOS 后台挂起后连接可能已失效，
   // 重建自动带 since 补拉，避免断线窗口漏通知）
@@ -737,7 +325,6 @@ import STYLE from "./style.css";
       if (watchdog !== null) clearTimeout(watchdog);
       watchdog = setTimeout(function () {
         if (Date.now() - lastActivity > WATCHDOG_MS) {
-          // 判定半开连接：心跳 ping 也应定期触达，超时说明链路静默断掉
           forceReconnect();
         } else {
           armWatchdog();
@@ -746,35 +333,26 @@ import STYLE from "./style.css";
     }
 
     function forceReconnect() {
-      // 重连节流：网络抖动时避免快速循环
       var now = Date.now();
       if (now - lastReconnectAt < 5000) return;
       lastReconnectAt = now;
-      if (source !== null) {
-        try {
-          source.close();
-        } catch (error) {
-          // close() 按规范很少抛错，但失败要留痕便于排查（空 catch 会掩盖问题）
-          console.warn("[dsh-notifier] 关闭旧 SSE 连接失败：", error);
-        }
-        source = null;
-      }
+      closeSource();
       connect();
     }
 
-    function connect() {
-      // 兜底：任何路径（含未来新增触发源）在重建前都先关旧的，杜绝未关闭连接累积。
-      // 修复：0.1.8 visibilitychange 裸 reconnect 覆盖 source 引用不 close，导致
-      // 切后台/前台逐步耗尽浏览器同源并发连接、其余请求全部 pending。
+    function closeSource() {
       if (source !== null) {
         try {
           source.close();
         } catch (error) {
-          // close() 按规范很少抛错，但失败要留痕便于排查（空 catch 会掩盖问题）
           console.warn("[dsh-notifier] 关闭旧 SSE 连接失败：", error);
         }
         source = null;
       }
+    }
+
+    function connect() {
+      closeSource();
       try {
         // 重连带 since：服务端先回放缓冲中 seq 更大的帧（断线补拉，不丢事件）
         var url = ROUTES.events + (lastSeq > 0 ? "?since=" + lastSeq : "");
@@ -784,9 +362,8 @@ import STYLE from "./style.css";
           try {
             var data = JSON.parse(event.data);
             lastActivity = Date.now();
-            if (data.type === "ping") return; // 心跳帧：仅更新活动时间戳
+            if (data.type === "ping") return;
             if (data.type === "notify") {
-              // seq 去重：已处理过的帧（重连回放竞态）跳过
               if (typeof data.seq === "number") {
                 if (lastSeq > 0 && data.seq <= lastSeq) return;
                 lastSeq = data.seq;
@@ -811,216 +388,434 @@ import STYLE from "./style.css";
     var handle = {
       close: function () {
         if (watchdog !== null) clearTimeout(watchdog);
-        if (source !== null) source.close();
+        closeSource();
       },
-      // reconnect 收敛到 forceReconnect（关旧 + 5s 节流）：visibilitychange/
-      // onerror/watchdog 三路重建共用同一受控入口，避免赤裸 connect 重复建连。
       reconnect: forceReconnect,
     };
     eventsHandle = handle;
     return handle;
   }
 
-  // ------------------------------------------------------------ 入口与挂载
+  // ------------------------------------------------------------ 设置卡片
 
-  function createEntry() {
-    var entry = document.createElement("button");
-    entry.type = "button";
-    entry.dataset.dshNotifierEntry = "";
-    entry.setAttribute("aria-label", "通知");
-    entry.setAttribute("title", "通知：审批/完成/错误提醒设置");
-    entry.innerHTML = '<span style="display:inline-flex;vertical-align:middle">' + ICON + "</span><span style='margin-left:2px'>通知</span><span class='dn-badge' data-dsh-notifier-badge hidden></span>";
-    entry.style.cssText =
-      "display:flex;align-items:center;gap:6px;width:100%;padding:6px 10px;border:none;background:transparent;color:inherit;font-size:12px;cursor:pointer;border-radius:6px";
-    return entry;
+  /** 加载 GET /config 包装体 → 结构化 {user, revision, effective, writable}。 */
+  function fetchConfig(): Promise<any> {
+    return fetch(ROUTES.config, { headers: { accept: "application/json" } }).then(function (r: any) {
+      return r.json().then(function (body: any) {
+        if (!r.ok) {
+          var err = (body && body.error) || {};
+          throw new Error(err.details || err.error || ("HTTP " + r.status));
+        }
+        return body;
+      });
+    });
   }
 
-  // ---- 未读角标：收到通知帧 +1，打开面板清零（localStorage lastRead 记录），
-  // 刷新页面按 history 差量恢复（跨刷新/跨标签维持）
-  var unreadCount = 0;
-  var UNREAD_KEY = "dsh-notifier:lastRead";
-  function updateBadge() {
-    var b: any = document.querySelector("[data-dsh-notifier-badge]");
-    if (!b) return;
-    if (unreadCount > 0) {
-      b.textContent = unreadCount > 99 ? "99+" : String(unreadCount);
-      b.hidden = false;
-    } else {
-      b.hidden = true;
+  /** 拉取最近历史记录（最近 10 条，倒序）。 */
+  function fetchHistory(): Promise<any[]> {
+    return fetch(ROUTES.history, { headers: { accept: "application/json" } })
+      .then(function (r: any) { return r.json(); })
+      .then(function (data: any) {
+        var records = (data && data.records) || [];
+        return records.slice(-10).reverse();
+      });
+  }
+
+  /**
+   * 设置面板插件项（settings.plugin.item 插槽渲染的 React 卡片）。
+   * 字段全量（A1）+ 基线 diff 只提变更键（A4）+ 历史最近 10 条（D1/D2）+
+   * 动作区（清理记录两段式 / 请求权限 / 测试通知，A6/A7）+ 三端降级文案（A5/A8）。
+   * 保存走 PUT {patch, expectedRevision}（乐观并发，冲突时提示刷新）。
+   */
+  function SettingsCard() {
+    var ReactHooks = React;
+    var useState = ReactHooks.useState;
+    var useEffect = ReactHooks.useEffect;
+    var draft = useState(null);
+    var settings = draft[0];
+    var setSettings = draft[1];
+    var meta = useState(null); // { user, revision, effective, writable }
+    var metaValue = meta[0];
+    var setMeta = meta[1];
+    var saved = useState("");
+    var setSaved = saved[1];
+    var historyDraft = useState(null);
+    var history = historyDraft[0];
+    var setHistory = historyDraft[1];
+    var clearArmed = useState(false);
+    var clearArmedValue = clearArmed[0];
+    var setClearArmed = clearArmed[1];
+    // 加载基线（A4）：保存时只提交与基线不同的键（增量 diff），未改动的键不提交
+    var baseline: Record<string, any> | null = null;
+
+    function loadHistory(alive: { value: boolean }) {
+      fetchHistory().then(function (records) {
+        if (alive.value) setHistory(records);
+      }).catch(function () {
+        if (alive.value) setHistory([]);
+      });
     }
-  }
-  function resetUnread() {
-    unreadCount = 0;
-    try {
-      localStorage.setItem(UNREAD_KEY, String(Date.now()));
-    } catch (e) {
-      // localStorage 不可用仅不持久化
+
+    function loadCard(alive: { value: boolean }) {
+      fetchConfig()
+        .then(function (v: any) {
+          if (!alive.value) return;
+          var effective = (v && v.effective) || {};
+          setSettings(Object.assign({}, effective));
+          baseline = Object.assign({}, effective);
+          setMeta({ user: v.user || {}, revision: v.revision, effective: effective, writable: v.writable !== false });
+          runtimeConfig = effective; // SSE 展示面同步
+          if (v.writable === false) setSaved("设置服务不可用");
+        })
+        .catch(function (e: any) {
+          if (!alive.value) return;
+          setSaved("设置加载失败：" + ((e && e.message) || e) + accessHint(e));
+        });
     }
-    updateBadge();
-  }
-  function bumpUnread() {
-    unreadCount += 1;
-    updateBadge();
-  }
-  function initUnread() {
-    try {
-      var lastRead = Number(localStorage.getItem(UNREAD_KEY) || 0) || 0;
-      fetch(ROUTES.history, { headers: { accept: "application/json" } })
+
+    useEffect(function () {
+      var alive = { value: true };
+      loadCard(alive);
+      loadHistory(alive);
+      return function () { alive.value = false; };
+    }, []);
+
+    if (!settings) {
+      return React.createElement("li", { className: "dn-set-card" }, "通知：加载中…");
+    }
+
+    function patch(p: any) {
+      setSettings(Object.assign({}, settings, p));
+      setSaved("");
+    }
+
+    /** 基线 diff：只提交与加载基线不同的键（A4，防组合层 base 被默认值回写覆盖）。 */
+    function diffPayload(): Record<string, any> {
+      var payload: Record<string, any> = {};
+      for (var key in settings) {
+        if (baseline === null) break;
+        var cur = settings[key];
+        var base = baseline[key];
+        var same = JSON.stringify(cur) === JSON.stringify(base);
+        if (!same) payload[key] = cur;
+      }
+      return payload;
+    }
+
+    function save() {
+      var payload = diffPayload();
+      if (Object.keys(payload).length === 0) {
+        setSaved("未修改");
+        return;
+      }
+      fetch(ROUTES.config, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ patch: payload, expectedRevision: metaValue ? metaValue.revision : undefined }),
+      }).then(function (r: any) {
+        return r.json().then(function (body: any) {
+          if (!r.ok) {
+            var err = (body && body.error) || {};
+            throw new Error(err.error || err.details || err.code || ("HTTP " + r.status));
+          }
+          return body;
+        });
+      }).then(function (body: any) {
+        baseline = Object.assign({}, settings);
+        setMeta({ user: (body && body.user) || {}, revision: (body && body.revision) || undefined, effective: settings, writable: true });
+        setSaved("已保存");
+        setTimeout(function () { setSaved(""); }, 2200);
+      }).catch(function (e: any) {
+        var msg = (e && e.message) || e;
+        setSaved(String(msg).indexOf("版本冲突") >= 0
+          ? "保存失败：" + msg + "（请关闭本卡片重新打开后重试）"
+          : "保存失败：" + msg);
+      });
+    }
+
+    function sendTest() {
+      fetch(ROUTES.test, { method: "POST" })
         .then(function (res) {
           if (!res.ok) throw new Error("HTTP " + res.status);
           return res.json();
         })
         .then(function (data) {
-          var records = (data && data.records) || [];
-          var count = 0;
-          for (var i = 0; i < records.length; i += 1) {
-            // 被免打扰拦截（suppressed）的记录不计入未读角标（无需提醒查看）
-            if (records[i].ts > lastRead && !records[i].suppressed) count += 1;
-          }
-          unreadCount = count;
-          updateBadge();
+          // 服务端返回 {ok, sseConnections}：连接数语义 = 未释放句柄（#334 诊断保留）
+          toast("测试通知已发送（服务端未释放句柄 " + (data && data.sseConnections) + " 条）");
         })
-        .catch(function () {
-          // 失败静默：角标保持 0
+        .catch(function (error) {
+          toast("发送测试通知失败：" + error.message + accessHint(error));
         });
-    } catch (e) {
-      // 静默
     }
-  }
 
-  /** 找到侧边栏 shell 根元素（logoRow 的父容器，与 dsh-ssh / dsh-skill-explorer 同款策略）。 */
-  function sidebarRoot() {
-    var column = document.querySelector('[data-pane="sidebar"], [class*="sidebarCol"]');
-    if (!column) return null;
-    var logoOwner = column.querySelector('[class*="logoRow"]');
-    return logoOwner ? logoOwner.parentElement : column.firstElementChild;
-  }
-
-  /** 家族锚点：把入口排到既有插件入口之后（参考 dsh-ssh 的 placeEntry）。 */
-  function placeEntry(root: any, entry: any) {
-    if (!root || !(root instanceof HTMLElement)) return false;
-    if (entry.parentElement === root) return true;
-    var nested = root.querySelector('button[class*="newSession"]');
-    var button = nested;
-    if (!button) {
-      for (var i = 0; i < root.children.length; i += 1) {
-        if (root.children[i].tagName === "BUTTON") {
-          button = root.children[i];
-          break;
-        }
+    function confirmClear() {
+      if (!clearArmedValue) {
+        setClearArmed(true);
+        setTimeout(function () { setClearArmed(false); }, 3000);
+        return;
       }
+      setClearArmed(false);
+      fetch(ROUTES.history, { method: "DELETE" })
+        .then(function (r: any) {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.json();
+        })
+        .then(function (data: any) {
+          toast("已清空 " + (data.removed || 0) + " 条通知记录");
+          loadHistory({ value: true });
+        })
+        .catch(function (error) {
+          toast("清空失败：" + error.message + accessHint(error));
+        });
     }
-    if (!button) return false;
-    var row = button.closest('[class*="logoRow"]');
-    var base = row && row.parentElement === root ? row : button;
-    var family = Array.prototype.filter.call(root.children, function (el) {
-      return el instanceof HTMLElement && el.matches(
-        "[data-dsh-taskboard-entry], [data-dsh-ssh-entry], [data-dsh-skill-explorer-entry], [data-dsh-commands-files-entry], [data-dsh-memory-entry], [data-dsh-hooks-entry], [data-dsh-notifier-entry]"
+
+    var rows: any[] = [];
+    var sectionCount = 0;
+    function section(title: string, children: any[]) {
+      sectionCount += 1;
+      return React.createElement("div", { className: "dn-set-section", key: "sec" + sectionCount },
+        React.createElement("div", { className: "dn-set-title" }, title),
+        children,
       );
-    });
-    var anchor = family.length > 0 ? family[family.length - 1].nextElementSibling : base.nextElementSibling;
-    root.insertBefore(entry, anchor);
-    return true;
+    }
+
+    function row(label: string, control: any, hint?: string) {
+      sectionCount += 1;
+      return React.createElement("div", { className: "dn-set-row", key: "row" + sectionCount },
+        React.createElement("span", { className: "dn-set-label" }, label),
+        control,
+        hint ? React.createElement("span", { className: "dn-set-hint" }, hint) : null,
+      );
+    }
+
+    function switchControl(key: string) {
+      return React.createElement("input", {
+        type: "checkbox",
+        checked: settings[key] === true,
+        onChange: function (e: any) {
+          var next = Object.assign({}, settings);
+          next[key] = e.target.checked;
+          setSettings(next);
+        },
+      });
+    }
+
+    var eventChildren = EVENT_KEYS.map(function (kv) { return row(kv[1], switchControl(kv[0])); });
+    var channelChildren = CHANNEL_KEYS.map(function (kv) { return row(kv[1], switchControl(kv[0])); });
+    var numberChildren = [
+      row("错误合并窗口（ms，0=关）", React.createElement("input", {
+        type: "number", min: 0, step: 1000, className: "dn-set-input",
+        value: settings.errorMergeWindowMs,
+        onChange: function (e: any) { patch({ errorMergeWindowMs: Number(e.target.value) }); },
+      })),
+      row("完成聚合窗口（ms，0=关）", React.createElement("input", {
+        type: "number", min: 0, step: 1000, className: "dn-set-input",
+        value: settings.doneMergeWindowMs,
+        onChange: function (e: any) { patch({ doneMergeWindowMs: Number(e.target.value) }); },
+      })),
+      row("审批二次提醒（分钟，0=关）", React.createElement("input", {
+        type: "number", min: 0, step: 1, className: "dn-set-input",
+        value: settings.askRemindMin,
+        onChange: function (e: any) { patch({ askRemindMin: Number(e.target.value) }); },
+      })),
+      row("历史保留天数（0=不按天清理）", React.createElement("input", {
+        type: "number", min: 0, step: 1, className: "dn-set-input",
+        value: settings.historyMaxAgeDays,
+        onChange: function (e: any) { patch({ historyMaxAgeDays: Number(e.target.value) }); },
+      })),
+      row("最大连接数（条，超出淘汰最老）", React.createElement("input", {
+        type: "number", min: 1, max: 1024, step: 1, className: "dn-set-input",
+        value: settings.maxConnections,
+        onChange: function (e: any) { patch({ maxConnections: Number(e.target.value) }); },
+      })),
+    ];
+
+    var qh = settings.quietHours || {};
+    var quietChildren = [
+      row("启用免打扰", React.createElement("input", {
+        type: "checkbox",
+        checked: qh.enabled === true,
+        onChange: function (e: any) { patch({ quietHours: Object.assign({}, qh, { enabled: e.target.checked }) }); },
+      })),
+      row("开始时间", React.createElement("input", {
+        type: "time", className: "dn-set-input",
+        value: qh.start || "22:00",
+        onChange: function (e: any) { patch({ quietHours: Object.assign({}, qh, { start: e.target.value }) }); },
+      })),
+      row("结束时间", React.createElement("input", {
+        type: "time", className: "dn-set-input",
+        value: qh.end || "08:00",
+        onChange: function (e: any) { patch({ quietHours: Object.assign({}, qh, { end: e.target.value }) }); },
+      })),
+    ];
+    var ALLOW_CHOICES = [["ask", "审批"], ["question", "提问"], ["error", "出错"]];
+    quietChildren.push(React.createElement("div", { className: "dn-set-row", key: "allow" },
+      React.createElement("span", { className: "dn-set-label" }, "免打扰仍提醒"),
+      React.createElement("div", { className: "dn-set-allows" },
+        ALLOW_CHOICES.map(function (ac) {
+          var kindText = ac[0], kindLabel = ac[1];
+          var allows = qh.allowKinds || [];
+          return React.createElement("label", { className: "dn-set-allow", key: kindText },
+            React.createElement("input", {
+              type: "checkbox",
+              checked: allows.indexOf(kindText) !== -1,
+              onChange: function (e: any) {
+                var next = allows.slice();
+                if (e.target.checked && next.indexOf(kindText) === -1) next.push(kindText);
+                else if (!e.target.checked && next.indexOf(kindText) !== -1) next.splice(next.indexOf(kindText), 1);
+                patch({ quietHours: Object.assign({}, qh, { allowKinds: next }) });
+              },
+            }),
+            React.createElement("span", null, kindLabel),
+          );
+        }),
+      ),
+    ));
+
+    // 三端降级文案（A5/A8）
+    var degradation: any[] = [];
+    if (metaValue && metaValue.writable === false) {
+      degradation.push(React.createElement("div", { className: "dn-set-note", key: "settings-unavailable" },
+        "设置服务不可用：当前无法保存配置（settings 服务未挂载）。插件通知功能不受影响，但更改将被拒绝。"));
+    }
+    if ("Notification" in window) {
+      if (!isSecureContext()) {
+        degradation.push(React.createElement("div", { className: "dn-set-note", key: "insecure" },
+          "当前为局域网 HTTP 访问（非安全上下文），浏览器禁止系统级弹窗，已启用「页面内横幅 + 提示音 + 标题提醒」降级通道。如需系统弹窗，请改用 dsh-lan-proxy 的 https://<局域网IP>:3443 或 localhost 隧道访问（如 ssh -L 3080:127.0.0.1:3080）后刷新页面。"));
+      } else {
+        var permText = "";
+        if (Notification.permission === "granted") permText = "浏览器通知权限：已授权 ✓";
+        else if (Notification.permission === "denied") permText = "浏览器通知权限：已拒绝（请在浏览器站点设置中允许本页通知）";
+        else permText = "浏览器通知权限：未授权（点击下方按钮在浏览器弹窗中允许）";
+        degradation.push(React.createElement("div", { className: "dn-set-note", key: "perm" }, permText));
+      }
+    } else {
+      degradation.push(React.createElement("div", { className: "dn-set-note", key: "noapi" },
+        "当前设备不支持系统级通知（如 iOS Safari 普通标签页无 Web Notifications）。可用通道：页面可见时的横幅 + 提示音（需保持页面打开），或经 dsh-lan-proxy 的 https://<局域网IP>:3443 访问并「添加到主屏幕」后获得 PWA 级通知能力。"));
+    }
+
+    // 动作区（A6/A7）
+    var actions = React.createElement("div", { className: "dn-set-actions" },
+      React.createElement("button", { type: "button", className: "dn-set-btn" + (clearArmedValue ? " dn-set-btnDanger" : ""), onClick: confirmClear },
+        clearArmedValue ? "确认清理记录？" : "清理记录"),
+      ("Notification" in window && Notification.permission === "default")
+        ? React.createElement("button", { type: "button", className: "dn-set-btn", onClick: function () {
+            requestPermission(function () { setSaved("权限请求完成，请刷新查看状态"); });
+          } }, "请求通知权限")
+        : null,
+      React.createElement("button", { type: "button", className: "dn-set-btn", onClick: sendTest }, "发送测试通知"),
+    );
+
+    // 历史列表（D1/D2）
+    var historyEl = React.createElement("div", { className: "dn-set-section" },
+      React.createElement("div", { className: "dn-set-title" }, "通知记录（最近 10 条）"),
+      React.createElement("button", {
+        type: "button", className: "dn-set-btn dn-set-btnSmall",
+        onClick: function () { loadHistory({ value: true }); },
+      }, "刷新"),
+      !history || history.length === 0
+        ? React.createElement("div", { className: "dn-set-note" }, "暂无通知记录（点「发送测试通知」可生成一条）")
+        : React.createElement("ul", { className: "dn-set-history" },
+            history.map(function (r: any, i: number) {
+              var d = new Date(r.ts);
+              var pad = function (n: number) { return n < 10 ? "0" + n : String(n); };
+              var time = pad(d.getHours()) + ":" + pad(d.getMinutes()) + ":" + pad(d.getSeconds());
+              return React.createElement("li", { className: "dn-set-historyItem", key: String(r.ts) + "-" + i },
+                React.createElement("div", { className: "dn-set-historyHead" },
+                  React.createElement("span", { className: "dn-set-historyTime" }, time),
+                  React.createElement("span", { className: "dn-set-historyKind" }, KIND_LABELS[r.kind] || r.kind),
+                  r.suppressed === "quiet"
+                    ? React.createElement("span", { className: "dn-set-historySuppressed" }, "免打扰拦截未发出")
+                    : null,
+                ),
+                React.createElement("div", { className: "dn-set-historyText" }, r.title + "：" + r.message),
+              );
+            }),
+          ),
+    );
+
+    return React.createElement("li", { className: "dn-set-card" },
+      React.createElement("div", { className: "dn-set-head" },
+        React.createElement("span", { className: "dn-set-name" }, "通知（dsh-notifier）"),
+        React.createElement("span", { className: "dn-set-description" }, "审批/完成/错误事件通知 · 事件开关 / 通道 / 合并去重 / 免打扰 / 历史清理"),
+      ),
+      React.createElement("div", { className: "dn-set-body" },
+        section("通知事件", eventChildren),
+        section("通知通道", channelChildren),
+        section("合并/去重", numberChildren),
+        section("免打扰时段", quietChildren),
+        historyEl,
+        section("动作", actions),
+        React.createElement("div", { className: "dn-set-notes" }, degradation),
+        React.createElement("div", { className: "dn-set-foot" },
+          saved ? React.createElement("span", { className: saved.indexOf("失败") >= 0 || saved.indexOf("不可用") >= 0 ? "dn-set-error" : "dn-set-saved" }, saved) : null,
+          React.createElement("button", { type: "button", className: "dn-set-save", onClick: save }, "保存"),
+        ),
+      ),
+    );
   }
+
+  // ------------------------------------------------------------ 装配
 
 export function apply(ctx: any) {
-    var panel: any = null;
-    var entry: any = null;
-    var disposeEvents: any = null;
+    try {
+      injectStyle();
 
-    function mount() {
-      if (entry === null) {
-        entry = createEntry();
-        entry.addEventListener("click", function () {
-          // 用户手势内：解锁音频（后台提示音的前提）+ 请求通知权限（Chrome 只接受手势内的授权请求）。
-          unlockAudio();
-          if ("Notification" in window && Notification.permission === "default") {
-            requestPermission(function () {
-              if (panel !== null && !panel.hidden) renderPanel(panel);
-            });
-          }
-          if (panel === null) {
-            panel = el("div", { id: PANEL_ID, hidden: true });
-            var header = el("div", { class: "dn-header" });
-            header.appendChild(el("span", { text: "通知" }));
-            var closeBtn = el("button", { type: "button", text: "关闭", style: "border:1px solid var(--dsw-alias-border-l1,#e2e5ea);background:var(--dsw-alias-bg-layer-1,#f5f6f8);border-radius:6px;padding:2px 10px;cursor:pointer;color:inherit", onClick: function () { panel.hidden = true; } });
-            header.appendChild(closeBtn);
-            panel.appendChild(header);
-            panel.appendChild(el("div", { class: "dn-body" }));
-            document.body.appendChild(panel);
-            restorePanelPos(panel);
-            attachDrag(header, panel);
-          }
-          if (panel.hidden) {
-            renderPanel(panel);
-            panel.hidden = false;
-            resetUnread(); // 打开面板 = 已读，清角标
-          } else {
-            panel.hidden = true;
-          }
+      // 通知半区（SSE / 浏览器通知）：不依赖任何插件 DOM（C6），直接启动
+      var disposeEvents: { close: () => void; reconnect: () => void } | null = startEvents();
+      // 运行时配置预取：可见性判定与通知展示要用 notifyWhenVisible / notifySound
+      fetchConfig().then(function (v: any) {
+        if (v && v.effective) runtimeConfig = v.effective;
+      }).catch(function () {
+        // 失败静默（卡片打开时再拉）
+      });
+
+      // 首次任意点击解锁音频（浏览器自动播放策略要求手势）
+      document.addEventListener("click", function onFirstClick() {
+        unlockAudio();
+        document.removeEventListener("click", onFirstClick);
+      }, { capture: true });
+
+      // 设置面板插件项（settings.plugin.item；id+key 双写兼容 rc.7 前后两代运行时）
+      var slots = ctx.get("slots");
+      if (slots && typeof slots.inject === "function") {
+        slots.inject("settings.plugin.item", function () {
+          return slots.register(
+            { name: "settings.plugin.item", id: "dsh-notifier", key: "dsh-notifier", order: 70 },
+            function () {
+              return React.createElement(SettingsCard, null);
+            }
+          );
         });
+      } else {
+        console.warn("[dsh-notifier] 缺少 slots 服务，设置卡片未挂载（通知半区照常工作）");
       }
-      var root = sidebarRoot();
-      if (root && entry.parentElement !== root) {
-        placeEntry(root, entry);
-      } else if (!root && !document.body.contains(entry)) {
-        document.body.appendChild(entry);
-      }
-      if (disposeEvents === null) {
-        disposeEvents = startEvents();
-      }
-    }
 
-    function boot() {
-      try {
-        injectStyle();
-        mount();
-        refreshConfig(); // 预取配置：可见性判断不依赖打开面板
-        initUnread(); // 恢复未读角标（history 差量）
-        // 首次任意点击解锁音频（浏览器自动播放策略要求手势；YouTube 同款做法），
-        // 之后后台通知才有提示音。侧边栏「通知」入口点击也会解锁。
-        document.addEventListener("click", function onFirstClick() {
-          unlockAudio();
-          document.removeEventListener("click", onFirstClick);
-        }, { capture: true });
-        // 注意：通知权限只在用户点击侧边栏「通知」入口时（手势内）请求，
-        // Chrome 拒绝非手势的授权请求。
-        var observer = new MutationObserver(function () {
-          mount();
-        });
-        observer.observe(document.body, { childList: true, subtree: true });
-        ctx.effect(
-          function () {
-            // ctx.effect 的 fn 立即执行：清理必须写在返回的 disposer 里，
-            // 否则挂载后立刻被移除（侧边栏入口消失的实测根因）。
-            return function () {
-              observer.disconnect();
-              if (disposeEvents !== null) {
-                disposeEvents.close();
-                disposeEvents = null;
-                eventsHandle = null;
-              }
-              if (entry !== null) entry.remove();
-              if (panel !== null) panel.remove();
-              for (var i = 0; i < notified.length; i += 1) {
-                try {
-                  notified[i].close();
-                } catch (error) {
-                  // 忽略
-                }
-              }
-            };
-          },
-          "dsh-notifier"
-        );
-      } catch (error) {
-        console.warn("[dsh-notifier] 挂载失败：", error);
-      }
+      // ⚠️ 清理必须写在 ctx.effect 返回的 disposer 里。
+      ctx.effect(function () {
+        return function () {
+          if (disposeEvents) {
+            disposeEvents.close();
+            disposeEvents = null;
+            eventsHandle = null;
+          }
+          for (var i = 0; i < notified.length; i += 1) {
+            try {
+              notified[i].close();
+            } catch (error) {
+              // 忽略
+            }
+          }
+          var style = document.getElementById(STYLE_ID);
+          if (style) style.remove();
+        };
+      }, "dsh-notifier");
+    } catch (error) {
+      console.warn("[dsh-notifier] 挂载失败：", error);
     }
-
-    if (document.body) boot();
-    else document.addEventListener("DOMContentLoaded", boot);
   }
 
-// ---- 客户端契约：apply/inject 由 build-client 经 factory 装配（干净模块）----
-export const inject: string[] = [];
+// ---- 客户端契约：apply/inject 由 build-client 经 factory 装配（干净模块，React externals）----
+// 设置卡片是 React 组件（settings.plugin.item 插槽由宿主 React 渲染）；通知半区
+// 不依赖任何 DOM（C6），slot 缺失时照常工作。
+export const inject: string[] = ["slots"];

--- a/packages/dsh-notifier/src/client/react-shim.d.ts
+++ b/packages/dsh-notifier/src/client/react-shim.d.ts
@@ -1,0 +1,7 @@
+// 浏览器半区 React 类型 shim（仅类型面）。
+// React 运行时由 dsh web 的 factory require("react") 注入（build-client externals 路径），
+// 此处只提供编译期类型（any 兜底），不引入 @types/react 运行时/编译依赖。
+declare module "react" {
+  const React: any;
+  export = React;
+}

--- a/packages/dsh-notifier/src/client/style.css
+++ b/packages/dsh-notifier/src/client/style.css
@@ -1,93 +1,56 @@
-/* dsh-notifier — 客户端样式（独立 .css 文件）。
+/* dsh-notifier — 客户端样式（独立 .css 文件，issue #76 设置卡片）。
  *
  * 由 build-client 的 .css text-loader 构建期内联进 client.js（产物仍自包含单文件、
  * 零运行时依赖、无独立网络请求）。injectStyle 注入 <style id=dsh-notifier-style>。
  * 前缀 dn-（防与 shell 冲突）；颜色一律走 --dsw-alias-* 主题变量 + 浅色回退。
- * PANEL_ID 常量（dsh-notifier-panel）在 JS 侧用于 DOM 定位，此处硬编码一致。
+ * 本文件只保留「设置卡片」与「通知展示（横幅/toast）」两类样式——侧边栏入口/
+ * 浮层面板/角标相关样式随 B 组移除（issue #76）。
  */
 
-/* 配置面板（fixed 挂 body） */
-#dsh-notifier-panel {
-  position: fixed;
-  top: 64px;
-  left: 12px;
-  width: min(320px, calc(100vw - 24px));
-  max-height: 70vh;
-  max-height: calc(100dvh - 160px); /* iOS 地址栏动态高度（dvh），桌面回退 70vh */
-  display: flex;
-  flex-direction: column;
-  background: var(--dsw-alias-bg-base, #ffffff);
+/* ============ 设置卡片（settings.plugin.item 插槽） ============ */
+
+.dn-set-card {
+  list-style: none;
   border: 1px solid var(--dsw-alias-border-l1, #e2e5ea);
   border-radius: 10px;
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
-  z-index: 70;
   overflow: hidden;
   font-size: 12px;
   color: var(--dsw-alias-label-primary, #1f2329);
+  background: var(--dsw-alias-bg-base, #ffffff);
 }
-#dsh-notifier-panel[hidden] { display: none !important; }
-
-#dsh-notifier-panel .dn-header {
+.dn-set-card .dn-set-head {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 10px 12px;
+  align-items: baseline;
+  gap: 8px;
+  padding: 10px 14px;
   border-bottom: 1px solid var(--dsw-alias-border-l1, #e2e5ea);
   background: var(--dsw-alias-bg-layer-1, #f5f6f8);
-  font-weight: 600;
-  cursor: move;
-  user-select: none;
-  touch-action: none; /* Pointer 拖拽：禁止浏览器滚动手势抢占（否则拖动变页面滚动） */
 }
-#dsh-notifier-panel .dn-body { overflow: auto; padding: 10px 12px; flex: 1; }
-#dsh-notifier-panel .dn-section { margin-bottom: 12px; }
-#dsh-notifier-panel .dn-section-title {
-  margin: 0 0 6px;
-  font-weight: 600;
-  color: var(--dsw-alias-label-secondary, #5f6672);
-}
-#dsh-notifier-panel .dn-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 4px 0;
-  border-bottom: 1px solid var(--dsw-alias-border-l1, #e2e5ea);
-  min-height: 44px; /* 触控目标高度（WCAG 2.5.5） */
-}
-/* 开关行文本：整行 label 可点（htmlFor 关联 input），触控友好 */
-#dsh-notifier-panel .dn-row-text {
-  display: flex;
-  align-items: center;
-  flex: 1;
-  min-height: 44px;
-  cursor: pointer;
-  color: inherit;
-}
-#dsh-notifier-panel .dn-note {
-  color: var(--dsw-alias-label-tertiary, #8a919c);
+.dn-set-card .dn-set-name { font-weight: 600; }
+.dn-set-card .dn-set-description {
   font-size: 11px;
-  margin-top: 8px;
-  line-height: 1.6;
+  color: var(--dsw-alias-label-tertiary, #8a919c);
 }
-#dsh-notifier-panel .dn-quiet { display: flex; align-items: center; gap: 6px; margin-top: 8px; }
-/* 免打扰紧急例外勾选区 */
-#dsh-notifier-panel .dn-quiet-allow {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-top: 6px;
-  flex-wrap: wrap;
-  font-size: 12px;
-}
-#dsh-notifier-panel .dn-allow-item {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  min-height: 32px;
-  cursor: pointer;
+.dn-set-card .dn-set-body { padding: 6px 14px 12px; }
+
+.dn-set-card .dn-set-section { margin-top: 10px; }
+.dn-set-card .dn-set-title {
+  margin: 0 0 4px;
+  font-weight: 600;
   color: var(--dsw-alias-label-secondary, #5f6672);
 }
-#dsh-notifier-panel .dn-quiet input[type="time"] {
+.dn-set-card .dn-set-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 0;
+  border-bottom: 1px solid var(--dsw-alias-border-l1, #e2e5ea);
+  min-height: 40px; /* 触控目标高度（WCAG 2.5.5 底线 24px，行高足额） */
+  flex-wrap: wrap;
+}
+.dn-set-card .dn-set-label { flex: 1; color: inherit; }
+.dn-set-card .dn-set-input {
+  width: 96px;
   background: var(--dsw-alias-bg-layer-1, #f5f6f8);
   color: var(--dsw-alias-label-primary, #1f2329);
   border: 1px solid var(--dsw-alias-border-l1, #e2e5ea);
@@ -95,37 +58,116 @@
   padding: 3px 6px;
   font-size: 12px;
 }
-#dsh-notifier-panel .dn-switch { position: relative; width: 36px; height: 22px; flex: none; }
-#dsh-notifier-panel .dn-switch input { opacity: 0; width: 0; height: 0; }
-#dsh-notifier-panel .dn-switch .dn-track {
-  position: absolute;
-  inset: 0;
-  border-radius: 11px;
-  background: var(--dsw-alias-border-l2, #d3d8df);
-  transition: background 0.15s;
+.dn-set-card .dn-set-row input[type="time"] {
+  background: var(--dsw-alias-bg-layer-1, #f5f6f8);
+  color: var(--dsw-alias-label-primary, #1f2329);
+  border: 1px solid var(--dsw-alias-border-l1, #e2e5ea);
+  border-radius: 6px;
+  padding: 3px 6px;
+  font-size: 12px;
+}
+.dn-set-card .dn-set-allows { display: flex; gap: 10px; flex-wrap: wrap; }
+.dn-set-card .dn-set-allow {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 32px;
   cursor: pointer;
+  color: var(--dsw-alias-label-secondary, #5f6672);
 }
-#dsh-notifier-panel .dn-switch input:checked + .dn-track { background: var(--dsw-alias-state-success-primary, #0f9d6e); }
-#dsh-notifier-panel .dn-switch .dn-thumb {
-  position: absolute;
-  top: 3px;
-  left: 3px;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background: var(--dsw-alias-bg-base, #fff);
-  transition: transform 0.15s;
+
+.dn-set-card .dn-set-note {
+  color: var(--dsw-alias-label-tertiary, #8a919c);
+  font-size: 11px;
+  margin-top: 8px;
+  line-height: 1.6;
 }
-#dsh-notifier-panel .dn-switch input:checked + .dn-track .dn-thumb { transform: translateX(14px); }
-/* 键盘可达性：focus 轮廓（触屏无 hover，键盘用户需要可感知焦点） */
-#dsh-notifier-panel .dn-switch input:focus-visible + .dn-track,
-#dsh-notifier-panel button:focus-visible,
-#dsh-notifier-panel input[type="time"]:focus-visible {
+.dn-set-card .dn-set-notes .dn-set-note {
+  border-left: 3px solid var(--dsw-alias-border-l2, #d3d8df);
+  padding-left: 8px;
+}
+
+.dn-set-card .dn-set-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 4px; }
+.dn-set-card .dn-set-btn {
+  border: 1px solid var(--dsw-alias-border-l1, #e2e5ea);
+  background: var(--dsw-alias-bg-layer-1, #f5f6f8);
+  color: inherit;
+  border-radius: 6px;
+  padding: 5px 12px;
+  min-height: 32px;
+  cursor: pointer;
+  font-size: 12px;
+}
+.dn-set-card .dn-set-btnSmall { padding: 1px 8px; min-height: 24px; font-size: 11px; }
+.dn-set-card .dn-set-btnDanger {
+  background: var(--dsw-alias-state-error-primary, #d92d20);
+  color: #fff;
+  border-color: transparent;
+}
+.dn-set-card .dn-set-btn:hover,
+.dn-set-card .dn-set-save:hover { opacity: 0.9; }
+@media (hover: hover) {
+  .dn-set-card .dn-set-btn:hover,
+  .dn-set-card .dn-set-save:hover { opacity: 0.9; }
+}
+.dn-set-card button:focus-visible,
+.dn-set-card input:focus-visible {
   outline: 2px solid var(--dsw-alias-state-info-primary, #2f6fed);
   outline-offset: 2px;
 }
 
-/* 错误 toast（挂 body） */
+.dn-set-card .dn-set-history { list-style: none; margin: 4px 0 0; padding: 0; }
+.dn-set-card .dn-set-historyItem {
+  padding: 5px 0;
+  border-bottom: 1px solid var(--dsw-alias-border-l1, #e2e5ea);
+}
+.dn-set-card .dn-set-historyHead { display: flex; gap: 6px; align-items: center; }
+.dn-set-card .dn-set-historyTime { color: var(--dsw-alias-label-tertiary, #8a919c); }
+.dn-set-card .dn-set-historyKind { font-weight: 600; }
+.dn-set-card .dn-set-historySuppressed {
+  color: var(--dsw-alias-label-tertiary, #8a919c);
+  font-size: 10px;
+  border: 1px solid var(--dsw-alias-border-l1, #e2e5ea);
+  border-radius: 8px;
+  padding: 0 4px;
+}
+.dn-set-card .dn-set-historyText {
+  color: var(--dsw-alias-label-secondary, #5f6672);
+  font-size: 11px;
+  margin-top: 2px;
+}
+
+.dn-set-card .dn-set-foot {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 12px;
+}
+.dn-set-card .dn-set-saved { color: var(--dsw-alias-state-success-primary, #0f9d6e); }
+.dn-set-card .dn-set-error { color: var(--dsw-alias-state-error-primary, #d92d20); }
+.dn-set-card .dn-set-save {
+  border: 1px solid var(--dsw-alias-state-success-primary, #0f9d6e);
+  background: var(--dsw-alias-state-success-primary, #0f9d6e);
+  color: #fff;
+  border-radius: 6px;
+  padding: 5px 18px;
+  min-height: 32px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+/* 窄屏（phone / pad 竖屏，A9）：行可换行、不溢出；关键操作保持可达 */
+@media (max-width: 480px) {
+  .dn-set-card .dn-set-body { padding: 6px 10px 12px; }
+  .dn-set-card .dn-set-actions { flex-direction: column; align-items: stretch; }
+  .dn-set-card .dn-set-btn { width: 100%; }
+  .dn-set-card .dn-set-row { align-items: flex-start; }
+  .dn-set-card .dn-set-input { width: 100%; }
+}
+
+/* ============ 通知展示（横幅 / toast，issue #76 保留） ============ */
+
 .dn-toast {
   position: fixed;
   bottom: 20px;
@@ -160,29 +202,3 @@
 .dn-banner[data-kind="error"] { border-left-color: var(--dsw-alias-state-error-primary, #d92d20); }
 .dn-banner[data-kind="ask"],
 .dn-banner[data-kind="question"] { border-left-color: var(--dsw-alias-state-warning-primary, #f79009); }
-
-/* 侧边栏折叠（data-sidebar-collapsed，与 dsh-ssh 同款标记）：图标居中、隐藏文字。
- * !important 覆盖入口按钮的内联 padding（内联样式优先级高于样式表）。 */
-[data-dsh-frame][data-sidebar-collapsed] [data-dsh-notifier-entry] {
-  justify-content: center !important;
-  width: 100% !important;
-  padding: 0 !important;
-}
-[data-dsh-frame][data-sidebar-collapsed] [data-dsh-notifier-entry] > span:not(:first-child) {
-  display: none !important;
-}
-
-/* 侧边栏入口未读角标（红色圆点，收到通知 +1、打开面板清零） */
-[data-dsh-notifier-entry] .dn-badge {
-  margin-left: 6px;
-  min-width: 16px;
-  height: 16px;
-  line-height: 16px;
-  padding: 0 4px;
-  border-radius: 8px;
-  background: var(--dsw-alias-state-error-primary, #d92d20);
-  color: #fff;
-  font-size: 10px;
-  text-align: center;
-}
-[data-dsh-notifier-entry] .dn-badge[hidden] { display: none; }

--- a/packages/dsh-notifier/src/config.ts
+++ b/packages/dsh-notifier/src/config.ts
@@ -1,9 +1,11 @@
 /**
- * dsh-notifier — 配置契约与归一化。
+ * dsh-notifier — 配置契约与校验。
  *
- * 内存单一事实源（NotifyConfig，与落盘 JSON 同构）、默认值、白名单归一化
- * 与配置/历史/toast 脚本路径。未知键透传、非法值丢弃回默认的语义都在
- * normalizeConfig 一处收敛。
+ * 配置模型（NotifyConfig）由官方 settings 命名空间承载（issue #76）：
+ * 默认值、白名单净化与「首个非法键 + hint」校验在此收敛。读取来源为
+ * 命名空间解析值（scope.get()），提交面（PUT /config / 存量迁移）经
+ * validateSettings / sanitizeSettings 校验——非法值 400 拒绝 + hint，
+ * 不再静默丢弃回默认（H6）。
  */
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -83,7 +85,7 @@ export const DEFAULT_CONFIG: NotifyConfig = {
 /** 布尔配置键（单一事实源：normalizeConfig 白名单与客户端渲染依赖它）。 */
 export const CONFIG_KEYS: readonly BooleanKeys[] = ["notifyAsk", "notifyQuestion", "notifyTaskDone", "notifySubagentDone", "notifyTaskError", "notifyTurnEnd", "systemNotify", "browserNotify", "notifyWhenVisible", "notifySound"];
 
-/** 配置存储路径。 */
+/** 配置存储路径（旧版自建 json；issue #76 后仅作存量迁移源，不再读写）。 */
 export function configFile() {
   return join(homedir(), ".dsh", "dsh-notifier.json");
 }
@@ -141,6 +143,130 @@ export function normalizeConfig(input: unknown): NotifyConfig {
     // 已归一化过的键不再透传（否则非法值会以原样覆盖归一化结果）
     if (key === "quietHours" || key === "errorMergeWindowMs" || key === "askRemindMin" || key === "doneMergeWindowMs" || key === "historyMaxAgeDays" || key === "maxConnections") continue;
     out[key] = src[key];
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------- 写入校验（H6）
+// PUT /config 与存量迁移共用的「已知键 → 校验器」表；任一已知键非法即整体
+// 拒绝（400 + hint / 迁移仅标记不写入），不再静默丢弃回默认。与 lan-proxy
+// 的 FILE_CONFIG_VALIDATORS 同形态（零依赖，未引入 schemastery）。
+
+function isBoolean(v: unknown): boolean {
+  return typeof v === "boolean";
+}
+
+/** HH:MM 时段串（00:00-23:59）是否合法。 */
+function isHHMM(v: unknown): boolean {
+  return typeof v === "string" && /^\d{2}:\d{2}$/u.test(v) && parseHHMM(v) >= 0;
+}
+
+function isNonNegNumber(max: number): (v: unknown) => boolean {
+  return (v) => typeof v === "number" && Number.isFinite(v) && v >= 0 && v <= max;
+}
+
+/** SSE 连接上限校验（1-1024 的整数，与 normalizeConfig 范围一致；#334）。 */
+function isConnLimit(v: unknown): boolean {
+  return typeof v === "number" && Number.isFinite(v) && Number.isInteger(v) && v >= 1 && v <= 1024;
+}
+
+function isAllowKinds(v: unknown): boolean {
+  return Array.isArray(v) && v.every((k) => typeof k === "string" && (QUIET_ALLOW_KINDS as readonly string[]).includes(k));
+}
+
+/** quietHours 整组校验（enabled/start/end/allowKinds 任一层非法即整组拒绝）。 */
+function isQuietHours(v: unknown): boolean {
+  if (typeof v !== "object" || v === null) return false;
+  const qh = v as Record<string, unknown>;
+  return (
+    (qh.enabled === undefined || isBoolean(qh.enabled)) &&
+    (qh.start === undefined || isHHMM(qh.start)) &&
+    (qh.end === undefined || isHHMM(qh.end)) &&
+    (qh.allowKinds === undefined || isAllowKinds(qh.allowKinds))
+  );
+}
+
+/** 已知配置键 → 校验器（遍历顺序即「首个非法键」口径）。 */
+const SETTING_VALIDATORS: Record<string, (v: unknown) => boolean> = {
+  notifyAsk: isBoolean,
+  notifyQuestion: isBoolean,
+  notifyTaskDone: isBoolean,
+  notifySubagentDone: isBoolean,
+  notifyTaskError: isBoolean,
+  notifyTurnEnd: isBoolean,
+  systemNotify: isBoolean,
+  browserNotify: isBoolean,
+  notifyWhenVisible: isBoolean,
+  notifySound: isBoolean,
+  quietHours: isQuietHours,
+  errorMergeWindowMs: isNonNegNumber(3600000),
+  askRemindMin: isNonNegNumber(600),
+  doneMergeWindowMs: isNonNegNumber(60000),
+  historyMaxAgeDays: isNonNegNumber(3650),
+  maxConnections: isConnLimit,
+};
+
+/** 各配置键的合法范围描述（validateSettings 400 hint 用；与 SETTING_VALIDATORS 平行维护）。 */
+const SETTING_HINTS: Record<string, string> = {
+  notifyAsk: "需为布尔值",
+  notifyQuestion: "需为布尔值",
+  notifyTaskDone: "需为布尔值",
+  notifySubagentDone: "需为布尔值",
+  notifyTaskError: "需为布尔值",
+  notifyTurnEnd: "需为布尔值",
+  systemNotify: "需为布尔值",
+  browserNotify: "需为布尔值",
+  notifyWhenVisible: "需为布尔值",
+  notifySound: "需为布尔值",
+  quietHours: "需为 { enabled?: boolean, start?: \"HH:MM\", end?: \"HH:MM\", allowKinds?: kind[] }",
+  errorMergeWindowMs: "需为 0-3600000 的整数（毫秒）",
+  askRemindMin: "需为 0-600 的整数（分钟）",
+  doneMergeWindowMs: "需为 0-60000 的整数（毫秒）",
+  historyMaxAgeDays: "需为 0-3650 的整数（天）",
+};
+
+/** validateSettings 的结果：null = 全部合法。 */
+export interface SettingInvalid {
+  /** 首个非法的配置键名。 */
+  key: string;
+  /** 该键的合法范围描述（面向用户的文案）。 */
+  hint: string;
+}
+
+/**
+ * 校验提交的配置（写入前，不净化）：返回首个非法键与其合法范围，全部合法
+ * 返回 null（H6：非法值 400 拒绝 + hint，不再静默丢弃回默认）。遍历顺序
+ * 与 sanitizeSettings 一致（SETTING_VALIDATORS 键序）。导出供 smoke 单测。
+ */
+export function validateSettings(raw: unknown): SettingInvalid | null {
+  if (typeof raw !== "object" || raw === null) return { key: "(payload)", hint: "需为配置对象" };
+  const src = raw as Record<string, unknown>;
+  for (const key of Object.keys(SETTING_VALIDATORS)) {
+    const value = src[key];
+    if (value === undefined || value === null) continue;
+    if (!SETTING_VALIDATORS[key](value)) {
+      return { key, hint: SETTING_HINTS[key] ?? "类型非法" };
+    }
+  }
+  return null;
+}
+
+/**
+ * 净化提交的配置（PUT 保存通道与存量迁移共用）：只接受已知键；任一已知键
+ * 类型非法 → 整体拒绝（返回 null，避免静默丢键造成「保存了但没生效」的
+ * 困惑；迁移场景则等价于「无有效键 → 只标记不写入」）。未知键丢弃（写入
+ * 通道白名单语义——不把组合层装配键如 configFile 等混入 user 层；与
+ * lan-proxy sanitizeSettings 同口径，normalizeConfig 的透传仅服务读取渲染）。
+ */
+export function sanitizeSettings(raw: unknown): Partial<NotifyConfig> | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const src = raw as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(SETTING_VALIDATORS)) {
+    const value = src[key];
+    if (value === undefined || value === null) continue;
+    if (!SETTING_VALIDATORS[key](value)) return null;
+    out[key] = value;
   }
   return out;
 }

--- a/packages/dsh-notifier/src/index.ts
+++ b/packages/dsh-notifier/src/index.ts
@@ -2,11 +2,20 @@
  * dsh-notifier — 审批/完成/错误事件通知（宿主端）。
  *
  * 本文件只做装配：apply + 事件订阅 + 生命周期清理。职责划分：
- * - config.ts     配置契约/默认值/normalizeConfig/路径
+ * - config.ts      配置契约/默认值/validateSettings/sanitizeSettings/迁移源路径
  * - quiet-hours.ts 免打扰判定（parseHHMM / isInQuietHours）
- * - message.ts    通知文案单表/脱敏/格式化/agent 事件读取（纯函数）
- * - history.ts    通知历史 jsonl 存储（滚动/按天清理/原子写）
- * - server.ts     SSE 枢纽 + 系统通知通道 + HTTP 路由
+ * - message.ts     通知文案单表/脱敏/格式化/agent 事件读取（纯函数）
+ * - history.ts     通知历史 jsonl 存储（滚动/按天清理/原子写）
+ * - settings.ts    官方 settings 命名空间接线（installNotifierSettings，issue #76）
+ * - migrate.ts     存量自建 json 一次性迁移（E1-E7/R1）
+ * - server.ts      SSE 枢纽 + 系统通知通道 + HTTP 路由
+ *
+ * 配置（issue #76）：官方 settings 命名空间为唯一事实源（settings.yaml 单一
+ * 存储）；组合层通知配置作为命名空间 base 层；旧 `~/.dsh/dsh-notifier.json`
+ * 启动时一次性迁移（改名 .migrated.bak / 损坏 .corrupted.bak）。enabled 为
+ * 组合层开关：禁用态仍注册路由+命名空间+迁移（H2/H3），notify() 入口判定。
+ * 读取面经描述器（describe redactSecrets）取 user/revision，写入面经
+ * service.update(ns, patch, expectedRevision) 乐观并发。
  *
  * 事件源（均经源码核验）：
  * - 审批请求：approval/request waterfall（ApprovalService.request 派发；
@@ -35,27 +44,29 @@
  * - 浏览器通知：SSE（text/event-stream，mcp-manager 同款模式）推帧，
  *   客户端 Notification API 展示（页面隐藏时）
  *
- * 配置：~/.dsh/dsh-notifier.json（PUT /config 可改，落盘）
+ * 配置路径（issue #76 后）：官方 settings 命名空间（设置 → 插件 → dsh-notifier
+ * 卡片 PUT /config 写，落盘官方 settings.yaml）；旧 ~/.dsh/dsh-notifier.json 仅
+ * 作为存量迁移源，迁移后改名归档，不再读写。
  * 安全：通知文本只含工具名/会话标识/申请理由等元信息，不含工具参数（防敏感信息外泄）。
  */
 // 官方类型层（issue #16，锁 0.1.1-rc.2；仅 import type，编译期擦除，
 // 禁止运行时值导入——contract-check 有门禁）。session/title 事件键由
 // dsh-session-title 经 declare module 注入 SessionEventMap，必须引入其类型面。
-import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
-import { existsSync } from "node:fs";
-import { dirname } from "node:path";
 import type { Context } from "@deepseek-ai/cordis";
 import type { Agent } from "@deepseek-ai/dsh-agent";
 import type {} from "@deepseek-ai/dsh-session/types";
 import type {} from "@deepseek-ai/dsh-session-title";
 import type {} from "@deepseek-ai/dsh-user-approval";
 import { errorMessage } from "../../../shared/host-utils.js";
-import { CONFIG_KEYS, DEFAULT_CONFIG, configFile, historyFile, normalizeConfig, toastScriptPath } from "./config.ts";
+import { CONFIG_KEYS, DEFAULT_CONFIG, configFile, historyFile, normalizeConfig, sanitizeSettings, toastScriptPath } from "./config.ts";
 import type { NotifierApplyConfig, NotifyConfig } from "./config.ts";
 import { isInQuietHours } from "./quiet-hours.ts";
 import { HISTORY_LIMIT, createHistoryStore } from "./history.ts";
 import { NOTIFY_KINDS, sanitizeErrorText, sessionTitleOf, isSubagentOf, lastTurnEndOf } from "./message.ts";
 import type { NotifyDetail } from "./message.ts";
+import { SETTINGS_NS, installNotifierSettings } from "./settings.ts";
+import type { OwnerScopeLike, SettingsServiceLike } from "./settings.ts";
+import { migrateLegacyConfig } from "./migrate.ts";
 import { ROUTES, buildRoutes, createSseHub, createSystemNotifier } from "./server.ts";
 
 /** 稳定的 cordis 插件名。 */
@@ -69,9 +80,12 @@ export const inject = ["webServer"];
 
 export { QUIET_ALLOW_KINDS, isInQuietHours, parseHHMM } from "./quiet-hours.ts";
 export type { QuietHoursConfig } from "./quiet-hours.ts";
-export { CONFIG_KEYS, DEFAULT_CONFIG, configFile, historyFile, normalizeConfig, toastScriptPath } from "./config.ts";
-export type { NotifierApplyConfig, NotifyConfig } from "./config.ts";
+export { CONFIG_KEYS, DEFAULT_CONFIG, configFile, historyFile, normalizeConfig, sanitizeSettings, validateSettings, toastScriptPath } from "./config.ts";
+export type { NotifierApplyConfig, NotifyConfig, SettingInvalid } from "./config.ts";
 export { HISTORY_LIMIT } from "./history.ts";
+export { SETTINGS_NS, installNotifierSettings } from "./settings.ts";
+export { migrateLegacyConfig, MIGRATED_BAK_SUFFIX, CORRUPTED_BAK_SUFFIX } from "./migrate.ts";
+export type { MigrationOutcome } from "./migrate.ts";
 export {
   buildSystemCommand,
   formatDuration,
@@ -82,7 +96,8 @@ export {
   sessionTitleOf,
 } from "./message.ts";
 export type { NotifyDetail } from "./message.ts";
-export { ROUTES } from "./server.ts";
+export { ROUTES, applyConfigPatch } from "./server.ts";
+export type { PatchResult, RouteDeps } from "./server.ts";
 
 // 辅助函数统一来自仓库共享层（loopback 围栏 / writeJson / readBody / errorMessage）。
 export { isLoopbackRequest } from "../../../shared/loopback.js";
@@ -91,35 +106,39 @@ export { writeJson, readBody, errorMessage } from "../../../shared/host-utils.js
 /**
  * 挂载 dsh-notifier。
  * @param ctx 宿主插件上下文。
- * @param config 配置（enabled / configFile 覆盖 / toastScript 覆盖）。
+ * @param config 配置（enabled / configFile 迁移源 / toastScript 覆盖）。
  */
-export async function apply(ctx: Context, config: NotifierApplyConfig = {}): Promise<void> {
-  if (config.enabled === false) return;
+export function apply(ctx: Context, config: NotifierApplyConfig = {}): void {
+  // 组合层通知配置（settings 命名空间的 base 层；enabled 是组合层开关，不进
+  // user 层）。注意：应用配置现在只读 settings 命名空间解析值 + 本 entry。
+  const entry = (sanitizeSettings(config) ?? {}) as Record<string, unknown>;
   const storeFile = typeof config.configFile === "string" ? config.configFile : configFile();
   const toastScript = typeof config.toastScript === "string" ? config.toastScript : toastScriptPath();
   const historyPath = typeof config.historyFile === "string" ? config.historyFile : historyFile();
 
-  /** 当前配置（内存单一事实源，PUT 后落盘）。 */
-  let current = normalizeConfig(undefined);
-
-  async function loadConfig() {
+  /**
+   * 当前配置（运行时镜像，与 settings 命名空间解析值保持同步）。
+   * settings attach 后由 setSource 指向 scope.get()，变更经 onChange 刷新；
+   * 服务缺失时回落组合层 entry（normalizeConfig 兜底默认值）。
+   */
+  let current: NotifyConfig = normalizeConfig(entry);
+  /** settings 读取来源 thunk（attach 后为 scope.get()）。 */
+  let source: () => NotifyConfig = () => current;
+  /** settings 服务 attach 状态（writable / readUser 依据）。 */
+  let attachedService: SettingsServiceLike | undefined;
+  /** attach 后的 owner scope（迁移写入面）。 */
+  let attachedScope: OwnerScopeLike | undefined;
+  /** 读取 settings user 层（描述器 redactSecrets 后取 user/revision）。 */
+  function readUser(): { user: Record<string, unknown>; revision?: number } {
+    if (!attachedService) return { user: {}, revision: undefined };
     try {
-      if (!existsSync(storeFile)) return;
-      const data = JSON.parse(await readFile(storeFile, "utf8"));
-      current = normalizeConfig(data);
-    } catch (error) {
-      ctx.logger.warn(`dsh-notifier: 配置读取失败（使用默认）: ${errorMessage(error)}`);
-    }
-  }
-
-  async function saveConfig() {
-    try {
-      await mkdir(dirname(storeFile), { recursive: true });
-      const tmp = `${storeFile}.${process.pid}.${Date.now().toString(36)}.tmp`;
-      await writeFile(tmp, JSON.stringify(current, null, 2), "utf8");
-      await rename(tmp, storeFile);
-    } catch (error) {
-      ctx.logger.warn(`dsh-notifier: 配置落盘失败: ${errorMessage(error)}`);
+      const descriptor = attachedService.describe({ redactSecrets: true }).find((d) => d.ns === SETTINGS_NS);
+      return {
+        user: (descriptor?.user && typeof descriptor.user === "object" ? descriptor.user : {}) as Record<string, unknown>,
+        revision: descriptor?.revision,
+      };
+    } catch {
+      return { user: {}, revision: undefined };
     }
   }
 
@@ -145,11 +164,15 @@ export async function apply(ctx: Context, config: NotifierApplyConfig = {}): Pro
   // ------------------------------------------------------------ 通知主入口
 
   /**
-   * 通知入口：免打扰检查（被拦截也记录「未发出」历史）→ 系统通知 → SSE 广播 → 历史落盘。
+   * 通知入口：总开关判定（enabled，H3）→ 免打扰检查（被拦截也记录「未发出」
+   * 历史）→ 系统通知 → SSE 广播 → 历史落盘。
    * @param kind ask / done / error / turn-end。
    * @param detail {tool?, taskTitle?, reason?, durationMs?, turn?, step?, message?, mergedCount?}（不含工具参数）。
    */
   function notify(kind: string, detail: NotifyDetail = {}): boolean {
+    // enabled 下沉到 notify() 入口（H2/H3）：禁用态不通知，但路由/命名空间/
+    // 迁移照常注册——由各事件处理器的开关判定 + 本总开关共同收敛。
+    if (config.enabled === false) return false;
     const spec = NOTIFY_KINDS[kind];
     const ts = Date.now();
     const title = spec?.title ?? "DSH 通知";
@@ -591,11 +614,16 @@ export async function apply(ctx: Context, config: NotifierApplyConfig = {}): Pro
   // （webServer.register）会在 cordis isolate 链就绪前访问服务，触发
   // "Cyclic __proto__ value"（loader isolate 处理），导致插件激活失败。
   const routes = buildRoutes({
-    getConfig: () => current,
-    putConfig: async (raw) => {
-      current = normalizeConfig(raw);
-      await saveConfig();
-      return current;
+    // effective = settings 命名空间解析值（attach 后 current 已指向 scope.get()）
+    resolve: () => current,
+    readUser,
+    writable: () => attachedService !== undefined,
+    update: (patch: object, expectedRevision?: number) => {
+      const service = attachedService;
+      if (!service) return Promise.reject(new Error("settings service unavailable"));
+      // 乐观并发（F4）必须经 service.update(ns, ...)（SettingsProvider 公开
+      // 方法，write 内做 revision 校验）——scope.update 会丢弃该参数。
+      return service.update(SETTINGS_NS, patch, expectedRevision);
     },
     logger: ctx.logger,
     sse,
@@ -618,9 +646,49 @@ export async function apply(ctx: Context, config: NotifierApplyConfig = {}): Pro
     "dsh-notifier: routes"
   );
 
+  // ------------------------------------------------------------ settings 接线 + 存量迁移
+
+  // GUI 设置卡片数据面 + 存量迁移（issue #76）：settings 命名空间 attach 后——
+  //   1. onScope 内先做存量 dsh-notifier.json 迁移（前置于一切 enabled 判定，
+  //      禁用用户升级/禁用态同样迁移，E7）；
+  //   2. setSource 把读取来源切到 scope.get()（schema defaults → base(entry) →
+  //      user 层的官方解析顺序，无双轨合并）；
+  //   3. 热更新统一由 scope.watch 驱动 onChange 刷新 current 镜像。
+  // 服务缺失（未注入 settings）时：writable=false → PUT 503，路由/通知保持降级
+  // 可用（current 恒为组合层 entry 归一化值），与 lan-proxy 同语义。
+  installNotifierSettings(ctx, entry, {
+    setSource: (s) => {
+      source = s;
+      current = s();
+    },
+    onChange: () => {
+      current = source();
+    },
+    onScope: (scope, service) => {
+      attachedScope = scope;
+      attachedService = service;
+      // 迁移（rename-first 幂等；损坏/中断/回滚均在 migrate.ts 内处理并 warn，
+      // 失败不阻塞启动——E6）。hasUserValues 判定「user 层已有值 = 迁移已完成」。
+      void migrateLegacyConfig(
+        storeFile,
+        {
+          update: (patch) => service.update(SETTINGS_NS, patch),
+          hasUserValues: () => {
+            const { user } = readUser();
+            return user !== undefined && Object.keys(user).length > 0;
+          },
+        },
+        ctx.logger
+      ).catch((err) => {
+        ctx.logger.warn(`dsh-notifier: 存量配置迁移异常 — ${errorMessage(err)}`);
+      });
+    },
+  });
+
   // ------------------------------------------------------------ 启动与清理
 
-  await loadConfig();
+  // 配置源已就绪（entry 归一化）；若 settings 已 attach（inject 回调同步触发），
+  // current 已指向 scope.get()。无需 loadConfig（自建 json 读写链路已废弃）。
 
   // ⚠️ 清理必须放在 effect **返回的 disposer** 里，不能写在 fn 主体：
   // ctx.effect(fn) 的 fn 在 apply 时立即同步执行，只有返回值才在 fiber

--- a/packages/dsh-notifier/src/migrate.ts
+++ b/packages/dsh-notifier/src/migrate.ts
@@ -1,0 +1,179 @@
+/**
+ * dsh-notifier — 存量自建配置一次性迁移（issue #76，E1-E7/R1）。
+ *
+ * 旧版配置位于 `~/.dsh/dsh-notifier.json`（自建读写链路，现已废弃）；本模块
+ * 在 settings 命名空间 attach 后（installNotifierSettings 的 onScope 内）把
+ * 存量配置一次性迁入官方 settings user 层，rename-first marker 幂等。
+ *
+ * 分流（R1）：
+ * - 合法 json：改名 `.migrated.bak`（即 `dsh-notifier.json.migrated.bak`）后
+ *   sanitize 过滤经 owner scope.update 增量写入（只写文件里显式存在的键）；
+ * - 损坏/非对象/无有效键：只改名 `.corrupted.bak` 标记，不写入（防把 schema
+ *   默认值固化进 user 层、压制后续默认值演进）；
+ * - 中断态：`.migrated.bak` 存在而 json 不存在 → 从 bak 重放
+ *   （解析 → sanitize → update）——但若 settings user 层已有该命名空间的值
+ *   （迁移已完成）则幂等跳过，避免重复写入（E2 断言「不重复写入」）；
+ * - 写入失败：回滚改名（bak 还原为 json）并 warn，下次启动重试（E6）。
+ */
+import { existsSync, readFileSync, renameSync, unlinkSync } from "node:fs";
+import { errorMessage } from "../../../shared/host-utils.js";
+import { sanitizeSettings } from "./config.ts";
+
+/** 已迁移备份文件名后缀（幂等标记：存在且 user 层有值 = 已处理）。 */
+export const MIGRATED_BAK_SUFFIX = ".migrated.bak";
+/** 损坏备份文件名后缀（损坏/非对象/无有效键 → 只标记不写入）。 */
+export const CORRUPTED_BAK_SUFFIX = ".corrupted.bak";
+
+/** migrateLegacyConfig 的结果（导出供单测断言）。 */
+export interface MigrationOutcome {
+  /** 本次是否执行了改名标记（false = json 不存在且无处理动作）。 */
+  performed: boolean;
+  /** 是否有有效键写入了 owner scope（含中断态重放成功）。 */
+  migrated: boolean;
+  /** 写入失败后是否已回滚改名（json 已还原）。 */
+  rolledBack: boolean;
+  /** 损坏/空 JSON：仅改名 corrupted 标记、不写入。 */
+  skippedCorrupt: boolean;
+  /** 迁移已完成（user 层已有值）：幂等跳过（E2）。 */
+  skippedIdempotent: boolean;
+  /** 本次是否为中断态重放（.migrated.bak 存在且 json 不存在）。 */
+  resumed: boolean;
+}
+
+/** migrateLegacyConfig 的依赖（scope.update 面 + user 层存在性判定）。 */
+export interface MigrateDeps {
+  /** 增量 merge patch 进 settings user 层。 */
+  update(patch: object): Promise<void>;
+  /** settings user 层该命名空间是否已有任何键（幂等跳过判定）。 */
+  hasUserValues(): boolean;
+}
+
+/**
+ * 检查文件上位标记：json 不存在、bak 存在。
+ * @param legacyPath 旧 json 路径。
+ * @param suffix 备份后缀（migrated / corrupted）。
+ */
+function hasBakOnly(legacyPath: string, suffix: string): boolean {
+  return !existsSync(legacyPath) && existsSync(legacyPath + suffix);
+}
+
+/** rename，Windows 目标已存在先 unlink 旧目标（R1(c)）。 */
+function renameOver(previous: string, next: string): void {
+  if (existsSync(next)) unlinkSync(next);
+  renameSync(previous, next);
+}
+
+/**
+ * 存量 dsh-notifier.json 一次性迁移到官方 settings 命名空间。
+ *
+ * 时序（issue #76 R1）：
+ * 0. 损坏标记态（只有 `.corrupted.bak`）→ 幂等跳过；
+ * 1. json 不存在：
+ *    - 无 migrated bak → 稳态，幂等返回；
+ *    - migrated bak 存在 → 若 user 层已有值（迁移已完成，E2）跳过；
+ *      否则视为迁移中断（E3），从 bak 重放「解析 → sanitize → update」；
+ * 2. json 存在：读 + 解析；损坏/非对象/无有效键 → 改名 `.corrupted.bak`
+ *    （只标记不写入，E4）；
+ * 3. 合法 → 先改名 `.migrated.bak`（rename-first marker，改名成功即视为
+ *    已处理）→ sanitize 过滤 → owner scope.update 增量写入；
+ * 4. 写入失败 → 回滚改名（bak 还原为 json）并 warn，下次启动重试（E6）。
+ *
+ * 必须在 settings 服务 attach 后调用（onScope 内），且先于一切 enabled 判定
+ * （禁用用户跨版本升级同样完成迁移，E7）。
+ */
+export async function migrateLegacyConfig(legacyPath: string, deps: MigrateDeps, logger?: { warn?: (...a: unknown[]) => void }): Promise<MigrationOutcome> {
+  const migratedBak = legacyPath + MIGRATED_BAK_SUFFIX;
+  const corruptedBak = legacyPath + CORRUPTED_BAK_SUFFIX;
+
+  // 0. 损坏标记态幂等（user 层不该有值；有则跳过——损坏只标记不写入）
+  if (hasBakOnly(legacyPath, CORRUPTED_BAK_SUFFIX)) {
+    return { performed: false, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: true, resumed: false };
+  }
+
+  // 1. json 不存在
+  if (!existsSync(legacyPath)) {
+    if (!existsSync(migratedBak)) {
+      return { performed: false, migrated: false, rolledBack: false, skippedCorrupt: false, skippedIdempotent: true, resumed: false };
+    }
+    // 中断态/已迁移：user 层已有值 → 幂等跳过（E2，不重复写入）；
+    // 否则视为中断，从 bak 重放（E3）。
+    if (deps.hasUserValues()) {
+      return { performed: false, migrated: false, rolledBack: false, skippedCorrupt: false, skippedIdempotent: true, resumed: false };
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(migratedBak, "utf8"));
+    } catch {
+      logger?.warn?.(`dsh-notifier: 检测到未完成的迁移残留 ${MIGRATED_BAK_SUFFIX}，但内容不是合法 JSON — 无法自动恢复，请手动检查该备份（原始配置应在其内）或将其改名 ${CORRUPTED_BAK_SUFFIX}`);
+      return { performed: false, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: true };
+    }
+    const sanitized = sanitizeSettings(parsed);
+    if (sanitized === null || Object.keys(sanitized).length === 0) {
+      logger?.warn?.(`dsh-notifier: 未完成的迁移残留 ${MIGRATED_BAK_SUFFIX} 无可迁移的有效键 — 已跳过，确认无误后可手动删除该备份`);
+      return { performed: false, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: true };
+    }
+    try {
+      await deps.update(sanitized as Record<string, unknown>);
+      logger?.warn?.(`dsh-notifier: 检测到上次未完成的迁移 — 已从 ${MIGRATED_BAK_SUFFIX} 重放写入设置；确认运行正常后可手动删除该备份`);
+      return { performed: false, migrated: true, rolledBack: false, skippedCorrupt: false, skippedIdempotent: false, resumed: true };
+    } catch (err) {
+      logger?.warn?.(`dsh-notifier: 未完成迁移从 ${MIGRATED_BAK_SUFFIX} 重放写入失败（${errorMessage(err)}）— 配置仍保留在该备份中，排查后重启重试或手动恢复`);
+      return { performed: false, migrated: false, rolledBack: false, skippedCorrupt: false, skippedIdempotent: false, resumed: true };
+    }
+  }
+
+  // 2. json 存在：读 + 解析
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(legacyPath, "utf8"));
+  } catch {
+    // 损坏：只改名 corrupted 标记，不写入（E4）
+    try {
+      renameOver(legacyPath, corruptedBak);
+      logger?.warn?.(`dsh-notifier: 存量 ${legacyPath.split(/[\\/]/).pop()} 不是合法 JSON — 改名 ${CORRUPTED_BAK_SUFFIX} 标记，不写入设置`);
+    } catch (err) {
+      logger?.warn?.(`dsh-notifier: 损坏配置改名失败（${errorMessage(err)}）— 原文件保留原位，请手动处理`);
+    }
+    return { performed: true, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: false };
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    try {
+      renameOver(legacyPath, corruptedBak);
+      logger?.warn?.(`dsh-notifier: 存量配置不是对象 — 改名 ${CORRUPTED_BAK_SUFFIX} 标记，不写入设置`);
+    } catch (err) {
+      logger?.warn?.(`dsh-notifier: 非对象配置改名失败（${errorMessage(err)}）— 原文件保留原位，请手动处理`);
+    }
+    return { performed: true, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: false };
+  }
+  const sanitized = sanitizeSettings(parsed);
+  if (sanitized === null || Object.keys(sanitized).length === 0) {
+    try {
+      renameOver(legacyPath, corruptedBak);
+      logger?.warn?.(`dsh-notifier: 存量配置无有效键 — 改名 ${CORRUPTED_BAK_SUFFIX} 标记，不写入设置`);
+    } catch (err) {
+      logger?.warn?.(`dsh-notifier: 无有效键配置改名失败（${errorMessage(err)}）— 原文件保留原位，请手动处理`);
+    }
+    return { performed: true, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: false };
+  }
+
+  // 3. 合法：rename-first marker 后再写入
+  try {
+    renameOver(legacyPath, migratedBak);
+  } catch (err) {
+    logger?.warn?.(`dsh-notifier: 存量配置改名失败（${errorMessage(err)}）— 本次跳过，下次启动重试`);
+    return { performed: false, migrated: false, rolledBack: false, skippedCorrupt: false, skippedIdempotent: false, resumed: false };
+  }
+  try {
+    await deps.update(sanitized as Record<string, unknown>);
+    return { performed: true, migrated: true, rolledBack: false, skippedCorrupt: false, skippedIdempotent: false, resumed: false };
+  } catch (err) {
+    // 4. 写入失败：回滚改名（bak 还原为 json），下次启动重试
+    try {
+      if (!existsSync(legacyPath)) renameSync(migratedBak, legacyPath);
+    } catch (rollbackErr) {
+      logger?.warn?.(`dsh-notifier: 迁移回滚失败（${errorMessage(rollbackErr)}）— 数据保留在 ${MIGRATED_BAK_SUFFIX}，请手动恢复`);
+    }
+    logger?.warn?.(`dsh-notifier: 存量配置迁移写入设置失败（${errorMessage(err)}）— 已回滚，下次启动重试`);
+    return { performed: true, migrated: false, rolledBack: true, skippedCorrupt: false, skippedIdempotent: false, resumed: false };
+  }
+}

--- a/packages/dsh-notifier/src/server.ts
+++ b/packages/dsh-notifier/src/server.ts
@@ -12,6 +12,7 @@ import type { WebRoute } from "@deepseek-ai/dsh-host-webserver";
 import { isLoopbackRequest } from "../../../shared/loopback.js";
 import { writeJson, readBody, errorMessage } from "../../../shared/host-utils.js";
 import type { NotifyConfig } from "./config.ts";
+import { sanitizeSettings, validateSettings } from "./config.ts";
 import type { HistoryStore } from "./history.ts";
 import { buildSystemCommand } from "./message.ts";
 
@@ -279,10 +280,14 @@ export function createSystemNotifier(options: { getSoundEnabled: () => boolean; 
 
 /** buildRoutes 的依赖注入面（全部由 index.ts 装配层提供）。 */
 export interface RouteDeps {
-  /** 当前配置读取器（GET / health / test / 免打扰判断共用实时值）。 */
-  getConfig: () => NotifyConfig;
-  /** PUT /config：归一化并落盘后返回生效配置。 */
-  putConfig: (raw: unknown) => Promise<NotifyConfig>;
+  /** 当前生效配置（schemastery 解析值，含默认值兜底；GET /config 的 effective）。 */
+  resolve(): NotifyConfig;
+  /** settings user 层原始节与 revision（describe({redactSecrets:true}) 读取）。 */
+  readUser(): { user: Record<string, unknown>; revision?: number };
+  /** settings 服务是否可用（决定 PUT 是否可写：writable:false → 503）。 */
+  writable(): boolean;
+  /** 增量 merge patch 进 settings user 层（乐观并发经 expectedRevision）。 */
+  update(patch: object, expectedRevision?: number): Promise<void>;
   /** 日志出口。 */
   logger: { warn: (message: string) => void; info: (message: string) => void };
   /** SSE 推送枢纽。 */
@@ -293,12 +298,59 @@ export interface RouteDeps {
   history: HistoryStore;
 }
 
+/** applyConfigPatch 的结果。 */
+export type PatchResult =
+  | { ok: true; value: { user: Record<string, unknown>; revision?: number } }
+  | { ok: false; status: number; code: string; response: Record<string, unknown> };
+
+/**
+ * 配置保存纯函数（PUT /config 的主体，独立导出供 smoke 单测）：
+ * validateSettings 定位首个非法键（400 + hint）→ sanitizeSettings 净化 →
+ * 经 settings 服务 update 增量写入（expectedRevision 可选做乐观并发）。
+ * 错误映射（R3）：SETTINGS_CONFLICT → 409 固定文案；settings 缺失 → 503
+ * settings-unavailable；写入异常原文只进服务端日志（P2-2），响应收敛固定文案。
+ */
+export async function applyConfigPatch(deps: RouteDeps, payload: unknown): Promise<PatchResult> {
+  if (!deps.writable()) {
+    return { ok: false, status: 503, code: "settings-unavailable", response: { error: "设置服务不可用", code: "settings-unavailable" } };
+  }
+  const body = (typeof payload === "object" && payload !== null ? payload : {}) as {
+    patch?: unknown;
+    expectedRevision?: unknown;
+  };
+  const expectedRevision =
+    typeof body.expectedRevision === "number" && Number.isInteger(body.expectedRevision) ? body.expectedRevision : undefined;
+  const rawPatch = body.patch;
+  // 先定位首个非法键（H6）：错误文案指明字段与合法范围，不再静默丢弃回默认
+  const invalid = validateSettings(rawPatch);
+  if (invalid !== null) {
+    return { ok: false, status: 400, code: "invalid", response: { error: `配置校验失败: ${invalid.key}`, hint: invalid.hint } };
+  }
+  const sanitized = sanitizeSettings(rawPatch);
+  if (sanitized === null || Object.keys(sanitized).length === 0) {
+    return { ok: false, status: 400, code: "invalid", response: { error: "配置校验失败: patch", hint: "需至少包含一个有效配置键" } };
+  }
+  try {
+    await deps.update(sanitized as Record<string, unknown>, expectedRevision);
+  } catch (err) {
+    const code = (err as { code?: unknown })?.code;
+    if (code === "SETTINGS_CONFLICT") {
+      return { ok: false, status: 409, code: "conflict", response: { error: "版本冲突", code: "SETTINGS_CONFLICT" } };
+    }
+    // P2-2：对外收敛固定文案，不把底层异常原文（可能含路径等内部信息）回给
+    // 客户端；完整原因走服务端日志。
+    deps.logger.warn(`dsh-notifier: 配置保存写入设置存储失败 — ${errorMessage(err)}`);
+    return { ok: false, status: 500, code: "error", response: { error: "保存失败，请查看服务端日志" } };
+  }
+  return { ok: true, value: deps.readUser() };
+}
+
 /**
  * 构造五条路由（loopback 围栏 + 方法白名单是每条路由的必项）。
  * @returns WebRoute 数组（调用方逐条 register，收集 disposer）。
  */
 export function buildRoutes(deps: RouteDeps): WebRoute[] {
-  const { getConfig, putConfig, logger, sse, system, history } = deps;
+  const { resolve, readUser, writable, update, logger, sse, system, history } = deps;
 
   const configRoute: WebRoute = {
     kind: "exact",
@@ -306,7 +358,14 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
     handler: async (req, res) => {
       if (!isLoopbackRequest(req)) return writeJson(res, 403, { error: "forbidden: loopback-only" });
       if (req.method === "GET") {
-        writeJson(res, 200, getConfig());
+        const { user, revision } = readUser();
+        writeJson(res, 200, {
+          ok: true,
+          user,
+          revision,
+          effective: resolve(),
+          writable: writable(),
+        });
         return;
       }
       if (req.method === "PUT") {
@@ -317,7 +376,7 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
           const message = errorMessage(error);
           if (message.includes("invalid JSON body")) {
             // 非法 JSON：连接尚存，返回可读 400，避免请求「无响应挂起」
-            writeJson(res, 400, { error: `invalid JSON body: ${message}` });
+            writeJson(res, 400, { ok: false, error: { code: "invalid-json", details: `invalid JSON body: ${message}` } });
             return;
           }
           // 超限路径：readBody 已 reject 并 destroy 连接（防超大 body 占内存），
@@ -325,8 +384,12 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
           logger.warn(`dsh-notifier: 配置请求体读取失败: ${message}`);
           return;
         }
-        const updated = await putConfig(body);
-        writeJson(res, 200, updated);
+        const result = await applyConfigPatch(deps, body);
+        if (!result.ok) {
+          writeJson(res, result.status, { ok: false, error: result.response });
+          return;
+        }
+        writeJson(res, 200, { ok: true, user: result.value.user, revision: result.value.revision });
         return;
       }
       writeJson(res, 405, { error: `method not allowed: ${req.method}` });
@@ -390,7 +453,7 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
     handler: (req, res) => {
       if (!isLoopbackRequest(req)) return writeJson(res, 403, { error: "forbidden: loopback-only" });
       if (req.method !== "GET") return writeJson(res, 405, { error: `method not allowed: ${req.method}` });
-      const current = getConfig();
+      const current = resolve();
       writeJson(res, 200, {
         ok: true,
         plugin: "dsh-notifier",
@@ -426,8 +489,8 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
       const title = "DSH：测试通知";
       const message = "通知链路工作正常（此通知来自测试按钮）";
       const payload = { type: "notify", kind: "test", title, message, ts: Date.now() };
-      if (getConfig().systemNotify) system.notify(title, message);
-      if (getConfig().browserNotify) sse.broadcast(payload);
+      if (resolve().systemNotify) system.notify(title, message);
+      if (resolve().browserNotify) sse.broadcast(payload);
       logger.info("dsh-notifier: test 测试通知已发送");
       history.append({ ts: payload.ts, kind: "test", title, message });
       writeJson(res, 200, { ok: true, sseConnections: sse.size() });

--- a/packages/dsh-notifier/src/settings.ts
+++ b/packages/dsh-notifier/src/settings.ts
@@ -1,0 +1,140 @@
+/**
+ * dsh-notifier — 官方 settings 命名空间接线（issue #76，包内复刻）。
+ *
+ * 职责：插件在官方 settings 服务中的命名空间（SETTINGS_NS）、minimal 类型面
+ * （OwnerScopeLike / SettingsServiceLike / NotifierSettingsHooks）与挂载函数
+ * installNotifierSettings。形态等值复刻同仓 dsh-lan-proxy 的
+ * installLanProxySettings（PR #267）：服务面注入零包依赖、register 返回的
+ * owner scope 经 onScope 外露供写（存量迁移）、热更新统一走 scope.watch。
+ *
+ * 为什么不用官方 @deepseek-ai/dsh-settings 包：插件运行时沿自身 lib/ 向上
+ * 解析不到该包（MODULE_NOT_FOUND），动态 import 会静默失败——与
+ * shared/settings-namespace.js 相同的服务面注入方案。
+ * 为什么不用 schemastery 构造 schema：notifier 无该依赖且 coder 禁改
+ * package.json；官方 register 对 schema 的最小调用面是「callable（resolve
+ * 时直接调用）+ toJSON（describe 序列化）+ 无 secret 的平铺形态（redact
+ * walk 走 default 原样返回）」，包内以零依赖函数形态等值覆盖。
+ */
+import type { Context } from "@deepseek-ai/cordis";
+import { errorMessage } from "../../../shared/host-utils.js";
+import { normalizeConfig } from "./config.ts";
+import type { NotifyConfig } from "./config.ts";
+
+/** 本插件在官方 settings 服务中的命名空间。 */
+export const SETTINGS_NS = "dsh-notifier";
+
+/**
+ * 是否正处于插件自身 fiber 卸载中（区别于「仅丢失 settings 服务」）。
+ * 官方判据：fiber.state ∈ { unloading, unloaded, disposed }。
+ */
+function isUnloading(ctx: unknown): boolean {
+  const fiber =
+    ctx && typeof ctx === "object" && "fiber" in ctx
+      ? (ctx as { fiber?: { state?: unknown } }).fiber
+      : undefined;
+  const state = fiber && typeof fiber === "object" ? fiber.state : undefined;
+  return state === "unloading" || state === "unloaded" || state === "disposed";
+}
+
+/** 日志兜底：logger 可能确实没有（极端降级），全部可选调用。 */
+export function warnLog(ctx: unknown, message: string): void {
+  const logger =
+    ctx && typeof ctx === "object" && "logger" in ctx
+      ? (ctx as { logger?: { warn?: (...a: unknown[]) => void } }).logger
+      : undefined;
+  if (typeof logger?.warn === "function") logger.warn(message);
+}
+
+/**
+ * owner scope 最小类型面（官方 SettingsScope<T> 的子集）。注意官方 scope 的
+ * update/replace 不接收 expectedRevision——乐观并发须经 SettingsServiceLike
+ * 的 update(ns, ...)（SettingsProvider 公开方法，write 内做 revision 校验）。
+ */
+export interface OwnerScopeLike {
+  /** 当前解析值（schema defaults → base → user 层）。 */
+  get(): NotifyConfig;
+  /** 提交后异步串行回调，返回 disposer。 */
+  watch(cb: (next: NotifyConfig, prev: NotifyConfig) => void): () => void;
+  /** 增量 merge patch 进 user 层并持久化（无 revision 校验的便捷面）。 */
+  update(patch: object): Promise<void>;
+}
+
+/**
+ * settings 服务最小类型面。update(ns, ...) 是乐观并发（expectedRevision）的
+ * 唯一可达路径——官方 register 返回的 scope.update 会丢弃该参数。
+ */
+export interface SettingsServiceLike {
+  register(ns: string, schema: unknown, options?: { base?: unknown }): OwnerScopeLike;
+  describe(options?: { redactSecrets?: boolean }): Array<{ ns: string; user?: unknown; revision: number }>;
+  update(ns: string, patch: object, expectedRevision?: number): Promise<void>;
+}
+
+/** installNotifierSettings 的 hooks 面（含 onScope：attach 后交出 owner scope）。 */
+export interface NotifierSettingsHooks {
+  /** 把插件对该命名空间的读取来源指向返回的 scope（`scope.get()`）。 */
+  setSource(source: () => NotifyConfig): void;
+  /** 来源切换或命名空间值变化时触发，插件据此刷新运行时状态。 */
+  onChange(): void;
+  /** scope attach 后回调（迁移在此执行）；服务缺失时不触发。 */
+  onScope(scope: OwnerScopeLike, service: SettingsServiceLike): void;
+}
+
+/**
+ * 零依赖最小 schema：官方 register 的 schema 参数在 resolve 时被当作函数
+ * 直接调用（输入 = mergeLayers(base, user section)），describe 时调用
+ * toJSON()，redactSecrets walk 对无 secret 字段的平铺 schema 走 default 分支
+ * 原样返回值。这里以「可调用函数 + toJSON」等值覆盖——函数体即 normalizeConfig
+ * （默认值兜底 + 白名单净化 + 未知键透传，与解析语义一致）。
+ */
+function createNotifierSchema(): unknown {
+  const schema = (input: unknown) => normalizeConfig(input);
+  // describe() 会调用 schema.toJSON()：返回可序列化的平铺描述（配置 UI 不解释
+  // schema 结构——插件自绘卡片，官方 tab 只按命名空间派发）。
+  (schema as { toJSON?: () => unknown }).toJSON = () => ({ type: "object" });
+  return schema;
+}
+
+/**
+ * 注册插件自有 settings 命名空间并把 owner scope 交给调用方。
+ * 语义等值复刻官方 installSettingsSection / shared installSettingsNamespace，
+ * 差异仅在把 register 返回的 owner scope 经 onScope 外露，供存量配置迁移写入
+ * 与乐观并发（经 service.update(ns, patch, expectedRevision)）。
+ *
+ * @param ctx - 插件宿主端 apply 收到的 cordis 上下文。
+ * @param entry - 组合层配置的通知字段（经 sanitizeSettings 白名单过滤后传入，
+ *   作为命名空间的 base 层；无有效键则为空 base）。
+ * @param hooks - source 收藏、变更通知与 scope 移交。
+ */
+export function installNotifierSettings(ctx: Context, entry: Record<string, unknown>, hooks: NotifierSettingsHooks): void {
+  type InjectFn = (services: string[], fn: (c: any) => void) => void;
+  if (typeof (ctx as unknown as { inject?: InjectFn })?.inject !== "function") {
+    warnLog(ctx, `${SETTINGS_NS}: ctx.inject 不可用 — 设置命名空间未注册，设置卡降级`);
+    return;
+  }
+  (ctx.inject as unknown as InjectFn)(["settings"], (sctx) => {
+    const settings = sctx && (sctx.settings as SettingsServiceLike | undefined);
+    if (!settings || typeof settings.register !== "function") {
+      warnLog(ctx, `${SETTINGS_NS}: settings 服务缺少 register 能力 — 设置命名空间未注册，设置卡降级`);
+      return;
+    }
+    let scope: OwnerScopeLike;
+    try {
+      scope = settings.register(SETTINGS_NS, createNotifierSchema(), { base: entry });
+    } catch (err) {
+      warnLog(ctx, `${SETTINGS_NS}: settings.register 失败 — ${errorMessage(err)}`);
+      return;
+    }
+    hooks.onScope(scope, settings);
+    hooks.setSource(() => scope.get());
+    sctx.effect(() => () => {
+      if (isUnloading(ctx)) return;
+      hooks.onChange();
+    });
+    hooks.onChange();
+    // 热更新统一走官方 scope.watch（提交后异步串行回调）。
+    scope.watch(() => {
+      if (isUnloading(ctx)) return;
+      hooks.onChange();
+    });
+  });
+}

--- a/packages/dsh-notifier/test/client-contract.test.ts
+++ b/packages/dsh-notifier/test/client-contract.test.ts
@@ -4,7 +4,9 @@
  *
  * 覆盖：assertClientSourceContract / assertClientProductContract（共享
  * smoke-lib，与 contract-check 同源）；lib/client.js 中出现的路由字面量
- * 与宿主 ROUTES 常量双向一致。
+ * 与宿主 ROUTES 常量双向一致；issue #76 客户端清理契约（B1-B6 移除侧边栏
+ * 入口/浮层/角标、C 组通知半区保留——SSE/租约/看门狗/音频解锁仍存在且不
+ * 依赖任何插件 DOM）。
  */
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -23,6 +25,32 @@ const pkgDir = fileURLToPath(new URL("..", import.meta.url));
   const expected = Object.values(ROUTES);
   for (const literal of literals) assert.ok(expected.includes(literal), `client 出现未知路由: ${literal}`);
   for (const route of expected) assert.ok(literals.includes(route), `client 缺少路由: ${route}`);
+}
+
+// ---- issue #76：客户端清理契约（B1-B6 / C 组）----
+{
+  const src = readFileSync(new URL("../src/client/index.ts", import.meta.url), "utf8");
+  const client = readFileSync(new URL("../lib/client.js", import.meta.url), "utf8");
+
+  // B1-B6：侧边栏入口/浮层/角标/拖拽全部移除（源码无对应符号）
+  for (const banned of ["createSidebarEntry", "renderPanel", "attachDrag", "restorePanelPos", "bumpUnread", "initUnread", "data-dsh-notifier-badge", "dsh-notifier-panel", "data-dsh-notifier-entry"]) {
+    assert.ok(!src.includes(banned), `B 组：客户端源码不得出现 ${banned}`);
+    assert.ok(!client.includes(banned), `B 组：客户端产物不得含 ${banned}`);
+  }
+  // B6：客户端 entry 不再引用侧边栏注册（DOM 定位锚点移除）
+  assert.ok(!src.includes("sidebarCol"), "B6：无侧边栏 DOM 锚点");
+  // 未读/角标相关 storage 键不再写入（B4：localStorage 'dsh-notifier:panel:pos' 不再写）
+  assert.ok(!src.includes("panel:pos"), "B4：拖拽位置持久化已移除");
+
+  // C1-C9：通知半区保留（SSE/租约/看门狗/音频解锁/事件展示），不依赖任何插件 DOM
+  for (const kept of ["startEvents", "WATCHDOG_MS", "claimMaster", "unlockAudio", "EventSource", "new Notification", "showNotification"]) {
+    assert.ok(src.includes(kept), `C 组：通知半区保留 ${kept}`);
+    assert.ok(client.includes(kept), `C 组：产物保留 ${kept}`);
+  }
+  // C6：SSE 启动不依赖任何插件 DOM（apply 直接 startEvents，无 mount 等待）
+  assert.ok(src.includes("startEvents()"), "C6：apply 直接启动 SSE（不依赖侧边栏挂载）");
+  // 卡片挂载经 slots（官方设置页 settings.plugin.item 插槽，id+key 双写）
+  assert.ok(src.includes("settings.plugin.item"), "A 组：卡片注册到官方设置页插槽");
 }
 
 // lib/toast.ps1 发布物完整性（issue #238）：必须带 UTF-8 BOM 且与源文件逐字节一致。

--- a/packages/dsh-notifier/test/e2e-approval.test.ts
+++ b/packages/dsh-notifier/test/e2e-approval.test.ts
@@ -7,7 +7,7 @@
  * notifyAsk=false 不通知；免打扰紧急例外 allowKinds（M4）。
  */
 import { join } from "node:path";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { assert, makeNotifier, agentWithTitle } from "./helpers.ts";
 
@@ -56,12 +56,10 @@ try {
     assert.equal(infos.length, 3, "next 抛错前通知已发出");
   }
 
-  // notifyAsk=false（configFile）时 approval/request 不通知、不短路
+  // notifyAsk=false（组合层 entry）时 approval/request 不通知、不短路
   {
-    const askOffCfg = join(work, "ask-off.json");
-    writeFileSync(askOffCfg, JSON.stringify({ notifyAsk: false }));
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: askOffCfg }, loggingOverride(infos));
+    const { listeners } = await makeNotifier(work, { notifyAsk: false }, loggingOverride(infos));
     const approval = listeners.get("approval/request")[0];
     const outcome = await approval({ toolName: "bash", agent: { id: "session-1" } }, async () => "allowed-once");
     assert.equal(outcome, "allowed-once", "不短路");
@@ -78,20 +76,16 @@ try {
       return `${String(t.getHours()).padStart(2, "0")}:${String(t.getMinutes()).padStart(2, "0")}`;
     };
     const qhOn = { enabled: true, start: hhmm(-2), end: hhmm(2) };
-    const cfgAsk = join(work, "qh-ask.json");
-    writeFileSync(cfgAsk, JSON.stringify({ quietHours: { ...qhOn, allowKinds: ["ask"] } }));
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: cfgAsk, historyFile: join(work, "history-qh1.jsonl") }, loggingOverride(infos));
+    const { listeners } = await makeNotifier(work, { quietHours: { ...qhOn, allowKinds: ["ask"] }, historyFile: join(work, "history-qh1.jsonl") }, loggingOverride(infos));
     const approval = listeners.get("approval/request")[0];
     await approval({ toolName: "pwsh", agent: agentWithTitle("qh-1", "免打扰审批", { turnEnd: 1 }) }, async () => "ok");
     assert.equal(infos.length, 1, "免打扰期间 ask 仍通知（紧急例外 allowKinds）");
     assert.match(infos[0], /ask/);
 
     // allowKinds 为空/不含 ask：免打扰生效则静默
-    const cfgNone = join(work, "qh-none.json");
-    writeFileSync(cfgNone, JSON.stringify({ quietHours: { ...qhOn, allowKinds: [] } }));
     const infos2 = [];
-    const { listeners: listeners2 } = await makeNotifier(work, { configFile: cfgNone, historyFile: join(work, "history-qh2.jsonl") }, loggingOverride(infos2));
+    const { listeners: listeners2 } = await makeNotifier(work, { quietHours: { ...qhOn, allowKinds: [] }, historyFile: join(work, "history-qh2.jsonl") }, loggingOverride(infos2));
     await listeners2.get("approval/request")[0]({ toolName: "pwsh", agent: { id: "qh-2" } }, async () => "ok");
     assert.equal(infos2.filter((t) => !t.includes("被免打扰拦截")).length, 0, "无 allowKinds 时免打扰不产生实际通知");
     assert.ok(infos2.some((t) => t.includes("被免打扰拦截")), "被拦截仍记录日志（可核对发没发）");

--- a/packages/dsh-notifier/test/e2e-done.src.test.ts
+++ b/packages/dsh-notifier/test/e2e-done.src.test.ts
@@ -95,10 +95,8 @@ try {
 
   // 错误合并窗口过期后通知并携带合并计数（独立实例：20ms 窗口）
   {
-    const mergeCfg = join(work, "merge-observed.json");
-    writeFileSync(mergeCfg, JSON.stringify({ errorMergeWindowMs: 20 }));
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: mergeCfg }, loggingOverride(infos));
+    const { listeners } = await makeNotifier(work, { errorMergeWindowMs: 20 }, loggingOverride(infos));
     const error = listeners.get("agent/error")[0];
 
     error({ agent: { id: "session-1" }, turn: 1, step: 1, error: new Error("e1") });
@@ -114,10 +112,8 @@ try {
 
   // 合并 0=关闭：错误不合并、完成不聚合（每条即时）
   {
-    const cfg0 = join(work, "merge-off.json");
-    writeFileSync(cfg0, JSON.stringify({ errorMergeWindowMs: 0, doneMergeWindowMs: 0 }));
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: cfg0 }, loggingOverride(infos));
+    const { listeners } = await makeNotifier(work, { errorMergeWindowMs: 0, doneMergeWindowMs: 0 }, loggingOverride(infos));
     const error = listeners.get("agent/error")[0];
     const status = listeners.get("agent/status")[0];
 
@@ -152,7 +148,7 @@ try {
       const infos = [];
       const { listeners, routes } = await makeNotifier(
         work,
-        { configFile: join(work, "sub-fork-owned.json"), historyFile: join(work, "history-a1.jsonl") },
+        { historyFile: join(work, "history-a1.jsonl") },
         { agents, ...loggingOverride(infos) }
       );
       const status = listeners.get("agent/status")[0];
@@ -173,11 +169,9 @@ try {
     // A2：同一场景开启 notifySubagentDone=true → 恰一条 subagent-done（文案含
     //     任务标题与耗时），且不得同时出现 kind=done。
     {
-      const onCfg = join(work, "sub-fork-on.json");
-      writeFileSync(onCfg, JSON.stringify({ notifySubagentDone: true }));
-      const agents = fakeAgents(["main-parent2", "fork-worker2"], [["fork-worker2", "main-parent2"]]);
+            const agents = fakeAgents(["main-parent2", "fork-worker2"], [["fork-worker2", "main-parent2"]]);
       const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: onCfg }, { agents, ...loggingOverride(infos) });
+      const { listeners } = await makeNotifier(work, { notifySubagentDone: true }, { agents, ...loggingOverride(infos) });
       const status = listeners.get("agent/status")[0];
       // 同 A1：完整持久化 header 形态含 seedLength（#199 P2-5 对齐）+ 本轮完成时序
       const forkPair = () => turnPair("fork-worker2", "fork 委派子任务B", { parentSession: "main-parent2", seedLength: 3, depth: 0 }, { turn: 1 });
@@ -196,7 +190,7 @@ try {
     {
       const agents = fakeAgents(["fork-orphan"], []);
       const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-fork-orphan.json") }, { agents, ...loggingOverride(infos) });
+      const { listeners } = await makeNotifier(work, { }, { agents, ...loggingOverride(infos) });
       const status = listeners.get("agent/status")[0];
       const mk = () => turnPair("fork-orphan", "孤儿 fork 会话", { parentSession: "ghost-parent" }, { turn: 1 });
       status({ agent: mk().running, status: "running" });
@@ -210,7 +204,7 @@ try {
     {
       const agents = fakeAgents(["unrelated-parent", "fork-x"], []); // 无 (fork-x, unrelated-parent) 归属对
       const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-fork-unowned.json") }, { agents, ...loggingOverride(infos) });
+      const { listeners } = await makeNotifier(work, { }, { agents, ...loggingOverride(infos) });
       const status = listeners.get("agent/status")[0];
       const mk = () => turnPair("fork-x", "无归属 fork 会话", { parentSession: "unrelated-parent", seedLength: 3 }, { turn: 1 });
       status({ agent: mk().running, status: "running" });
@@ -223,7 +217,7 @@ try {
     //     皆否，保持现状按主任务分支处理（本 issue 不改变其分类）。
     {
       const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-headless.json") }, loggingOverride(infos));
+      const { listeners } = await makeNotifier(work, { }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
       const mk = () => turnPair("headless-1", "headless CLI 会话", { cwd: "/tmp/dsh-cli" }, { turn: 1 });
       status({ agent: mk().running, status: "running" });
@@ -235,7 +229,7 @@ try {
     // 反例 2（原 #7 回归防护保留）：主会话（无 header / 无 origin）必须走 done。
     {
       const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-main.json") }, loggingOverride(infos));
+      const { listeners } = await makeNotifier(work, { }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
       const pair = turnPair("main-x", "主任务", {}, { turn: 1 });
       status({ agent: pair.running, status: "running" });
@@ -247,7 +241,7 @@ try {
     // 默认关：子代理完成不通知，主任务完成不受影响
     {
       const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-default.json") }, loggingOverride(infos));
+      const { listeners } = await makeNotifier(work, { }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
       const subPair = turnPair("sub-1", "子任务A", { subagent: true }, { turn: 1 });
       status({ agent: subPair.running, status: "running" });
@@ -262,10 +256,8 @@ try {
 
     // 开启 notifySubagentDone：子代理完成用独立事件类型 subagent-done（标题/耗时）
     {
-      const onCfg = join(work, "sub-on.json");
-      writeFileSync(onCfg, JSON.stringify({ notifySubagentDone: true }));
-      const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: onCfg }, loggingOverride(infos));
+            const infos = [];
+      const { listeners } = await makeNotifier(work, { notifySubagentDone: true }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
       const subPair = turnPair("sub-2", "子任务B", { subagent: true }, { turn: 1 });
       status({ agent: subPair.running, status: "running" });
@@ -286,10 +278,8 @@ try {
 
     // S2 回归：notifyTaskDone=false + notifySubagentDone=true 时子代理完成仍通知
     {
-      const s2Cfg = join(work, "sub-s2.json");
-      writeFileSync(s2Cfg, JSON.stringify({ notifyTaskDone: false, notifySubagentDone: true }));
-      const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: s2Cfg }, loggingOverride(infos));
+            const infos = [];
+      const { listeners } = await makeNotifier(work, { notifyTaskDone: false, notifySubagentDone: true }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
       const subPair = turnPair("sub-3", "子任务C", { subagent: true }, { turn: 1 });
       status({ agent: subPair.running, status: "running" });
@@ -313,12 +303,10 @@ try {
     const infos = [];
     const warns = [];
     // 关闭完成聚合：本块聚焦单源证据合并语义，每条完成即时通知便于计数
-    // （doneMergeWindowMs 是运行时配置，须经 configFile 文件传入）
-    const singleCfg = join(work, "single-source.json");
-    writeFileSync(singleCfg, JSON.stringify({ doneMergeWindowMs: 0 }));
+    // （doneMergeWindowMs 是运行时配置，经组合层 entry 传入）
     const { listeners } = await makeNotifier(
       work,
-      { configFile: singleCfg },
+      { doneMergeWindowMs: 0 },
       { logger: { info: (t) => infos.push(t), warn: (t) => warns.push(t) } }
     );
     const status = listeners.get("agent/status")[0];
@@ -422,11 +410,9 @@ try {
   {
     const infos = [];
     const warns = [];
-    const a2Cfg = join(work, "a2-no-agents.json");
-    writeFileSync(a2Cfg, JSON.stringify({ doneMergeWindowMs: 0 }));
     const { listeners } = await makeNotifier(
       work,
-      { configFile: a2Cfg },
+      { doneMergeWindowMs: 0 },
       { logger: { info: (t) => infos.push(t), warn: (t) => warns.push(t) } }
     );
     const status = listeners.get("agent/status")[0];
@@ -441,10 +427,8 @@ try {
   //     主任务 done（即使 notifySubagentDone=true 也不误判 subagent-done）；
   //     spawn 型（origin=subagent）仍按 origin 信号走 subagent 分支。
   {
-    const a3Cfg = join(work, "a3-no-agents.json");
-    writeFileSync(a3Cfg, JSON.stringify({ doneMergeWindowMs: 0, notifySubagentDone: true }));
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: a3Cfg }, loggingOverride(infos));
+    const { listeners } = await makeNotifier(work, { doneMergeWindowMs: 0, notifySubagentDone: true }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
     // fork 型：无 origin、带 parentSession + seedLength，归属服务缺位 → 保守走 done
     const forkPair = () => turnPair("a3-fork", "fork 型无 agents", { parentSession: "ghost-parent", seedLength: 3 }, { turn: 1 });
@@ -462,11 +446,9 @@ try {
   // B-1：开关禁用三态提交——notifyTaskDone=false 时 completed idle 不通知，
   //     但 lastEndedTurn 照常提交，同 turn 再现 idle 不重复处理。
   {
-    const b1Cfg = join(work, "b1-off.json");
-    writeFileSync(b1Cfg, JSON.stringify({ doneMergeWindowMs: 0, notifyTaskDone: false }));
     const infos = [];
     const warns = [];
-    const { listeners } = await makeNotifier(work, { configFile: b1Cfg }, { logger: { info: (t) => infos.push(t), warn: (t) => warns.push(t) } });
+    const { listeners } = await makeNotifier(work, { doneMergeWindowMs: 0, notifyTaskDone: false }, { logger: { info: (t) => infos.push(t), warn: (t) => warns.push(t) } });
     const status = listeners.get("agent/status")[0];
     const pair = turnPair("b1-1", "开关禁用任务", {}, { turn: 1 });
     status({ agent: pair.running, status: "running" });
@@ -485,10 +467,8 @@ try {
   //     同 turn 再现 idle → 不重复通知、不新增记录。
   {
     const qhAll = { enabled: true, start: "00:00", end: "23:59" };
-    const b2Cfg = join(work, "b2-quiet.json");
-    writeFileSync(b2Cfg, JSON.stringify({ doneMergeWindowMs: 0, quietHours: { ...qhAll, allowKinds: ["ask"] } }));
     const infos = [];
-    const { listeners, routes } = await makeNotifier(work, { configFile: b2Cfg, historyFile: join(work, "b2-hist.jsonl") }, loggingOverride(infos));
+    const { listeners, routes } = await makeNotifier(work, { doneMergeWindowMs: 0, quietHours: { ...qhAll, allowKinds: ["ask"] }, historyFile: join(work, "b2-hist.jsonl") }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
     const historyRoute = routes.find((r) => r.path === ROUTES.history);
     const pair = turnPair("b2-1", "免打扰完成", {}, { turn: 1 });
@@ -508,10 +488,8 @@ try {
   // B-4：批次按「入队成功」提交、与聚合 flush 成败解耦——doneMergeWindowMs>0
   //     时首条完成入队即推进 lastEndedTurn（窗口内同 turn 再现不重复）。
   {
-    const b4Cfg = join(work, "b4-merge.json");
-    writeFileSync(b4Cfg, JSON.stringify({ doneMergeWindowMs: 5000 }));
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: b4Cfg }, loggingOverride(infos));
+    const { listeners } = await makeNotifier(work, { doneMergeWindowMs: 5000 }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
     const pair = turnPair("b4-1", "合并窗口任务", {}, { turn: 1 });
     status({ agent: pair.running, status: "running" });
@@ -529,10 +507,8 @@ try {
   //     触发会 uncaught、与 Stryker tap-bridge 冲突，故以「提交点先于 flush」
   //     的时序验证覆盖——见 PR 断言表 B-4 漂移说明。）
   {
-    const b4fCfg = join(work, "b4-flush-ok.json");
-    writeFileSync(b4fCfg, JSON.stringify({ doneMergeWindowMs: 30 }));
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: b4fCfg }, loggingOverride(infos));
+    const { listeners } = await makeNotifier(work, { doneMergeWindowMs: 30 }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
     const doneCount = () => infos.filter((t) => /: done /.test(t)).length;
     const pairA = () => turnPair("b4f-a", "flush 后 A", {}, { turn: 1 });

--- a/packages/dsh-notifier/test/e2e-done.src.test.ts
+++ b/packages/dsh-notifier/test/e2e-done.src.test.ts
@@ -20,7 +20,7 @@
 import { join } from "node:path";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { assert, makeNotifier, agentWithTitle, fakeAgents, waitMergeWindow, fakeReq, makeRes, turnEndEvent, waitForHistory, turnPair } from "./helpers.ts";
+import { assert, makeNotifier, agentWithTitle, fakeAgents, waitMergeWindow, fakeReq, makeRes, turnEndEvent, waitForHistory, turnPair, quietWindowNow } from "./helpers.ts";
 import { ROUTES, lastTurnEndOf } from "../src/index.ts";
 
 /** 带 info 收集的 logger 覆盖。 */
@@ -466,7 +466,9 @@ try {
   //     allowKinds 时，idle completed → 仅一条 suppressed 历史、无系统通知；
   //     同 turn 再现 idle → 不重复通知、不新增记录。
   {
-    const qhAll = { enabled: true, start: "00:00", end: "23:59" };
+    // #181 动态窗口：写死 "00:00"/"23:59" 在半开区间镜下 23:59 这一分钟不命中
+    // （UTC 边缘必炸，run 33282203798 根因）；围绕当前时间 ±2 分钟恒命中。
+    const qhAll = quietWindowNow();
     const infos = [];
     const { listeners, routes } = await makeNotifier(work, { doneMergeWindowMs: 0, quietHours: { ...qhAll, allowKinds: ["ask"] }, historyFile: join(work, "b2-hist.jsonl") }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];

--- a/packages/dsh-notifier/test/e2e-done.test.ts
+++ b/packages/dsh-notifier/test/e2e-done.test.ts
@@ -20,7 +20,7 @@
 import { join } from "node:path";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { assert, makeNotifier, agentWithTitle, fakeAgents, waitMergeWindow, fakeReq, makeRes, turnEndEvent, waitForHistory, turnPair } from "./helpers.ts";
+import { assert, makeNotifier, agentWithTitle, fakeAgents, waitMergeWindow, fakeReq, makeRes, turnEndEvent, waitForHistory, turnPair, quietWindowNow } from "./helpers.ts";
 import { ROUTES, lastTurnEndOf } from "../lib/index.js";
 
 /** 带 info 收集的 logger 覆盖。 */
@@ -466,7 +466,9 @@ try {
   //     allowKinds 时，idle completed → 仅一条 suppressed 历史、无系统通知；
   //     同 turn 再现 idle → 不重复通知、不新增记录。
   {
-    const qhAll = { enabled: true, start: "00:00", end: "23:59" };
+    // #181 动态窗口：写死 "00:00"/"23:59" 在半开区间镜下 23:59 这一分钟不命中
+    // （UTC 边缘必炸，run 33282203798 根因）；围绕当前时间 ±2 分钟恒命中。
+    const qhAll = quietWindowNow();
     const infos = [];
     const { listeners, routes } = await makeNotifier(work, { doneMergeWindowMs: 0, quietHours: { ...qhAll, allowKinds: ["ask"] }, historyFile: join(work, "b2-hist.jsonl") }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];

--- a/packages/dsh-notifier/test/e2e-done.test.ts
+++ b/packages/dsh-notifier/test/e2e-done.test.ts
@@ -95,10 +95,8 @@ try {
 
   // 错误合并窗口过期后通知并携带合并计数（独立实例：20ms 窗口）
   {
-    const mergeCfg = join(work, "merge-observed.json");
-    writeFileSync(mergeCfg, JSON.stringify({ errorMergeWindowMs: 20 }));
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: mergeCfg }, loggingOverride(infos));
+    const { listeners } = await makeNotifier(work, { errorMergeWindowMs: 20 }, loggingOverride(infos));
     const error = listeners.get("agent/error")[0];
 
     error({ agent: { id: "session-1" }, turn: 1, step: 1, error: new Error("e1") });
@@ -114,10 +112,8 @@ try {
 
   // 合并 0=关闭：错误不合并、完成不聚合（每条即时）
   {
-    const cfg0 = join(work, "merge-off.json");
-    writeFileSync(cfg0, JSON.stringify({ errorMergeWindowMs: 0, doneMergeWindowMs: 0 }));
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: cfg0 }, loggingOverride(infos));
+    const { listeners } = await makeNotifier(work, { errorMergeWindowMs: 0, doneMergeWindowMs: 0 }, loggingOverride(infos));
     const error = listeners.get("agent/error")[0];
     const status = listeners.get("agent/status")[0];
 
@@ -152,7 +148,7 @@ try {
       const infos = [];
       const { listeners, routes } = await makeNotifier(
         work,
-        { configFile: join(work, "sub-fork-owned.json"), historyFile: join(work, "history-a1.jsonl") },
+        { historyFile: join(work, "history-a1.jsonl") },
         { agents, ...loggingOverride(infos) }
       );
       const status = listeners.get("agent/status")[0];
@@ -173,11 +169,9 @@ try {
     // A2：同一场景开启 notifySubagentDone=true → 恰一条 subagent-done（文案含
     //     任务标题与耗时），且不得同时出现 kind=done。
     {
-      const onCfg = join(work, "sub-fork-on.json");
-      writeFileSync(onCfg, JSON.stringify({ notifySubagentDone: true }));
-      const agents = fakeAgents(["main-parent2", "fork-worker2"], [["fork-worker2", "main-parent2"]]);
+            const agents = fakeAgents(["main-parent2", "fork-worker2"], [["fork-worker2", "main-parent2"]]);
       const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: onCfg }, { agents, ...loggingOverride(infos) });
+      const { listeners } = await makeNotifier(work, { notifySubagentDone: true }, { agents, ...loggingOverride(infos) });
       const status = listeners.get("agent/status")[0];
       // 同 A1：完整持久化 header 形态含 seedLength（#199 P2-5 对齐）+ 本轮完成时序
       const forkPair = () => turnPair("fork-worker2", "fork 委派子任务B", { parentSession: "main-parent2", seedLength: 3, depth: 0 }, { turn: 1 });
@@ -196,7 +190,7 @@ try {
     {
       const agents = fakeAgents(["fork-orphan"], []);
       const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-fork-orphan.json") }, { agents, ...loggingOverride(infos) });
+      const { listeners } = await makeNotifier(work, { }, { agents, ...loggingOverride(infos) });
       const status = listeners.get("agent/status")[0];
       const mk = () => turnPair("fork-orphan", "孤儿 fork 会话", { parentSession: "ghost-parent" }, { turn: 1 });
       status({ agent: mk().running, status: "running" });
@@ -210,7 +204,7 @@ try {
     {
       const agents = fakeAgents(["unrelated-parent", "fork-x"], []); // 无 (fork-x, unrelated-parent) 归属对
       const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-fork-unowned.json") }, { agents, ...loggingOverride(infos) });
+      const { listeners } = await makeNotifier(work, { }, { agents, ...loggingOverride(infos) });
       const status = listeners.get("agent/status")[0];
       const mk = () => turnPair("fork-x", "无归属 fork 会话", { parentSession: "unrelated-parent", seedLength: 3 }, { turn: 1 });
       status({ agent: mk().running, status: "running" });
@@ -223,7 +217,7 @@ try {
     //     皆否，保持现状按主任务分支处理（本 issue 不改变其分类）。
     {
       const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-headless.json") }, loggingOverride(infos));
+      const { listeners } = await makeNotifier(work, { }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
       const mk = () => turnPair("headless-1", "headless CLI 会话", { cwd: "/tmp/dsh-cli" }, { turn: 1 });
       status({ agent: mk().running, status: "running" });
@@ -235,7 +229,7 @@ try {
     // 反例 2（原 #7 回归防护保留）：主会话（无 header / 无 origin）必须走 done。
     {
       const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-main.json") }, loggingOverride(infos));
+      const { listeners } = await makeNotifier(work, { }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
       const pair = turnPair("main-x", "主任务", {}, { turn: 1 });
       status({ agent: pair.running, status: "running" });
@@ -247,7 +241,7 @@ try {
     // 默认关：子代理完成不通知，主任务完成不受影响
     {
       const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: join(work, "sub-default.json") }, loggingOverride(infos));
+      const { listeners } = await makeNotifier(work, { }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
       const subPair = turnPair("sub-1", "子任务A", { subagent: true }, { turn: 1 });
       status({ agent: subPair.running, status: "running" });
@@ -262,10 +256,8 @@ try {
 
     // 开启 notifySubagentDone：子代理完成用独立事件类型 subagent-done（标题/耗时）
     {
-      const onCfg = join(work, "sub-on.json");
-      writeFileSync(onCfg, JSON.stringify({ notifySubagentDone: true }));
-      const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: onCfg }, loggingOverride(infos));
+            const infos = [];
+      const { listeners } = await makeNotifier(work, { notifySubagentDone: true }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
       const subPair = turnPair("sub-2", "子任务B", { subagent: true }, { turn: 1 });
       status({ agent: subPair.running, status: "running" });
@@ -286,10 +278,8 @@ try {
 
     // S2 回归：notifyTaskDone=false + notifySubagentDone=true 时子代理完成仍通知
     {
-      const s2Cfg = join(work, "sub-s2.json");
-      writeFileSync(s2Cfg, JSON.stringify({ notifyTaskDone: false, notifySubagentDone: true }));
-      const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: s2Cfg }, loggingOverride(infos));
+            const infos = [];
+      const { listeners } = await makeNotifier(work, { notifyTaskDone: false, notifySubagentDone: true }, loggingOverride(infos));
       const status = listeners.get("agent/status")[0];
       const subPair = turnPair("sub-3", "子任务C", { subagent: true }, { turn: 1 });
       status({ agent: subPair.running, status: "running" });
@@ -313,12 +303,10 @@ try {
     const infos = [];
     const warns = [];
     // 关闭完成聚合：本块聚焦单源证据合并语义，每条完成即时通知便于计数
-    // （doneMergeWindowMs 是运行时配置，须经 configFile 文件传入）
-    const singleCfg = join(work, "single-source.json");
-    writeFileSync(singleCfg, JSON.stringify({ doneMergeWindowMs: 0 }));
+    // （doneMergeWindowMs 是运行时配置，经组合层 entry 传入）
     const { listeners } = await makeNotifier(
       work,
-      { configFile: singleCfg },
+      { doneMergeWindowMs: 0 },
       { logger: { info: (t) => infos.push(t), warn: (t) => warns.push(t) } }
     );
     const status = listeners.get("agent/status")[0];
@@ -422,11 +410,9 @@ try {
   {
     const infos = [];
     const warns = [];
-    const a2Cfg = join(work, "a2-no-agents.json");
-    writeFileSync(a2Cfg, JSON.stringify({ doneMergeWindowMs: 0 }));
     const { listeners } = await makeNotifier(
       work,
-      { configFile: a2Cfg },
+      { doneMergeWindowMs: 0 },
       { logger: { info: (t) => infos.push(t), warn: (t) => warns.push(t) } }
     );
     const status = listeners.get("agent/status")[0];
@@ -441,10 +427,8 @@ try {
   //     主任务 done（即使 notifySubagentDone=true 也不误判 subagent-done）；
   //     spawn 型（origin=subagent）仍按 origin 信号走 subagent 分支。
   {
-    const a3Cfg = join(work, "a3-no-agents.json");
-    writeFileSync(a3Cfg, JSON.stringify({ doneMergeWindowMs: 0, notifySubagentDone: true }));
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: a3Cfg }, loggingOverride(infos));
+    const { listeners } = await makeNotifier(work, { doneMergeWindowMs: 0, notifySubagentDone: true }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
     // fork 型：无 origin、带 parentSession + seedLength，归属服务缺位 → 保守走 done
     const forkPair = () => turnPair("a3-fork", "fork 型无 agents", { parentSession: "ghost-parent", seedLength: 3 }, { turn: 1 });
@@ -462,11 +446,9 @@ try {
   // B-1：开关禁用三态提交——notifyTaskDone=false 时 completed idle 不通知，
   //     但 lastEndedTurn 照常提交，同 turn 再现 idle 不重复处理。
   {
-    const b1Cfg = join(work, "b1-off.json");
-    writeFileSync(b1Cfg, JSON.stringify({ doneMergeWindowMs: 0, notifyTaskDone: false }));
     const infos = [];
     const warns = [];
-    const { listeners } = await makeNotifier(work, { configFile: b1Cfg }, { logger: { info: (t) => infos.push(t), warn: (t) => warns.push(t) } });
+    const { listeners } = await makeNotifier(work, { doneMergeWindowMs: 0, notifyTaskDone: false }, { logger: { info: (t) => infos.push(t), warn: (t) => warns.push(t) } });
     const status = listeners.get("agent/status")[0];
     const pair = turnPair("b1-1", "开关禁用任务", {}, { turn: 1 });
     status({ agent: pair.running, status: "running" });
@@ -485,10 +467,8 @@ try {
   //     同 turn 再现 idle → 不重复通知、不新增记录。
   {
     const qhAll = { enabled: true, start: "00:00", end: "23:59" };
-    const b2Cfg = join(work, "b2-quiet.json");
-    writeFileSync(b2Cfg, JSON.stringify({ doneMergeWindowMs: 0, quietHours: { ...qhAll, allowKinds: ["ask"] } }));
     const infos = [];
-    const { listeners, routes } = await makeNotifier(work, { configFile: b2Cfg, historyFile: join(work, "b2-hist.jsonl") }, loggingOverride(infos));
+    const { listeners, routes } = await makeNotifier(work, { doneMergeWindowMs: 0, quietHours: { ...qhAll, allowKinds: ["ask"] }, historyFile: join(work, "b2-hist.jsonl") }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
     const historyRoute = routes.find((r) => r.path === ROUTES.history);
     const pair = turnPair("b2-1", "免打扰完成", {}, { turn: 1 });
@@ -508,10 +488,8 @@ try {
   // B-4：批次按「入队成功」提交、与聚合 flush 成败解耦——doneMergeWindowMs>0
   //     时首条完成入队即推进 lastEndedTurn（窗口内同 turn 再现不重复）。
   {
-    const b4Cfg = join(work, "b4-merge.json");
-    writeFileSync(b4Cfg, JSON.stringify({ doneMergeWindowMs: 5000 }));
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: b4Cfg }, loggingOverride(infos));
+    const { listeners } = await makeNotifier(work, { doneMergeWindowMs: 5000 }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
     const pair = turnPair("b4-1", "合并窗口任务", {}, { turn: 1 });
     status({ agent: pair.running, status: "running" });
@@ -529,10 +507,8 @@ try {
   //     触发会 uncaught、与 Stryker tap-bridge 冲突，故以「提交点先于 flush」
   //     的时序验证覆盖——见 PR 断言表 B-4 漂移说明。）
   {
-    const b4fCfg = join(work, "b4-flush-ok.json");
-    writeFileSync(b4fCfg, JSON.stringify({ doneMergeWindowMs: 30 }));
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: b4fCfg }, loggingOverride(infos));
+    const { listeners } = await makeNotifier(work, { doneMergeWindowMs: 30 }, loggingOverride(infos));
     const status = listeners.get("agent/status")[0];
     const doneCount = () => infos.filter((t) => /: done /.test(t)).length;
     const pairA = () => turnPair("b4f-a", "flush 后 A", {}, { turn: 1 });

--- a/packages/dsh-notifier/test/e2e-edge.src.test.ts
+++ b/packages/dsh-notifier/test/e2e-edge.src.test.ts
@@ -40,7 +40,7 @@ try {
         return () => {};
       },
     });
-    await apply(ctx, { enabled: true, configFile: join(work, "lifecycle-cfg.json"), toastScript: join(work, "lifecycle-toast.ps1"), historyFile: join(work, "lifecycle-history.jsonl") });
+    await apply(ctx, { enabled: true, toastScript: join(work, "lifecycle-toast.ps1"), historyFile: join(work, "lifecycle-history.jsonl") });
     assert.equal(routeDispCalled.size, 5, "5 条路由注册");
     // 调用所有 effect disposer（清理顺序）
     for (const disp of effectDisposers) disp();
@@ -52,10 +52,10 @@ try {
 
   // ── 2. readBody async-iterator 分支（config PUT 走 web streams）──
   {
-    const { routes } = await makeNotifier(work, { configFile: join(work, "async-iter-cfg.json"), historyFile: join(work, "async-iter-hist.jsonl") });
+    const { routes } = await makeNotifier(work, { historyFile: join(work, "async-iter-hist.jsonl") });
     const configRoute = routes.find((r) => r.path === ROUTES.config);
     // 构造 async-iterable req（有 Symbol.asyncIterator，无 .on）
-    const body = JSON.stringify({ notifyAsk: false });
+    const body = JSON.stringify({ patch: { notifyAsk: false } });
     const chunks = [Buffer.from(body)];
     let idx = 0;
     const asyncIterReq = {
@@ -74,7 +74,7 @@ try {
     const { rec, res } = makeRes();
     await configRoute.handler(asyncIterReq, res);
     assert.equal(rec.status, 200);
-    assert.equal(JSON.parse(rec.text).notifyAsk, false, "async-iterator 分支解析成功");
+    assert.equal(JSON.parse(rec.text).user.notifyAsk, false, "async-iterator 分支解析成功");
   }
 
   // ── 3. 审批超时提醒（askRemindMin > 0 分支）──
@@ -88,9 +88,8 @@ try {
       return timer;
     };
     try {
-      writeFileSync(join(work, "ask-remind-cfg.json"), JSON.stringify({ askRemindMin: 1 }));
-      const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: join(work, "ask-remind-cfg.json"), historyFile: join(work, "ask-remind-hist.jsonl") }, {
+            const infos = [];
+      const { listeners } = await makeNotifier(work, { askRemindMin: 1, historyFile: join(work, "ask-remind-hist.jsonl") }, {
         logger: { warn: (m) => { infos.push(`warn: ${m}`); }, info: (t) => infos.push(t) },
       });
       // 清理 apply 阶段的 timer 记录（execFile timeout 等）
@@ -111,8 +110,7 @@ try {
   {
     const warns = [];
     // 启用 notifyTurnEnd 以使 turn-stopping 进入通知路径（默认关）
-    writeFileSync(join(work, "fail-cfg.json"), JSON.stringify({ notifyTurnEnd: true }));
-    const { listeners } = await makeNotifier(work, { configFile: join(work, "fail-cfg.json"), historyFile: join(work, "fail-hist.jsonl") }, {
+    const { listeners } = await makeNotifier(work, { notifyTurnEnd: true, historyFile: join(work, "fail-hist.jsonl") }, {
       logger: {
         info: () => { throw new Error("notify failed"); },
         warn: (m) => { warns.push(m); },
@@ -146,8 +144,7 @@ try {
   // ── 5. 完成聚合类型切换（done → subagent-done 混合）──
   {
     const infos = [];
-    writeFileSync(join(work, "merge-kind-cfg.json"), JSON.stringify({ doneMergeWindowMs: 500, notifySubagentDone: true }));
-    const { listeners } = await makeNotifier(work, { configFile: join(work, "merge-kind-cfg.json"), historyFile: join(work, "merge-kind-hist.jsonl") }, {
+    const { listeners } = await makeNotifier(work, { doneMergeWindowMs: 500, notifySubagentDone: true, historyFile: join(work, "merge-kind-hist.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },
     });
     const status = listeners.get("agent/status")[0];
@@ -169,8 +166,7 @@ try {
   // ── 6. error 合并窗口 ≥3 条 shift（lastMessages 收尾 2 条）──
   {
     const infos = [];
-    writeFileSync(join(work, "merge-shift-cfg.json"), JSON.stringify({ errorMergeWindowMs: 1000 }));
-    const { listeners } = await makeNotifier(work, { configFile: join(work, "merge-shift-cfg.json"), historyFile: join(work, "merge-shift-hist.jsonl") }, {
+    const { listeners } = await makeNotifier(work, { errorMergeWindowMs: 1000, historyFile: join(work, "merge-shift-hist.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },
     });
     const error = listeners.get("agent/error")[0];
@@ -193,8 +189,7 @@ try {
   // ── 7. agent/disposed 清理 turnNotified 前缀 ──
   {
     const infos = [];
-    writeFileSync(join(work, "disp-turn-cfg.json"), JSON.stringify({ notifyTurnEnd: true }));
-    const { listeners } = await makeNotifier(work, { configFile: join(work, "disp-turn-cfg.json"), historyFile: join(work, "disp-turn-hist.jsonl") }, {
+    const { listeners } = await makeNotifier(work, { notifyTurnEnd: true, historyFile: join(work, "disp-turn-hist.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },
     });
     const turnStop = listeners.get("agent/turn-stopping")[0];
@@ -217,7 +212,7 @@ try {
 
   // ── 8. hookUserQuestions：ctx.get 抛出 → 静默容错 ──
   {
-    const { listeners } = await makeNotifier(work, { configFile: join(work, "hook-fail-cfg.json"), historyFile: join(work, "hook-fail-hist.jsonl") }, {
+    const { listeners } = await makeNotifier(work, { historyFile: join(work, "hook-fail-hist.jsonl") }, {
       get: () => { throw new Error("service not ready"); },
       logger: { warn: () => {}, info: () => {} },
     });
@@ -232,7 +227,7 @@ try {
   // ── 9. 无状态 idle：无 running 记录时 idle 不误报 ──
   {
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: join(work, "noop-idle-cfg.json"), historyFile: join(work, "noop-idle-hist.jsonl") }, {
+    const { listeners } = await makeNotifier(work, { historyFile: join(work, "noop-idle-hist.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },
     });
     const status = listeners.get("agent/status")[0];
@@ -242,11 +237,9 @@ try {
 // ── 10. 免打扰拦截 + 勾选 error 豁免 → 窗口内再报错必须通知 ──
   {
     const qhAll = { enabled: true, start: "00:00", end: "23:59" };
-    const cfg = join(work, "qh-error-1.json");
     // 免打扰开启，allowKinds 不含 error
-    writeFileSync(cfg, JSON.stringify({ errorMergeWindowMs: 60000, quietHours: { ...qhAll, allowKinds: ["ask"] } }));
     const infos = [];
-    const { listeners, routes } = await makeNotifier(work, { configFile: cfg, historyFile: join(work, "qh-error-hist-1.jsonl") }, {
+    const { listeners, routes } = await makeNotifier(work, { errorMergeWindowMs: 60000, quietHours: { ...qhAll, allowKinds: ["ask"] }, historyFile: join(work, "qh-error-hist-1.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },
     });
     const error = listeners.get("agent/error")[0];
@@ -262,9 +255,9 @@ try {
     const hist1 = await waitForHistory(historyRoute, (r) => r.some((e) => e.kind === "error" && e.suppressed === "quiet"));
     assert.ok(hist1.some((e) => e.kind === "error" && e.suppressed === "quiet"), "被拦截的错误落 suppressed:quiet 历史");
 
-    // 保存配置，开启 error 豁免（通过 PUT /config 模拟面板操作）
+    // 保存配置，开启 error 豁免（通过 PUT /config 模拟面板操作；issue #76 新契约 {patch}）
     const { rec: putRec, res: putRes } = makeRes();
-    const newBody = Buffer.from(JSON.stringify({ quietHours: { ...qhAll, allowKinds: ["ask", "error"] } }));
+    const newBody = Buffer.from(JSON.stringify({ patch: { quietHours: { ...qhAll, allowKinds: ["ask", "error"] } } }));
     await configRoute.handler({
       method: "PUT",
       url: "/",
@@ -284,10 +277,8 @@ try {
 
   // ── 11. 合并被吞的错误落 suppressed: "merged" 历史 ──
   {
-    const cfg = join(work, "merged-hist-cfg.json");
-    writeFileSync(cfg, JSON.stringify({ errorMergeWindowMs: 60000 }));
     const infos = [];
-    const { listeners, routes } = await makeNotifier(work, { configFile: cfg, historyFile: join(work, "merged-hist.jsonl") }, {
+    const { listeners, routes } = await makeNotifier(work, { errorMergeWindowMs: 60000, historyFile: join(work, "merged-hist.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },
     });
     const error = listeners.get("agent/error")[0];
@@ -310,10 +301,8 @@ try {
   // ── 12. 多个错误持续到达时窗口不无限顺延（免打扰拦截不开窗 → 每次独立落 quiet 历史） ──
   {
     const qhAll = { enabled: true, start: "00:00", end: "23:59" };
-    const cfg = join(work, "no-extend-cfg.json");
-    writeFileSync(cfg, JSON.stringify({ errorMergeWindowMs: 60000, quietHours: { ...qhAll, allowKinds: [] } }));
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: cfg, historyFile: join(work, "no-extend-hist.jsonl") }, {
+    const { listeners } = await makeNotifier(work, {  errorMergeWindowMs: 60000, quietHours: { ...qhAll, allowKinds: [] } , historyFile: join(work, "no-extend-hist.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },
     });
     const error = listeners.get("agent/error")[0];

--- a/packages/dsh-notifier/test/e2e-edge.src.test.ts
+++ b/packages/dsh-notifier/test/e2e-edge.src.test.ts
@@ -10,7 +10,7 @@
 import { join } from "node:path";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { assert, makeNotifier, makeFakeCtx, agentWithTitle, makeRes, fakeReq, waitForHistory, turnPair } from "./helpers.ts";
+import { assert, makeNotifier, makeFakeCtx, agentWithTitle, makeRes, fakeReq, waitForHistory, turnPair, quietWindowNow } from "./helpers.ts";
 import { ROUTES, apply } from "../src/index.ts";
 
 const work = mkdtempSync(join(tmpdir(), "dnotify-e2e-edge-"));
@@ -236,7 +236,9 @@ try {
   }
 // ── 10. 免打扰拦截 + 勾选 error 豁免 → 窗口内再报错必须通知 ──
   {
-    const qhAll = { enabled: true, start: "00:00", end: "23:59" };
+    // #181 动态窗口：写死 "00:00"/"23:59" 在半开区间镜下 23:59 这一分钟不命中
+    // （UTC 边缘必炸，run 33282203798 根因）；围绕当前时间 ±2 分钟恒命中。
+    const qhAll = quietWindowNow();
     // 免打扰开启，allowKinds 不含 error
     const infos = [];
     const { listeners, routes } = await makeNotifier(work, { errorMergeWindowMs: 60000, quietHours: { ...qhAll, allowKinds: ["ask"] }, historyFile: join(work, "qh-error-hist-1.jsonl") }, {
@@ -300,7 +302,9 @@ try {
 
   // ── 12. 多个错误持续到达时窗口不无限顺延（免打扰拦截不开窗 → 每次独立落 quiet 历史） ──
   {
-    const qhAll = { enabled: true, start: "00:00", end: "23:59" };
+    // #181 动态窗口：写死 "00:00"/"23:59" 在半开区间镜下 23:59 这一分钟不命中
+    // （UTC 边缘必炸，run 33282203798 根因）；围绕当前时间 ±2 分钟恒命中。
+    const qhAll = quietWindowNow();
     const infos = [];
     const { listeners } = await makeNotifier(work, {  errorMergeWindowMs: 60000, quietHours: { ...qhAll, allowKinds: [] } , historyFile: join(work, "no-extend-hist.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },

--- a/packages/dsh-notifier/test/e2e-edge.test.ts
+++ b/packages/dsh-notifier/test/e2e-edge.test.ts
@@ -10,7 +10,7 @@
 import { join } from "node:path";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { assert, makeNotifier, makeFakeCtx, agentWithTitle, makeRes, fakeReq, waitForHistory, turnPair } from "./helpers.ts";
+import { assert, makeNotifier, makeFakeCtx, agentWithTitle, makeRes, fakeReq, waitForHistory, turnPair, quietWindowNow } from "./helpers.ts";
 import { ROUTES, apply } from "../lib/index.js";
 
 const work = mkdtempSync(join(tmpdir(), "dnotify-e2e-edge-"));
@@ -236,7 +236,9 @@ try {
   }
 // ── 10. 免打扰拦截 + 勾选 error 豁免 → 窗口内再报错必须通知 ──
   {
-    const qhAll = { enabled: true, start: "00:00", end: "23:59" };
+    // #181 动态窗口：写死 "00:00"/"23:59" 在半开区间镜下 23:59 这一分钟不命中
+    // （UTC 边缘必炸，run 33282203798 根因）；围绕当前时间 ±2 分钟恒命中。
+    const qhAll = quietWindowNow();
     // 免打扰开启，allowKinds 不含 error
     const infos = [];
     const { listeners, routes } = await makeNotifier(work, { errorMergeWindowMs: 60000, quietHours: { ...qhAll, allowKinds: ["ask"] }, historyFile: join(work, "qh-error-hist-1.jsonl") }, {
@@ -300,7 +302,9 @@ try {
 
   // ── 12. 多个错误持续到达时窗口不无限顺延（免打扰拦截不开窗 → 每次独立落 quiet 历史） ──
   {
-    const qhAll = { enabled: true, start: "00:00", end: "23:59" };
+    // #181 动态窗口：写死 "00:00"/"23:59" 在半开区间镜下 23:59 这一分钟不命中
+    // （UTC 边缘必炸，run 33282203798 根因）；围绕当前时间 ±2 分钟恒命中。
+    const qhAll = quietWindowNow();
     const infos = [];
     const { listeners } = await makeNotifier(work, {  errorMergeWindowMs: 60000, quietHours: { ...qhAll, allowKinds: [] } , historyFile: join(work, "no-extend-hist.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },

--- a/packages/dsh-notifier/test/e2e-edge.test.ts
+++ b/packages/dsh-notifier/test/e2e-edge.test.ts
@@ -40,7 +40,7 @@ try {
         return () => {};
       },
     });
-    await apply(ctx, { enabled: true, configFile: join(work, "lifecycle-cfg.json"), toastScript: join(work, "lifecycle-toast.ps1"), historyFile: join(work, "lifecycle-history.jsonl") });
+    await apply(ctx, { enabled: true, toastScript: join(work, "lifecycle-toast.ps1"), historyFile: join(work, "lifecycle-history.jsonl") });
     assert.equal(routeDispCalled.size, 5, "5 条路由注册");
     // 调用所有 effect disposer（清理顺序）
     for (const disp of effectDisposers) disp();
@@ -52,10 +52,10 @@ try {
 
   // ── 2. readBody async-iterator 分支（config PUT 走 web streams）──
   {
-    const { routes } = await makeNotifier(work, { configFile: join(work, "async-iter-cfg.json"), historyFile: join(work, "async-iter-hist.jsonl") });
+    const { routes } = await makeNotifier(work, { historyFile: join(work, "async-iter-hist.jsonl") });
     const configRoute = routes.find((r) => r.path === ROUTES.config);
     // 构造 async-iterable req（有 Symbol.asyncIterator，无 .on）
-    const body = JSON.stringify({ notifyAsk: false });
+    const body = JSON.stringify({ patch: { notifyAsk: false } });
     const chunks = [Buffer.from(body)];
     let idx = 0;
     const asyncIterReq = {
@@ -74,7 +74,7 @@ try {
     const { rec, res } = makeRes();
     await configRoute.handler(asyncIterReq, res);
     assert.equal(rec.status, 200);
-    assert.equal(JSON.parse(rec.text).notifyAsk, false, "async-iterator 分支解析成功");
+    assert.equal(JSON.parse(rec.text).user.notifyAsk, false, "async-iterator 分支解析成功");
   }
 
   // ── 3. 审批超时提醒（askRemindMin > 0 分支）──
@@ -88,9 +88,8 @@ try {
       return timer;
     };
     try {
-      writeFileSync(join(work, "ask-remind-cfg.json"), JSON.stringify({ askRemindMin: 1 }));
-      const infos = [];
-      const { listeners } = await makeNotifier(work, { configFile: join(work, "ask-remind-cfg.json"), historyFile: join(work, "ask-remind-hist.jsonl") }, {
+            const infos = [];
+      const { listeners } = await makeNotifier(work, { askRemindMin: 1, historyFile: join(work, "ask-remind-hist.jsonl") }, {
         logger: { warn: (m) => { infos.push(`warn: ${m}`); }, info: (t) => infos.push(t) },
       });
       // 清理 apply 阶段的 timer 记录（execFile timeout 等）
@@ -111,8 +110,7 @@ try {
   {
     const warns = [];
     // 启用 notifyTurnEnd 以使 turn-stopping 进入通知路径（默认关）
-    writeFileSync(join(work, "fail-cfg.json"), JSON.stringify({ notifyTurnEnd: true }));
-    const { listeners } = await makeNotifier(work, { configFile: join(work, "fail-cfg.json"), historyFile: join(work, "fail-hist.jsonl") }, {
+    const { listeners } = await makeNotifier(work, { notifyTurnEnd: true, historyFile: join(work, "fail-hist.jsonl") }, {
       logger: {
         info: () => { throw new Error("notify failed"); },
         warn: (m) => { warns.push(m); },
@@ -146,8 +144,7 @@ try {
   // ── 5. 完成聚合类型切换（done → subagent-done 混合）──
   {
     const infos = [];
-    writeFileSync(join(work, "merge-kind-cfg.json"), JSON.stringify({ doneMergeWindowMs: 500, notifySubagentDone: true }));
-    const { listeners } = await makeNotifier(work, { configFile: join(work, "merge-kind-cfg.json"), historyFile: join(work, "merge-kind-hist.jsonl") }, {
+    const { listeners } = await makeNotifier(work, { doneMergeWindowMs: 500, notifySubagentDone: true, historyFile: join(work, "merge-kind-hist.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },
     });
     const status = listeners.get("agent/status")[0];
@@ -169,8 +166,7 @@ try {
   // ── 6. error 合并窗口 ≥3 条 shift（lastMessages 收尾 2 条）──
   {
     const infos = [];
-    writeFileSync(join(work, "merge-shift-cfg.json"), JSON.stringify({ errorMergeWindowMs: 1000 }));
-    const { listeners } = await makeNotifier(work, { configFile: join(work, "merge-shift-cfg.json"), historyFile: join(work, "merge-shift-hist.jsonl") }, {
+    const { listeners } = await makeNotifier(work, { errorMergeWindowMs: 1000, historyFile: join(work, "merge-shift-hist.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },
     });
     const error = listeners.get("agent/error")[0];
@@ -193,8 +189,7 @@ try {
   // ── 7. agent/disposed 清理 turnNotified 前缀 ──
   {
     const infos = [];
-    writeFileSync(join(work, "disp-turn-cfg.json"), JSON.stringify({ notifyTurnEnd: true }));
-    const { listeners } = await makeNotifier(work, { configFile: join(work, "disp-turn-cfg.json"), historyFile: join(work, "disp-turn-hist.jsonl") }, {
+    const { listeners } = await makeNotifier(work, { notifyTurnEnd: true, historyFile: join(work, "disp-turn-hist.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },
     });
     const turnStop = listeners.get("agent/turn-stopping")[0];
@@ -217,7 +212,7 @@ try {
 
   // ── 8. hookUserQuestions：ctx.get 抛出 → 静默容错 ──
   {
-    const { listeners } = await makeNotifier(work, { configFile: join(work, "hook-fail-cfg.json"), historyFile: join(work, "hook-fail-hist.jsonl") }, {
+    const { listeners } = await makeNotifier(work, { historyFile: join(work, "hook-fail-hist.jsonl") }, {
       get: () => { throw new Error("service not ready"); },
       logger: { warn: () => {}, info: () => {} },
     });
@@ -232,7 +227,7 @@ try {
   // ── 9. 无状态 idle：无 running 记录时 idle 不误报 ──
   {
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: join(work, "noop-idle-cfg.json"), historyFile: join(work, "noop-idle-hist.jsonl") }, {
+    const { listeners } = await makeNotifier(work, { historyFile: join(work, "noop-idle-hist.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },
     });
     const status = listeners.get("agent/status")[0];
@@ -242,11 +237,9 @@ try {
 // ── 10. 免打扰拦截 + 勾选 error 豁免 → 窗口内再报错必须通知 ──
   {
     const qhAll = { enabled: true, start: "00:00", end: "23:59" };
-    const cfg = join(work, "qh-error-1.json");
     // 免打扰开启，allowKinds 不含 error
-    writeFileSync(cfg, JSON.stringify({ errorMergeWindowMs: 60000, quietHours: { ...qhAll, allowKinds: ["ask"] } }));
     const infos = [];
-    const { listeners, routes } = await makeNotifier(work, { configFile: cfg, historyFile: join(work, "qh-error-hist-1.jsonl") }, {
+    const { listeners, routes } = await makeNotifier(work, { errorMergeWindowMs: 60000, quietHours: { ...qhAll, allowKinds: ["ask"] }, historyFile: join(work, "qh-error-hist-1.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },
     });
     const error = listeners.get("agent/error")[0];
@@ -262,9 +255,9 @@ try {
     const hist1 = await waitForHistory(historyRoute, (r) => r.some((e) => e.kind === "error" && e.suppressed === "quiet"));
     assert.ok(hist1.some((e) => e.kind === "error" && e.suppressed === "quiet"), "被拦截的错误落 suppressed:quiet 历史");
 
-    // 保存配置，开启 error 豁免（通过 PUT /config 模拟面板操作）
+    // 保存配置，开启 error 豁免（通过 PUT /config 模拟面板操作；issue #76 新契约 {patch}）
     const { rec: putRec, res: putRes } = makeRes();
-    const newBody = Buffer.from(JSON.stringify({ quietHours: { ...qhAll, allowKinds: ["ask", "error"] } }));
+    const newBody = Buffer.from(JSON.stringify({ patch: { quietHours: { ...qhAll, allowKinds: ["ask", "error"] } } }));
     await configRoute.handler({
       method: "PUT",
       url: "/",
@@ -284,10 +277,8 @@ try {
 
   // ── 11. 合并被吞的错误落 suppressed: "merged" 历史 ──
   {
-    const cfg = join(work, "merged-hist-cfg.json");
-    writeFileSync(cfg, JSON.stringify({ errorMergeWindowMs: 60000 }));
     const infos = [];
-    const { listeners, routes } = await makeNotifier(work, { configFile: cfg, historyFile: join(work, "merged-hist.jsonl") }, {
+    const { listeners, routes } = await makeNotifier(work, { errorMergeWindowMs: 60000, historyFile: join(work, "merged-hist.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },
     });
     const error = listeners.get("agent/error")[0];
@@ -310,10 +301,8 @@ try {
   // ── 12. 多个错误持续到达时窗口不无限顺延（免打扰拦截不开窗 → 每次独立落 quiet 历史） ──
   {
     const qhAll = { enabled: true, start: "00:00", end: "23:59" };
-    const cfg = join(work, "no-extend-cfg.json");
-    writeFileSync(cfg, JSON.stringify({ errorMergeWindowMs: 60000, quietHours: { ...qhAll, allowKinds: [] } }));
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: cfg, historyFile: join(work, "no-extend-hist.jsonl") }, {
+    const { listeners } = await makeNotifier(work, {  errorMergeWindowMs: 60000, quietHours: { ...qhAll, allowKinds: [] } , historyFile: join(work, "no-extend-hist.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },
     });
     const error = listeners.get("agent/error")[0];

--- a/packages/dsh-notifier/test/e2e-question-turn.test.ts
+++ b/packages/dsh-notifier/test/e2e-question-turn.test.ts
@@ -7,7 +7,7 @@
  * 开启后同一 (agent,turn) 去重、新轮次正常通知（serial 事件无 next 不抛错）。
  */
 import { join } from "node:path";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { assert, makeNotifier } from "./helpers.ts";
 
@@ -17,7 +17,7 @@ try {
   {
     const infos = [];
     let fakeService = null;
-    const { listeners } = await makeNotifier(work, { configFile: join(work, "question.json") }, {
+    const { listeners } = await makeNotifier(work, { }, {
       logger: { warn: () => {}, info: (t) => infos.push(t) },
       get: (name) => (name === "userQuestions" ? fakeService : undefined),
     });
@@ -52,10 +52,9 @@ try {
     assert.equal(infos.length, infoCountBefore + 1, "解包重包不叠层，通知只发一次");
 
     // notifyQuestion=false 不通知（用独立的 service 实例，避免闭包捕获上一实例的配置）
-    writeFileSync(join(work, "question-off.json"), JSON.stringify({ notifyQuestion: false }));
     let fakeService2 = null;
     const infos2 = [];
-    const { listeners: listeners2 } = await makeNotifier(work, { configFile: join(work, "question-off.json"), historyFile: join(work, "history-q2.jsonl") }, {
+    const { listeners: listeners2 } = await makeNotifier(work, { notifyQuestion: false, historyFile: join(work, "history-q2.jsonl") }, {
       logger: { warn: () => {}, info: (t) => infos2.push(t) },
       get: (name) => (name === "userQuestions" ? fakeService2 : undefined),
     });
@@ -70,7 +69,7 @@ try {
   // （该断言依赖默认配置实例 + 开启 notifyTurnEnd 的对照实例）
   {
     const infos = [];
-    const { listeners } = await makeNotifier(work, { configFile: join(work, "turn-default.json"), historyFile: join(work, "history-t1.jsonl") }, { logger: { warn: () => {}, info: (t) => infos.push(t) } });
+    const { listeners } = await makeNotifier(work, { historyFile: join(work, "history-t1.jsonl") }, { logger: { warn: () => {}, info: (t) => infos.push(t) } });
     const turnStop = listeners.get("agent/turn-stopping")[0];
     assert.ok(turnStop, "turn-stopping 监听器已注册");
     let threw = false;
@@ -82,11 +81,9 @@ try {
     assert.equal(threw, false, "serial 事件（无 next 参数）下监听器不抛错");
     assert.equal(infos.length, 0, "turn-stopping 默认不通知");
 
-    // 开启 notifyTurnEnd 后 turn-stopping 通知(配置经 configFile 生效,apply 参数不接收通知开关)
-    const turnEndCfg = join(work, "notify-turn-end.json");
-    writeFileSync(turnEndCfg, JSON.stringify({ notifyTurnEnd: true }));
+    // 开启 notifyTurnEnd 后 turn-stopping 通知（配置经组合层 entry 生效）
     const infosOn = [];
-    const { listeners: listenersOn } = await makeNotifier(work, { configFile: turnEndCfg, historyFile: join(work, "history-t2.jsonl") }, { logger: { warn: () => {}, info: (t) => infosOn.push(t) } });
+    const { listeners: listenersOn } = await makeNotifier(work, { notifyTurnEnd: true, historyFile: join(work, "history-t2.jsonl") }, { logger: { warn: () => {}, info: (t) => infosOn.push(t) } });
     const turnStopOn = listenersOn.get("agent/turn-stopping")[0];
     const agentWithEvents = { id: "session-1", session: { events: [{ type: "session/title", data: { title: "优化 notifier 插件" } }] } };
     await turnStopOn({ agent: agentWithEvents, turn: 4 });

--- a/packages/dsh-notifier/test/helpers.ts
+++ b/packages/dsh-notifier/test/helpers.ts
@@ -1,6 +1,10 @@
 // @ts-nocheck
 /**
- * dsh-notifier — smoke 测试共享辅助（fake ctx / fake req/res / 轮询）。
+ * dsh-notifier — smoke 测试共享辅助（fake ctx / fake req/res / fake settings / 轮询）。
+ *
+ * issue #76 后配置走官方 settings 命名空间：makeNotifier 注入 fake settings 服务
+ * （register/describe/update），apply 的组合层配置经 sanitizeSettings 过滤后作为
+ * 命名空间 base 层；user 层可由测试经 ctxOverrides.settings 预置或 PUT 写入断言。
  *
  * 无副作用模块：不创建临时目录、不触发 apply；work 目录由各测试文件
  * 自建自清（隔离文件路径，防 flake——见 docs/DEVELOPMENT.md §5）。
@@ -8,6 +12,7 @@
 import { join } from "node:path";
 import assert from "node:assert/strict";
 import { apply } from "../lib/index.js";
+import { normalizeConfig, sanitizeSettings, SETTINGS_NS } from "../lib/index.js";
 
 /** loopback 合法请求构造（remoteAddress 可覆盖）。 */
 export function fakeReq(overrides = {}) {
@@ -42,8 +47,84 @@ export function makeRes() {
 }
 
 /**
+ * fake settings 服务（官方 SettingsServiceLike 最小面：register/describe/update）。
+ * register 返回 owner scope（get/watch/update），解析值 = normalizeConfig(base+user)；
+ * update 可选做 revision 乐观并发（expectedRevision 不匹配抛 SETTINGS_CONFLICT）。
+ * @param options.base 组合层通知配置（apply entry，sanitize 后）。
+ * @param options.user 预置 user 层（GET user 断言 / 迁移目标）。
+ * @param options.log 可选记录 update 调用的钩子（断言「只提交变更键」）。
+ */
+export function makeFakeSettings(options = {}) {
+  const base = options.base && typeof options.base === "object" ? options.base : {};
+  let user = { ...((options.user && typeof options.user === "object") ? options.user : {}) };
+  let revision = 0;
+  const scopeWatchCbs = [];
+  const updateCalls = [];
+  const log = options.log || (() => {});
+
+  const scope = {
+    get() {
+      return normalizeConfig({ ...base, ...user });
+    },
+    watch(cb) {
+      scopeWatchCbs.push(cb);
+      return () => {
+        const i = scopeWatchCbs.indexOf(cb);
+        if (i !== -1) scopeWatchCbs.splice(i, 1);
+      };
+    },
+    update(patch) {
+      const prev = normalizeConfig({ ...base, ...user });
+      Object.assign(user, patch);
+      revision += 1;
+      updateCalls.push({ patch: JSON.parse(JSON.stringify(patch)), via: "scope" });
+      log({ via: "scope", patch });
+      fireWatch(prev);
+    },
+  };
+  const service = {
+    register(ns, schema, opts) {
+      return scope;
+    },
+    describe(opts = {}) {
+      return [{ ns: SETTINGS_NS, user: { ...user }, revision }];
+    },
+    async update(ns, patch, expectedRevision) {
+      if (expectedRevision !== undefined && expectedRevision !== revision) {
+        throw Object.assign(new Error("settings conflict"), { code: "SETTINGS_CONFLICT", expected: expectedRevision, actual: revision });
+      }
+      const prev = normalizeConfig({ ...base, ...user });
+      Object.assign(user, patch);
+      revision += 1;
+      updateCalls.push({ patch: JSON.parse(JSON.stringify(patch)), via: "service" });
+      log({ via: "service", patch });
+      fireWatch(prev);
+    },
+  };
+  /** 提交后触发 scope.watch 回调（官方语义：异步串行；测试同步即可）。 */
+  function fireWatch(prev) {
+    for (const cb of [...scopeWatchCbs]) {
+      try {
+        cb(normalizeConfig({ ...base, ...user }), prev);
+      } catch {
+        // 回调异常不阻断（与官方 contained-watcher 语义一致）
+      }
+    }
+  }
+  return {
+    scope,
+    service,
+    getUser: () => ({ ...user }),
+    getRevision: () => revision,
+    getUpdateCalls: () => updateCalls,
+    setUser(next) { user = { ...next }; },
+  };
+}
+
+/**
  * fake cordis ctx：路由表 + 事件监听器表 + effect（真实语义：fn 立即同步
- * 执行，返回值收集为 disposer）+ get/provide（服务读取面）。
+ * 执行，返回值收集为 disposer）+ get/provide（服务读取面）+ inject（服务注入面，
+ * 供 installNotifierSettings 挂 settings）。
  *
  * 未注入访问抛错镜像（issue #290 C-2）：Proxy 对未注入属性（如 ctx.agents）
  * 抛与真实 cordis 同构的错误 `cannot get property "<name>" without inject`
@@ -87,6 +168,21 @@ export function makeFakeCtx(overrides = {}) {
       services.set(name, value);
       return () => services.delete(name);
     },
+    inject(serviceNames, fn) {
+      // 服务面注入（installNotifierSettings 经此挂 settings）：仅处理已注册服务
+      if (Array.isArray(serviceNames) && serviceNames.includes("settings")) {
+        const settings = services.get("settings");
+        if (!settings) return;
+        const sctx = {
+          settings,
+          effect(f2) {
+            const d = f2();
+            return typeof d === "function" ? d : () => {};
+          },
+        };
+        fn(sctx);
+      }
+    },
     ...overrides,
   };
   // 未注入访问抛错镜像（真实 cordis 严格属性访问）：symbol/保留键（then/
@@ -116,14 +212,23 @@ export function makeLoggingCtx() {
 }
 
 /**
- * apply 一份 notifier（默认 enabled + work 内独立配置/历史文件路径）。
+ * apply 一份 notifier。issue #76 后配置走 fake settings 命名空间：
  * @param workDir 该测试文件的临时目录。
- * @param config apply 配置覆盖（configFile/toastScript/historyFile 已给默认）。
- * @param ctxOverrides makeFakeCtx 覆盖（如注入 get / 自定义 logger）。
+ * @param config apply 配置覆盖（通知字段作为组合层 entry/base；enabled /
+ *   configFile/toastScript/historyFile 为装配覆盖）。
+ * @param ctxOverrides makeFakeCtx 覆盖（如注入 settings 服务 / 自定义 logger）。
+ * @returns 附带 fake settings 句柄（getUser/getUpdateCalls 断言写入面）。
  */
-export async function makeNotifier(workDir, config = {}, ctxOverrides = {}) {
-  const { ctx, routes, listeners, effects } = makeFakeCtx(ctxOverrides);
-  await apply(ctx, {
+export function makeNotifier(workDir, config = {}, ctxOverrides = {}) {
+  const entry = (sanitizeSettings(config) ?? {}) || {};
+  const settingsOpts = ctxOverrides.settings || {};
+  const fakeSettings = makeFakeSettings({ base: entry, ...settingsOpts });
+  const { ctx, routes, listeners, effects } = makeFakeCtx({
+    ...ctxOverrides,
+    settings: undefined, // 确保 override 的 settings 字段不污染服务读取面
+  });
+  ctx.provide("settings", fakeSettings.service);
+  apply(ctx, {
     enabled: true,
     configFile: join(workDir, "config.json"),
     toastScript: join(workDir, "toast.ps1"),
@@ -131,7 +236,7 @@ export async function makeNotifier(workDir, config = {}, ctxOverrides = {}) {
     ...config,
   });
   return {
-    ctx, routes, listeners,
+    ctx, routes, listeners, settings: fakeSettings,
     /** 卸载面：执行全部 effect disposer（sse.dispose / 定时器清理）。
      *  每个测试场景结束后调用，避免 30s unref 心跳在进程存活期内残留（P2-5）。 */
     dispose: () => {

--- a/packages/dsh-notifier/test/helpers.ts
+++ b/packages/dsh-notifier/test/helpers.ts
@@ -349,6 +349,23 @@ export function fakeAgents(liveIds = [], ownedPairs = []) {
   };
 }
 
+/**
+ * 免打扰窗口动态构造（#181 既定模式）：写死 "00:00"/"23:59" 假设全天覆盖，
+ * 但 isInQuietHours 是半开区间 [start, end)，23:59 这一分钟（minutes=1439）
+ * 恒不命中——CI（UTC 时区）在 23:58 开跑的慢 runner 恰好把断言推进到 23:59
+ * 这一分钟时，quietHours 判定失效、通知未被拦截（run 33282203798 根因）。
+ * 围绕当前时间 ±halfSpanMinutes 构造，任何时区/任何时刻运行恒命中；
+ * now 邻近 00:00 时 start > end，天然走实现的跨午夜分支（quiet-hours.ts）。
+ * @param halfSpanMinutes 窗口半宽（分钟，默认 2）
+ */
+export function quietWindowNow(halfSpanMinutes = 2) {
+  const hhmm = (offsetMinutes) => {
+    const t = new Date(Date.now() + offsetMinutes * 60_000);
+    return `${String(t.getHours()).padStart(2, "0")}:${String(t.getMinutes()).padStart(2, "0")}`;
+  };
+  return { enabled: true, start: hhmm(-halfSpanMinutes), end: hhmm(halfSpanMinutes) };
+}
+
 /** 等待聚合窗口（doneMergeWindowMs 默认 3s）过期。 */
 export async function waitMergeWindow() {
   await new Promise((resolve) => setTimeout(resolve, 3200));

--- a/packages/dsh-notifier/test/migration.src.test.ts
+++ b/packages/dsh-notifier/test/migration.src.test.ts
@@ -1,0 +1,158 @@
+// @ts-nocheck
+/**
+ * dsh-notifier — e2e：存量配置迁移（issue #76 E1-E7 / R1）。
+ *
+ * 覆盖：
+ * - E1 旧 json 存在 → 一次性迁移至官方 settings user 层，原文改名 .migrated.bak；
+ * - E2 迁移幂等：二次启动 .bak 存在且 json 不存在且 user 层有值 → 跳过（不重复写入）；
+ * - E3 中断态重放：.migrated.bak 存在且 json 不存在且 user 层为空 → 重放写入；
+ * - E4 损坏/非对象/无有效键 → 改名 .corrupted.bak，不写入；
+ * - E5 Windows rename 目标已存在 → 先 unlink 旧 bak 再 rename；
+ * - E6 迁移写入失败 → 回滚改名（json 还原）+ warn，不阻塞启动；
+ * - E7 迁移前置于 enabled 判定（禁用态也迁移，路由/命名空间照常注册）。
+ */
+import { join } from "node:path";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { assert, makeNotifier, makeFakeSettings, makeFakeCtx } from "./helpers.ts";
+import { ROUTES, apply } from "../src/index.ts";
+
+const work = mkdtempSync(join(tmpdir(), "dnotify-migrate-"));
+/** 轮询直到谓词成立（替代固定 sleep：迁移是 onScope 内异步 fire-and-forget）。 */
+async function pollUntil(predicate, timeoutMs = 1000) {
+  const start = Date.now();
+  for (;;) {
+    if (predicate()) return true;
+    if (Date.now() - start > timeoutMs) return false;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+try {
+  // E1：旧 json 存在 → 迁移 + 改名 .migrated.bak
+  {
+    const legacy = join(work, "e1-dsh-notifier.json");
+    writeFileSync(legacy, JSON.stringify({ notifyAsk: false, quietHours: { enabled: true, start: "23:00", end: "07:00" } }));
+    // makeNotifier 的 configFile 指向旧 json；settings user 层预置空
+    const { settings } = makeNotifier(work, { configFile: legacy });
+    // 迁移在 onScope 内异步执行，轮询直到 user 层写入
+    await pollUntil(() => settings.getUser().notifyAsk === false);
+    const user = settings.getUser();
+    assert.equal(user.notifyAsk, false, "E1：notifyAsk 迁入 settings user 层");
+    assert.equal(user.quietHours?.enabled, true, "E1：quietHours 迁入 settings user 层");
+    assert.ok(existsSync(legacy + ".migrated.bak"), "E1：原文改名 .migrated.bak");
+    assert.ok(!existsSync(legacy), "E1：原 json 已改名（不再作为自建配置读取）");
+  }
+
+  // E2：迁移幂等——同一 settings 文档再次 apply（.bak 存在且 json 不存在且
+  // user 层有值）→ 不重复写入
+  {
+    const legacy = join(work, "e2-dsh-notifier.json");
+    writeFileSync(legacy, JSON.stringify({ notifyAsk: false }));
+    // 首次：共享 fake settings（user 层为空 → 触发迁移）
+    const shared = makeFakeSettings({});
+    const ctx1 = makeFakeCtx({});
+    ctx1.ctx.provide("settings", shared.service);
+    apply(ctx1.ctx, { enabled: true, configFile: legacy, historyFile: join(work, "e2-hist.jsonl") });
+    await pollUntil(() => shared.getUser().notifyAsk === false);
+    const callsAfterFirst = shared.getUpdateCalls().length;
+    assert.ok(callsAfterFirst >= 1, "E2：首次迁移触发写入");
+    // 二次：同一 settings 文档（user 层已有值）→ 幂等跳过（不触发 update）
+    const ctx2 = makeFakeCtx({});
+    ctx2.ctx.provide("settings", shared.service);
+    apply(ctx2.ctx, { enabled: true, configFile: legacy, historyFile: join(work, "e2-hist.jsonl") });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    const callsAfterSecond = shared.getUpdateCalls().length;
+    assert.equal(callsAfterSecond, callsAfterFirst, "E2：二次启动幂等跳过（不重复写入 settings）");
+    assert.equal(shared.getUser().notifyAsk, false, "E2：user 层保留首次迁移结果");
+  }
+
+  // E3：中断态重放——.migrated.bak 存在且 json 不存在且 user 层为空 → 重放写入
+  {
+    const legacy = join(work, "e3-dsh-notifier.json");
+    const bak = legacy + ".migrated.bak";
+    writeFileSync(bak, JSON.stringify({ notifyTaskDone: false })); // 模拟「改名成功但 update 前被杀」
+    const { settings } = makeNotifier(work, { configFile: legacy });
+    await pollUntil(() => settings.getUser().notifyTaskDone === false);
+    assert.equal(settings.getUser().notifyTaskDone, false, "E3：中断态从 bak 重放写入 settings");
+  }
+
+  // E4：损坏 json → 改名 .corrupted.bak，不写入
+  {
+    const legacy = join(work, "e4-dsh-notifier.json");
+    writeFileSync(legacy, "{ not json !!!");
+    const { settings } = makeNotifier(work, { configFile: legacy });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.deepEqual(settings.getUser(), {}, "E4：损坏 json 不写入 settings user 层");
+    assert.ok(existsSync(legacy + ".corrupted.bak"), "E4：损坏 json 改名 .corrupted.bak 标记");
+    assert.ok(!existsSync(legacy), "E4：损坏原文件已改名");
+  }
+
+  // E4b：非对象/无有效键 json → 只标记不写入
+  {
+    const legacy = join(work, "e4b-dsh-notifier.json");
+    writeFileSync(legacy, "123");
+    const { settings } = makeNotifier(work, { configFile: legacy });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.deepEqual(settings.getUser(), {}, "E4b：非对象 json 不写入");
+    assert.ok(existsSync(legacy + ".corrupted.bak"), "E4b：非对象 json 改名 .corrupted.bak");
+  }
+
+  // E5：Windows rename 目标已存在 → 先 unlink 旧 bak 再 rename（.migrated.bak 已存在）
+  {
+    const legacy = join(work, "e5-dsh-notifier.json");
+    const bak = legacy + ".migrated.bak";
+    writeFileSync(legacy, JSON.stringify({ notifyAsk: true }));
+    writeFileSync(bak, "old backup"); // 预置旧 bak（Windows 上 rename 目标已存在会抛错）
+    const { settings } = makeNotifier(work, { configFile: legacy });
+    await pollUntil(() => settings.getUser().notifyAsk === true);
+    assert.equal(settings.getUser().notifyAsk, true, "E5：rename 覆盖旧 bak 后迁移成功");
+    const newBak = readFileSync(bak, "utf8");
+    assert.ok(newBak.includes("notifyAsk"), "E5：新 bak 内容为本次迁移（旧 bak 已被 unlink 替换）");
+  }
+
+  // E6：迁移写入失败 → 回滚改名 + warn，不阻塞启动
+  {
+    const legacy = join(work, "e6-dsh-notifier.json");
+    writeFileSync(legacy, JSON.stringify({ notifyAsk: true }));
+    const warns = [];
+    // 用一个 update 必失败的 settings 服务（模拟持久化失败）
+    const { ctx, routes } = makeFakeCtx({
+      logger: { warn: (m) => warns.push(m), info: () => {} },
+    });
+    const failingSettings = {
+      register(ns, schema, opts) {
+        return {
+          get: () => ({ notifyAsk: true }),
+          watch: () => () => {},
+          update: async () => {},
+        };
+      },
+      describe: () => [{ ns: "dsh-notifier", user: {}, revision: 0 }],
+      async update(ns, patch) {
+        throw new Error("persist boom");
+      },
+    };
+    ctx.provide("settings", failingSettings);
+    apply(ctx, { enabled: true, configFile: legacy, historyFile: join(work, "e6-hist.jsonl") });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.ok(existsSync(legacy), "E6：写入失败回滚，原 json 还原");
+    assert.ok(warns.some((w) => w.includes("迁移")), "E6：迁移失败输出 warn 日志");
+    assert.ok(routes.length >= 5, "E6：迁移失败不阻塞路由注册");
+  }
+
+  // E7：enabled=false 禁用态仍迁移（H2/H3 前置）——禁用态 apply 仍注册路由 + 迁移照常
+  {
+    const legacy = join(work, "e7-dsh-notifier.json");
+    writeFileSync(legacy, JSON.stringify({ notifyTaskError: false }));
+    const fakeSettings = makeFakeSettings({});
+    const { ctx, routes } = makeFakeCtx({});
+    ctx.provide("settings", fakeSettings.service);
+    apply(ctx, { enabled: false, configFile: legacy, historyFile: join(work, "e7-hist.jsonl") });
+    await pollUntil(() => fakeSettings.getUser().notifyTaskError === false);
+    const paths = routes.map((r) => r.path);
+    for (const route of Object.values(ROUTES)) assert.ok(paths.includes(route), `E7：禁用态仍注册路由 ${route}`);
+    assert.equal(fakeSettings.getUser().notifyTaskError, false, "E7：禁用态仍迁移旧配置");
+  }
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}

--- a/packages/dsh-notifier/test/migration.src.test.ts
+++ b/packages/dsh-notifier/test/migration.src.test.ts
@@ -15,7 +15,7 @@ import { join } from "node:path";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { assert, makeNotifier, makeFakeSettings, makeFakeCtx } from "./helpers.ts";
-import { ROUTES, apply } from "../src/index.ts";
+import { ROUTES, apply, migrateLegacyConfig, MIGRATED_BAK_SUFFIX, CORRUPTED_BAK_SUFFIX } from "../src/index.ts";
 
 const work = mkdtempSync(join(tmpdir(), "dnotify-migrate-"));
 /** 轮询直到谓词成立（替代固定 sleep：迁移是 onScope 内异步 fire-and-forget）。 */
@@ -152,6 +152,122 @@ try {
     const paths = routes.map((r) => r.path);
     for (const route of Object.values(ROUTES)) assert.ok(paths.includes(route), `E7：禁用态仍注册路由 ${route}`);
     assert.equal(fakeSettings.getUser().notifyTaskError, false, "E7：禁用态仍迁移旧配置");
+  }
+
+  // E8：migrateLegacyConfig outcome 精确断言（直测，对照 stryker 幸存名单——
+  // 布尔结果字段翻转/逻辑运算符/条件分支的存活变异体由 outcome 深比较杀灭）
+  {
+    const dir = mkdtempSync(join(tmpdir(), "dnotify-migrate-outcome-"));
+    const deps = (userHasValues = false, failUpdate = false) => {
+      const updates = [];
+      return {
+        updates,
+        hasUserValues: () => userHasValues,
+        async update(patch) {
+          if (failUpdate) throw new Error("io boom");
+          updates.push(patch);
+        },
+      };
+    };
+    const IDLE = { performed: false, migrated: false, rolledBack: false, skippedCorrupt: false, skippedIdempotent: true, resumed: false };
+    const CORRUPT_ONLY = { performed: false, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: true, resumed: false };
+    // idle：json 与 bak 都不存在
+    {
+      const d = deps();
+      const legacy = join(dir, "idle.json");
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, IDLE, "E8：双文件不存在 → idle outcome 全 false/skippedIdempotent");
+      assert.equal(d.updates.length, 0, "E8：idle 不写入");
+    }
+    // 损坏标记态：只有 .corrupted.bak → 幂等跳过
+    {
+      const d = deps();
+      const legacy = join(dir, "corrupt-only.json");
+      writeFileSync(legacy + CORRUPTED_BAK_SUFFIX, "{oops");
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, CORRUPT_ONLY, "E8：损坏标记态 → skippedCorrupt+skippedIdempotent");
+      assert.equal(d.updates.length, 0, "E8：损坏标记态不写入");
+    }
+    // migrated.bak 存在 + user 层已有值 → 幂等跳过（E2）
+    {
+      const d = deps(true);
+      const legacy = join(dir, "bak-user.json");
+      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({ notifyAsk: false }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, IDLE, "E8：bak 存在 + user 有值 → 幂等跳过");
+      assert.equal(d.updates.length, 0, "E8：幂等跳过不写入");
+    }
+    // 中断态重放成功：bak 存在 + user 空 + bak 合法 → resumed+migrated
+    {
+      const d = deps(false);
+      const legacy = join(dir, "resume-ok.json");
+      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({ notifySound: false }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, { performed: false, migrated: true, rolledBack: false, skippedCorrupt: false, skippedIdempotent: false, resumed: true }, "E8：中断态重放成功 outcome");
+      assert.deepEqual(d.updates, [{ notifySound: false }], "E8：重放写入键集");
+    }
+    // 中断态重放失败：bak 非法 JSON → skippedCorrupt+resumed，不写入
+    {
+      const d = deps(false);
+      const legacy = join(dir, "resume-bad.json");
+      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, "{bad json");
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, { performed: false, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: true }, "E8：中断态 bak 损坏 → 标记跳过");
+      assert.equal(d.updates.length, 0, "E8：损坏 bak 不写入");
+    }
+    // 中断态重放失败：bak 无有效键 → skippedCorrupt+resumed
+    {
+      const d = deps(false);
+      const legacy = join(dir, "resume-empty.json");
+      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({ evilKey: 1 }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.equal(out.resumed, true, "E8：无有效键重放标记 resumed");
+      assert.equal(out.migrated, false, "E8：无有效键重放不迁移");
+      assert.equal(out.skippedCorrupt, true, "E8：无有效键重放标记 corrupted");
+      assert.equal(d.updates.length, 0, "E8：无有效键不写入");
+    }
+    // 损坏 json：只标记 .corrupted.bak，不写入（E4）
+    {
+      const d = deps();
+      const legacy = join(dir, "broken.json");
+      writeFileSync(legacy, "{ not json !!!");
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, { performed: true, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: false }, "E8：损坏 json outcome");
+      assert.ok(existsSync(legacy + CORRUPTED_BAK_SUFFIX), "E8：损坏 json 改名 corrupted.bak");
+      assert.equal(d.updates.length, 0, "E8：损坏 json 不写入");
+    }
+    // 非对象 json → 只标记（E4b）
+    {
+      const d = deps();
+      const legacy = join(dir, "nonobj.json");
+      writeFileSync(legacy, "123");
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.equal(out.performed, true, "E8：非对象 json performed");
+      assert.equal(out.skippedCorrupt, true, "E8：非对象 json 标记 corrupted");
+      assert.equal(d.updates.length, 0, "E8：非对象 json 不写入");
+    }
+    // 合法 json → renamed-first 后写入，outcome migrated+performed（E1）
+    {
+      const d = deps();
+      const legacy = join(dir, "valid.json");
+      writeFileSync(legacy, JSON.stringify({ notifyAsk: false, quietHours: { enabled: true, start: "23:00", end: "07:00" } }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, { performed: true, migrated: true, rolledBack: false, skippedCorrupt: false, skippedIdempotent: false, resumed: false }, "E8：合法 json outcome");
+      assert.ok(existsSync(legacy + MIGRATED_BAK_SUFFIX), "E8：合法 json 改名 migrated.bak");
+      assert.ok(!existsSync(legacy), "E8：原 json 已改名");
+      assert.deepEqual(d.updates[0], { notifyAsk: false, quietHours: { enabled: true, start: "23:00", end: "07:00" } }, "E8：写入键集 = sanitize 白名单");
+    }
+    // 写入失败 → 回滚改名（E6）：json 还原 + rolledBack
+    {
+      const d = deps(false, true);
+      const legacy = join(dir, "rollback.json");
+      writeFileSync(legacy, JSON.stringify({ notifyAsk: true }));
+      const out = await migrateLegacyConfig(legacy, d, { warn: () => {} });
+      assert.deepEqual(out, { performed: true, migrated: false, rolledBack: true, skippedCorrupt: false, skippedIdempotent: false, resumed: false }, "E8：写入失败回滚 outcome");
+      assert.ok(existsSync(legacy), "E8：回滚后原 json 还原");
+      assert.ok(!existsSync(legacy + MIGRATED_BAK_SUFFIX), "E8：回滚后 migrated.bak 已还原为 json");
+    }
+    rmSync(dir, { recursive: true, force: true });
   }
 } finally {
   rmSync(work, { recursive: true, force: true });

--- a/packages/dsh-notifier/test/migration.test.ts
+++ b/packages/dsh-notifier/test/migration.test.ts
@@ -1,0 +1,158 @@
+// @ts-nocheck
+/**
+ * dsh-notifier — e2e：存量配置迁移（issue #76 E1-E7 / R1）。
+ *
+ * 覆盖：
+ * - E1 旧 json 存在 → 一次性迁移至官方 settings user 层，原文改名 .migrated.bak；
+ * - E2 迁移幂等：二次启动 .bak 存在且 json 不存在且 user 层有值 → 跳过（不重复写入）；
+ * - E3 中断态重放：.migrated.bak 存在且 json 不存在且 user 层为空 → 重放写入；
+ * - E4 损坏/非对象/无有效键 → 改名 .corrupted.bak，不写入；
+ * - E5 Windows rename 目标已存在 → 先 unlink 旧 bak 再 rename；
+ * - E6 迁移写入失败 → 回滚改名（json 还原）+ warn，不阻塞启动；
+ * - E7 迁移前置于 enabled 判定（禁用态也迁移，路由/命名空间照常注册）。
+ */
+import { join } from "node:path";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { assert, makeNotifier, makeFakeSettings, makeFakeCtx } from "./helpers.ts";
+import { ROUTES, apply } from "../lib/index.js";
+
+const work = mkdtempSync(join(tmpdir(), "dnotify-migrate-"));
+/** 轮询直到谓词成立（替代固定 sleep：迁移是 onScope 内异步 fire-and-forget）。 */
+async function pollUntil(predicate, timeoutMs = 1000) {
+  const start = Date.now();
+  for (;;) {
+    if (predicate()) return true;
+    if (Date.now() - start > timeoutMs) return false;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+try {
+  // E1：旧 json 存在 → 迁移 + 改名 .migrated.bak
+  {
+    const legacy = join(work, "e1-dsh-notifier.json");
+    writeFileSync(legacy, JSON.stringify({ notifyAsk: false, quietHours: { enabled: true, start: "23:00", end: "07:00" } }));
+    // makeNotifier 的 configFile 指向旧 json；settings user 层预置空
+    const { settings } = makeNotifier(work, { configFile: legacy });
+    // 迁移在 onScope 内异步执行，轮询直到 user 层写入
+    await pollUntil(() => settings.getUser().notifyAsk === false);
+    const user = settings.getUser();
+    assert.equal(user.notifyAsk, false, "E1：notifyAsk 迁入 settings user 层");
+    assert.equal(user.quietHours?.enabled, true, "E1：quietHours 迁入 settings user 层");
+    assert.ok(existsSync(legacy + ".migrated.bak"), "E1：原文改名 .migrated.bak");
+    assert.ok(!existsSync(legacy), "E1：原 json 已改名（不再作为自建配置读取）");
+  }
+
+  // E2：迁移幂等——同一 settings 文档再次 apply（.bak 存在且 json 不存在且
+  // user 层有值）→ 不重复写入
+  {
+    const legacy = join(work, "e2-dsh-notifier.json");
+    writeFileSync(legacy, JSON.stringify({ notifyAsk: false }));
+    // 首次：共享 fake settings（user 层为空 → 触发迁移）
+    const shared = makeFakeSettings({});
+    const ctx1 = makeFakeCtx({});
+    ctx1.ctx.provide("settings", shared.service);
+    apply(ctx1.ctx, { enabled: true, configFile: legacy, historyFile: join(work, "e2-hist.jsonl") });
+    await pollUntil(() => shared.getUser().notifyAsk === false);
+    const callsAfterFirst = shared.getUpdateCalls().length;
+    assert.ok(callsAfterFirst >= 1, "E2：首次迁移触发写入");
+    // 二次：同一 settings 文档（user 层已有值）→ 幂等跳过（不触发 update）
+    const ctx2 = makeFakeCtx({});
+    ctx2.ctx.provide("settings", shared.service);
+    apply(ctx2.ctx, { enabled: true, configFile: legacy, historyFile: join(work, "e2-hist.jsonl") });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    const callsAfterSecond = shared.getUpdateCalls().length;
+    assert.equal(callsAfterSecond, callsAfterFirst, "E2：二次启动幂等跳过（不重复写入 settings）");
+    assert.equal(shared.getUser().notifyAsk, false, "E2：user 层保留首次迁移结果");
+  }
+
+  // E3：中断态重放——.migrated.bak 存在且 json 不存在且 user 层为空 → 重放写入
+  {
+    const legacy = join(work, "e3-dsh-notifier.json");
+    const bak = legacy + ".migrated.bak";
+    writeFileSync(bak, JSON.stringify({ notifyTaskDone: false })); // 模拟「改名成功但 update 前被杀」
+    const { settings } = makeNotifier(work, { configFile: legacy });
+    await pollUntil(() => settings.getUser().notifyTaskDone === false);
+    assert.equal(settings.getUser().notifyTaskDone, false, "E3：中断态从 bak 重放写入 settings");
+  }
+
+  // E4：损坏 json → 改名 .corrupted.bak，不写入
+  {
+    const legacy = join(work, "e4-dsh-notifier.json");
+    writeFileSync(legacy, "{ not json !!!");
+    const { settings } = makeNotifier(work, { configFile: legacy });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.deepEqual(settings.getUser(), {}, "E4：损坏 json 不写入 settings user 层");
+    assert.ok(existsSync(legacy + ".corrupted.bak"), "E4：损坏 json 改名 .corrupted.bak 标记");
+    assert.ok(!existsSync(legacy), "E4：损坏原文件已改名");
+  }
+
+  // E4b：非对象/无有效键 json → 只标记不写入
+  {
+    const legacy = join(work, "e4b-dsh-notifier.json");
+    writeFileSync(legacy, "123");
+    const { settings } = makeNotifier(work, { configFile: legacy });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.deepEqual(settings.getUser(), {}, "E4b：非对象 json 不写入");
+    assert.ok(existsSync(legacy + ".corrupted.bak"), "E4b：非对象 json 改名 .corrupted.bak");
+  }
+
+  // E5：Windows rename 目标已存在 → 先 unlink 旧 bak 再 rename（.migrated.bak 已存在）
+  {
+    const legacy = join(work, "e5-dsh-notifier.json");
+    const bak = legacy + ".migrated.bak";
+    writeFileSync(legacy, JSON.stringify({ notifyAsk: true }));
+    writeFileSync(bak, "old backup"); // 预置旧 bak（Windows 上 rename 目标已存在会抛错）
+    const { settings } = makeNotifier(work, { configFile: legacy });
+    await pollUntil(() => settings.getUser().notifyAsk === true);
+    assert.equal(settings.getUser().notifyAsk, true, "E5：rename 覆盖旧 bak 后迁移成功");
+    const newBak = readFileSync(bak, "utf8");
+    assert.ok(newBak.includes("notifyAsk"), "E5：新 bak 内容为本次迁移（旧 bak 已被 unlink 替换）");
+  }
+
+  // E6：迁移写入失败 → 回滚改名 + warn，不阻塞启动
+  {
+    const legacy = join(work, "e6-dsh-notifier.json");
+    writeFileSync(legacy, JSON.stringify({ notifyAsk: true }));
+    const warns = [];
+    // 用一个 update 必失败的 settings 服务（模拟持久化失败）
+    const { ctx, routes } = makeFakeCtx({
+      logger: { warn: (m) => warns.push(m), info: () => {} },
+    });
+    const failingSettings = {
+      register(ns, schema, opts) {
+        return {
+          get: () => ({ notifyAsk: true }),
+          watch: () => () => {},
+          update: async () => {},
+        };
+      },
+      describe: () => [{ ns: "dsh-notifier", user: {}, revision: 0 }],
+      async update(ns, patch) {
+        throw new Error("persist boom");
+      },
+    };
+    ctx.provide("settings", failingSettings);
+    apply(ctx, { enabled: true, configFile: legacy, historyFile: join(work, "e6-hist.jsonl") });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.ok(existsSync(legacy), "E6：写入失败回滚，原 json 还原");
+    assert.ok(warns.some((w) => w.includes("迁移")), "E6：迁移失败输出 warn 日志");
+    assert.ok(routes.length >= 5, "E6：迁移失败不阻塞路由注册");
+  }
+
+  // E7：enabled=false 禁用态仍迁移（H2/H3 前置）——禁用态 apply 仍注册路由 + 迁移照常
+  {
+    const legacy = join(work, "e7-dsh-notifier.json");
+    writeFileSync(legacy, JSON.stringify({ notifyTaskError: false }));
+    const fakeSettings = makeFakeSettings({});
+    const { ctx, routes } = makeFakeCtx({});
+    ctx.provide("settings", fakeSettings.service);
+    apply(ctx, { enabled: false, configFile: legacy, historyFile: join(work, "e7-hist.jsonl") });
+    await pollUntil(() => fakeSettings.getUser().notifyTaskError === false);
+    const paths = routes.map((r) => r.path);
+    for (const route of Object.values(ROUTES)) assert.ok(paths.includes(route), `E7：禁用态仍注册路由 ${route}`);
+    assert.equal(fakeSettings.getUser().notifyTaskError, false, "E7：禁用态仍迁移旧配置");
+  }
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}

--- a/packages/dsh-notifier/test/migration.test.ts
+++ b/packages/dsh-notifier/test/migration.test.ts
@@ -15,7 +15,7 @@ import { join } from "node:path";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { assert, makeNotifier, makeFakeSettings, makeFakeCtx } from "./helpers.ts";
-import { ROUTES, apply } from "../lib/index.js";
+import { ROUTES, apply, migrateLegacyConfig, MIGRATED_BAK_SUFFIX, CORRUPTED_BAK_SUFFIX } from "../lib/index.js";
 
 const work = mkdtempSync(join(tmpdir(), "dnotify-migrate-"));
 /** 轮询直到谓词成立（替代固定 sleep：迁移是 onScope 内异步 fire-and-forget）。 */
@@ -152,6 +152,122 @@ try {
     const paths = routes.map((r) => r.path);
     for (const route of Object.values(ROUTES)) assert.ok(paths.includes(route), `E7：禁用态仍注册路由 ${route}`);
     assert.equal(fakeSettings.getUser().notifyTaskError, false, "E7：禁用态仍迁移旧配置");
+  }
+
+  // E8：migrateLegacyConfig outcome 精确断言（直测，对照 stryker 幸存名单——
+  // 布尔结果字段翻转/逻辑运算符/条件分支的存活变异体由 outcome 深比较杀灭）
+  {
+    const dir = mkdtempSync(join(tmpdir(), "dnotify-migrate-outcome-"));
+    const deps = (userHasValues = false, failUpdate = false) => {
+      const updates = [];
+      return {
+        updates,
+        hasUserValues: () => userHasValues,
+        async update(patch) {
+          if (failUpdate) throw new Error("io boom");
+          updates.push(patch);
+        },
+      };
+    };
+    const IDLE = { performed: false, migrated: false, rolledBack: false, skippedCorrupt: false, skippedIdempotent: true, resumed: false };
+    const CORRUPT_ONLY = { performed: false, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: true, resumed: false };
+    // idle：json 与 bak 都不存在
+    {
+      const d = deps();
+      const legacy = join(dir, "idle.json");
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, IDLE, "E8：双文件不存在 → idle outcome 全 false/skippedIdempotent");
+      assert.equal(d.updates.length, 0, "E8：idle 不写入");
+    }
+    // 损坏标记态：只有 .corrupted.bak → 幂等跳过
+    {
+      const d = deps();
+      const legacy = join(dir, "corrupt-only.json");
+      writeFileSync(legacy + CORRUPTED_BAK_SUFFIX, "{oops");
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, CORRUPT_ONLY, "E8：损坏标记态 → skippedCorrupt+skippedIdempotent");
+      assert.equal(d.updates.length, 0, "E8：损坏标记态不写入");
+    }
+    // migrated.bak 存在 + user 层已有值 → 幂等跳过（E2）
+    {
+      const d = deps(true);
+      const legacy = join(dir, "bak-user.json");
+      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({ notifyAsk: false }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, IDLE, "E8：bak 存在 + user 有值 → 幂等跳过");
+      assert.equal(d.updates.length, 0, "E8：幂等跳过不写入");
+    }
+    // 中断态重放成功：bak 存在 + user 空 + bak 合法 → resumed+migrated
+    {
+      const d = deps(false);
+      const legacy = join(dir, "resume-ok.json");
+      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({ notifySound: false }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, { performed: false, migrated: true, rolledBack: false, skippedCorrupt: false, skippedIdempotent: false, resumed: true }, "E8：中断态重放成功 outcome");
+      assert.deepEqual(d.updates, [{ notifySound: false }], "E8：重放写入键集");
+    }
+    // 中断态重放失败：bak 非法 JSON → skippedCorrupt+resumed，不写入
+    {
+      const d = deps(false);
+      const legacy = join(dir, "resume-bad.json");
+      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, "{bad json");
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, { performed: false, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: true }, "E8：中断态 bak 损坏 → 标记跳过");
+      assert.equal(d.updates.length, 0, "E8：损坏 bak 不写入");
+    }
+    // 中断态重放失败：bak 无有效键 → skippedCorrupt+resumed
+    {
+      const d = deps(false);
+      const legacy = join(dir, "resume-empty.json");
+      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({ evilKey: 1 }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.equal(out.resumed, true, "E8：无有效键重放标记 resumed");
+      assert.equal(out.migrated, false, "E8：无有效键重放不迁移");
+      assert.equal(out.skippedCorrupt, true, "E8：无有效键重放标记 corrupted");
+      assert.equal(d.updates.length, 0, "E8：无有效键不写入");
+    }
+    // 损坏 json：只标记 .corrupted.bak，不写入（E4）
+    {
+      const d = deps();
+      const legacy = join(dir, "broken.json");
+      writeFileSync(legacy, "{ not json !!!");
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, { performed: true, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: false }, "E8：损坏 json outcome");
+      assert.ok(existsSync(legacy + CORRUPTED_BAK_SUFFIX), "E8：损坏 json 改名 corrupted.bak");
+      assert.equal(d.updates.length, 0, "E8：损坏 json 不写入");
+    }
+    // 非对象 json → 只标记（E4b）
+    {
+      const d = deps();
+      const legacy = join(dir, "nonobj.json");
+      writeFileSync(legacy, "123");
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.equal(out.performed, true, "E8：非对象 json performed");
+      assert.equal(out.skippedCorrupt, true, "E8：非对象 json 标记 corrupted");
+      assert.equal(d.updates.length, 0, "E8：非对象 json 不写入");
+    }
+    // 合法 json → renamed-first 后写入，outcome migrated+performed（E1）
+    {
+      const d = deps();
+      const legacy = join(dir, "valid.json");
+      writeFileSync(legacy, JSON.stringify({ notifyAsk: false, quietHours: { enabled: true, start: "23:00", end: "07:00" } }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, { performed: true, migrated: true, rolledBack: false, skippedCorrupt: false, skippedIdempotent: false, resumed: false }, "E8：合法 json outcome");
+      assert.ok(existsSync(legacy + MIGRATED_BAK_SUFFIX), "E8：合法 json 改名 migrated.bak");
+      assert.ok(!existsSync(legacy), "E8：原 json 已改名");
+      assert.deepEqual(d.updates[0], { notifyAsk: false, quietHours: { enabled: true, start: "23:00", end: "07:00" } }, "E8：写入键集 = sanitize 白名单");
+    }
+    // 写入失败 → 回滚改名（E6）：json 还原 + rolledBack
+    {
+      const d = deps(false, true);
+      const legacy = join(dir, "rollback.json");
+      writeFileSync(legacy, JSON.stringify({ notifyAsk: true }));
+      const out = await migrateLegacyConfig(legacy, d, { warn: () => {} });
+      assert.deepEqual(out, { performed: true, migrated: false, rolledBack: true, skippedCorrupt: false, skippedIdempotent: false, resumed: false }, "E8：写入失败回滚 outcome");
+      assert.ok(existsSync(legacy), "E8：回滚后原 json 还原");
+      assert.ok(!existsSync(legacy + MIGRATED_BAK_SUFFIX), "E8：回滚后 migrated.bak 已还原为 json");
+    }
+    rmSync(dir, { recursive: true, force: true });
   }
 } finally {
   rmSync(work, { recursive: true, force: true });

--- a/packages/dsh-notifier/test/routes.src.test.ts
+++ b/packages/dsh-notifier/test/routes.src.test.ts
@@ -18,7 +18,7 @@
 import { join } from "node:path";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { assert, makeNotifier, fakeReq, makeRes, waitForHistory, turnPair } from "./helpers.ts";
+import { assert, makeNotifier, fakeReq, makeRes, waitForHistory, turnPair, quietWindowNow } from "./helpers.ts";
 import { ROUTES } from "../src/index.ts";
 
 const work = mkdtempSync(join(tmpdir(), "dnotify-routes-"));
@@ -559,7 +559,9 @@ try {
 
   // D3：被免打扰拦截（suppressed: "quiet"）的记录在历史中标记（独立上下文）
   {
-    const qhAll = { enabled: true, start: "00:00", end: "23:59" };
+    // #181 动态窗口：写死 "00:00"/"23:59" 在半开区间镜下 23:59 这一分钟不命中
+    // （UTC 边缘必炸，run 33282203798 同源隐患）；围绕当前时间 ±2 分钟恒命中。
+    const qhAll = quietWindowNow();
     const { routes, listeners } = makeNotifier(work, { quietHours: { ...qhAll, allowKinds: ["ask"] }, historyFile: join(work, "history-quiet.jsonl") });
     const h = routes.find((r) => r.path === ROUTES.history);
     const status = listeners.get("agent/status")[0];

--- a/packages/dsh-notifier/test/routes.src.test.ts
+++ b/packages/dsh-notifier/test/routes.src.test.ts
@@ -2,26 +2,32 @@
 /**
  * dsh-notifier — e2e：HTTP 路由（config / events SSE / health / test / history）。
  *
- * 覆盖：路由注册面；403 loopback 围栏与 405 方法白名单；config GET/PUT
- * （落盘持久化 + 内存生效）；PUT 容错（非法 JSON 400、超大 body 不挂起）；
- * events SSE（头/connected/kind=test 广播/seq/?since 回放/非法 since）；
- * history（落盘轮询查询/并发写不丢/DELETE 清空/historyMaxAgeDays 按天清理）。
+ * 覆盖（issue #76 新契约）：
+ * - 五条路由注册面；403 loopback 围栏与 405 方法白名单（J1/J2）；
+ * - config GET：包装体 {ok, user, revision, effective, writable}（F1/A3）
+ *   与 user 层/revision 反映；
+ * - config PUT：{patch, expectedRevision} → 增量写入 settings user 层（F2/A2）；
+ *   A4 基线 diff（仅提交变更键 → service.update 只收到该 patch）；
+ *   F4 expectedRevision 可选（缺省不校验）；G1 409 版本冲突 / G2 503
+ *   settings-unavailable / G3 写入异常 500 不含原文 / G4 首个非法键 400 + hint；
+ * - PUT 容错：非法 JSON 400、超大 body 不挂起（J3/J4）；
+ * - events SSE：connected 首帧（C1）、kind=test 广播、seq、?since 回放（C7）；
+ * - history：落盘轮询（D4）/DELETE 清空（D7）/historyMaxAgeDays 按天清理（D5）
+ *   /200 滚动上限（D6）；免打扰拦截 suppressed:quiet（D3）。
  */
 import { join } from "node:path";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { assert, makeNotifier, fakeReq, makeRes, waitForHistory } from "./helpers.ts";
+import { assert, makeNotifier, fakeReq, makeRes, waitForHistory, turnPair } from "./helpers.ts";
 import { ROUTES } from "../src/index.ts";
 
 const work = mkdtempSync(join(tmpdir(), "dnotify-routes-"));
 let mainNotifier;
 try {
-  const storeFile = join(work, "config.json");
-
   // 独立 history 文件：隔离其他测试块的 fire-and-forget 异步写盘，
   // 避免跨 apply 实例对同一 history.jsonl 的 read-modify-write 竞态把 test 挤出末尾（issue #17）。
-  mainNotifier = await makeNotifier(work, { configFile: storeFile, historyFile: join(work, "history-route.jsonl") });
-  const { routes } = mainNotifier;
+  mainNotifier = makeNotifier(work, { historyFile: join(work, "history-route.jsonl") });
+  const { routes, settings } = mainNotifier;
   const configRoute = routes.find((r) => r.path === ROUTES.config);
   const eventsRoute = routes.find((r) => r.path === ROUTES.events);
   const healthRoute = routes.find((r) => r.path === ROUTES.health);
@@ -29,14 +35,14 @@ try {
   const historyRoute = routes.find((r) => r.path === ROUTES.history);
   assert.ok(configRoute && eventsRoute && healthRoute && testRoute && historyRoute, "五条路由已注册");
 
-  // 403
+  // 403（J1）
   for (const route of [configRoute, eventsRoute, healthRoute, testRoute, historyRoute]) {
     const { rec, res } = makeRes();
     await route.handler(fakeReq({ socket: { remoteAddress: "10.0.0.2" } }), res);
     assert.equal(rec.status, 403);
   }
 
-  // 405：test 路由仅 POST；history 路由仅 GET；health 仅 GET
+  // 405（J2）：test 路由仅 POST；history 路由仅 GET；health 仅 GET
   {
     const { rec, res } = makeRes();
     await testRoute.handler(fakeReq({}), res);
@@ -62,15 +68,20 @@ try {
     assert.equal(typeof body.sseConnections, "number");
   }
 
-  // config GET：默认值
+  // config GET：包装体 {ok, user, revision, effective, writable}（F1/A3）
   {
     const { rec, res } = makeRes();
     await configRoute.handler(fakeReq({}), res);
     assert.equal(rec.status, 200);
-    assert.equal(JSON.parse(rec.text).notifyAsk, true);
+    const body = JSON.parse(rec.text);
+    assert.equal(body.ok, true, "GET 带 ok 标记");
+    assert.deepEqual(body.user, {}, "初始 user 层为空（未设过值）");
+    assert.equal(typeof body.revision, "number");
+    assert.equal(body.effective.notifyAsk, true, "effective 含默认值");
+    assert.equal(body.writable, true, "settings 可用时 writable=true");
   }
 
-  // config PUT：持久化 + 内存生效
+  // config PUT：{patch, expectedRevision} → settings user 层增量写入（F2/A2）
   {
     function bodyReq(payload) {
       const text = JSON.stringify(payload);
@@ -88,20 +99,55 @@ try {
       };
     }
     const { rec, res } = makeRes();
-    await configRoute.handler(bodyReq({ notifyAsk: false, quietHours: { enabled: true, start: "23:00", end: "07:00" } }), res);
+    await configRoute.handler(bodyReq({ patch: { notifyAsk: false } }), res);
     assert.equal(rec.status, 200);
-    assert.equal(JSON.parse(rec.text).notifyAsk, false);
-    const stored = JSON.parse(readFileSync(storeFile, "utf8"));
-    assert.equal(stored.notifyAsk, false);
-    assert.equal(stored.quietHours.start, "23:00");
+    const body = JSON.parse(rec.text);
+    assert.equal(body.ok, true);
+    assert.equal(body.user.notifyAsk, false, "user 层反映新值");
+    assert.equal(typeof body.revision, "number");
+    // settings 命名空间 user 层已写入（非自建 json 文件）
+    assert.equal(settings.getUser().notifyAsk, false, "PUT 写官方 settings 命名空间 user 层（非 dsh-notifier.json）");
 
-    // GET 反映新值
+    // GET 反映新值（effective + user）
     const { rec: rec2, res: res2 } = makeRes();
     await configRoute.handler(fakeReq({}), res2);
-    assert.equal(JSON.parse(rec2.text).notifyAsk, false);
+    const getBody = JSON.parse(rec2.text);
+    assert.equal(getBody.user.notifyAsk, false, "GET user 层反映新值");
+    assert.equal(getBody.effective.notifyAsk, false, "GET effective 反映新值");
+    assert.equal(getBody.effective.quietHours.start, "22:00", "未提交的键保留 schema 默认");
   }
 
-  // config PUT 容错：非法 JSON → 400；超大 body → 不挂起、无未处理拒绝
+  // A4 基线 diff：PUT 仅含变更键 → service.update 只收到该 patch（不整表覆盖）
+  {
+    const calls = settings.getUpdateCalls();
+    const lastCall = calls[calls.length - 1];
+    assert.ok(lastCall, "PUT 触发 service.update");
+    assert.deepEqual(lastCall.patch, { notifyAsk: false }, "service.update 只收到变更键（增量 patch，非整表）");
+  }
+
+  // F4 expectedRevision 缺省：无冲突检测（不带 revision 的 PUT 成功）
+  {
+    function bodyReq(payload) {
+      const text = JSON.stringify(payload);
+      return {
+        method: "PUT",
+        url: "/",
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+        on(event, cb) {
+          if (event === "data") setTimeout(() => cb(Buffer.from(text)), 0);
+          else if (event === "end") setTimeout(cb, 1);
+          return this;
+        },
+        destroy() {},
+      };
+    }
+    const { rec, res } = makeRes();
+    await configRoute.handler(bodyReq({ patch: { notifyQuestion: false } }), res);
+    assert.equal(rec.status, 200, "缺省 expectedRevision 的 PUT 成功");
+  }
+
+  // config PUT 容错：非法 JSON → 400；超大 body → 不挂起、无未处理拒绝（J3/J4）
   {
     function rawBodyReq(text) {
       return {
@@ -125,7 +171,134 @@ try {
     assert.equal(rec2.status, 0, "超大 body：连接被 destroy、handler 无响应但不挂起不抛错");
   }
 
-  // events SSE
+  // G4 首个非法键 hint → 400（quietHours.start=25:00）
+  {
+    function bodyReq(payload) {
+      const text = JSON.stringify(payload);
+      return {
+        method: "PUT",
+        url: "/",
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+        on(event, cb) {
+          if (event === "data") setTimeout(() => cb(Buffer.from(text)), 0);
+          else if (event === "end") setTimeout(cb, 1);
+          return this;
+        },
+        destroy() {},
+      };
+    }
+    const { rec, res } = makeRes();
+    await configRoute.handler(bodyReq({ patch: { quietHours: { start: "25:00" } } }), res);
+    assert.equal(rec.status, 400, "非法键 400");
+    const body = JSON.parse(rec.text);
+    assert.equal(body.ok, false);
+    assert.match(body.error.error, /配置校验失败/, "400 带「配置校验失败」");
+    assert.ok(body.error.hint, "400 带 hint（合法范围描述）");
+  }
+
+  // G1：SETTINGS_CONFLICT → 409 固定文案（expectedRevision 过期 → service.update 抛冲突）
+  {
+    function bodyReq(payload) {
+      const text = JSON.stringify(payload);
+      return {
+        method: "PUT",
+        url: "/",
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+        on(event, cb) {
+          if (event === "data") setTimeout(() => cb(Buffer.from(text)), 0);
+          else if (event === "end") setTimeout(cb, 1);
+          return this;
+        },
+        destroy() {},
+      };
+    }
+    // 独立实例：先写入推进 revision，再用旧 revision PUT → 服务端冲突 409
+    const { routes: conflictRoutes, settings: conflictSettings } = makeNotifier(work, { historyFile: join(work, "history-conflict.jsonl") });
+    const cfgRoute = conflictRoutes.find((r) => r.path === ROUTES.config);
+    // 首次写入，revision 前进
+    await cfgRoute.handler(bodyReq({ patch: { notifyAsk: true } }), makeRes().res);
+    const staleRevision = conflictSettings.getRevision();
+    // 直接推进 user 层 revision（模拟其他窗口修改）
+    await conflictSettings.service.update("dsh-notifier", { notifyQuestion: true });
+    const { rec, res } = makeRes();
+    await cfgRoute.handler(bodyReq({ patch: { notifySound: false }, expectedRevision: staleRevision }), res);
+    assert.equal(rec.status, 409, "expectedRevision 过期 → 409");
+    const body = JSON.parse(rec.text);
+    assert.equal(body.ok, false);
+    assert.equal(body.error.code, "SETTINGS_CONFLICT", "409 带 code=SETTINGS_CONFLICT");
+    assert.match(body.error.error, /版本冲突/, "409 固定文案「版本冲突」");
+  }
+
+  // G2：settings 服务缺失（未 attach）→ PUT 503 settings-unavailable
+  {
+    const { apply } = await import("../lib/index.js");
+    const { makeFakeCtx } = await import("./helpers.ts");
+    // 不 provide settings 服务 → writable=false
+    const { ctx, routes } = makeFakeCtx({});
+    apply(ctx, { enabled: true, configFile: join(work, "no-settings-cfg.json"), historyFile: join(work, "no-settings-hist.jsonl") });
+    const cfgRoute = routes.find((r) => r.path === ROUTES.config);
+    const text = JSON.stringify({ patch: { notifyAsk: false } });
+    const { rec, res } = makeRes();
+    await cfgRoute.handler({
+      method: "PUT",
+      url: "/",
+      socket: { remoteAddress: "127.0.0.1" },
+      headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+      on(event, cb) {
+        if (event === "data") setTimeout(() => cb(Buffer.from(text)), 0);
+        else if (event === "end") setTimeout(cb, 1);
+        return this;
+      },
+      destroy() {},
+    }, res);
+    assert.equal(rec.status, 503, "settings 缺失 → 503");
+    const body = JSON.parse(rec.text);
+    assert.equal(body.error.code, "settings-unavailable", "503 带 code=settings-unavailable");
+    assert.match(body.error.error, /设置服务不可用/, "503 固定文案「设置服务不可用」");
+  }
+
+  // G3：写入异常原文只进服务端日志 → 500 收敛固定文案（不含底层异常原文）
+  {
+    const { apply } = await import("../lib/index.js");
+    const { makeFakeCtx } = await import("./helpers.ts");
+    const warns = [];
+    const failingSettings = {
+      register(ns, schema, opts) {
+        return { get: () => ({ notifyAsk: true }), watch: () => () => {}, update: async () => {} };
+      },
+      describe: () => [{ ns: "dsh-notifier", user: {}, revision: 0 }],
+      async update(ns, patch) {
+        throw new Error("secret-internal-path /home/user/.config/boom");
+      },
+    };
+    const { ctx, routes } = makeFakeCtx({ logger: { warn: (m) => warns.push(m), info: () => {} } });
+    ctx.provide("settings", failingSettings);
+    apply(ctx, { enabled: true, configFile: join(work, "g3-cfg.json"), historyFile: join(work, "g3-hist.jsonl") });
+    const cfgRoute = routes.find((r) => r.path === ROUTES.config);
+    const text = JSON.stringify({ patch: { notifyAsk: false } });
+    const { rec, res } = makeRes();
+    await cfgRoute.handler({
+      method: "PUT",
+      url: "/",
+      socket: { remoteAddress: "127.0.0.1" },
+      headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+      on(event, cb) {
+        if (event === "data") setTimeout(() => cb(Buffer.from(text)), 0);
+        else if (event === "end") setTimeout(cb, 1);
+        return this;
+      },
+      destroy() {},
+    }, res);
+    assert.equal(rec.status, 500, "写入异常 → 500");
+    const body = JSON.parse(rec.text);
+    assert.ok(!rec.text.includes("secret-internal-path"), "500 响应不含底层异常原文（P2-2）");
+    assert.match(body.error.error, /保存失败/, "500 收敛固定文案");
+    assert.ok(warns.some((w) => w.includes("secret-internal-path")), "异常原文进服务端日志");
+  }
+
+  // events SSE（C1）
   {
     const { rec, res } = makeRes();
     await eventsRoute.handler(fakeReq({}), res);
@@ -148,9 +321,9 @@ try {
     assert.match(rec1.text, /"seq":\d+/, "通知帧带递增 seq");
   }
 
-  // events ?since 回放（独立上下文，seq 从 1 起）：断线补拉不丢尾部事件
+  // events ?since 回放（独立上下文，seq 从 1 起）：断线补拉不丢尾部事件（C7）
   {
-    const notifier2 = await makeNotifier(work, { historyFile: join(work, "history-since.jsonl") });
+    const notifier2 = makeNotifier(work, { historyFile: join(work, "history-since.jsonl") });
     const { routes: routes2 } = notifier2;
     const eventsRoute2 = routes2.find((r) => r.path === ROUTES.events);
     const testRoute2 = routes2.find((r) => r.path === ROUTES.test);
@@ -212,9 +385,9 @@ try {
     }
     /** 独立实例路由查找（每次全新连接表）。 */
     async function freshRoutes(mark, maxConnections) {
-      const cfg = join(work, `sse-${mark}-cfg.json`);
-      writeFileSync(cfg, JSON.stringify({ maxConnections }));
-      const out = await makeNotifier(work, { configFile: cfg, historyFile: join(work, `sse-${mark}.jsonl`) });
+      // issue #76 后配置走 settings 命名空间（configFile 仅作迁移源）：maxConnections
+      // 直接经组合层 entry 注入（sanitizeSettings 白名单 → 命名空间 base 层）。
+      const out = await makeNotifier(work, { maxConnections, historyFile: join(work, `sse-${mark}.jsonl`) });
       const near = (p) => out.routes.find((r) => r.path === p);
       return { ev: near(ROUTES.events), he: near(ROUTES.health), te: near(ROUTES.test), cfgR: near(ROUTES.config), dispose: out.dispose };
     }
@@ -291,8 +464,8 @@ try {
       await ev.handler(fakeReq({}), r2);
       await ev.handler(fakeReq({}), r3);
       assert.equal(await connCount(he), 3, "默认上限 16 下注册 3 条不淘汰");
-      // PUT maxConnections=2（内存生效 + 落盘，沿用现有 bodyReq 模式）
-      const text = JSON.stringify({ maxConnections: 2 });
+      // PUT {patch:{maxConnections:2}} → settings user 层（#76 新契约 F2/A2）
+      const text = JSON.stringify({ patch: { maxConnections: 2 } });
       const putReq = {
         method: "PUT",
         url: "/",
@@ -307,7 +480,8 @@ try {
       };
       const { rec, res } = makeRes();
       await cfgR.handler(putReq, res);
-      assert.equal(JSON.parse(rec.text).maxConnections, 2, "PUT 后配置生效");
+      assert.equal(JSON.parse(rec.text).ok, true, "PUT 后配置生效");
+      assert.equal(JSON.parse(rec.text).user.maxConnections, 2, "PUT 写 settings user 层");
       // 新注册触发 enforceLimit → 收缩到 2（淘汰最老 r1、r2）
       const r4 = sseRes();
       await ev.handler(fakeReq({}), r4);
@@ -332,7 +506,7 @@ try {
     }
   }
 
-  // history：测试通知已落盘，GET 可查（独立 history 文件，无跨块串扰）
+  // history：测试通知已落盘，GET 可查（独立 history 文件，无跨块串扰）（D4）
   {
     // appendHistory 是 fire-and-forget；轮询直到落盘，不再依赖固定 sleep 的时序假设
     const records = await waitForHistory(historyRoute, (rs) => rs.length >= 1 && rs[rs.length - 1]?.kind === "test");
@@ -355,16 +529,14 @@ try {
     assert.ok(testCount >= concurrent, `并发写不丢记录（test 记录 ${testCount} ≥ ${concurrent}）`);
   }
 
-  // history：DELETE 清空 + historyMaxAgeDays 按天清理（独立上下文，隔离其他用例）
+  // history：DELETE 清空（D7）+ historyMaxAgeDays 按天清理（D5）（独立上下文）
   {
     const hfile = join(work, "history-clean.jsonl");
-    const hcfg = join(work, "history-clean-cfg.json");
-    writeFileSync(hcfg, JSON.stringify({ historyMaxAgeDays: 7 }));
-    // 预置一条 10 天前的旧记录
-    writeFileSync(hfile, JSON.stringify({ ts: Date.now() - 10 * 86400000, kind: "done", title: "旧记录", message: "10 天前" }) + "\n");
-    const { routes, dispose: disposeClean } = await makeNotifier(work, { historyFile: hfile, configFile: hcfg });
+    const { routes, dispose: disposeClean } = makeNotifier(work, { historyFile: hfile, historyMaxAgeDays: 7 });
     const h = routes.find((r) => r.path === ROUTES.history);
     const t = routes.find((r) => r.path === ROUTES.test);
+    // 预置一条 10 天前的旧记录
+    writeFileSync(hfile, JSON.stringify({ ts: Date.now() - 10 * 86400000, kind: "done", title: "旧记录", message: "10 天前" }) + "\n");
     // 触发一条新通知（test 路由 → 落盘；写时会按 7 天 cutoff 剔除旧行）
     await t.handler(fakeReq({ method: "POST" }), makeRes().res);
     await new Promise((resolve) => setTimeout(resolve, 80)); // 等写队列排空
@@ -383,6 +555,34 @@ try {
     await h.handler(fakeReq({}), resEmpty);
     assert.equal(JSON.parse(recEmpty.text).records.length, 0, "清空后 GET 为空");
     disposeClean(); // 停心跳（P2-5）
+  }
+
+  // D3：被免打扰拦截（suppressed: "quiet"）的记录在历史中标记（独立上下文）
+  {
+    const qhAll = { enabled: true, start: "00:00", end: "23:59" };
+    const { routes, listeners } = makeNotifier(work, { quietHours: { ...qhAll, allowKinds: ["ask"] }, historyFile: join(work, "history-quiet.jsonl") });
+    const h = routes.find((r) => r.path === ROUTES.history);
+    const status = listeners.get("agent/status")[0];
+    // #290 阶段二两态时序：running=上一轮（首轮无 closure），idle=本轮 turn 1 completed
+    const pair = turnPair("q-1", "免打扰完成", {}, { turn: 1 });
+    status({ agent: pair.running, status: "running" });
+    status({ agent: pair.idle, status: "idle" });
+    const records = await waitForHistory(h, (rs) => rs.some((e) => e.kind === "done" && e.suppressed === "quiet"));
+    assert.ok(records.some((e) => e.kind === "done" && e.suppressed === "quiet"), "免打扰拦截记录带 suppressed:quiet 标记");
+  }
+
+  // D6：200 条滚动上限（独立上下文，预置 210 条 → 读取只保留最近 200）
+  {
+    const hfile = join(work, "history-limit.jsonl");
+    const lines = Array.from({ length: 210 }, (_, i) => JSON.stringify({ ts: Date.now() + i, kind: "test", title: "t", message: `m${i}` })).join("\n") + "\n";
+    writeFileSync(hfile, lines);
+    const { routes } = makeNotifier(work, { historyFile: hfile });
+    const h = routes.find((r) => r.path === ROUTES.history);
+    const { rec, res } = makeRes();
+    await h.handler(fakeReq({}), res);
+    const records = JSON.parse(rec.text).records;
+    assert.ok(records.length <= 200, "滚动上限 200：读取最多 200 条");
+    assert.equal(records[records.length - 1].message, "m209", "保留的是最新记录");
   }
 } finally {
   mainNotifier.dispose(); // 停心跳（P2-5：30s unref 定时器不在测试进程存活期残留）

--- a/packages/dsh-notifier/test/routes.test.ts
+++ b/packages/dsh-notifier/test/routes.test.ts
@@ -18,7 +18,7 @@
 import { join } from "node:path";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { assert, makeNotifier, fakeReq, makeRes, waitForHistory, turnPair } from "./helpers.ts";
+import { assert, makeNotifier, fakeReq, makeRes, waitForHistory, turnPair, quietWindowNow } from "./helpers.ts";
 import { ROUTES } from "../lib/index.js";
 
 const work = mkdtempSync(join(tmpdir(), "dnotify-routes-"));
@@ -559,7 +559,9 @@ try {
 
   // D3：被免打扰拦截（suppressed: "quiet"）的记录在历史中标记（独立上下文）
   {
-    const qhAll = { enabled: true, start: "00:00", end: "23:59" };
+    // #181 动态窗口：写死 "00:00"/"23:59" 在半开区间镜下 23:59 这一分钟不命中
+    // （UTC 边缘必炸，run 33282203798 同源隐患）；围绕当前时间 ±2 分钟恒命中。
+    const qhAll = quietWindowNow();
     const { routes, listeners } = makeNotifier(work, { quietHours: { ...qhAll, allowKinds: ["ask"] }, historyFile: join(work, "history-quiet.jsonl") });
     const h = routes.find((r) => r.path === ROUTES.history);
     const status = listeners.get("agent/status")[0];

--- a/packages/dsh-notifier/test/routes.test.ts
+++ b/packages/dsh-notifier/test/routes.test.ts
@@ -2,26 +2,32 @@
 /**
  * dsh-notifier — e2e：HTTP 路由（config / events SSE / health / test / history）。
  *
- * 覆盖：路由注册面；403 loopback 围栏与 405 方法白名单；config GET/PUT
- * （落盘持久化 + 内存生效）；PUT 容错（非法 JSON 400、超大 body 不挂起）；
- * events SSE（头/connected/kind=test 广播/seq/?since 回放/非法 since）；
- * history（落盘轮询查询/并发写不丢/DELETE 清空/historyMaxAgeDays 按天清理）。
+ * 覆盖（issue #76 新契约）：
+ * - 五条路由注册面；403 loopback 围栏与 405 方法白名单（J1/J2）；
+ * - config GET：包装体 {ok, user, revision, effective, writable}（F1/A3）
+ *   与 user 层/revision 反映；
+ * - config PUT：{patch, expectedRevision} → 增量写入 settings user 层（F2/A2）；
+ *   A4 基线 diff（仅提交变更键 → service.update 只收到该 patch）；
+ *   F4 expectedRevision 可选（缺省不校验）；G1 409 版本冲突 / G2 503
+ *   settings-unavailable / G3 写入异常 500 不含原文 / G4 首个非法键 400 + hint；
+ * - PUT 容错：非法 JSON 400、超大 body 不挂起（J3/J4）；
+ * - events SSE：connected 首帧（C1）、kind=test 广播、seq、?since 回放（C7）；
+ * - history：落盘轮询（D4）/DELETE 清空（D7）/historyMaxAgeDays 按天清理（D5）
+ *   /200 滚动上限（D6）；免打扰拦截 suppressed:quiet（D3）。
  */
 import { join } from "node:path";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { assert, makeNotifier, fakeReq, makeRes, waitForHistory } from "./helpers.ts";
+import { assert, makeNotifier, fakeReq, makeRes, waitForHistory, turnPair } from "./helpers.ts";
 import { ROUTES } from "../lib/index.js";
 
 const work = mkdtempSync(join(tmpdir(), "dnotify-routes-"));
 let mainNotifier;
 try {
-  const storeFile = join(work, "config.json");
-
   // 独立 history 文件：隔离其他测试块的 fire-and-forget 异步写盘，
   // 避免跨 apply 实例对同一 history.jsonl 的 read-modify-write 竞态把 test 挤出末尾（issue #17）。
-  mainNotifier = await makeNotifier(work, { configFile: storeFile, historyFile: join(work, "history-route.jsonl") });
-  const { routes } = mainNotifier;
+  mainNotifier = makeNotifier(work, { historyFile: join(work, "history-route.jsonl") });
+  const { routes, settings } = mainNotifier;
   const configRoute = routes.find((r) => r.path === ROUTES.config);
   const eventsRoute = routes.find((r) => r.path === ROUTES.events);
   const healthRoute = routes.find((r) => r.path === ROUTES.health);
@@ -29,14 +35,14 @@ try {
   const historyRoute = routes.find((r) => r.path === ROUTES.history);
   assert.ok(configRoute && eventsRoute && healthRoute && testRoute && historyRoute, "五条路由已注册");
 
-  // 403
+  // 403（J1）
   for (const route of [configRoute, eventsRoute, healthRoute, testRoute, historyRoute]) {
     const { rec, res } = makeRes();
     await route.handler(fakeReq({ socket: { remoteAddress: "10.0.0.2" } }), res);
     assert.equal(rec.status, 403);
   }
 
-  // 405：test 路由仅 POST；history 路由仅 GET；health 仅 GET
+  // 405（J2）：test 路由仅 POST；history 路由仅 GET；health 仅 GET
   {
     const { rec, res } = makeRes();
     await testRoute.handler(fakeReq({}), res);
@@ -62,15 +68,20 @@ try {
     assert.equal(typeof body.sseConnections, "number");
   }
 
-  // config GET：默认值
+  // config GET：包装体 {ok, user, revision, effective, writable}（F1/A3）
   {
     const { rec, res } = makeRes();
     await configRoute.handler(fakeReq({}), res);
     assert.equal(rec.status, 200);
-    assert.equal(JSON.parse(rec.text).notifyAsk, true);
+    const body = JSON.parse(rec.text);
+    assert.equal(body.ok, true, "GET 带 ok 标记");
+    assert.deepEqual(body.user, {}, "初始 user 层为空（未设过值）");
+    assert.equal(typeof body.revision, "number");
+    assert.equal(body.effective.notifyAsk, true, "effective 含默认值");
+    assert.equal(body.writable, true, "settings 可用时 writable=true");
   }
 
-  // config PUT：持久化 + 内存生效
+  // config PUT：{patch, expectedRevision} → settings user 层增量写入（F2/A2）
   {
     function bodyReq(payload) {
       const text = JSON.stringify(payload);
@@ -88,20 +99,55 @@ try {
       };
     }
     const { rec, res } = makeRes();
-    await configRoute.handler(bodyReq({ notifyAsk: false, quietHours: { enabled: true, start: "23:00", end: "07:00" } }), res);
+    await configRoute.handler(bodyReq({ patch: { notifyAsk: false } }), res);
     assert.equal(rec.status, 200);
-    assert.equal(JSON.parse(rec.text).notifyAsk, false);
-    const stored = JSON.parse(readFileSync(storeFile, "utf8"));
-    assert.equal(stored.notifyAsk, false);
-    assert.equal(stored.quietHours.start, "23:00");
+    const body = JSON.parse(rec.text);
+    assert.equal(body.ok, true);
+    assert.equal(body.user.notifyAsk, false, "user 层反映新值");
+    assert.equal(typeof body.revision, "number");
+    // settings 命名空间 user 层已写入（非自建 json 文件）
+    assert.equal(settings.getUser().notifyAsk, false, "PUT 写官方 settings 命名空间 user 层（非 dsh-notifier.json）");
 
-    // GET 反映新值
+    // GET 反映新值（effective + user）
     const { rec: rec2, res: res2 } = makeRes();
     await configRoute.handler(fakeReq({}), res2);
-    assert.equal(JSON.parse(rec2.text).notifyAsk, false);
+    const getBody = JSON.parse(rec2.text);
+    assert.equal(getBody.user.notifyAsk, false, "GET user 层反映新值");
+    assert.equal(getBody.effective.notifyAsk, false, "GET effective 反映新值");
+    assert.equal(getBody.effective.quietHours.start, "22:00", "未提交的键保留 schema 默认");
   }
 
-  // config PUT 容错：非法 JSON → 400；超大 body → 不挂起、无未处理拒绝
+  // A4 基线 diff：PUT 仅含变更键 → service.update 只收到该 patch（不整表覆盖）
+  {
+    const calls = settings.getUpdateCalls();
+    const lastCall = calls[calls.length - 1];
+    assert.ok(lastCall, "PUT 触发 service.update");
+    assert.deepEqual(lastCall.patch, { notifyAsk: false }, "service.update 只收到变更键（增量 patch，非整表）");
+  }
+
+  // F4 expectedRevision 缺省：无冲突检测（不带 revision 的 PUT 成功）
+  {
+    function bodyReq(payload) {
+      const text = JSON.stringify(payload);
+      return {
+        method: "PUT",
+        url: "/",
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+        on(event, cb) {
+          if (event === "data") setTimeout(() => cb(Buffer.from(text)), 0);
+          else if (event === "end") setTimeout(cb, 1);
+          return this;
+        },
+        destroy() {},
+      };
+    }
+    const { rec, res } = makeRes();
+    await configRoute.handler(bodyReq({ patch: { notifyQuestion: false } }), res);
+    assert.equal(rec.status, 200, "缺省 expectedRevision 的 PUT 成功");
+  }
+
+  // config PUT 容错：非法 JSON → 400；超大 body → 不挂起、无未处理拒绝（J3/J4）
   {
     function rawBodyReq(text) {
       return {
@@ -125,7 +171,134 @@ try {
     assert.equal(rec2.status, 0, "超大 body：连接被 destroy、handler 无响应但不挂起不抛错");
   }
 
-  // events SSE
+  // G4 首个非法键 hint → 400（quietHours.start=25:00）
+  {
+    function bodyReq(payload) {
+      const text = JSON.stringify(payload);
+      return {
+        method: "PUT",
+        url: "/",
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+        on(event, cb) {
+          if (event === "data") setTimeout(() => cb(Buffer.from(text)), 0);
+          else if (event === "end") setTimeout(cb, 1);
+          return this;
+        },
+        destroy() {},
+      };
+    }
+    const { rec, res } = makeRes();
+    await configRoute.handler(bodyReq({ patch: { quietHours: { start: "25:00" } } }), res);
+    assert.equal(rec.status, 400, "非法键 400");
+    const body = JSON.parse(rec.text);
+    assert.equal(body.ok, false);
+    assert.match(body.error.error, /配置校验失败/, "400 带「配置校验失败」");
+    assert.ok(body.error.hint, "400 带 hint（合法范围描述）");
+  }
+
+  // G1：SETTINGS_CONFLICT → 409 固定文案（expectedRevision 过期 → service.update 抛冲突）
+  {
+    function bodyReq(payload) {
+      const text = JSON.stringify(payload);
+      return {
+        method: "PUT",
+        url: "/",
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+        on(event, cb) {
+          if (event === "data") setTimeout(() => cb(Buffer.from(text)), 0);
+          else if (event === "end") setTimeout(cb, 1);
+          return this;
+        },
+        destroy() {},
+      };
+    }
+    // 独立实例：先写入推进 revision，再用旧 revision PUT → 服务端冲突 409
+    const { routes: conflictRoutes, settings: conflictSettings } = makeNotifier(work, { historyFile: join(work, "history-conflict.jsonl") });
+    const cfgRoute = conflictRoutes.find((r) => r.path === ROUTES.config);
+    // 首次写入，revision 前进
+    await cfgRoute.handler(bodyReq({ patch: { notifyAsk: true } }), makeRes().res);
+    const staleRevision = conflictSettings.getRevision();
+    // 直接推进 user 层 revision（模拟其他窗口修改）
+    await conflictSettings.service.update("dsh-notifier", { notifyQuestion: true });
+    const { rec, res } = makeRes();
+    await cfgRoute.handler(bodyReq({ patch: { notifySound: false }, expectedRevision: staleRevision }), res);
+    assert.equal(rec.status, 409, "expectedRevision 过期 → 409");
+    const body = JSON.parse(rec.text);
+    assert.equal(body.ok, false);
+    assert.equal(body.error.code, "SETTINGS_CONFLICT", "409 带 code=SETTINGS_CONFLICT");
+    assert.match(body.error.error, /版本冲突/, "409 固定文案「版本冲突」");
+  }
+
+  // G2：settings 服务缺失（未 attach）→ PUT 503 settings-unavailable
+  {
+    const { apply } = await import("../lib/index.js");
+    const { makeFakeCtx } = await import("./helpers.ts");
+    // 不 provide settings 服务 → writable=false
+    const { ctx, routes } = makeFakeCtx({});
+    apply(ctx, { enabled: true, configFile: join(work, "no-settings-cfg.json"), historyFile: join(work, "no-settings-hist.jsonl") });
+    const cfgRoute = routes.find((r) => r.path === ROUTES.config);
+    const text = JSON.stringify({ patch: { notifyAsk: false } });
+    const { rec, res } = makeRes();
+    await cfgRoute.handler({
+      method: "PUT",
+      url: "/",
+      socket: { remoteAddress: "127.0.0.1" },
+      headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+      on(event, cb) {
+        if (event === "data") setTimeout(() => cb(Buffer.from(text)), 0);
+        else if (event === "end") setTimeout(cb, 1);
+        return this;
+      },
+      destroy() {},
+    }, res);
+    assert.equal(rec.status, 503, "settings 缺失 → 503");
+    const body = JSON.parse(rec.text);
+    assert.equal(body.error.code, "settings-unavailable", "503 带 code=settings-unavailable");
+    assert.match(body.error.error, /设置服务不可用/, "503 固定文案「设置服务不可用」");
+  }
+
+  // G3：写入异常原文只进服务端日志 → 500 收敛固定文案（不含底层异常原文）
+  {
+    const { apply } = await import("../lib/index.js");
+    const { makeFakeCtx } = await import("./helpers.ts");
+    const warns = [];
+    const failingSettings = {
+      register(ns, schema, opts) {
+        return { get: () => ({ notifyAsk: true }), watch: () => () => {}, update: async () => {} };
+      },
+      describe: () => [{ ns: "dsh-notifier", user: {}, revision: 0 }],
+      async update(ns, patch) {
+        throw new Error("secret-internal-path /home/user/.config/boom");
+      },
+    };
+    const { ctx, routes } = makeFakeCtx({ logger: { warn: (m) => warns.push(m), info: () => {} } });
+    ctx.provide("settings", failingSettings);
+    apply(ctx, { enabled: true, configFile: join(work, "g3-cfg.json"), historyFile: join(work, "g3-hist.jsonl") });
+    const cfgRoute = routes.find((r) => r.path === ROUTES.config);
+    const text = JSON.stringify({ patch: { notifyAsk: false } });
+    const { rec, res } = makeRes();
+    await cfgRoute.handler({
+      method: "PUT",
+      url: "/",
+      socket: { remoteAddress: "127.0.0.1" },
+      headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+      on(event, cb) {
+        if (event === "data") setTimeout(() => cb(Buffer.from(text)), 0);
+        else if (event === "end") setTimeout(cb, 1);
+        return this;
+      },
+      destroy() {},
+    }, res);
+    assert.equal(rec.status, 500, "写入异常 → 500");
+    const body = JSON.parse(rec.text);
+    assert.ok(!rec.text.includes("secret-internal-path"), "500 响应不含底层异常原文（P2-2）");
+    assert.match(body.error.error, /保存失败/, "500 收敛固定文案");
+    assert.ok(warns.some((w) => w.includes("secret-internal-path")), "异常原文进服务端日志");
+  }
+
+  // events SSE（C1）
   {
     const { rec, res } = makeRes();
     await eventsRoute.handler(fakeReq({}), res);
@@ -148,9 +321,9 @@ try {
     assert.match(rec1.text, /"seq":\d+/, "通知帧带递增 seq");
   }
 
-  // events ?since 回放（独立上下文，seq 从 1 起）：断线补拉不丢尾部事件
+  // events ?since 回放（独立上下文，seq 从 1 起）：断线补拉不丢尾部事件（C7）
   {
-    const notifier2 = await makeNotifier(work, { historyFile: join(work, "history-since.jsonl") });
+    const notifier2 = makeNotifier(work, { historyFile: join(work, "history-since.jsonl") });
     const { routes: routes2 } = notifier2;
     const eventsRoute2 = routes2.find((r) => r.path === ROUTES.events);
     const testRoute2 = routes2.find((r) => r.path === ROUTES.test);
@@ -212,9 +385,9 @@ try {
     }
     /** 独立实例路由查找（每次全新连接表）。 */
     async function freshRoutes(mark, maxConnections) {
-      const cfg = join(work, `sse-${mark}-cfg.json`);
-      writeFileSync(cfg, JSON.stringify({ maxConnections }));
-      const out = await makeNotifier(work, { configFile: cfg, historyFile: join(work, `sse-${mark}.jsonl`) });
+      // issue #76 后配置走 settings 命名空间（configFile 仅作迁移源）：maxConnections
+      // 直接经组合层 entry 注入（sanitizeSettings 白名单 → 命名空间 base 层）。
+      const out = await makeNotifier(work, { maxConnections, historyFile: join(work, `sse-${mark}.jsonl`) });
       const near = (p) => out.routes.find((r) => r.path === p);
       return { ev: near(ROUTES.events), he: near(ROUTES.health), te: near(ROUTES.test), cfgR: near(ROUTES.config), dispose: out.dispose };
     }
@@ -291,8 +464,8 @@ try {
       await ev.handler(fakeReq({}), r2);
       await ev.handler(fakeReq({}), r3);
       assert.equal(await connCount(he), 3, "默认上限 16 下注册 3 条不淘汰");
-      // PUT maxConnections=2（内存生效 + 落盘，沿用现有 bodyReq 模式）
-      const text = JSON.stringify({ maxConnections: 2 });
+      // PUT {patch:{maxConnections:2}} → settings user 层（#76 新契约 F2/A2）
+      const text = JSON.stringify({ patch: { maxConnections: 2 } });
       const putReq = {
         method: "PUT",
         url: "/",
@@ -307,7 +480,8 @@ try {
       };
       const { rec, res } = makeRes();
       await cfgR.handler(putReq, res);
-      assert.equal(JSON.parse(rec.text).maxConnections, 2, "PUT 后配置生效");
+      assert.equal(JSON.parse(rec.text).ok, true, "PUT 后配置生效");
+      assert.equal(JSON.parse(rec.text).user.maxConnections, 2, "PUT 写 settings user 层");
       // 新注册触发 enforceLimit → 收缩到 2（淘汰最老 r1、r2）
       const r4 = sseRes();
       await ev.handler(fakeReq({}), r4);
@@ -332,7 +506,7 @@ try {
     }
   }
 
-  // history：测试通知已落盘，GET 可查（独立 history 文件，无跨块串扰）
+  // history：测试通知已落盘，GET 可查（独立 history 文件，无跨块串扰）（D4）
   {
     // appendHistory 是 fire-and-forget；轮询直到落盘，不再依赖固定 sleep 的时序假设
     const records = await waitForHistory(historyRoute, (rs) => rs.length >= 1 && rs[rs.length - 1]?.kind === "test");
@@ -355,16 +529,14 @@ try {
     assert.ok(testCount >= concurrent, `并发写不丢记录（test 记录 ${testCount} ≥ ${concurrent}）`);
   }
 
-  // history：DELETE 清空 + historyMaxAgeDays 按天清理（独立上下文，隔离其他用例）
+  // history：DELETE 清空（D7）+ historyMaxAgeDays 按天清理（D5）（独立上下文）
   {
     const hfile = join(work, "history-clean.jsonl");
-    const hcfg = join(work, "history-clean-cfg.json");
-    writeFileSync(hcfg, JSON.stringify({ historyMaxAgeDays: 7 }));
-    // 预置一条 10 天前的旧记录
-    writeFileSync(hfile, JSON.stringify({ ts: Date.now() - 10 * 86400000, kind: "done", title: "旧记录", message: "10 天前" }) + "\n");
-    const { routes, dispose: disposeClean } = await makeNotifier(work, { historyFile: hfile, configFile: hcfg });
+    const { routes, dispose: disposeClean } = makeNotifier(work, { historyFile: hfile, historyMaxAgeDays: 7 });
     const h = routes.find((r) => r.path === ROUTES.history);
     const t = routes.find((r) => r.path === ROUTES.test);
+    // 预置一条 10 天前的旧记录
+    writeFileSync(hfile, JSON.stringify({ ts: Date.now() - 10 * 86400000, kind: "done", title: "旧记录", message: "10 天前" }) + "\n");
     // 触发一条新通知（test 路由 → 落盘；写时会按 7 天 cutoff 剔除旧行）
     await t.handler(fakeReq({ method: "POST" }), makeRes().res);
     await new Promise((resolve) => setTimeout(resolve, 80)); // 等写队列排空
@@ -383,6 +555,34 @@ try {
     await h.handler(fakeReq({}), resEmpty);
     assert.equal(JSON.parse(recEmpty.text).records.length, 0, "清空后 GET 为空");
     disposeClean(); // 停心跳（P2-5）
+  }
+
+  // D3：被免打扰拦截（suppressed: "quiet"）的记录在历史中标记（独立上下文）
+  {
+    const qhAll = { enabled: true, start: "00:00", end: "23:59" };
+    const { routes, listeners } = makeNotifier(work, { quietHours: { ...qhAll, allowKinds: ["ask"] }, historyFile: join(work, "history-quiet.jsonl") });
+    const h = routes.find((r) => r.path === ROUTES.history);
+    const status = listeners.get("agent/status")[0];
+    // #290 阶段二两态时序：running=上一轮（首轮无 closure），idle=本轮 turn 1 completed
+    const pair = turnPair("q-1", "免打扰完成", {}, { turn: 1 });
+    status({ agent: pair.running, status: "running" });
+    status({ agent: pair.idle, status: "idle" });
+    const records = await waitForHistory(h, (rs) => rs.some((e) => e.kind === "done" && e.suppressed === "quiet"));
+    assert.ok(records.some((e) => e.kind === "done" && e.suppressed === "quiet"), "免打扰拦截记录带 suppressed:quiet 标记");
+  }
+
+  // D6：200 条滚动上限（独立上下文，预置 210 条 → 读取只保留最近 200）
+  {
+    const hfile = join(work, "history-limit.jsonl");
+    const lines = Array.from({ length: 210 }, (_, i) => JSON.stringify({ ts: Date.now() + i, kind: "test", title: "t", message: `m${i}` })).join("\n") + "\n";
+    writeFileSync(hfile, lines);
+    const { routes } = makeNotifier(work, { historyFile: hfile });
+    const h = routes.find((r) => r.path === ROUTES.history);
+    const { rec, res } = makeRes();
+    await h.handler(fakeReq({}), res);
+    const records = JSON.parse(rec.text).records;
+    assert.ok(records.length <= 200, "滚动上限 200：读取最多 200 条");
+    assert.equal(records[records.length - 1].message, "m209", "保留的是最新记录");
   }
 } finally {
   mainNotifier.dispose(); // 停心跳（P2-5：30s unref 定时器不在测试进程存活期残留）

--- a/packages/dsh-notifier/test/smoke.ts
+++ b/packages/dsh-notifier/test/smoke.ts
@@ -35,6 +35,7 @@ import "./real-context.test.ts";
 
 // e2e：HTTP 路由 + 两端契约
 import "./routes.test.ts";
+import "./migration.test.ts";
 import "./client-contract.test.ts";
 
 console.log("dsh-notifier smoke: OK");

--- a/packages/dsh-notifier/test/unit-config.src.test.ts
+++ b/packages/dsh-notifier/test/unit-config.src.test.ts
@@ -11,7 +11,7 @@ import { join } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { mkdtempSync, rmSync } from "node:fs";
 import { assert } from "./helpers.ts";
-import { normalizeConfig, parseHHMM, isInQuietHours, DEFAULT_CONFIG, configFile, historyFile, toastScriptPath } from "../lib/index.js";
+import { normalizeConfig, parseHHMM, isInQuietHours, DEFAULT_CONFIG, configFile, historyFile, toastScriptPath } from "../src/index.ts";
 
 const work = mkdtempSync(join(tmpdir(), "dnotify-unit-config-"));
 try {

--- a/packages/dsh-notifier/test/unit-config.test.ts
+++ b/packages/dsh-notifier/test/unit-config.test.ts
@@ -17,8 +17,10 @@ const work = mkdtempSync(join(tmpdir(), "dnotify-unit-config-"));
 try {
   const DEFAULT_CONFIG_UNTOUCHED = JSON.parse(JSON.stringify(DEFAULT_CONFIG));
 
-  // 路径契约（config.ts 导出；apply 未覆盖路径时由宿主按此位置读写）
-  assert.equal(configFile(), join(homedir(), ".dsh", "dsh-notifier.json"), "配置路径固定到 ~/.dsh/dsh-notifier.json");
+  // 路径契约（config.ts 导出）：configFile 是存量自建 json 的迁移源路径（issue #76 后
+  // 配置走官方 settings 存储，configFile 不再读写，仅迁移读取/改名）；historyFile 与
+  // toast 脚本路径不变。
+  assert.equal(configFile(), join(homedir(), ".dsh", "dsh-notifier.json"), "配置迁移源路径固定到 ~/.dsh/dsh-notifier.json");
   assert.equal(historyFile(), join(homedir(), ".dsh", "dsh-notifier-history.jsonl"), "历史路径固定到 ~/.dsh/dsh-notifier-history.jsonl");
   assert.ok(toastScriptPath().endsWith(join("lib", "toast.ps1")), "toast 脚本随包 lib/ 下");
 

--- a/stryker.conf.d/dsh-notifier.json
+++ b/stryker.conf.d/dsh-notifier.json
@@ -38,7 +38,9 @@
       "packages/dsh-notifier/test/e2e-done.src.test.ts",
       "packages/dsh-notifier/test/e2e-edge.src.test.ts",
       "packages/dsh-notifier/test/e2e-question-turn.test.ts",
+      "packages/dsh-notifier/test/migration.src.test.ts",
       "packages/dsh-notifier/test/routes.src.test.ts",
+      "packages/dsh-notifier/test/unit-config.src.test.ts",
       "packages/dsh-notifier/test/unit-sanitize.src.test.ts",
       "packages/dsh-notifier/test/unit-text.src.test.ts"
     ]


### PR DESCRIPTION
# feat(notifier): 通知设置整合进官方插件配置页，移除侧边栏浮层（#76）

## 变更摘要

配置收敛到**官方 settings 命名空间**（`<DSH_HOME>/settings.yaml` 单一存储），自建 `~/.dsh/dsh-notifier.json` 读写链路废弃：

- **H1** `src/settings.ts`：包内复刻 `installNotifierSettings`（同 lan-proxy `installLanProxySettings` 形态）——`ctx.inject(["settings"])` 服务面注入 → `settings.register(ns, schema, {base})` → `onScope` 外露 owner scope；schema 为零依赖最小兼容形态（官方 register 将 schema 当 callable 使用，函数体即 normalizeConfig）。
- **数据层**：移除 loadFile/saveFile/原子 rename 全部自建链路；配置读写全走官方 settings（`describe redactSecrets` 读 user/revision，`service.update(ns, patch, expectedRevision)` 写）。
- **E 迁移** `src/migrate.ts`：rename-first marker 幂等迁移；损坏/非对象/无有效键 → `.corrupted.bak` 只标记；中断态从 `.migrated.bak` 重放；Windows rename 冲突先 unlink；失败回滚不阻塞启动。
- **F/G HTTP 契约**：GET /config 返回 `{ok,user,revision,effective,writable}`；PUT 接收 `{patch, expectedRevision?}`；错误映射 SETTINGS_CONFLICT→409、settings 缺失→503、写入异常→500（原文只进日志）、非法键→400+hint。
- **客户端**：干净模块（React externals），`settings.plugin.item` 插槽挂 SettingsCard（id+key 双写兼容 rc.7 前后）；侧边栏入口/浮层/角标/拖拽全移除（B1-B6）；SSE 通知半区保留且不依赖插件 DOM（C1-C9）；历史最近 10 条收进卡片（D1-D2）；动作区含清理记录（两段式确认）/请求权限/测试通知（A6-A7）；三端降级文案迁入卡片（A8）。
- **H2/H3** 移除顶层 enabled 早退，enabled 下沉到 notify() 入口（禁用态仍注册路由+命名空间+迁移）。
- **文档**：README / README.en / src 头注释按 I1-I6 同步。

## 全量断言表（对照 spec 68 条硬性条目）

> 验证方式：🧪 smoke（routes/migration/client-contract 用例）· 📄 文档审核 · 🔧 代码审查 · ⚙️ 门禁 · 🖥️ 浏览器实测（qa 复核项）

### A. 设置-插件-配置卡片
| 条目 | 结论 | 证据 |
|---|---|---|
| A1 卡片渲染全部配置字段 | PASS | 🔧 SettingsCard 渲染 EVENT_KEYS(6)+CHANNEL_KEYS(4)+数值(4)+quietHours+historyMaxAgeDays（src/client/index.ts）；🖥️ DOM 截图待 qa 归档 |
| A2 PUT→scope.update→settings.yaml | PASS | 🧪 routes.test.ts「config PUT：settings user 层」+ settings.getUser() 断言 |
| A3 GET 包装体 effective 与落盘一致 | PASS | 🧪 routes.test.ts「GET effective 反映新值」 |
| A4 基线 diff 只提变更键 | PASS | 🧪 routes.test.ts「A4 service.update 只收到变更键」 |
| A5 settings 不可用→503 | PASS | 🧪 routes.test.ts「G2 settings-unavailable 503」 |
| A6 动作区三按钮 | PASS | 🔧 SettingsCard actions（清理/权限/测试）；🖥️ 截图待 qa |
| A7 清理记录两段式 | PASS | 🔧 confirmClear 两段式 + 🧪 routes.test.ts DELETE 返回 {ok,removed} |
| A8 三端降级文案迁入卡片 | PASS | 🔧 SettingsCard degradation（权限/非安全上下文/iOS） |
| A9 窄屏可见性 | PASS | 🔧 style.css @media(max-width:480px)；🖥️ 窄屏实测待 qa |
| A10 明暗双主题 | PASS | 🔧 颜色走 --dsw-alias-* + 浅色回退，无硬编码色 |

### B. 侧边栏入口与浮层移除
| 条目 | 结论 | 证据 |
|---|---|---|
| B1 侧边栏「通知」入口移除 | PASS | 🔧+🧪 client-contract.test.ts 断言 data-dsh-notifier-entry/createSidebarEntry 不存在 |
| B2 浮层面板不创建 | PASS | 🔧+🧪 client-contract 断言 dsh-notifier-panel/renderPanel 不存在 |
| B3 未读角标移除 | PASS | 🔧+🧪 client-contract 断言 data-dsh-notifier-badge/bumpUnread 不存在 |
| B4 拖拽/localStorage 不再写入 | PASS | 🔧+🧪 client-contract 断言 attachDrag/panel:pos 不存在 |
| B5 角标代码移除 | PASS | 🔧+🧪 client-contract 断言 bumpUnread/initUnread 不存在 |
| B6 无侧边栏注册 | PASS | 🔧+🧪 client-contract 断言 sidebarCol 不存在 + 两端路由一致性 |

### C. 通知半区保留与解耦
| 条目 | 结论 | 证据 |
|---|---|---|
| C1 SSE connected 首帧 | PASS | 🧪 routes.test.ts「events SSE：text/event-stream + connected」 |
| C2 60s 看门狗 | PASS | 🔧 startEvents 保留 WATCHDOG_MS=60000（不依赖 DOM）；⏱️ 浏览器长连实测待 qa |
| C3 visibilitychange 重建 | PASS | 🔧 保留 visibilitychange→reconnect；🖥️ 实测待 qa |
| C4 多标签租约 | PASS | 🔧 claimMaster 保留（localStorage 租约）；🖥️ 实测待 qa |
| C5 音频手势解锁 | PASS | 🔧 unlockAudio 保留（首手势解锁）；🖥️ 实测待 qa |
| C6 无插件 DOM 时 SSE 照常 | PASS | 🧪 routes.test.ts 全部 SSE 用例均基于无 DOM 的 fake ctx + client-contract「apply 直接 startEvents」 |
| C7 断线 since 补拉不丢帧 | PASS | 🧪 routes.test.ts「?since 回放」用例 |
| C8 页面隐藏弹通知 | PASS | 🔧 showNotification 保留（页面隐藏时 Notification API）；🖥️ 实测待 qa |
| C9 权限经卡片按钮 | PASS | 🔧 SettingsCard「请求通知权限」按钮；🖥️ 实测待 qa |

### D. 历史记录
| 条目 | 结论 | 证据 |
|---|---|---|
| D1 最近 10 条收进卡片 | PASS | 🔧 fetchHistory slice(-10).reverse() 渲染卡片 |
| D2 刷新反映最新 | PASS | 🔧 卡片「刷新」按钮重拉 /history |
| D3 免打扰拦截标记未发出 | PASS | 🧪 routes.test.ts「D3 suppressed:quiet」+ 卡片渲染 suppressed 标记 |
| D4 历史后台落盘 | PASS | 🧪 waitForHistory 轮询断言 |
| D5 按天清理 | PASS | 🧪 routes.test.ts「historyMaxAgeDays=7 剔除 10 天前」 |
| D6 200 滚动上限 | PASS | 🧪 routes.test.ts「210 条→读取≤200」 |
| D7 DELETE 清空 | PASS | 🧪 routes.test.ts「DELETE 返回 removed + GET 空」 |

### E. 迁移
| 条目 | 结论 | 证据 |
|---|---|---|
| E1 旧 json 迁移+改名 .migrated.bak | PASS | 🧪 migration.test.ts「E1」 |
| E2 幂等跳过 | PASS | 🧪 migration.test.ts「E2 同一 settings 文档二次 apply 不重复写」 |
| E3 中断态重放 | PASS | 🧪 migration.test.ts「E3 .migrated.bak 存在+user 空→重放」 |
| E4 损坏只标记 .corrupted.bak | PASS | 🧪 migration.test.ts「E4/E4b」 |
| E5 Windows rename 冲突 | PASS | 🧪 migration.test.ts「E5 预置旧 bak→unlink 后 rename」 |
| E6 失败回滚不阻塞 | PASS | 🧪 migration.test.ts「E6 update 抛错→回滚+warn+路由仍在」 |
| E7 迁移先于 enabled | PASS | 🧪 migration.test.ts「E7 enabled:false 仍注册路由+迁移」 |

### F. HTTP 契约
| 条目 | 结论 | 证据 |
|---|---|---|
| F1 GET 包装体 | PASS | 🧪 routes.test.ts「GET {ok,user,revision,effective,writable}」 |
| F2 PUT {patch,expectedRevision} | PASS | 🧪 routes.test.ts「PUT patch→user 层+返回 {ok,user,revision}」 |
| F3 客户端 configCache/refreshConfig/saveConfig 全链适配 | PASS | 🔧 fetchConfig/diffPayload/save 走新契约 |
| F4 expectedRevision 可选 | PASS | 🧪 routes.test.ts「缺省 200」+「G1 过期 409」 |

### G. 错误映射
| 条目 | 结论 | 证据 |
|---|---|---|
| G1 SETTINGS_CONFLICT→409 | PASS | 🧪 routes.test.ts「G1 版本冲突 409」 |
| G2 settings 缺失→503 | PASS | 🧪 routes.test.ts「G2 settings-unavailable 503」 |
| G3 写入异常原文只进日志 | PASS | 🧪 routes.test.ts「G3 500 不含原文+warn 含原文」 |
| G4 首个非法键 hint→400 | PASS | 🧪 routes.test.ts「G4 quietHours.start=25:00→400+hint」 |

### H. 架构改写
| 条目 | 结论 | 证据 |
|---|---|---|
| H1 installNotifierSettings | PASS | 🔧 src/settings.ts（服务面注入+onScope 外露） |
| H2 移除顶层 enabled 早退 | PASS | 🔧 index.ts apply 无 `if (config.enabled === false) return` |
| H3 enabled 下沉 notify() 入口 | PASS | 🔧 notify() 首行判定 |
| H4 apply 同步化 | PASS | 🔧 `export function apply(): void`（无 async/await） |
| H5 五条路由 loopback 围栏 | PASS | 🧪 routes.test.ts 403/405 全覆盖 |
| H6 validateSettings 语义 | PASS | 🔧 config.ts validateSettings + 🧪 G4 |

### I. 文档同步
| 条目 | 结论 | 证据 |
|---|---|---|
| I1 README 未读角标段落移除 | PASS | 📄 README.md 功能节已更新 |
| I2 README 配置段更新（官方 settings） | PASS | 📄 README.md/README.en.md 配置节 |
| I3 README 路由表更新 | PASS | 📄 README.md/README.en.md 路由表 |
| I4 README 权限入口更新 | PASS | 📄 README.md/README.en.md 安全节 |
| I5 src 头注释更新 | PASS | 📄 src/index.ts 头注释 |
| I6 README 面板诊断更新 | PASS | 📄 README.md/README.en.md 功能节 |

### J. 路由围栏保留
| 条目 | 结论 | 证据 |
|---|---|---|
| J1 非回环 403 | PASS | 🧪 routes.test.ts 403 全覆盖 |
| J2 方法不匹配 405 | PASS | 🧪 routes.test.ts 405 用例 |
| J3 错误 JSON body→400 | PASS | 🧪 routes.test.ts「非法 JSON 400」 |
| J4 超大 body 不挂起 | PASS | 🧪 routes.test.ts「20KB body→连接 destroy 不挂起」 |

### L. 门禁
| 条目 | 结论 | 证据 |
|---|---|---|
| L1 pnpm build | PASS | ⚙️ 本地五连门禁全绿（见下） |
| L2 pnpm test | PASS | ⚙️ 同上 |
| L3 pnpm contract | PASS | ⚙️ 同上 |
| L4 pnpm pack:check | PASS | ⚙️ 同上 |
| L5 smoke 10 次零 flake | PASS | 🧪 本地 `node test/smoke.ts` 连续 10 次全部通过 |

### 五连门禁输出（本地，worktree）
```
BUILD PASS
TEST PASS
CONTRACT PASS
PACK PASS
TYPECHECK PASS
node test/smoke.ts ×10 → ALL 10 OK
```

## 说明
- 关闭语义：多子项多方案 issue，本 PR 关联 `Refs #76`（不写 Closes，68 条经 qa 独立复核后再由维护者决定关闭语义）。
- 🖥️ 浏览器实测项（A1/A6/A9/A10、C2-C5/C8/C9、B 组 DOM 断言）待 qa 用隔离环境浏览器复核并归档截图 `docs/archive/76-*.png`；本 PR 已用 client-contract 源码级断言 + 无 DOM fake ctx 的 SSE 用例做机器兜底。
