### PR TITLE
test(mcp-manager): 固定 sleep 等响应模式系统性收敛为 await/pollUntil（#315 批次B）

### DIFF
--- a/packages/dsh-mcp-manager/test/helpers.ts
+++ b/packages/dsh-mcp-manager/test/helpers.ts
@@ -1,0 +1,96 @@
+// @ts-nocheck
+/**
+ * dsh-mcp-manager — 测试共享辅助（smoke + 各 unit 双份共用）。
+ *
+ * 防 flake 纪律（DEVELOPMENT.md §5 / issue #315）：一律用事件驱动 await /
+ * pollUntil 轮询替代「固定 sleep 等响应/等后台」的时序假设。本文件是单一事实源：
+ * 任何测试文件需要「等 handler 响应」或「等后台异步落定」时，从这里取原语，
+ * 禁止在测试里自行写固定 sleep。
+ */
+import assert from "node:assert/strict";
+
+export { assert };
+
+/** 伪造 node:http res：捕获 writeHead / end，供断言状态码与响应体。 */
+export function fakeRes() {
+  const state = { status: 200, headers: {}, body: "", destroyed: false, writableEnded: false };
+  return {
+    state,
+    get destroyed() {
+      return state.destroyed;
+    },
+    get writableEnded() {
+      return state.writableEnded;
+    },
+    writeHead(status, headers) {
+      state.status = status;
+      Object.assign(state.headers, headers ?? {});
+    },
+    write(chunk) {
+      state.body += chunk.toString();
+    },
+    end(chunk) {
+      if (chunk !== undefined) state.body += chunk.toString();
+      state.writableEnded = true;
+    },
+    setHeader() {},
+    on(event, cb) {
+      if (event === "close") state.onClose = cb;
+    },
+    destroy() {
+      state.destroyed = true;
+    },
+  };
+}
+
+/**
+ * 统一调用路由 handler 并拿响应。
+ *
+ * 防 flake 关键形态：async handler 时 await（writeJson 在 resolve 前同步触发
+ * end 回调，故 await 返回后 res 已完整写入）；同步 handler 时立即返回。
+ * 返回 { status, payload }：payload 为 JSON 解析后的响应体，非 JSON 时回退原文。
+ * 禁止在调用方「调用 handler 后 sleep 再读外联变量」——一律用本封装或直接 await。
+ *
+ * @param {{ handler: Function }} route 路由对象（makeRoutes 产物）。
+ * @param {object} req 请求桩（fakeReq 形态）。
+ * @param {object} [res] 响应桩，缺省用 fakeRes()。
+ */
+export async function callHandler(route, req, res = fakeRes()) {
+  const ret = route.handler(req, res);
+  if (ret !== undefined && typeof ret.then === "function") await ret;
+  let payload;
+  try {
+    payload = JSON.parse(res.state.body || "null");
+  } catch {
+    payload = res.state.body;
+  }
+  return { status: res.state.status, payload };
+}
+
+/**
+ * 轮询等待条件成立（防 flake：轮询替代固定 sleep）。超时抛错。
+ * 谓词每 tick 重估；tick 是轮询 tick（语义分类：轮询 tick），非「等够毫秒」。
+ */
+export async function pollUntil(label, cond, { timeoutMs = 5000, tickMs = 10 } = {}) {
+  const start = Date.now();
+  for (;;) {
+    if (cond()) return;
+    if (Date.now() - start > timeoutMs) throw new Error(`timeout waiting for ${label}`);
+    await new Promise((r) => setTimeout(r, tickMs));
+  }
+}
+
+/**
+ * 观察窗口内持续轮询断言测量值保持 baseline（反向验证：确认某后台行为停止，
+ * 如 close/disposer 后不再写心跳帧）。窗口内每 tick 都断言，任何时刻偏离立即失败，
+ * 比「单次固定 sleep 后一次性断言」更能即时暴露竞态。窗口时长是物理必需
+ * （无法不经过时间就证明『未来无新帧』），tick 属轮询 tick。
+ */
+export async function assertNoGrowth(label, measure, baseline, { windowMs = 120, tickMs = 10 } = {}) {
+  const deadline = Date.now() + windowMs;
+  for (;;) {
+    assert.equal(measure(), baseline, label);
+    if (Date.now() >= deadline) return;
+    await new Promise((r) => setTimeout(r, tickMs));
+  }
+}

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -15,11 +15,12 @@
 //
 // 运行：node dsh-mcp-manager/test/smoke.mjs
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, rmSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { assertClientProductContract, assertClientSourceContract } from "../../../test/smoke-lib.ts";
+import { pollUntil } from "./helpers.ts";
 
 const pkgDir = join(dirname(fileURLToPath(import.meta.url)), "..");
 import {
@@ -902,15 +903,15 @@ const main = async () => {
       store.data.servers = [normalizeServer({ name: "a", transport: "stdio", command: "echo" })];
       await store.save();
       assert.equal(await store.reloadIfChanged(), false, "无外部变更不重读");
-      // 外部修改（模拟 git pull / 手动编辑 mcp.json）
-      await new Promise((r) => setTimeout(r, 20)); // mtime 毫秒精度保护
+      // 外部修改（模拟 git pull / 手动编辑 mcp.json）——显式拨未来 mtime，
+      // 避免与 save() 基线同毫秒导致 reloadIfChanged 检测不到（事件驱动替代固定 sleep）。
       writeFileSync(path, JSON.stringify({ version: 1, servers: [{ name: "b", transport: "stdio", command: "echo", enabled: true }] }));
+      utimesSync(path, Date.now() / 1000 + 10, Date.now() / 1000 + 10);
       assert.equal(await store.reloadIfChanged(), true, "外部修改触发重读");
       assert.equal(store.data.servers.length, 1);
       assert.equal(store.data.servers[0].name, "b", "重读后数据来自磁盘");
       assert.equal(await store.reloadIfChanged(), false, "重读后基线推进");
-      // 外部删除 → 清空配置
-      await new Promise((r) => setTimeout(r, 20));
+      // 外部删除 → 清空配置（删除后 stat 失败 current=0，与基线 mtime 恒异，无需等待）。
       rmSync(path);
       assert.equal(await store.reloadIfChanged(), true, "删除触发重读");
       assert.deepEqual(store.data.servers, [], "删除 = 清空配置");
@@ -1098,11 +1099,12 @@ const main = async () => {
       });
 
       await checkAsync("外部新增 disabled 服务器 → refreshFromDisk 重读并进 summary（不 spawn）", async () => {
-        await new Promise((r) => setTimeout(r, 20));
+        // 显式拨未来 mtime，避免与 setSession 基线同毫秒导致 reloadIfChanged 检测不到。
         writeFileSync(cfg, JSON.stringify({
           version: 1,
           servers: [normalizeServer({ name: "p1", transport: "stdio", command: "true", enabled: false })],
         }));
+        utimesSync(cfg, Date.now() / 1000 + 10, Date.now() / 1000 + 10);
         await manager.refreshFromDisk();
         const names = manager.summary().servers.filter((s) => s.scope === SCOPE_PROJECT).map((s) => s.name);
         assert.deepEqual(names, ["p1"], "外部新增出现在面板数据");
@@ -1110,17 +1112,24 @@ const main = async () => {
       });
 
       await checkAsync("外部移除配置 → 已连接 supervisor 被断开", async () => {
-        await new Promise((r) => setTimeout(r, 20));
         writeFileSync(cfg, JSON.stringify({ version: 1, servers: [] }));
+        utimesSync(cfg, Date.now() / 1000 + 10, Date.now() / 1000 + 10);
         await manager.refreshFromDisk();
         assert.equal(disconnected, 1, "ghost 被断开");
         assert.equal(manager.supervisors.has("ghost"), false);
       });
 
       await checkAsync("无配置变化时 refreshFromDisk 不广播（防 SSE 空转循环）", async () => {
-        // 前一测试的 emitStatus 是 coalesce 异步（setTimeout 0），先等其落定，
+        // 前一测试的 emitStatus 是 coalesce 异步（setTimeout 0）：哨兵主动 emit 一次
+        // 并轮询等其落定（事件驱动替代固定 sleep），再注册本测试计数监听，
         // 避免上一轮广播误入本测试的监听计数。
-        await new Promise((r) => setTimeout(r, 10));
+        let settled = 0;
+        const offSentinel = manager.onStatus(() => {
+          settled += 1;
+        });
+        manager.emitStatus();
+        await pollUntil("coalesce 广播落定", () => settled >= 1);
+        offSentinel();
         let emitted = 0;
         manager.onStatus(() => {
           emitted += 1;

--- a/packages/dsh-mcp-manager/test/unit-manager2.src.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-manager2.src.test.ts
@@ -18,6 +18,7 @@ import assert from "node:assert/strict";
 import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pollUntil } from "./helpers.ts";
 
 const {
   apply,
@@ -334,12 +335,17 @@ function rmStatSafe(p) {
       count += 1;
     });
     manager.emitStatus();
-    // emitStatus 是 coalesce 异步（setTimeout 0），等待宏任务落定。
-    await new Promise((resolve) => setTimeout(resolve, 5));
-    assert.equal(count, 1);
+    // emitStatus 是 coalesce 异步（setTimeout 0）：轮询等广播 handler 落定（事件驱动）。
+    await pollUntil("onStatus 广播落定", () => count === 1);
     off();
+    // 注销后再广播：哨兵确认广播仍发生（事件驱动），原监听不再被调用。
+    let sentinel = 0;
+    const offSentinel = manager.onStatus(() => {
+      sentinel += 1;
+    });
     manager.emitStatus();
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await pollUntil("注销后广播仍发出", () => sentinel === 1);
+    offSentinel();
     assert.equal(count, 1, "注销后不再回调");
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -563,16 +569,16 @@ function rmStatSafe(p) {
     const { utimesSync } = await import("node:fs");
     utimesSync(join(dir, "global.json"), future, future);
     await manager.refreshFromDisk();
-    // emitStatus 是 coalesce 异步（setTimeout 0），等待宏任务落定。
-    await new Promise((resolve) => setTimeout(resolve, 5));
-    assert.ok(broadcasts >= 1, "配置变化广播一次");
+    // emitStatus 是 coalesce 异步（setTimeout 0）：轮询等广播落定且无未决 coalesce
+    //（statusTimer 清空 = 广播 handler 已全部执行），再取基线（事件驱动）。
+    await pollUntil("配置变化广播落定", () => broadcasts >= 1 && manager.statusTimer === undefined);
     assert.ok(store.data.servers.some((s) => s.name === "fresh"), "重读生效");
 
-    // 无变化时不广播。
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    // 无变化时不广播：先取基线（上一广播已完全落定），再 refreshFromDisk
+    //（无变化 → 不 emitStatus），轮询确认无未决广播后断言计数不变。
     const before = broadcasts;
     await manager.refreshFromDisk();
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await pollUntil("无变化后无未决广播", () => manager.statusTimer === undefined);
     assert.equal(broadcasts, before, "无变化不广播");
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/packages/dsh-mcp-manager/test/unit-manager2.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-manager2.test.ts
@@ -18,6 +18,7 @@ import assert from "node:assert/strict";
 import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pollUntil } from "./helpers.ts";
 
 const {
   apply,
@@ -334,12 +335,17 @@ function rmStatSafe(p) {
       count += 1;
     });
     manager.emitStatus();
-    // emitStatus 是 coalesce 异步（setTimeout 0），等待宏任务落定。
-    await new Promise((resolve) => setTimeout(resolve, 5));
-    assert.equal(count, 1);
+    // emitStatus 是 coalesce 异步（setTimeout 0）：轮询等广播 handler 落定（事件驱动）。
+    await pollUntil("onStatus 广播落定", () => count === 1);
     off();
+    // 注销后再广播：哨兵确认广播仍发生（事件驱动），原监听不再被调用。
+    let sentinel = 0;
+    const offSentinel = manager.onStatus(() => {
+      sentinel += 1;
+    });
     manager.emitStatus();
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await pollUntil("注销后广播仍发出", () => sentinel === 1);
+    offSentinel();
     assert.equal(count, 1, "注销后不再回调");
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -563,16 +569,16 @@ function rmStatSafe(p) {
     const { utimesSync } = await import("node:fs");
     utimesSync(join(dir, "global.json"), future, future);
     await manager.refreshFromDisk();
-    // emitStatus 是 coalesce 异步（setTimeout 0），等待宏任务落定。
-    await new Promise((resolve) => setTimeout(resolve, 5));
-    assert.ok(broadcasts >= 1, "配置变化广播一次");
+    // emitStatus 是 coalesce 异步（setTimeout 0）：轮询等广播落定且无未决 coalesce
+    //（statusTimer 清空 = 广播 handler 已全部执行），再取基线（事件驱动）。
+    await pollUntil("配置变化广播落定", () => broadcasts >= 1 && manager.statusTimer === undefined);
     assert.ok(store.data.servers.some((s) => s.name === "fresh"), "重读生效");
 
-    // 无变化时不广播。
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    // 无变化时不广播：先取基线（上一广播已完全落定），再 refreshFromDisk
+    //（无变化 → 不 emitStatus），轮询确认无未决广播后断言计数不变。
     const before = broadcasts;
     await manager.refreshFromDisk();
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await pollUntil("无变化后无未决广播", () => manager.statusTimer === undefined);
     assert.equal(broadcasts, before, "无变化不广播");
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/packages/dsh-mcp-manager/test/unit-routes-sse.src.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-routes-sse.src.test.ts
@@ -15,6 +15,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { callHandler, pollUntil, assertNoGrowth } from "./helpers.ts";
 
 const {
   makeRoutes,
@@ -140,14 +141,20 @@ const loopbackMethods = ["GET", "POST"];
       broadcastFrame(manager.sseConnections, sseData({ type: "summary" }));
     });
     manager.emitStatus();
-    await new Promise((resolve) => setTimeout(resolve, 5));
-    assert.equal(frames, 1);
+    // emitStatus 是 coalesce 异步（setTimeout 0）：轮询等广播落定（事件驱动替代固定 sleep）。
+    await pollUntil("广播落定 frames===1", () => frames === 1);
     // close 注销。
     resOk.state.onClose();
     assert.equal(manager.sseConnections.size, 0, "close 后注销");
+    // 二次广播应执行但不再写帧（连接已注销）——哨兵确认广播落定后断言帧数不变。
+    let landed = 0;
+    const offSentinel = manager.onStatus(() => {
+      landed += 1;
+    });
     manager.emitStatus();
-    await new Promise((resolve) => setTimeout(resolve, 5));
-    assert.equal(frames, 1);
+    await pollUntil("二次广播落定", () => landed >= 1);
+    offSentinel();
+    assert.equal(frames, 1, "close 注销后广播不再写帧");
     unsubscribe();
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -156,7 +163,6 @@ const loopbackMethods = ["GET", "POST"];
 
 // ---- SSE 心跳（#268）：data ping 帧 / 间隔常量 / close 与卸载 disposer 清理 ----
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const countPing = (res) => (res.state.body.match(/data: \{"type":"ping"\}/g) ?? []).length;
 
 {
@@ -171,15 +177,14 @@ const countPing = (res) => (res.state.body.match(/data: \{"type":"ping"\}/g) ?? 
     const res = fakeRes();
     route.handler(fakeReq("GET", ROUTES.events), res);
     assert.equal(manager.sseHeartbeatCleanups?.size, 1, "心跳清理函数已登记 disposer 注册表");
-    await sleep(45);
+    // 等心跳帧到达阈值（事件驱动轮询替代固定 sleep 等后台数据）。
+    await pollUntil("心跳 data ping 帧到达", () => countPing(res) >= 1);
     const pingsAtClose = countPing(res);
-    assert.ok(pingsAtClose >= 1, `心跳 data ping 帧按间隔到达（实际 ${pingsAtClose} 帧）`);
     // close：注销连接 + 清心跳定时器（防泄漏），此后不再有新帧。
     res.state.onClose();
     assert.equal(manager.sseConnections.size, 0, "close 后注销");
     assert.equal(manager.sseHeartbeatCleanups.size, 0, "close 自删 cleanup");
-    await sleep(45);
-    assert.equal(countPing(res), pingsAtClose, "close 后心跳停止");
+    await assertNoGrowth("close 后心跳停止", () => countPing(res), pingsAtClose);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -199,10 +204,10 @@ const countPing = (res) => (res.state.body.match(/data: \{"type":"ping"\}/g) ?? 
     assert.equal(manager.sseHeartbeatCleanups.size, 2, "每连接一条 cleanup");
     for (const stopHeartbeat of [...manager.sseHeartbeatCleanups]) stopHeartbeat();
     assert.equal(manager.sseHeartbeatCleanups.size, 0, "disposer 清空注册表");
-    await sleep(45);
-    // 清理发生在首个 interval 跳之前（同步路径），两连接均应零心跳帧。
-    assert.equal(countPing(resA), 0, "卸载后连接 A 心跳停止");
-    assert.equal(countPing(resB), 0, "卸载后连接 B 心跳停止");
+    // 清理发生在首个 interval 跳之前（同步路径），两连接均应零心跳帧：
+    // 观察窗口内持续断言（事件驱动轮询替代固定 sleep 等后台停止）。
+    await assertNoGrowth("卸载后连接 A 心跳停止", () => countPing(resA), 0);
+    await assertNoGrowth("卸载后连接 B 心跳停止", () => countPing(resB), 0);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -216,12 +221,10 @@ const countPing = (res) => (res.state.body.match(/data: \{"type":"ping"\}/g) ?? 
     const route = makeEventsRoute(manager, { heartbeatMs: 10 });
     const res = fakeRes();
     route.handler(fakeReq("GET", ROUTES.events), res);
-    await sleep(45);
+    await pollUntil("destroy 前心跳在写帧", () => countPing(res) >= 1);
     const pingsAtDestroy = countPing(res);
-    assert.ok(pingsAtDestroy >= 1, "destroy 前心跳在写帧");
     res.destroy(); // 不触发 onClose：走 destroyed 自愈而非 close 清理
-    await sleep(45);
-    assert.equal(countPing(res), pingsAtDestroy, "destroy 后心跳停止写帧");
+    await assertNoGrowth("destroy 后心跳停止写帧", () => countPing(res), pingsAtDestroy);
     assert.equal(manager.sseHeartbeatCleanups.size, 0, "自愈路径自删 cleanup");
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -281,45 +284,38 @@ const countPing = (res) => (res.state.body.match(/data: \{"type":"ping"\}/g) ?? 
     const find = (path) => routes.find((r) => r.path === path);
 
     // session：非 POST 405。
-    const sesGuard = fakeRes();
-    await find(ROUTES.session).handler(fakeReq("GET", ROUTES.session), sesGuard);
-    assert.equal(sesGuard.state.status, 405);
+    const sesGuard = await callHandler(find(ROUTES.session), fakeReq("GET", ROUTES.session));
+    assert.equal(sesGuard.status, 405);
 
     // session：body 无 cwd 字符串 → 400。
-    const sesBad = fakeRes();
-    await find(ROUTES.session).handler(fakeReq("POST", ROUTES.session, {}), sesBad);
-    assert.equal(sesBad.state.status, 400);
-    const sesNoBody = fakeRes();
-    await find(ROUTES.session).handler(fakeReq("POST", ROUTES.session), sesNoBody);
-    assert.equal(sesNoBody.state.status, 400);
+    const sesBad = await callHandler(find(ROUTES.session), fakeReq("POST", ROUTES.session, {}));
+    assert.equal(sesBad.status, 400);
+    const sesNoBody = await callHandler(find(ROUTES.session), fakeReq("POST", ROUTES.session));
+    assert.equal(sesNoBody.status, 400);
 
     // servers：PATCH 缺 name → 400；DELETE 缺 name → 400。
     for (const method of ["PATCH", "DELETE"]) {
-      const res = fakeRes();
-      await find(ROUTES.servers).handler(fakeReq(method, ROUTES.servers), res);
-      assert.equal(res.state.status, 400, `${method} 缺 name → 400`);
-      assert.match(res.state.body, /name query parameter is required/);
+      const res = await callHandler(find(ROUTES.servers), fakeReq(method, ROUTES.servers));
+      assert.equal(res.status, 400, `${method} 缺 name → 400`);
+      assert.match(JSON.stringify(res.payload), /name query parameter is required/);
     }
 
     // servers：PUT → 405。
-    const resPut = fakeRes();
-    await find(ROUTES.servers).handler(fakeReq("PUT", ROUTES.servers), resPut);
-    assert.equal(resPut.state.status, 405);
+    const resPut = await callHandler(find(ROUTES.servers), fakeReq("PUT", ROUTES.servers));
+    assert.equal(resPut.status, 405);
 
     // DELETE 存在的服务器 → 200 ok:true。
-    const resDel = fakeRes();
-    await find(ROUTES.servers).handler(fakeReq("DELETE", `${ROUTES.servers}?name=dup-a`), resDel);
-    assert.equal(resDel.state.status, 200);
-    assert.equal(JSON.parse(resDel.state.body).ok, true, "delete 返回 ok:true");
+    const resDel = await callHandler(find(ROUTES.servers), fakeReq("DELETE", `${ROUTES.servers}?name=dup-a`));
+    assert.equal(resDel.status, 200);
+    assert.equal(resDel.payload.ok, true, "delete 返回 ok:true");
 
     // PATCH 不存在的服务器 → 400 not found。
-    const resPatchMissing = fakeRes();
-    await find(ROUTES.servers).handler(
+    const resPatchMissing = await callHandler(
+      find(ROUTES.servers),
       fakeReq("PATCH", `${ROUTES.servers}?name=ghost`, { command: "x" }),
-      resPatchMissing,
     );
-    assert.equal(resPatchMissing.state.status, 400);
-    assert.match(resPatchMissing.state.body, /not found/);
+    assert.equal(resPatchMissing.status, 400);
+    assert.match(JSON.stringify(resPatchMissing.payload), /not found/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -334,35 +330,31 @@ const countPing = (res) => (res.state.body.match(/data: \{"type":"ping"\}/g) ?? 
     const importRoute = routes.find((r) => r.path === ROUTES.importJson);
 
     // 非 POST 405。
-    const guard = fakeRes();
-    await importRoute.handler(fakeReq("GET", ROUTES.importJson), guard);
-    assert.equal(guard.state.status, 405);
+    const guard = await callHandler(importRoute, fakeReq("GET", ROUTES.importJson));
+    assert.equal(guard.status, 405);
 
     // body 缺 json 字符串 → 400。
-    const badBody = fakeRes();
-    await importRoute.handler(fakeReq("POST", ROUTES.importJson, { json: 42 }), badBody);
-    assert.equal(badBody.state.status, 400);
-    assert.match(badBody.state.body, /must include a json string/);
+    const badBody = await callHandler(importRoute, fakeReq("POST", ROUTES.importJson, { json: 42 }));
+    assert.equal(badBody.status, 400);
+    assert.match(JSON.stringify(badBody.payload), /must include a json string/);
 
     // 同名导入默认 skip；overwrite=true 更新；非法条目整体 400。
     const payload = JSON.stringify({ "dup-a": { command: "echo2" }, fresh: { url: "http://f/" } });
-    const resSkip = fakeRes();
-    await importRoute.handler(fakeReq("POST", ROUTES.importJson, { json: payload }), resSkip);
-    assert.equal(resSkip.state.status, 200);
-    let out = JSON.parse(resSkip.state.body);
-    assert.deepEqual(out.skipped, ["dup-a"], "同名默认跳过");
-    assert.deepEqual(out.imported, ["fresh"]);
+    const resSkip = await callHandler(importRoute, fakeReq("POST", ROUTES.importJson, { json: payload }));
+    assert.equal(resSkip.status, 200);
+    assert.deepEqual(resSkip.payload.skipped, ["dup-a"], "同名默认跳过");
+    assert.deepEqual(resSkip.payload.imported, ["fresh"]);
 
-    const resOverwrite = fakeRes();
-    await importRoute.handler(fakeReq("POST", ROUTES.importJson, { json: payload, overwrite: true }), resOverwrite);
-    out = JSON.parse(resOverwrite.state.body);
-    assert.deepEqual(out.imported.sort(), ["dup-a", "fresh"], "overwrite 全部导入");
+    const resOverwrite = await callHandler(
+      importRoute,
+      fakeReq("POST", ROUTES.importJson, { json: payload, overwrite: true }),
+    );
+    assert.deepEqual(resOverwrite.payload.imported.sort(), ["dup-a", "fresh"], "overwrite 全部导入");
     assert.equal(manager.store.find("dup-a").command, "echo2", "overwrite 后配置更新");
 
-    const resInvalid = fakeRes();
-    await importRoute.handler(fakeReq("POST", ROUTES.importJson, { json: '{"bad":1}' }), resInvalid);
-    assert.equal(resInvalid.state.status, 400);
-    assert.match(resInvalid.state.body, /entry must be an object/, "非法条目整体 400");
+    const resInvalid = await callHandler(importRoute, fakeReq("POST", ROUTES.importJson, { json: '{"bad":1}' }));
+    assert.equal(resInvalid.status, 400);
+    assert.match(JSON.stringify(resInvalid.payload), /entry must be an object/, "非法条目整体 400");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/dsh-mcp-manager/test/unit-routes-sse.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-routes-sse.test.ts
@@ -15,6 +15,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { callHandler, pollUntil, assertNoGrowth } from "./helpers.ts";
 
 const {
   makeRoutes,
@@ -140,14 +141,20 @@ const loopbackMethods = ["GET", "POST"];
       broadcastFrame(manager.sseConnections, sseData({ type: "summary" }));
     });
     manager.emitStatus();
-    await new Promise((resolve) => setTimeout(resolve, 5));
-    assert.equal(frames, 1);
+    // emitStatus 是 coalesce 异步（setTimeout 0）：轮询等广播落定（事件驱动替代固定 sleep）。
+    await pollUntil("广播落定 frames===1", () => frames === 1);
     // close 注销。
     resOk.state.onClose();
     assert.equal(manager.sseConnections.size, 0, "close 后注销");
+    // 二次广播应执行但不再写帧（连接已注销）——哨兵确认广播落定后断言帧数不变。
+    let landed = 0;
+    const offSentinel = manager.onStatus(() => {
+      landed += 1;
+    });
     manager.emitStatus();
-    await new Promise((resolve) => setTimeout(resolve, 5));
-    assert.equal(frames, 1);
+    await pollUntil("二次广播落定", () => landed >= 1);
+    offSentinel();
+    assert.equal(frames, 1, "close 注销后广播不再写帧");
     unsubscribe();
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -156,7 +163,6 @@ const loopbackMethods = ["GET", "POST"];
 
 // ---- SSE 心跳（#268）：data ping 帧 / 间隔常量 / close 与卸载 disposer 清理 ----
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const countPing = (res) => (res.state.body.match(/data: \{"type":"ping"\}/g) ?? []).length;
 
 {
@@ -171,15 +177,14 @@ const countPing = (res) => (res.state.body.match(/data: \{"type":"ping"\}/g) ?? 
     const res = fakeRes();
     route.handler(fakeReq("GET", ROUTES.events), res);
     assert.equal(manager.sseHeartbeatCleanups?.size, 1, "心跳清理函数已登记 disposer 注册表");
-    await sleep(45);
+    // 等心跳帧到达阈值（事件驱动轮询替代固定 sleep 等后台数据）。
+    await pollUntil("心跳 data ping 帧到达", () => countPing(res) >= 1);
     const pingsAtClose = countPing(res);
-    assert.ok(pingsAtClose >= 1, `心跳 data ping 帧按间隔到达（实际 ${pingsAtClose} 帧）`);
     // close：注销连接 + 清心跳定时器（防泄漏），此后不再有新帧。
     res.state.onClose();
     assert.equal(manager.sseConnections.size, 0, "close 后注销");
     assert.equal(manager.sseHeartbeatCleanups.size, 0, "close 自删 cleanup");
-    await sleep(45);
-    assert.equal(countPing(res), pingsAtClose, "close 后心跳停止");
+    await assertNoGrowth("close 后心跳停止", () => countPing(res), pingsAtClose);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -199,10 +204,10 @@ const countPing = (res) => (res.state.body.match(/data: \{"type":"ping"\}/g) ?? 
     assert.equal(manager.sseHeartbeatCleanups.size, 2, "每连接一条 cleanup");
     for (const stopHeartbeat of [...manager.sseHeartbeatCleanups]) stopHeartbeat();
     assert.equal(manager.sseHeartbeatCleanups.size, 0, "disposer 清空注册表");
-    await sleep(45);
-    // 清理发生在首个 interval 跳之前（同步路径），两连接均应零心跳帧。
-    assert.equal(countPing(resA), 0, "卸载后连接 A 心跳停止");
-    assert.equal(countPing(resB), 0, "卸载后连接 B 心跳停止");
+    // 清理发生在首个 interval 跳之前（同步路径），两连接均应零心跳帧：
+    // 观察窗口内持续断言（事件驱动轮询替代固定 sleep 等后台停止）。
+    await assertNoGrowth("卸载后连接 A 心跳停止", () => countPing(resA), 0);
+    await assertNoGrowth("卸载后连接 B 心跳停止", () => countPing(resB), 0);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -216,12 +221,10 @@ const countPing = (res) => (res.state.body.match(/data: \{"type":"ping"\}/g) ?? 
     const route = makeEventsRoute(manager, { heartbeatMs: 10 });
     const res = fakeRes();
     route.handler(fakeReq("GET", ROUTES.events), res);
-    await sleep(45);
+    await pollUntil("destroy 前心跳在写帧", () => countPing(res) >= 1);
     const pingsAtDestroy = countPing(res);
-    assert.ok(pingsAtDestroy >= 1, "destroy 前心跳在写帧");
     res.destroy(); // 不触发 onClose：走 destroyed 自愈而非 close 清理
-    await sleep(45);
-    assert.equal(countPing(res), pingsAtDestroy, "destroy 后心跳停止写帧");
+    await assertNoGrowth("destroy 后心跳停止写帧", () => countPing(res), pingsAtDestroy);
     assert.equal(manager.sseHeartbeatCleanups.size, 0, "自愈路径自删 cleanup");
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -281,45 +284,38 @@ const countPing = (res) => (res.state.body.match(/data: \{"type":"ping"\}/g) ?? 
     const find = (path) => routes.find((r) => r.path === path);
 
     // session：非 POST 405。
-    const sesGuard = fakeRes();
-    await find(ROUTES.session).handler(fakeReq("GET", ROUTES.session), sesGuard);
-    assert.equal(sesGuard.state.status, 405);
+    const sesGuard = await callHandler(find(ROUTES.session), fakeReq("GET", ROUTES.session));
+    assert.equal(sesGuard.status, 405);
 
     // session：body 无 cwd 字符串 → 400。
-    const sesBad = fakeRes();
-    await find(ROUTES.session).handler(fakeReq("POST", ROUTES.session, {}), sesBad);
-    assert.equal(sesBad.state.status, 400);
-    const sesNoBody = fakeRes();
-    await find(ROUTES.session).handler(fakeReq("POST", ROUTES.session), sesNoBody);
-    assert.equal(sesNoBody.state.status, 400);
+    const sesBad = await callHandler(find(ROUTES.session), fakeReq("POST", ROUTES.session, {}));
+    assert.equal(sesBad.status, 400);
+    const sesNoBody = await callHandler(find(ROUTES.session), fakeReq("POST", ROUTES.session));
+    assert.equal(sesNoBody.status, 400);
 
     // servers：PATCH 缺 name → 400；DELETE 缺 name → 400。
     for (const method of ["PATCH", "DELETE"]) {
-      const res = fakeRes();
-      await find(ROUTES.servers).handler(fakeReq(method, ROUTES.servers), res);
-      assert.equal(res.state.status, 400, `${method} 缺 name → 400`);
-      assert.match(res.state.body, /name query parameter is required/);
+      const res = await callHandler(find(ROUTES.servers), fakeReq(method, ROUTES.servers));
+      assert.equal(res.status, 400, `${method} 缺 name → 400`);
+      assert.match(JSON.stringify(res.payload), /name query parameter is required/);
     }
 
     // servers：PUT → 405。
-    const resPut = fakeRes();
-    await find(ROUTES.servers).handler(fakeReq("PUT", ROUTES.servers), resPut);
-    assert.equal(resPut.state.status, 405);
+    const resPut = await callHandler(find(ROUTES.servers), fakeReq("PUT", ROUTES.servers));
+    assert.equal(resPut.status, 405);
 
     // DELETE 存在的服务器 → 200 ok:true。
-    const resDel = fakeRes();
-    await find(ROUTES.servers).handler(fakeReq("DELETE", `${ROUTES.servers}?name=dup-a`), resDel);
-    assert.equal(resDel.state.status, 200);
-    assert.equal(JSON.parse(resDel.state.body).ok, true, "delete 返回 ok:true");
+    const resDel = await callHandler(find(ROUTES.servers), fakeReq("DELETE", `${ROUTES.servers}?name=dup-a`));
+    assert.equal(resDel.status, 200);
+    assert.equal(resDel.payload.ok, true, "delete 返回 ok:true");
 
     // PATCH 不存在的服务器 → 400 not found。
-    const resPatchMissing = fakeRes();
-    await find(ROUTES.servers).handler(
+    const resPatchMissing = await callHandler(
+      find(ROUTES.servers),
       fakeReq("PATCH", `${ROUTES.servers}?name=ghost`, { command: "x" }),
-      resPatchMissing,
     );
-    assert.equal(resPatchMissing.state.status, 400);
-    assert.match(resPatchMissing.state.body, /not found/);
+    assert.equal(resPatchMissing.status, 400);
+    assert.match(JSON.stringify(resPatchMissing.payload), /not found/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -334,35 +330,31 @@ const countPing = (res) => (res.state.body.match(/data: \{"type":"ping"\}/g) ?? 
     const importRoute = routes.find((r) => r.path === ROUTES.importJson);
 
     // 非 POST 405。
-    const guard = fakeRes();
-    await importRoute.handler(fakeReq("GET", ROUTES.importJson), guard);
-    assert.equal(guard.state.status, 405);
+    const guard = await callHandler(importRoute, fakeReq("GET", ROUTES.importJson));
+    assert.equal(guard.status, 405);
 
     // body 缺 json 字符串 → 400。
-    const badBody = fakeRes();
-    await importRoute.handler(fakeReq("POST", ROUTES.importJson, { json: 42 }), badBody);
-    assert.equal(badBody.state.status, 400);
-    assert.match(badBody.state.body, /must include a json string/);
+    const badBody = await callHandler(importRoute, fakeReq("POST", ROUTES.importJson, { json: 42 }));
+    assert.equal(badBody.status, 400);
+    assert.match(JSON.stringify(badBody.payload), /must include a json string/);
 
     // 同名导入默认 skip；overwrite=true 更新；非法条目整体 400。
     const payload = JSON.stringify({ "dup-a": { command: "echo2" }, fresh: { url: "http://f/" } });
-    const resSkip = fakeRes();
-    await importRoute.handler(fakeReq("POST", ROUTES.importJson, { json: payload }), resSkip);
-    assert.equal(resSkip.state.status, 200);
-    let out = JSON.parse(resSkip.state.body);
-    assert.deepEqual(out.skipped, ["dup-a"], "同名默认跳过");
-    assert.deepEqual(out.imported, ["fresh"]);
+    const resSkip = await callHandler(importRoute, fakeReq("POST", ROUTES.importJson, { json: payload }));
+    assert.equal(resSkip.status, 200);
+    assert.deepEqual(resSkip.payload.skipped, ["dup-a"], "同名默认跳过");
+    assert.deepEqual(resSkip.payload.imported, ["fresh"]);
 
-    const resOverwrite = fakeRes();
-    await importRoute.handler(fakeReq("POST", ROUTES.importJson, { json: payload, overwrite: true }), resOverwrite);
-    out = JSON.parse(resOverwrite.state.body);
-    assert.deepEqual(out.imported.sort(), ["dup-a", "fresh"], "overwrite 全部导入");
+    const resOverwrite = await callHandler(
+      importRoute,
+      fakeReq("POST", ROUTES.importJson, { json: payload, overwrite: true }),
+    );
+    assert.deepEqual(resOverwrite.payload.imported.sort(), ["dup-a", "fresh"], "overwrite 全部导入");
     assert.equal(manager.store.find("dup-a").command, "echo2", "overwrite 后配置更新");
 
-    const resInvalid = fakeRes();
-    await importRoute.handler(fakeReq("POST", ROUTES.importJson, { json: '{"bad":1}' }), resInvalid);
-    assert.equal(resInvalid.state.status, 400);
-    assert.match(resInvalid.state.body, /entry must be an object/, "非法条目整体 400");
+    const resInvalid = await callHandler(importRoute, fakeReq("POST", ROUTES.importJson, { json: '{"bad":1}' }));
+    assert.equal(resInvalid.status, 400);
+    assert.match(JSON.stringify(resInvalid.payload), /entry must be an object/, "非法条目整体 400");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/dsh-mcp-manager/test/unit-supervisor.src.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-supervisor.src.test.ts
@@ -15,6 +15,7 @@
  * - disconnect：timer 清理、close 失败吞、最终 stopped
  */
 import assert from "node:assert/strict";
+import { pollUntil } from "./helpers.ts";
 
 const {
   ConnectionSupervisor,
@@ -150,8 +151,8 @@ const failServer = { name: "srv", transport: "stdio", command: "dsh-mcp-missing-
   assert.ok(sup.reconnectTimer !== undefined, "重连 timer 已安排");
   assert.equal(sup.reconnectTimer._idleTimeout, 10, "首次退避 = initialDelayMs");
 
-  // 等待重连循环自行耗尽预算（10ms + 20ms + 误差）。
-  await new Promise((r) => setTimeout(r, 220));
+  // 轮询等重连循环自行耗尽预算（10ms + 20ms + 误差），事件驱动替代固定 sleep。
+  await pollUntil("预算耗尽 status==='failed'", () => sup.status === "failed");
   assert.equal(sup.status, "failed", "预算耗尽 → failed");
   assert.match(sup.error.message, /gave up after 2 attempts/);
   assert.ok(Date.now() - t0 >= 25, "确实经历了退避等待");
@@ -207,13 +208,22 @@ const failServer = { name: "srv", transport: "stdio", command: "dsh-mcp-missing-
   await sup.syncChain;
   assert.deepEqual(log.disposed, ["tool:t"], "代际工具注销");
   assert.deepEqual(sup.tools, []);
-  await new Promise((r) => setTimeout(r, 10));
+  // transport.close 是 fire-and-forget 异步：轮询等其落定（事件驱动替代固定 sleep）。
+  await pollUntil("transport.close 调用", () => log.info.includes("closed"));
   assert.ok(log.info.includes("closed"), "transport.close 调用");
 
   // close 抛错吞掉不炸 teardown。
-  sup.client = { transport: { close: async () => { throw new Error("close boom"); } } };
+  let closeSettled = 0;
+  sup.client = {
+    transport: {
+      close: async () => {
+        closeSettled += 1;
+        throw new Error("close boom");
+      },
+    },
+  };
   sup.teardownGeneration(new Error("x"), false);
-  await new Promise((r) => setTimeout(r, 10));
+  await pollUntil("close 抛错已落定被吞", () => closeSettled === 1);
   assert.equal(sup.status, "failed");
 
   // disposed 短路：清理任务与状态更新都不做。

--- a/packages/dsh-mcp-manager/test/unit-supervisor.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-supervisor.test.ts
@@ -15,6 +15,7 @@
  * - disconnect：timer 清理、close 失败吞、最终 stopped
  */
 import assert from "node:assert/strict";
+import { pollUntil } from "./helpers.ts";
 
 const {
   ConnectionSupervisor,
@@ -150,8 +151,8 @@ const failServer = { name: "srv", transport: "stdio", command: "dsh-mcp-missing-
   assert.ok(sup.reconnectTimer !== undefined, "重连 timer 已安排");
   assert.equal(sup.reconnectTimer._idleTimeout, 10, "首次退避 = initialDelayMs");
 
-  // 等待重连循环自行耗尽预算（10ms + 20ms + 误差）。
-  await new Promise((r) => setTimeout(r, 220));
+  // 轮询等重连循环自行耗尽预算（10ms + 20ms + 误差），事件驱动替代固定 sleep。
+  await pollUntil("预算耗尽 status==='failed'", () => sup.status === "failed");
   assert.equal(sup.status, "failed", "预算耗尽 → failed");
   assert.match(sup.error.message, /gave up after 2 attempts/);
   assert.ok(Date.now() - t0 >= 25, "确实经历了退避等待");
@@ -207,13 +208,22 @@ const failServer = { name: "srv", transport: "stdio", command: "dsh-mcp-missing-
   await sup.syncChain;
   assert.deepEqual(log.disposed, ["tool:t"], "代际工具注销");
   assert.deepEqual(sup.tools, []);
-  await new Promise((r) => setTimeout(r, 10));
+  // transport.close 是 fire-and-forget 异步：轮询等其落定（事件驱动替代固定 sleep）。
+  await pollUntil("transport.close 调用", () => log.info.includes("closed"));
   assert.ok(log.info.includes("closed"), "transport.close 调用");
 
   // close 抛错吞掉不炸 teardown。
-  sup.client = { transport: { close: async () => { throw new Error("close boom"); } } };
+  let closeSettled = 0;
+  sup.client = {
+    transport: {
+      close: async () => {
+        closeSettled += 1;
+        throw new Error("close boom");
+      },
+    },
+  };
   sup.teardownGeneration(new Error("x"), false);
-  await new Promise((r) => setTimeout(r, 10));
+  await pollUntil("close 抛错已落定被吞", () => closeSettled === 1);
   assert.equal(sup.status, "failed");
 
   // disposed 短路：清理任务与状态更新都不做。


### PR DESCRIPTION
## 改动说明

issue #315 批次 B：将 `dsh-mcp-manager` 包 test/ 下「同步调用 async handler 后固定 sleep 再读外联变量」与「真后台异步数据用固定 sleep 等」的 flake 模式，系统性收敛为 await / pollUntil 轮询（DEVELOPMENT.md §5 / #217 纪律落地）。纯 test/ 改动，`src/**` 生产逻辑零改动。

- 新建 `packages/dsh-mcp-manager/test/helpers.ts`（B2 落点）：`callHandler(route, req) => Promise<{status, payload}>`（async handler 统一 await；writeJson 在 resolve 前同步触发 end 回调，故 await 后 res 已完整；同步 handler 立即返回）、`pollUntil(label, cond, opts)`（轮询替代固定 sleep）、`assertNoGrowth(label, measure, baseline, opts)`（观察窗口内持续断言「无增长」，用于 close/destroy/disposer 后不再写帧的反向验证）、`fakeRes()`（伪造 res）。
- `smoke.ts`：mtime 毫秒精度保护（4 处 20ms）改为显式 `utimesSync` 拨未来 mtime（删除场景无时序依赖直接删除等待）；emitStatus coalesce 落定（10ms）改为「哨兵主动 emit + pollUntil 等落定」事件驱动。
- `unit-routes-sse` 双份：心跳帧等待（sleep45 x5）改 pollUntil（等 countPing 阈值）/ assertNoGrowth（等停止）；emitStatus 落定（setTimeout5 x2）改哨兵 pollUntil；makeRoutes 边界块（session/servers/import）handler 调用接入 callHandler。
- `unit-manager2` 双份：emitStatus 落定（setTimeout5 x5）改 pollUntil（等广播计数 + statusTimer 清空信号）。
- `unit-supervisor` 双份：154 退避预算耗尽改 pollUntil `status==='failed'` + 保留下界时间断言；210/216 transport.close 宏任务改 pollUntil 落定信号。
- 双份 `.test.ts` / `.src.test.ts` diff 仅 import 目标行差异（`../lib/index.js` vs `../src/index.ts`）。

## 全文件 setTimeout 行语义分类表（B1 证据，当前 HEAD=3a9f462）

> 口径：等响应（同步调 async handler 后 sleep 再读外联变量）/ 等后台（真后台异步数据固定 sleep 等）/ 轮询 tick / 有意 fixture 延迟 / 触发用定时器（桩赋值）。注释仅说明不产生语义位。

| 文件 | 行号 | 代码 | 分类 |
|---|---|---|---|
| `helpers.ts` | 79 | `await new Promise((r) => setTimeout(r, tickMs))` | 轮询 tick（pollUntil 内部） |
| `helpers.ts` | 94 | `await new Promise((r) => setTimeout(r, tickMs))` | 轮询 tick（assertNoGrowth 内部） |
| `smoke.ts` | 378 | `inFlight: new Map([["gctx", new Promise((resolve) => setTimeout(() => {...}, 100))]])` | 有意 fixture 延迟（模拟中间层后台发现完成，测试 await 该 promise） |
| `smoke.ts` | 1123 | 注释：`emitStatus 是 coalesce 异步（setTimeout 0）…` | 非语义位（代码已改哨兵 pollUntil） |
| `smoke.ts` | 1800 | `await new Promise((resolve) => setTimeout(resolve, 25))` | 轮询 tick（waitFor 内部） |
| `unit-apply.test.ts` | 118 | `await new Promise((r) => setImmediate(r))` | 宏任务 flush（事件驱动，非固定 sleep；emitStatus → SSE 广播后让位） |
| `unit-apply.src.test.ts` | 118 | 同上 | 同上（双份） |
| `unit-manager2.test.ts` | 338 | 注释：`emitStatus 是 coalesce 异步（setTimeout 0）…` | 非语义位（代码已改 pollUntil） |
| `unit-manager2.test.ts` | 572 | 注释：同上 | 非语义位（代码已改 pollUntil） |
| `unit-manager2.test.ts` | 689 | `reconnectTimer: setTimeout(() => {}, 60_000)` | 触发用定时器（桩赋值，非等待） |
| `unit-manager2.src.test.ts` | 338/572/689 | 同 `.test.ts` | 同（双份） |
| `unit-routes-sse.test.ts` | 135/144 | 注释：emitStatus coalesce 说明 | 非语义位（代码已改哨兵 pollUntil） |
| `unit-routes-sse.src.test.ts` | 135/144 | 同 `.test.ts` | 同（双份） |
| `unit-supervisor.test.ts` | 349 | `sup.reconnectTimer = setTimeout(() => {}, 10_000)` | 触发用定时器（桩赋值，非等待） |
| `unit-supervisor.src.test.ts` | 349 | 同上 | 同上（双份） |

结论：**「等响应 / 等后台」固定 sleep 语义位 0 残留**；残余 setTimeout/setImmediate 全为轮询 tick、有意 fixture 延迟、宏任务 flush（事件驱动）或触发用定时器桩赋值，均属合法保留（spec N6 允许）。

## 断言表（对照 issue #315 [spec] 验收标准，批次 B）

| # | 断言条目 | 级别 | 结论 | 证据 |
|---|---|---|---|---|
| B1 | 等响应语义位全清：smoke.ts + 全部 unit 双份语义位 0 残留，PR 附分类表 | 硬性 | PASS | 本表「全文件 setTimeout 语义分类表」；grep 核对等响应/等后台位 0 残留 |
| B2 | callHandler 统一封装并接入；smoke.ts emitStatus coalesce 落定位改 await 链或 pollUntil | 硬性 | PASS | `test/helpers.ts` 新建 callHandler 并接入 unit-routes-sse 边界块（session/servers/import，12 处调用）；smoke.ts 1121-1130 改哨兵 pollUntil（`pollUntil("coalesce 广播落定", ...)`） |
| B3 | 真后台数据位轮询化：unit-routes-sse 心跳帧 sleep45x5 改 pollUntil；unit-manager2 emitStatus setTimeout5x5 改事件驱动/pollUntil；mtime 精度保护改显式写回 | 硬性 | PASS | unit-routes-sse 心跳帧改 `pollUntil(countPing>=1)` / `assertNoGrowth`；unit-manager2 改 `pollUntil(broadcasts>=1 && statusTimer===undefined)`；smoke.ts mtime 4 处改 `utimesSync(未来)` |
| B4 | unit-supervisor 154/210/216 整改；双份 diff 仅 import 行差异 | 硬性 | PASS | 154 改 `pollUntil(status==='failed')` + 保留下界时间断言（`Date.now()-t0>=25`）；210/216 改 pollUntil 落定信号；双份 diff 经 `diff` 核对仅 import 目标行 |
| B5 | mutation perTest 关联不受影响：三段 dry-run 通过、增量杀伤无异常回落；stryker 配置零改动 | 硬性 | PASS | 三段 `npx stryker run ... --dryRunOnly` 均通过（10 tests / 各约 3s）；增量杀伤对比 covered 得分 seg1 64.71→64.71、seg2 47.92→55.17（提升）、seg3 76.98→76.58（-0.4pp 噪声内，killed 781→780）；`git diff 3145f23 HEAD -- stryker.conf.d/` = 0 文件（配置零改动） |
| B6 | 五连门禁全绿 + CI mutation-gate 增量段绿 | 硬性 | 本地 PASS（CI 待 PR 触发） | 本地 `pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 全绿（build/contract/pack:check/typecheck 输出 PASS，`pnpm test` exit=0 全 9 包 Done）；CI mutation-gate 待 PR 触发后由 CI 复核 |
| B7 | smoke.ts 本地连续 3 次运行零 flake | 量级 | PASS | 后台串行 3 次 `node packages/dsh-mcp-manager/test/smoke.ts` 均 `exit=0`（run1/2/3 各 323s，含基线既有有界挂起——见下方说明） |

### 已知基线现象（非本批引入，不影响 PASS）

- `smoke.ts` 的 SDK 端到端块（mini-mcp-server 真实子进程）在 `supervisor.disconnect()` 后子进程句柄延迟回收，进程在打印 `all checks passed` 后约 5 分钟自然退出（exit 0）。此为 origin/main 既有行为（未改 HEAD 同样 5m23s 退出），CI 日志亦显示 smoke 步骤在 all checks passed 后约 5 分钟才进入下一步且 job 通过（job timeout 15min > 5min）。本批未触碰该块（N1：不动 src；非本 issue 语义位）。
- 量级条目 B7 按 spec 三要素留痕：实测值 = 3 次运行均 exit 0、单次 323s；归因 = 基线既有 SDK 端到端子进程回收延迟（非本批改动）；原区间（假设 smoke 快速退出）因该基线现象失效，已如实说明。

Refs #315
