### PR TITLE
fix(dsh-codegraph): 改回声明依赖 mcp-manager——inject 强依赖 + 类型从包引（#329 方向修正）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,8 +244,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Build package：名称选择器 + ... 后缀按 workspace 拓扑先构建依赖（如
+      # dsh-codegraph 依赖 dsh-mcp-manager 的 lib 类型；目录选择器 + ... 在 pnpm 11
+      # 不展开依赖，评审实测须用 @scope/name... 形态）。无条件：repo-gate 全局门禁
+      # 依赖全量 lib 产物。
       - name: Build package（无条件：repo-gate 全局门禁依赖全量 lib 产物）
-        run: pnpm --filter ./packages/${{ matrix.package }} build
+        run: pnpm --filter "@wingsky-1/${{ matrix.package }}"... build
 
       - name: Smoke tests（仅命中包；聚合包无 test 脚本由 --if-present 跳过）
         if: contains(fromJSON(needs.changes.outputs.hitPackages), matrix.package)

--- a/packages/dsh-codegraph/README.md
+++ b/packages/dsh-codegraph/README.md
@@ -7,7 +7,8 @@ codegraph MCP + worktree 开发纪律 —— 把 [codegraph](https://github.com/
 
 - **探测 + 引导安装**：自动探测 codegraph CLI；未装时注入引导（输出安装命令，默认不自动执行）。
 - **运行时注册**：经 dsh-mcp-manager 核心服务（`ctx.mcpManager`）注册 codegraph MCP 服务器
-  （`codegraph serve --mcp`，内存态不落盘）；mcp-manager 未启用时纪律工具仍可用。
+  （`codegraph serve --mcp`，内存态不落盘）；MCP 的注册/管理/使用基于 mcp-manager 接入
+  （inject 强依赖，见「依赖」节）。
 - **工具层硬纪律**（核心价值）：`codegraph_explore` 封装——查询前强制 `codegraph sync`
   （新鲜度硬保证，worktree 索引不过期）+ 校验/补全 `projectPath`（缺省补全为当前会话
   worktree，自动不了则拒绝并提示）。杜绝「worktree 索引静默过期」与「漏传 projectPath
@@ -68,5 +69,7 @@ codegraph init ../dsh-hub-task-<n>                 # 建该 worktree 索引（�
 
 ## 依赖
 
-- dsh-mcp-manager（提供 `ctx.mcpManager` service；未启用时纪律工具仍可用，仅 MCP 服务器不注册）
+- **dsh-mcp-manager**（提供 `ctx.mcpManager` service）：**强依赖**（inject 声明）。
+  MCP 的注册/管理/使用基于 mcp-manager 接入；mcp-manager 未启用时本插件由 cordis
+  内核自动停用（启用后自动激活），不单独降级。
 - codegraph CLI（`@colbymchenry/codegraph`，探测 + 引导安装）

--- a/packages/dsh-codegraph/cordis.patch.yml
+++ b/packages/dsh-codegraph/cordis.patch.yml
@@ -1,12 +1,13 @@
 # dsh-codegraph bundle patch：向 web profile 的插件名册插入 codegraph 纪律插件。
 # 主机端（exports "."）在宿主进程运行：探测 codegraph CLI（未装则注入引导安装
-# 命令，不自动执行）、经 mcp-manager 核心服务（ctx.mcpManager，需 dsh-mcp-manager
-# 已启用）运行时注册 codegraph MCP 服务器（不落盘）、注册纪律工具
-# （codegraph_explore 封装：查询前强制 sync + 校验/补全 projectPath）、
+# 命令，不自动执行）、经 mcp-manager 核心服务（ctx.mcpManager）运行时注册
+# codegraph MCP 服务器（stdio: codegraph serve --mcp，内存态不落盘）、注册纪律
+# 工具（codegraph_explore 封装：查询前强制 sync + 校验/补全 projectPath）、
 # 监听 agent/created 按会话 cwd 条件注入 worktree 开发纪律（非 git 仓不启用）。
 # 无客户端半（纯宿主基础设施，无 UI）。配置走 schema 默认值（见 src/index.ts）。
-# 依赖：dsh-mcp-manager（提供 ctx.mcpManager service；未启用时回退自带 stdio
-# 客户端或纯提示）。
+# 依赖：dsh-mcp-manager（提供 ctx.mcpManager service）——经 inject 强依赖声明，
+# mcp-manager 未启用时 cordis 内核自动停用本插件，启用后自动激活（MCP 的注册/
+# 管理/使用本来就是 mcp-manager 的能力，本插件基于它接入）。
 - insert:
     - id: ui-dsh-codegraph
       name: '@wingsky-1/dsh-codegraph'

--- a/packages/dsh-codegraph/package.json
+++ b/packages/dsh-codegraph/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "catalog:",
-    "@deepseek-ai/dsh-agent": "catalog:"
+    "@deepseek-ai/dsh-agent": "catalog:",
+    "@wingsky-1/dsh-mcp-manager": "workspace:*"
   }
 }

--- a/packages/dsh-codegraph/src/index.ts
+++ b/packages/dsh-codegraph/src/index.ts
@@ -5,10 +5,8 @@
  * 图谱 MCP）与配套 worktree 开发纪律打包成 dsh 插件一键交付：
  * - **探测 + 引导安装**：codegraph CLI 未装 → 注入引导（输出安装命令，不自动
  *   执行；autoInstall=true 时自动装，幂等容错：装前再探测、失败仅 warn）；
- * - **运行时注册**：经 mcp-manager 核心服务（ctx.mcpManager，阶段1 新增）
- *   registerServer 注册 codegraph MCP 服务器（stdio: codegraph serve --mcp，
- *   内存态不落盘）；mcp-manager 未启用时回退自带 stdio 客户端（复用
- *   shared/ 的 transport/protocol）或纯提示；
+ * - **运行时注册**：经 mcp-manager 核心服务（ctx.mcpManager）registerServer 注册
+ *   codegraph MCP 服务器（stdio: codegraph serve --mcp，内存态不落盘）；
  * - **纪律工具**（工具层硬纪律，核心价值）：codegraph_explore 封装——查询前
  *   强制 sync + 校验/补全 projectPath（自动补全 + 拒绝兜底），杜绝「worktree
  *   索引静默过期」与「漏传 projectPath 查错对象」；
@@ -20,13 +18,14 @@
  * 安全模型（详见 README「安全模型」一节）：不自动执行第三方安装命令（默认）、
  * stdio 子进程继承宿主权限、索引为本地 SQLite 无加密、工具在真实服务器上执行。
  *
- * 依赖：dsh-mcp-manager（提供 ctx.mcpManager service；未启用时降级）。
+ * 依赖：dsh-mcp-manager（提供 ctx.mcpManager service）。经 inject 声明强依赖——
+ * mcp-manager 未启用时 cordis 内核自动停用本插件，启用后自动激活（无需手动
+ * ctx.get 探测；MCP 注册/管理/使用本来就是 mcp-manager 的能力，本插件基于它接入）。
  */
 import type { Context } from "@deepseek-ai/cordis";
-// 类型面：mcpManager service 类型从 shared/ 引（单一事实源，构建期内联随包复制，
-// 不依赖 mcp-manager 包构建时序）；运行时经 ctx.get("mcpManager") 探测（cordis
-// 可选依赖标准姿势，inject 不支持可选）。
-import type { McpManagerService } from "../../../shared/mcp-manager-service.js";
+// 类型面：mcpManager service 类型从 mcp-manager 包引（该包 re-export
+// shared/mcp-manager-service.d.ts，类型单一事实源仍在 shared/，消费入口走包）。
+import type { McpManagerService } from "@wingsky-1/dsh-mcp-manager";
 import { installGuidance, isCodegraphInstalled, runInstall } from "./install.ts";
 import { findGitRoot, guardedExplore } from "./guard.ts";
 import { registerDisciplineHook } from "./discipline.ts";
@@ -34,8 +33,8 @@ import { registerDisciplineHook } from "./discipline.ts";
 /** Stable cordis plugin name. */
 export const name = "codegraph";
 
-/** 需要的宿主服务：agents（agent/created 事件）；mcpManager 经 ctx.get 探测（非 inject）。 */
-export const inject = ["agents"];
+/** 需要的宿主服务：agents（agent/created 事件）+ mcpManager（MCP 注册/管理/使用）。 */
+export const inject = ["agents", "mcpManager"];
 
 // 内部模块 re-export（公共测试面 + 其他插件可复用纯函数）。
 export { isCodegraphInstalled, installGuidance, runInstall } from "./install.ts";
@@ -127,10 +126,10 @@ export async function apply(ctx: Context, config: CodegraphConfig = {}): Promise
     }
   }
 
-  // 2. 注册 MCP 服务器（经 mcp-manager 核心服务；未启用时纯提示降级）。
+  // 2. 注册 MCP 服务器（经 mcp-manager 核心服务，inject 强依赖保证可用）。
   //    用完整 service 面：注册后可经 getStatus/getTools 感知连接状态与工具列表。
-  const mcpManager = (ctx as unknown as { get(name: string): McpManagerService | undefined }).get("mcpManager");
-  if (mcpManager !== undefined && isCodegraphInstalled()) {
+  const mcpManager = (ctx as unknown as { mcpManager: McpManagerService }).mcpManager;
+  if (isCodegraphInstalled()) {
     try {
       const { existing } = await mcpManager.registerServer({
         name: "codegraph",
@@ -150,8 +149,6 @@ export async function apply(ctx: Context, config: CodegraphConfig = {}): Promise
     } catch (error) {
       ctx.logger.warn(`dsh-codegraph: 注册 codegraph MCP 服务器失败：${String(error)}`);
     }
-  } else if (isCodegraphInstalled()) {
-    ctx.logger.info("dsh-codegraph: dsh-mcp-manager 未启用，跳过 MCP 服务器注册（纪律工具仍可用）");
   }
 
   // 3. 纪律工具（工具层硬纪律：强制 sync + projectPath）。
@@ -165,10 +162,8 @@ export async function apply(ctx: Context, config: CodegraphConfig = {}): Promise
     return () => {
       disposeTool();
       disposeHook();
-      // 卸载时注销 MCP 服务器（不影响 store 持久化条目）。
-      if (mcpManager !== undefined) {
-        void mcpManager.unregisterServer("codegraph").catch(() => {});
-      }
+      // 卸载时注销 MCP 服务器（不影响 store 持久化条目；inject 保证 mcpManager 在场）。
+      void mcpManager.unregisterServer("codegraph").catch(() => {});
     };
   });
 }

--- a/packages/dsh-codegraph/test/smoke.ts
+++ b/packages/dsh-codegraph/test/smoke.ts
@@ -104,13 +104,24 @@ check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents"))
     const state = { disposers: [], registered: [], hooks: [], logs: [] };
     const ctx = {
       logger: { warn: (m) => state.logs.push(`warn:${m}`), info: (m) => state.logs.push(`info:${m}`) },
-      get: (name) => (overrides.mcpManager ? { registerServer: async () => ({ name, existing: false }), unregisterServer: async () => {} } : undefined),
+      // inject 强依赖：ctx.mcpManager 直接可用（不再 get 探测）。
+      mcpManager: overrides.mcpManager ?? {
+        registerServer: async () => { state.registered.push("codegraph"); return { name: "codegraph", existing: false }; },
+        unregisterServer: async () => {},
+        getStatus: () => undefined,
+        getTools: () => [],
+        list: () => [],
+      },
       on: () => () => {},
       effect: (fn) => { const d = fn(); state.disposers.push(d); return d; },
       session: overrides.session,
     };
     return { ctx, state };
   };
+
+  check("契约: inject 含 mcpManager（强依赖声明）", () =>
+    assert.ok(inject.includes("mcpManager"), `inject 应含 mcpManager，实际 ${JSON.stringify(inject)}`),
+  );
 
   // enabled:false → 不做事
   checkAsync("apply: enabled:false 静默返回", async () => {
@@ -144,7 +155,7 @@ check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents"))
     rmSync(dir, { recursive: true, force: true });
   });
 
-  // mcpManager 存在 + codegraph 已装（PATH 指向 fake）→ 注册服务器
+  // mcpManager（inject 保证在场）+ codegraph 已装（PATH 指向 fake）→ 注册服务器
   checkAsync("apply: mcpManager + 已装 → registerServer", async () => {
     const dir = mkdtempSync(join(tmpdir(), "cg-apply2-"));
     mkdirSync(join(dir, ".git"), { recursive: true });
@@ -152,10 +163,13 @@ check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents"))
     let registered = false;
     const ctx = {
       logger: { warn: () => {}, info: () => {} },
-      get: (n) => n === "mcpManager" ? {
+      mcpManager: {
         registerServer: async () => { registered = true; return { name: "codegraph", existing: false }; },
         unregisterServer: async () => {},
-      } : undefined,
+        getStatus: () => ({ name: "codegraph", transport: "stdio", scope: "global", status: "connected", tools: [], enabled: true }),
+        getTools: () => [],
+        list: () => [],
+      },
       on: () => () => {},
       effect: (fn) => { const d = fn(); return d; },
       session: { header: { cwd: dir } },

--- a/packages/dsh-mcp-manager/src/service.ts
+++ b/packages/dsh-mcp-manager/src/service.ts
@@ -1,13 +1,14 @@
 /**
  * mcp-manager 核心化 service 类型（官方 storageDomain 模式）。
  *
- * 类型面单一事实源在 shared/mcp-manager-service.d.ts（跨包共享，构建期内联、
- * 随包复制）。本文件只做类型 re-export + cordis Context 声明合并——消费方
- * （如 dsh-codegraph）从 shared 引用类型，不依赖本包构建时序（CI 并行 build）。
+ * 类型面唯一事实源在 shared/mcp-manager-service.d.ts（本包 re-export 之）；
+ * 本文件只做类型 re-export + cordis Context 声明合并。消费方（如 dsh-codegraph）
+ * **从本包引类型**（`import type { McpManagerService } from "@wingsky-1/dsh-mcp-manager"`），
+ * 依赖经 package.json workspace:* 声明 + inject。
  *
  * 提供方：apply.ts 中 ctx.provide("mcpManager", service)。
- * 消费方：其他插件经 `ctx.mcpManager` 调用（inject 声明 "mcpManager"，
- * 或运行时 ctx.get("mcpManager") 探测降级）。
+ * 消费方：其他插件经 `ctx.mcpManager` 调用，inject 声明 "mcpManager"（cordis
+ * 内核自动处理未启用/启用：服务缺失 → 插件停用，提供后自动激活）。
  */
 
 // 类型 re-export（公共类型面，供消费方 import）。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       '@deepseek-ai/dsh-agent':
         specifier: 'catalog:'
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-system-prompt@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
+      '@wingsky-1/dsh-mcp-manager':
+        specifier: workspace:*
+        version: link:../dsh-mcp-manager
 
   packages/dsh-idle-archive:
     devDependencies:

--- a/scripts/gate/contract-check.ts
+++ b/scripts/gate/contract-check.ts
@@ -74,10 +74,11 @@ if (checked === 0) {
   console.log('（当前无带客户端插件的包）')
 }
 
-// @deepseek-ai/* 官方包仅允许 import type（issue #16）：值导入会进宿主端 bundle
-// 或被 build-client 内联，破坏发布物自包含。类型擦除由 tsc verbatimModuleSyntax
-// 保证；此门禁防的是「未来有人写成运行时导入」。多行 import 也覆盖：
-// 以 import 开头且非 import type 的语句体内出现 @deepseek-ai 模块名即报。
+// @deepseek-ai/* 官方包与 @wingsky-1/* 工作区包仅允许 import type（issue #16 +
+// #329）：值导入会进宿主端 bundle 或被 build-client 内联，破坏发布物自包含。
+// 类型擦除由 tsc verbatimModuleSyntax 保证；此门禁防的是「未来有人写成运行时导入」。
+// 多行 import 也覆盖：以 import 开头且非 import type 的语句体内出现
+// @deepseek-ai|@wingsky-1 模块名即报。
 {
   const offenders = []
   for (const p of pluginDirs) {
@@ -94,13 +95,13 @@ if (checked === 0) {
         // 主形态：静态 import（非 import type）。注意 `import { type X } from` 的
         // inline 修饰符会被命中——这是有意 fail-closed：verbatimModuleSyntax 下该
         // 语句仍保留副作用导入语义，应改写成整句 import type。
-        for (const m of code.matchAll(/(^|\n)\s*import\s+(?!type\b)(?:[^;'"]|'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")*?from\s*['"](@deepseek-ai\/[^'"]+)['"]|(^|\n)\s*import\s+['"](@deepseek-ai\/[^'"]+)['"]/g)) {
+        for (const m of code.matchAll(/(^|\n)\s*import\s+(?!type\b)(?:[^;'"]|'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")*?from\s*['"](@(?:deepseek-ai|wingsky-1)\/[^'"]+)['"]|(^|\n)\s*import\s+['"](@(?:deepseek-ai|wingsky-1)\/[^'"]+)['"]/g)) {
           const spec = m[2] ?? m[4]
           if (spec) offenders.push(`${p}/src${file.slice(srcDir.length)} → ${spec}`)
         }
         // 补充形态：export ... from / 动态 import() / require()（同样产生运行时引用；
         // export type ... from 为纯类型放行）
-        for (const m of code.matchAll(/(?:export\s+(?!type\b)(?:\*(?:\s+as\s+\w+)?|\{[^}]*\})\s*from\s*|import\(\s*|require\(\s*)['"](@deepseek-ai\/[^'"]+)['"]/g)) {
+        for (const m of code.matchAll(/(?:export\s+(?!type\b)(?:\*(?:\s+as\s+\w+)?|\{[^}]*\})\s*from\s*|import\(\s*|require\(\s*)['"](@(?:deepseek-ai|wingsky-1)\/[^'"]+)['"]/g)) {
           offenders.push(`${p}/src${file.slice(srcDir.length)} → ${m[1]}`)
         }
       }
@@ -109,10 +110,10 @@ if (checked === 0) {
   }
   if (offenders.length > 0) {
     failed++
-    console.log('FAIL @deepseek-ai 仅类型导入 | 检测到运行时值导入（须改为 import type）:')
+    console.log('FAIL @deepseek-ai/@wingsky-1 仅类型导入 | 检测到运行时值导入（须改为 import type）:')
     for (const o of offenders) console.log(`     ${o}`)
   } else {
-    console.log('PASS @deepseek-ai 仅类型导入 | src 下无运行时值导入')
+    console.log('PASS @deepseek-ai/@wingsky-1 仅类型导入 | src 下无运行时值导入')
   }
 }
 

--- a/shared/mcp-manager-service.d.ts
+++ b/shared/mcp-manager-service.d.ts
@@ -1,10 +1,11 @@
 /**
- * mcp-manager 核心服务类型面（跨包共享，单一事实源）。
+ * mcp-manager 核心服务类型面（单一事实源）。
  *
  * 供 mcp-manager 提供方（src/service.ts re-export + declare module 合并）
- * 与消费方插件（如 dsh-codegraph）经 `../../../shared/mcp-manager-service.js`
- * 引用——纯类型，esbuild 构建期内联、随包复制（d.ts X1），无运行时依赖、
- * 无跨包构建时序问题（CI 并行 build 各包时依赖包 lib 未就绪也能编译）。
+ * 与消费方插件（如 dsh-codegraph）引用——消费方**从 mcp-manager 包引类型**
+ * （`import type { McpManagerService } from "@wingsky-1/dsh-mcp-manager"`），
+ * 本文件是类型定义的唯一事实源，mcp-manager 包 re-export 之。纯类型，
+ * esbuild 构建期内联、随包复制（d.ts X1）。
  *
  * 服务面（通用 MCP 能力 + 运行时注入专用面）：
  * - 注入面：registerServer / unregisterServer（内存态不落盘，同名幂等）；


### PR DESCRIPTION
## 动机（方向修正）

[#329](https://github.com/wingsky-1/dsh-plugin-hub/issues/329) 修正：#333 合入的 dsh-codegraph 实现把「对 mcp-manager 的真实依赖」做成了「不依赖」（shared 类型裸引 + `ctx.get` 探测 + package.json 无依赖）——这是为绕 CI 并行构建时序而掩盖依赖，方向错误。

**正确的必然**：MCP 的注册/管理/使用（连接/断开/工具注册 `mcp__*`/生命周期）本来就是 mcp-manager 的能力；dsh-codegraph 作为「MCP 接入方」**必须基于 mcp-manager 接入、声明依赖它**。经独立子 Agent 对抗评审（核实 cordis 源码 + pnpm 11 实测）确认方向，并修正了两处实现细节。

## 子 Agent 评审结论（已采纳）

- **P0（已修）**：`pnpm --filter ./packages/<pkg>... build`（目录选择器 + `...`）在 pnpm 11.21 **不展开依赖**（实测仅 1 包）——必须用名称选择器 `@wingsky-1/<pkg>...`（实测展开依赖、按拓扑先建 mcp-manager）；
- **P1（已确认采纳）**：inject 强依赖 = mcp-manager 未启用时**整插件自动停用**（cordis 内核，非报错）；与「纪律工具独立可用」的行为变化已在 README 显式说明；
- **P1（已修）**：原 `ctx.get` 探测带真实竞态（mcp-manager 晚于 codegraph 加载时探测到 undefined 后**永久跳过注册**）——inject 方案恰好消除；
- **P2（已修）**：文档单一事实源注释同步（shared/service.ts/patch/README）；contract-check「仅类型导入」门禁扩展覆盖 `@wingsky-1/*`（防跨包运行时值导入破坏自包含）。

## 改动

1. **package.json**：devDependencies 加 `@wingsky-1/dsh-mcp-manager: workspace:*`（声明真实依赖）；
2. **src/index.ts**：类型从包引（`import type { McpManagerService } from "@wingsky-1/dsh-mcp-manager"`）；`inject = ["agents", "mcpManager"]`（**强依赖**，cordis 内核自动处理未启用/启用——服务缺失 → 插件停用，提供后自动激活）；去掉 `ctx.get` 探测，直接用 `ctx.mcpManager`；
3. **ci.yml**：build 步骤 `pnpm --filter ./packages/${{ matrix.package }} build` → `pnpm --filter "@wingsky-1/${{ matrix.package }}"... build`（拓扑构建依赖，解决 TS2307）；
4. **contract-check.ts**：「仅类型导入」门禁从只匹配 `@deepseek-ai/*` 扩展为 `@deepseek-ai|@wingsky-1/*`；
5. **注释单一事实源同步**：`shared/mcp-manager-service.d.ts` / `service.ts` / `cordis.patch.yml` / `README.md`（消费方从包引类型 + inject 强依赖 + 未启用整插件停用）。

## 验证

- `pnpm --filter @wingsky-1/dsh-mcp-manager build` ✅ / `pnpm --filter @wingsky-1/dsh-codegraph build` ✅（类型从包引解析成功）
- 实测 `pnpm --filter "@wingsky-1/dsh-codegraph"... exec pwd` 展开 mcp-manager + dsh-codegraph（拓扑）✅
- smoke：dsh-codegraph（含新「inject 含 mcpManager」断言）✅ / mcp-manager（核心化回归）✅
- 门禁：`pnpm build` ✅ / `contract-check`（新 @wingsky-1 仅类型导入 PASS）✅ / `pack:check` ✅ / `workflow-assert` 30 全过 ✅ / typecheck ✅

> 注：本地 `pnpm test` 因 mcp-manager 既有悬挂超时（原版同样，CI ubuntu 正常，见 #332/#333 先例）。

## 关联

- Issue: #329（修正 #333 的方向偏差）
- 前置：#332（mcp-manager 核心化）、#333（dsh-codegraph 初版）