### PR TITLE
fix(provider-usage): 余额卡片副标题精简——来源标识折叠进 title 悬停提示（#345）

### DIFF
--- a/packages/dsh-provider-usage/src/adapters/deepseek-official.mjs
+++ b/packages/dsh-provider-usage/src/adapters/deepseek-official.mjs
@@ -730,7 +730,7 @@ function formatPanelImpl(input) {
       <span class="dou-cardCur">${balance !== null && Number.isFinite(balance) ? `¥${balance.toFixed(2)}` : "--"}</span>
       ${trendHtml}
     </div>
-    <p class="dou-cardLimit">DeepSeek 官方（CNY） · 近 24 小时波动${rechargeHint}</p>
+    <p class="dou-cardLimit" title="${ea("DeepSeek 官方（CNY）")}">近 24 小时波动${rechargeHint}</p>
   </div>`;
 
   let chartHtml = "";

--- a/packages/dsh-provider-usage/test/unit-deepseek-official.src.test.ts
+++ b/packages/dsh-provider-usage/test/unit-deepseek-official.src.test.ts
@@ -649,6 +649,9 @@ assert.equal(parseAmount("Infinity"), null, "Infinity 非有限数 → null");
   assert.ok(panel.includes("<svg"), "内嵌 SVG 图表");
   assert.ok(panel.includes("近 15 日用量"), "卡2 柱形图卡");
   assert.ok(panel.includes("近 24 小时波动"), "卡1 余额波动卡");
+  // #345 卡片头部精简：来源标识折叠进 title 悬停提示，不占主行同排挤压
+  assert.ok(panel.includes('title="DeepSeek 官方（CNY）"'), "卡1 来源标识折叠进 title 悬停提示");
+  assert.ok(!panel.includes("DeepSeek 官方（CNY） · 近 24 小时波动"), "卡1 主行不再拼接来源标识");
   // D3 主题变量 + 浅色回退
   assert.ok(panel.includes("var(--dsw-alias-") && panel.includes("#3b82f6"), "主题变量 + 浅色回退形态");
   // K10 卡2 结构细节

--- a/packages/dsh-provider-usage/test/unit-deepseek-official.test.ts
+++ b/packages/dsh-provider-usage/test/unit-deepseek-official.test.ts
@@ -649,6 +649,9 @@ assert.equal(parseAmount("Infinity"), null, "Infinity 非有限数 → null");
   assert.ok(panel.includes("<svg"), "内嵌 SVG 图表");
   assert.ok(panel.includes("近 15 日用量"), "卡2 柱形图卡");
   assert.ok(panel.includes("近 24 小时波动"), "卡1 余额波动卡");
+  // #345 卡片头部精简：来源标识折叠进 title 悬停提示，不占主行同排挤压
+  assert.ok(panel.includes('title="DeepSeek 官方（CNY）"'), "卡1 来源标识折叠进 title 悬停提示");
+  assert.ok(!panel.includes("DeepSeek 官方（CNY） · 近 24 小时波动"), "卡1 主行不再拼接来源标识");
   // D3 主题变量 + 浅色回退
   assert.ok(panel.includes("var(--dsw-alias-") && panel.includes("#3b82f6"), "主题变量 + 浅色回退形态");
   // K10 卡2 结构细节


### PR DESCRIPTION
Fixes #345。

## 改动

**问题**：内置 DeepSeek 官方余额适配器卡片头部一行同排塞「余额 ¥43.01 已用 ¥4.24」与副标题「DeepSeek 官方（CNY） · 近 24 小时波动」，tablet/wide 档互相挤压，不好看。

**方案**（已获维护者确认）：精简副标题文案——副标题只保留「近 24 小时波动」（`rechargeHint` 断轴提示仍追加），来源标识「DeepSeek 官方（CNY）」折叠进 `<p class="dou-cardLimit" title="...">` 悬停提示，不占主行。

## 验证

- 门禁全绿：`pnpm build` / `pnpm test` / `pnpm contract` / `pnpm pack:check` 均 exit=0。
- 新增 smoke 断言（src 与产物双版本）：
  - `panel.includes('title="DeepSeek 官方（CNY）"')` —— 来源标识折叠进 title；
  - `!panel.includes("DeepSeek 官方（CNY） · 近 24 小时波动")` —— 主行不再拼接来源标识。

## 影响面

- 仅宿主端 `src/adapters/deepseek-official.mjs` 的 `formatPanelImpl` 副标题模板一行 + 对应测试断言；无 API / 契约 / 配置变更，无客户端构建产物变更。
