### PR TITLE
fix(dsh-codegraph): 启动崩溃三连修——隔离实例实测（session/tools/output 契约）

### DIFF
--- a/packages/dsh-codegraph/README.md
+++ b/packages/dsh-codegraph/README.md
@@ -15,8 +15,7 @@ codegraph MCP + worktree 开发纪律 —— 把 [codegraph](https://github.com/
   查错对象」。
 - **agent 纪律钩子**：`agent/created` + 会话 cwd 判定，git 仓（主 checkout / worktree）会话
   才注入 worktree 开发纪律（~200 tokens/次）；非 git 仓（日常维护/讨论空间）不注入——
-  多工作空间天然区分。
-- **requireGit**：非 git 仓不启用（默认），可配置覆盖。
+  多工作空间天然区分（按会话 cwd 判定，无需配置）。
 
 ## 安装
 
@@ -41,7 +40,6 @@ cd your-project && codegraph init
 | `installCommand` | `npm install -g @colbymchenry/codegraph` | 自定义安装命令 |
 | `syncBeforeQuery` | `true` | 查询前强制 sync |
 | `requireProjectPath` | `true` | 不传 projectPath 时拒绝调用（自动补全 + 拒绝兜底） |
-| `requireGit` | `true` | 非 git 仓不启用 |
 | `injectDiscipline` | `true` | 注入纪律到 git 仓会话 |
 
 ## Worktree 开发流程

--- a/packages/dsh-codegraph/src/index.ts
+++ b/packages/dsh-codegraph/src/index.ts
@@ -12,8 +12,8 @@
  *   索引静默过期」与「漏传 projectPath 查错对象」；
  * - **agent 钩子**：agent/created + 会话 cwd 判定，git 仓（主 checkout /
  *   worktree）才注入纪律（~200 tokens/次）；非 git 仓（日常维护/讨论空间）
- *   不注入——多工作空间天然区分；
- * - **requireGit**：非 git 仓不启用（默认），可配置覆盖。
+ *   不注入——多工作空间天然区分（按会话 cwd 判定，由 discipline/guard 承担，
+ *   不在 apply 阶段读取 ctx.session——apply 无会话概念）。
  *
  * 安全模型（详见 README「安全模型」一节）：不自动执行第三方安装命令（默认）、
  * stdio 子进程继承宿主权限、索引为本地 SQLite 无加密、工具在真实服务器上执行。
@@ -27,14 +27,15 @@ import type { Context } from "@deepseek-ai/cordis";
 // shared/mcp-manager-service.d.ts，类型单一事实源仍在 shared/，消费入口走包）。
 import type { McpManagerService } from "@wingsky-1/dsh-mcp-manager";
 import { installGuidance, isCodegraphInstalled, runInstall } from "./install.ts";
-import { findGitRoot, guardedExplore } from "./guard.ts";
+import { guardedExplore } from "./guard.ts";
 import { registerDisciplineHook } from "./discipline.ts";
 
 /** Stable cordis plugin name. */
 export const name = "codegraph";
 
-/** 需要的宿主服务：agents（agent/created 事件）+ mcpManager（MCP 注册/管理/使用）。 */
-export const inject = ["agents", "mcpManager"];
+/** 需要的宿主服务：agents（agent/created 事件）、mcpManager（MCP 注册/管理/使用）、
+ *  tools（纪律工具注册）。均经 inject 强依赖声明——缺失时 cordis 内核自动停用本插件。 */
+export const inject = ["agents", "mcpManager", "tools"];
 
 // 内部模块 re-export（公共测试面 + 其他插件可复用纯函数）。
 export { isCodegraphInstalled, installGuidance, runInstall } from "./install.ts";
@@ -53,22 +54,18 @@ export interface CodegraphConfig {
   syncBeforeQuery?: boolean;
   /** 不传 projectPath 时拒绝调用（默认 true：自动补全 + 拒绝兜底）。 */
   requireProjectPath?: boolean;
-  /** 非 git 仓不启用（默认 true）。 */
-  requireGit?: boolean;
   /** 注入纪律到 agent（默认 true）。 */
   injectDiscipline?: boolean;
 }
 
 const DEFAULT_INSTALL_COMMAND = "npm install -g @colbymchenry/codegraph";
 
-/** 注册纪律工具（ctx.tools）。返回 disposer。 */
+/** 注册纪律工具（ctx.tools，inject 保证在场）。返回 disposer。 */
 function registerGuardTool(
   ctx: Context,
   cfg: Required<Pick<CodegraphConfig, "syncBeforeQuery" | "requireProjectPath">>,
 ): () => void {
-  // ctx.tools 为官方 dsh-tools 服务；此处仅在其存在时注册（防御降级）。
-  const tools = (ctx as unknown as { tools?: { register(d: unknown): () => void } }).tools;
-  if (tools === undefined || typeof tools.register !== "function") return () => {};
+  const tools = (ctx as unknown as { tools: { register(d: unknown): () => void } }).tools;
   return tools.register({
     name: "codegraph_explore",
     description:
@@ -83,10 +80,28 @@ function registerGuardTool(
       },
       required: ["query"],
     },
-    output: { type: "text" },
+    // 官方 ToolOutputDefinition 契约（dsh-tools）：output 必含 schema + render。
+    // execute 返回 canonical JSON 值，render 投影为模型可读的 ContentBlock[]。
+    output: {
+      schema: {
+        type: "object",
+        properties: {
+          text: { type: "string" },
+        },
+        required: ["text"],
+        additionalProperties: false,
+      },
+      render(_args: unknown, value?: unknown) {
+        const text = value && typeof value === "object" && "text" in value
+          ? String((value as { text?: unknown }).text ?? "")
+          : "";
+        return [{ type: "text", text }];
+      },
+    },
+    // canonical 值：{ text }；guardedExplore 返回纯文本（含拒绝引导），不抛错。
     execute: async (args: { query: string; projectPath?: string }, exec: { agent?: { session?: { header?: { cwd?: string } } } }) => {
       const cwd = exec?.agent?.session?.header?.cwd;
-      return { content: [{ type: "text", text: await guardedExplore(args, cwd) }] };
+      return { text: await guardedExplore(args, cwd) };
     },
   });
 }
@@ -100,14 +115,14 @@ export async function apply(ctx: Context, config: CodegraphConfig = {}): Promise
   const installCommand = config.installCommand ?? DEFAULT_INSTALL_COMMAND;
   const syncBeforeQuery = config.syncBeforeQuery !== false;
   const requireProjectPath = config.requireProjectPath !== false;
-  const requireGit = config.requireGit !== false;
   const injectDiscipline = config.injectDiscipline !== false;
 
   if (!enabled) return;
 
-  // 0. requireGit：当前会话 cwd 非 git 仓 → 不启用（静默跳过）。
-  const sessionCwd = (ctx as unknown as { session?: { header?: { cwd?: string } } })?.session?.header?.cwd;
-  if (requireGit && findGitRoot(sessionCwd) === undefined) return;
+  // 注：不做 apply 阶段会话判定——apply（插件加载时）无「当前会话」概念，且
+  // ctx.session 需 inject 才能访问（cordis Proxy）。「非 git 仓不注入纪律」由
+  // discipline（agent 会话 cwd 判 git）与 guard（工具执行时按 exec 会话 cwd
+  // 补全 projectPath，非 git 拒绝）在会话级无条件承担，无需配置开关。
 
   // 1. 探测 codegraph CLI；未装 → autoInstall 或引导。
   if (!isCodegraphInstalled()) {

--- a/packages/dsh-codegraph/test/smoke.ts
+++ b/packages/dsh-codegraph/test/smoke.ts
@@ -8,7 +8,7 @@
 //   - findGitRoot / isGitRepo（.git 目录 / .git 文件(worktree) / 非 git 三分支）
 //   - shouldInject（cwd 判定）
 //   - guardedExplore（无 projectPath → 补全/拒绝；无索引 → 引导；sync 失败 → 拒绝）
-//   - apply（enabled:false / requireGit 非 git 跳过 / 探测未装引导 / 注册降级 / 纪律工具注册）
+//   - apply（enabled:false / 不读 ctx.session 回归 / 探测未装引导 / 注册 / 纪律工具注册）
 //
 // 运行：node dsh-codegraph/test/smoke.ts
 import assert from "node:assert/strict";
@@ -101,7 +101,7 @@ check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents"))
 // ---- apply ----
 {
   const makeCtx = (overrides = {}) => {
-    const state = { disposers: [], registered: [], hooks: [], logs: [] };
+    const state = { disposers: [], registered: [], hooks: [], logs: [], tools: [] };
     const ctx = {
       logger: { warn: (m) => state.logs.push(`warn:${m}`), info: (m) => state.logs.push(`info:${m}`) },
       // inject 强依赖：ctx.mcpManager 直接可用（不再 get 探测）。
@@ -112,16 +112,29 @@ check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents"))
         getTools: () => [],
         list: () => [],
       },
+      // inject 强依赖：ctx.tools 直接可用（纪律工具注册；此前未 inject 导致 cordis
+      // Proxy 抛 "cannot get property tools without inject" 启动失败）。
+      tools: { register: (d) => { state.tools.push(d.name); return () => {}; } },
       on: () => () => {},
       effect: (fn) => { const d = fn(); state.disposers.push(d); return d; },
-      session: overrides.session,
     };
     return { ctx, state };
   };
 
-  check("契约: inject 含 mcpManager（强依赖声明）", () =>
-    assert.ok(inject.includes("mcpManager"), `inject 应含 mcpManager，实际 ${JSON.stringify(inject)}`),
-  );
+  check("契约: inject 含 agents/mcpManager/tools（强依赖声明）", () => {
+    for (const svc of ["agents", "mcpManager", "tools"]) {
+      assert.ok(inject.includes(svc), `inject 应含 ${svc}，实际 ${JSON.stringify(inject)}`);
+    }
+  });
+
+  // 回归（启动崩溃根因）：apply 不读取 ctx.session（无 session 字段也能 apply）。
+  // 此前 apply 读 ctx.session 但未 inject session → cordis Proxy 抛
+  // "cannot get property session without inject" → dsh web 启动失败。
+  checkAsync("apply: 不读取 ctx.session（无 session 也能 apply，回归启动崩溃）", async () => {
+    const { ctx, state } = makeCtx(); // fake ctx 无 session 字段
+    await apply(ctx, {});
+    assert.ok(state.disposers.length >= 1, "apply 正常完成并注册 effect disposer");
+  });
 
   // enabled:false → 不做事
   checkAsync("apply: enabled:false 静默返回", async () => {
@@ -130,35 +143,24 @@ check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents"))
     assert.equal(state.disposers.length, 0);
   });
 
-  // requireGit + 非 git cwd → 跳过（不注册、不注入）
-  checkAsync("apply: requireGit 非 git cwd → 跳过", async () => {
-    const { ctx, state } = makeCtx({ session: { header: { cwd: "/tmp" } } });
-    await apply(ctx, { requireGit: true });
-    assert.equal(state.disposers.length, 0, "非 git 不启用");
-  });
-
-  // 正常路径：git cwd + codegraph 未装（PATH 空）→ 引导日志，注册降级
-  checkAsync("apply: git cwd + 未装 → 引导日志", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "cg-apply-"));
-    mkdirSync(join(dir, ".git"), { recursive: true });
-    const { ctx, state } = makeCtx({ session: { header: { cwd: dir } } });
+  // 正常路径：codegraph 未装（PATH 空）→ 引导日志，注册降级
+  checkAsync("apply: codegraph 未装 → 引导日志", async () => {
+    const { ctx, state } = makeCtx();
     // 隔离 PATH（不探测到真实 codegraph）
     const prevPath = process.env.PATH;
     process.env.PATH = "/nonexistent";
     try {
-      await apply(ctx, { requireGit: true });
+      await apply(ctx, {});
     } finally {
       process.env.PATH = prevPath;
     }
     assert.ok(state.logs.some((l) => l.includes("codegraph CLI 未安装") || l.includes("安装")), "有引导日志");
     assert.ok(state.disposers.length >= 1, "仍有 effect disposer（工具/钩子照常注册）");
-    rmSync(dir, { recursive: true, force: true });
   });
 
   // mcpManager（inject 保证在场）+ codegraph 已装（PATH 指向 fake）→ 注册服务器
   checkAsync("apply: mcpManager + 已装 → registerServer", async () => {
     const dir = mkdtempSync(join(tmpdir(), "cg-apply2-"));
-    mkdirSync(join(dir, ".git"), { recursive: true });
     writeFileSync(join(dir, "codegraph"), "#!/bin/sh\n");
     let registered = false;
     const ctx = {
@@ -170,14 +172,14 @@ check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents"))
         getTools: () => [],
         list: () => [],
       },
+      tools: { register: () => () => {} },
       on: () => () => {},
       effect: (fn) => { const d = fn(); return d; },
-      session: { header: { cwd: dir } },
     };
     const prevPath = process.env.PATH;
     process.env.PATH = dir;
     try {
-      await apply(ctx, { requireGit: true });
+      await apply(ctx, {});
     } finally {
       process.env.PATH = prevPath;
     }


### PR DESCRIPTION
## 动机

[#329](https://github.com/wingsky-1/dsh-plugin-hub/issues/329) 的 dsh-codegraph 插件**真实部署启动崩溃**：
`cannot get property "session" without inject`（用户实测 dsh web boot 失败）。单元 smoke 用 mock ctx
全绿、门禁全绿，但真机 boot 崩——暴露 mock ctx 掩盖 cordis Proxy 强制 inject 的盲区。

**本次用隔离实例实测**（临时 `DSH_HOME` + `verify_<随机>` profile + link 本包启动真实 dsh web），
连续抓到并修复 **3 个** smoke 测不出的崩溃点。

## 修复（3 个崩溃点，均经隔离实测验证）

### 1. apply 读 `ctx.session` 但未 inject + apply 阶段本无会话概念
- `src/index.ts` apply 里 `ctx.session?.header?.cwd`（requireGit 早退）→ cordis Proxy 抛
  `cannot get property "session" without inject`；
- 且 apply（插件加载时）**没有「当前会话」**——session 是 per-agent 运行时概念，此处读取本身是设计错误；
- **修复**：删除 apply 的 `sessionCwd` 读取与 requireGit 早退；git 判定由 discipline（`shouldInject`
  按 `agent.session.header.cwd`）+ guard（执行时按 `exec.agent.session` cwd）在**会话级**无条件承担；
  移除已无消费点的 `requireGit` 配置键（README / smoke 同步）。

### 2. `registerGuardTool` 读 `ctx.tools` 但未 inject
- 同上，`inject = ["agents", "mcpManager"]` 漏了 `tools` → cordis Proxy 抛
  `cannot get property "tools" without inject`；
- **修复**：`inject` 加 `"tools"`；删「防御降级」分支（inject 后必在场，直读 `ctx.tools`）。

### 3. 工具 `output` 声明不符 dsh-tools 契约
- `output: { type: "text" }` → dsh-tools 要求 `ToolOutputDefinition { schema, render, presentationMeta? }`，
  真机 `tools.register` 抛 `must declare output { schema, render, presentationMeta? }`；
- **修复**：抄 mcp-manager `buildToolDefinition` 正规形态——`output.schema`（canonical `{ text }`）+
  `output.render(args, value)` 投影 `ContentBlock[]`；execute 返回 canonical JSON 值。

## 隔离实例实测证据

```
DSH_HOME=$(mktemp -d) + verify_<随机> profile + link dsh-mcp-manager/dsh-codegraph
dsh --profile verify_XXXX --port 3467 --no-open
→ dsh web: http://127.0.0.1:3467        （boot 成功，不再抛任何 inject/output 错误）

curl /api/dsh-mcp/servers
→ {"servers":[{"name":"codegraph","transport":"stdio","status":"connected",
     "tools":["mcp__codegraph__codegraph_explore"]}], "counts":{"connected":1}}
curl /api/dsh-mcp/health
→ {"ok":true,"servers":1,"connected":1,"tools":1}
```

codegraph MCP 服务器**真实连接成功**、工具 `mcp__codegraph__codegraph_explore` 可用——证明
dsh-codegraph 的 apply 完整执行（注册 MCP 服务器 + 纪律工具 + agent 钩子）。

## 测试

- smoke 补「apply 不读取 ctx.session（无 session 也能 apply，回归启动崩溃）」+「inject 含
  agents/mcpManager/tools」断言（ctx.tools mock 对齐注入面）✅
- 门禁全绿：`pnpm build` / `contract-check`（@wingsky-1 仅类型导入 PASS）/ `pack:check` /
  `workflow-assert` 30 / dsh-codegraph smoke ✅
- CI 待跑（mcp-manager 既有悬挂在 CI 正常，见 #332/#333 先例）

## 关联

- Issue: [#329](https://github.com/wingsky-1/dsh-plugin-hub/issues/329)（dsh-codegraph 启动崩溃修复）