### PR TITLE
fix(dsh-codegraph): codegraph_explore 工具注册字段名修正（inputSchema→parameters）+ 死配置清理与纪律注入决策修复 (#356)

### DIFF
--- a/packages/dsh-codegraph/README.md
+++ b/packages/dsh-codegraph/README.md
@@ -38,9 +38,10 @@ cd your-project && codegraph init
 | `enabled` | `true` | 总开关 |
 | `autoInstall` | `false` | 未装 codegraph CLI 时自动安装（默认仅引导；开启需知悉供应链风险） |
 | `installCommand` | `npm install -g @colbymchenry/codegraph` | 自定义安装命令 |
-| `syncBeforeQuery` | `true` | 查询前强制 sync |
-| `requireProjectPath` | `true` | 不传 projectPath 时拒绝调用（自动补全 + 拒绝兜底） |
 | `injectDiscipline` | `true` | 注入纪律到 git 仓会话 |
+
+> 工具层纪律（查询前强制 sync + projectPath 校验/补全）是核心价值，固化为默认行为，
+> 不提供关闭开关——保证「worktree 索引不过期」「不漏传 projectPath」不被配置绕过。
 
 ## Worktree 开发流程
 

--- a/packages/dsh-codegraph/package.json
+++ b/packages/dsh-codegraph/package.json
@@ -56,6 +56,8 @@
   "devDependencies": {
     "@deepseek-ai/cordis": "catalog:",
     "@deepseek-ai/dsh-agent": "catalog:",
+    "@deepseek-ai/dsh-llm": "catalog:",
+    "@deepseek-ai/dsh-tools": "catalog:",
     "@wingsky-1/dsh-mcp-manager": "workspace:*"
   }
 }

--- a/packages/dsh-codegraph/src/discipline.ts
+++ b/packages/dsh-codegraph/src/discipline.ts
@@ -10,7 +10,9 @@
  * 多工作空间天然区分：每个会话独立判定，互不影响。
  */
 import type { Context } from "@deepseek-ai/cordis";
+import type { UserMessage } from "@deepseek-ai/dsh-llm";
 import type {} from "@deepseek-ai/dsh-agent";
+import { randomUUID } from "node:crypto";
 import { findGitRoot } from "./guard.ts";
 
 /** 注入给 agent 的 worktree 开发纪律文案（~200 tokens，保持精简）。 */
@@ -29,6 +31,16 @@ export function shouldInject(cwd: string | undefined): boolean {
   return findGitRoot(cwd) !== undefined;
 }
 
+/** 构造纪律注入消息（完整 UserMessage 契约：id + content block + source）。 */
+function disciplineMessage(): UserMessage {
+  return {
+    id: randomUUID() as UserMessage["id"],
+    role: "user",
+    content: [{ type: "text", text: DISCIPLINE_TEXT }],
+    source: { kind: "plugin", plugin: "codegraph", form: "instructions" },
+  };
+}
+
 /** 注册 agent/created 钩子（按 cwd 条件注入纪律）。返回 disposer。 */
 export function registerDisciplineHook(ctx: Context): () => void {
   const disposer = ctx.on("agent/created", ({ agent }) => {
@@ -38,16 +50,19 @@ export function registerDisciplineHook(ctx: Context): () => void {
     // 在子 agent 自己的 scope 注册 pre-step：首轮向 messages 追加纪律文本
     // （~200 tokens/次，非每 step），随 scope 自动清理。
     let injected = false;
-    agent.ctx.on("agent/pre-step", async ({ messages }, next) => {
+    agent.ctx.on("agent/pre-step", async ({ messages, signal }, next) => {
       const decision = await next();
-      if (injected) return decision;
+      signal.throwIfAborted();
+      // 尊重 reject 决策（如其他监听器拒绝进入本轮 step），不覆盖为 enter；
+      // 已注入过 → 原样放行（幂等，防重复注入）。
+      if (decision.kind === "reject" || injected) return decision;
       injected = true;
       // 不可变注入：返回新数组（不动传入 messages 引用），符合 PreStepDecision
       // 契约——mcp-manager 的 resolveCatalogInjection 同款构造式返回。
       const nextMessages = Array.isArray(messages)
-        ? [...messages, { role: "user", content: DISCIPLINE_TEXT }]
+        ? [...messages, disciplineMessage()]
         : messages;
-      return { kind: "enter", messages: nextMessages } as unknown as ReturnType<typeof next>;
+      return { kind: "enter", messages: nextMessages };
     });
   });
   return disposer;

--- a/packages/dsh-codegraph/src/index.ts
+++ b/packages/dsh-codegraph/src/index.ts
@@ -23,12 +23,13 @@
  * ctx.get 探测；MCP 注册/管理/使用本来就是 mcp-manager 的能力，本插件基于它接入）。
  */
 import type { Context } from "@deepseek-ai/cordis";
+import type { ToolDefinition } from "@deepseek-ai/dsh-tools";
 // 类型面：mcpManager service 类型从 mcp-manager 包引（该包 re-export
 // shared/mcp-manager-service.d.ts，类型单一事实源仍在 shared/，消费入口走包）。
 import type { McpManagerService } from "@wingsky-1/dsh-mcp-manager";
 import { installGuidance, isCodegraphInstalled, runInstall } from "./install.ts";
-import { guardedExplore } from "./guard.ts";
 import { registerDisciplineHook } from "./discipline.ts";
+import { buildGuardToolDefinition } from "./tool-definition.ts";
 
 /** Stable cordis plugin name. */
 export const name = "codegraph";
@@ -41,6 +42,7 @@ export const inject = ["agents", "mcpManager", "tools"];
 export { isCodegraphInstalled, installGuidance, runInstall } from "./install.ts";
 export { findGitRoot, isGitRepo, syncCodegraph, exploreCodegraph, guardedExplore } from "./guard.ts";
 export { shouldInject, DISCIPLINE_TEXT, registerDisciplineHook } from "./discipline.ts";
+export { buildGuardToolDefinition } from "./tool-definition.ts";
 
 /** 插件配置。 */
 export interface CodegraphConfig {
@@ -50,60 +52,22 @@ export interface CodegraphConfig {
   autoInstall?: boolean;
   /** 自定义安装命令（默认 npm install -g @colbymchenry/codegraph）。 */
   installCommand?: string;
-  /** 查询前强制 sync（默认 true）。 */
-  syncBeforeQuery?: boolean;
-  /** 不传 projectPath 时拒绝调用（默认 true：自动补全 + 拒绝兜底）。 */
-  requireProjectPath?: boolean;
   /** 注入纪律到 agent（默认 true）。 */
   injectDiscipline?: boolean;
 }
 
 const DEFAULT_INSTALL_COMMAND = "npm install -g @colbymchenry/codegraph";
 
-/** 注册纪律工具（ctx.tools，inject 保证在场）。返回 disposer。 */
-function registerGuardTool(
-  ctx: Context,
-  cfg: Required<Pick<CodegraphConfig, "syncBeforeQuery" | "requireProjectPath">>,
-): () => void {
-  const tools = (ctx as unknown as { tools: { register(d: unknown): () => void } }).tools;
-  return tools.register({
-    name: "codegraph_explore",
-    description:
-      "查询 codegraph 代码图谱（本地索引，返回相关符号源码 + 调用路径）。" +
-      "自动先 sync 目标 worktree 索引再查（新鲜度硬保证）；projectPath 缺省补全为当前" +
-      "会话 worktree；无索引/无法确定 projectPath 时拒绝并提示。结构类代码问题优先用它。",
-    inputSchema: {
-      type: "object",
-      properties: {
-        query: { type: "string", description: "代码问题/符号名（如：X 被谁调用）" },
-        projectPath: { type: "string", description: "目标 worktree 路径（缺省补全为当前会话 worktree）" },
-      },
-      required: ["query"],
-    },
-    // 官方 ToolOutputDefinition 契约（dsh-tools）：output 必含 schema + render。
-    // execute 返回 canonical JSON 值，render 投影为模型可读的 ContentBlock[]。
-    output: {
-      schema: {
-        type: "object",
-        properties: {
-          text: { type: "string" },
-        },
-        required: ["text"],
-        additionalProperties: false,
-      },
-      render(_args: unknown, value?: unknown) {
-        const text = value && typeof value === "object" && "text" in value
-          ? String((value as { text?: unknown }).text ?? "")
-          : "";
-        return [{ type: "text", text }];
-      },
-    },
-    // canonical 值：{ text }；guardedExplore 返回纯文本（含拒绝引导），不抛错。
-    execute: async (args: { query: string; projectPath?: string }, exec: { agent?: { session?: { header?: { cwd?: string } } } }) => {
-      const cwd = exec?.agent?.session?.header?.cwd;
-      return { text: await guardedExplore(args, cwd) };
-    },
-  });
+/**
+ * 注册纪律工具（ctx.tools，inject 保证在场）。返回 disposer。
+ *
+ * 注册定义以官方 ToolDefinition 类型约束（不再用 unknown 断言）——
+ * 参数 schema 字段名是 `parameters`（ToolSchema 契约），此前误用 MCP 风格的
+ * `inputSchema` 导致 schema 投影抛 "parameters must be lossless JSON"（#356）。
+ */
+function registerGuardTool(ctx: Context): () => void {
+  const tools = (ctx as unknown as { tools: { register(d: ToolDefinition): () => void } }).tools;
+  return tools.register(buildGuardToolDefinition());
 }
 
 /**
@@ -113,8 +77,6 @@ export async function apply(ctx: Context, config: CodegraphConfig = {}): Promise
   const enabled = config.enabled !== false;
   const autoInstall = config.autoInstall === true;
   const installCommand = config.installCommand ?? DEFAULT_INSTALL_COMMAND;
-  const syncBeforeQuery = config.syncBeforeQuery !== false;
-  const requireProjectPath = config.requireProjectPath !== false;
   const injectDiscipline = config.injectDiscipline !== false;
 
   if (!enabled) return;
@@ -166,8 +128,9 @@ export async function apply(ctx: Context, config: CodegraphConfig = {}): Promise
     }
   }
 
-  // 3. 纪律工具（工具层硬纪律：强制 sync + projectPath）。
-  const disposeTool = registerGuardTool(ctx, { syncBeforeQuery, requireProjectPath });
+  // 3. 纪律工具（工具层硬纪律：强制 sync + projectPath——纪律行为固化为默认，
+  //    不提供关闭开关，保证「查询前 sync + projectPath 校验」不被配置绕过）。
+  const disposeTool = registerGuardTool(ctx);
 
   // 4. agent 纪律钩子（git 仓会话才注入）。
   const disposeHook = injectDiscipline ? registerDisciplineHook(ctx) : () => {};

--- a/packages/dsh-codegraph/src/tool-definition.ts
+++ b/packages/dsh-codegraph/src/tool-definition.ts
@@ -1,0 +1,58 @@
+/**
+ * 纪律工具注册定义（codegraph_explore）——独立纯函数，便于测试与复用。
+ *
+ * 契约要点（#356 回归）：
+ * - 参数 schema 字段名必须是 `parameters`（@deepseek-ai/dsh-llm 的 ToolSchema
+ *   契约），**不是** MCP 风格的 `inputSchema`——字段名错误会导致 dsh-tools
+ *   投影时 `snapshotJsonValue(undefined)` 抛
+ *   "tool \"<name>\" parameters must be lossless JSON before schema projection"；
+ * - output 必含 schema + render（ToolOutputDefinition 契约），execute 返回
+ *   canonical JSON 值，render 投影为模型可读的 ContentBlock[]。
+ */
+import type { ToolDefinition } from "@deepseek-ai/dsh-tools";
+import { guardedExplore } from "./guard.ts";
+
+/** 构建 codegraph_explore 工具注册定义（纯函数，无副作用）。 */
+export function buildGuardToolDefinition(): ToolDefinition {
+  return {
+    name: "codegraph_explore",
+    description:
+      "查询 codegraph 代码图谱（本地索引，返回相关符号源码 + 调用路径）。" +
+      "自动先 sync 目标 worktree 索引再查（新鲜度硬保证）；projectPath 缺省补全为当前" +
+      "会话 worktree；无索引/无法确定 projectPath 时拒绝并提示。结构类代码问题优先用它。",
+    parameters: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "代码问题/符号名（如：X 被谁调用）" },
+        projectPath: { type: "string", description: "目标 worktree 路径（缺省补全为当前会话 worktree）" },
+      },
+      required: ["query"],
+    },
+    // 官方 ToolOutputDefinition 契约（dsh-tools）：output 必含 schema + render。
+    // execute 返回 canonical JSON 值，render 投影为模型可读的 ContentBlock[]。
+    output: {
+      schema: {
+        type: "object",
+        properties: {
+          text: { type: "string" },
+        },
+        required: ["text"],
+        additionalProperties: false,
+      },
+      render(_args: unknown, value?: unknown) {
+        const text = value && typeof value === "object" && "text" in value
+          ? String((value as { text?: unknown }).text ?? "")
+          : "";
+        return [{ type: "text", text }];
+      },
+    },
+    // canonical 值：{ text }；guardedExplore 返回纯文本（含拒绝引导），不抛错。
+    execute: async (
+      args: { query: string; projectPath?: string },
+      exec: { agent?: { session?: { header?: { cwd?: string } } } },
+    ) => {
+      const cwd = exec?.agent?.session?.header?.cwd;
+      return { text: await guardedExplore(args, cwd) };
+    },
+  };
+}

--- a/packages/dsh-codegraph/test/smoke.ts
+++ b/packages/dsh-codegraph/test/smoke.ts
@@ -8,13 +8,15 @@
 //   - findGitRoot / isGitRepo（.git 目录 / .git 文件(worktree) / 非 git 三分支）
 //   - shouldInject（cwd 判定）
 //   - guardedExplore（无 projectPath → 补全/拒绝；无索引 → 引导；sync 失败 → 拒绝）
+//   - 工具注册定义（#356 回归）：buildGuardToolDefinition 字段名契约
+//     （parameters 而非 inputSchema）+ 真实 dsh-tools 注册投影不抛错
 //   - apply（enabled:false / 不读 ctx.session 回归 / 探测未装引导 / 注册 / 纪律工具注册）
 //
 // 运行：node dsh-codegraph/test/smoke.ts
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const pkgDir = join(new URL("..", import.meta.url).pathname);
@@ -23,6 +25,38 @@ const { apply, name, inject } = mod;
 const { isCodegraphInstalled, installGuidance } = mod;
 const { findGitRoot, isGitRepo, guardedExplore } = mod;
 const { shouldInject, DISCIPLINE_TEXT } = mod;
+const { buildGuardToolDefinition } = mod;
+
+// 解析真实 dsh-tools + cordis（#356 回归投影断言用）。
+// 候选顺序：依赖树解析 → DSH_TOOLS_PATH / DSH_CORDIS_PATH 环境变量 → Volta 全局
+// 安装布局。全部失败时警告而非静默跳过（避免"测试通过但覆盖缺失"的假象）。
+// 先例：dsh-mcp-manager test/smoke.ts 的 dsh-tools 解析（同款候选策略）。
+async function resolveModule(name, envVar) {
+  const candidates = [];
+  try {
+    candidates.push(import.meta.resolve(name));
+  } catch {
+    // 不在依赖树，继续尝试其他候选
+  }
+  if (typeof process.env[envVar] === "string" && process.env[envVar] !== "") {
+    candidates.push(pathToFileURL(process.env[envVar]).href);
+  }
+  try {
+    const voltaPackages = join(dirname(dirname(dirname(process.execPath))), "packages");
+    candidates.push(pathToFileURL(join(voltaPackages, "@deepseek-ai", "dsh", "node_modules", "@deepseek-ai", "dsh", "node_modules", "@deepseek-ai", name, "lib", "index.js")).href);
+  } catch {
+    // 非 Volta 环境，跳过布局候选
+  }
+  let lastError;
+  for (const url of candidates) {
+    try {
+      return await import(url);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  return { error: lastError };
+}
 
 const failures = [];
 function check(label, fn) {
@@ -47,6 +81,53 @@ async function checkAsync(label, fn) {
 // ---- 契约 ----
 check("契约: name = codegraph", () => assert.equal(name, "codegraph"));
 check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents")));
+
+// ---- 工具注册定义（#356 回归）----
+// 根因：注册定义误用 MCP 风格字段 inputSchema，而 dsh-tools 契约要求 parameters，
+// 导致 schema 投影时 parameters===undefined → 抛 "must be lossless JSON"。
+{
+  const definition = buildGuardToolDefinition();
+  check("工具定义: 使用 parameters 字段（非 inputSchema，#356）", () => {
+    assert.ok(definition.parameters, "parameters 必须存在");
+    assert.equal(definition.inputSchema, undefined, "inputSchema 不应存在");
+  });
+  check("工具定义: parameters 为合法对象 schema", () => {
+    assert.equal(definition.parameters.type, "object");
+    assert.ok(definition.parameters.properties.query, "query 属性存在");
+    assert.ok(definition.parameters.properties.projectPath, "projectPath 属性存在");
+    assert.deepEqual(definition.parameters.required, ["query"]);
+  });
+  check("工具定义: output 契约完整（schema + render）", () => {
+    assert.ok(definition.output, "output 必须存在");
+    assert.ok(definition.output.schema, "output.schema 必须存在");
+    assert.equal(typeof definition.output.render, "function", "output.render 必须是函数");
+  });
+
+  // 真实 dsh-tools 注册 + 投影：注册定义后调用 schemas() 不抛错（堵住 mock 盲区——
+  // 此前 smoke 的 tools.register 是 mock，不触发真实 schemaOf 投影，契约字段错误溜过门禁）。
+  checkAsync("工具定义: 真实 dsh-tools 注册 + schemas() 投影不抛错（#356 回归）", async () => {
+    const dshTools = await resolveModule("@deepseek-ai/dsh-tools", "DSH_TOOLS_PATH");
+    const cordis = await resolveModule("@deepseek-ai/cordis", "DSH_CORDIS_PATH");
+    if (dshTools.error || cordis.error) {
+      console.warn(`smoke: @deepseek-ai/dsh-tools / @deepseek-ai/cordis 不可解析（dsh-tools: ${dshTools.error?.message ?? "无候选"}；cordis: ${cordis.error?.message ?? "无候选"}）——真实投影断言跳过；可设置 DSH_TOOLS_PATH / DSH_CORDIS_PATH`);
+      return;
+    }
+    const { Context } = cordis;
+    const ToolRuntime = dshTools.default ?? dshTools.ToolRuntime;
+    const ctx = new Context();
+    ctx.provide("systemPrompt", {
+      tools: () => () => {},
+      section: () => () => {},
+    });
+    const tools = new ToolRuntime(ctx, { mode: "native" });
+    tools.register(buildGuardToolDefinition());
+    const schemas = tools.schemas();
+    assert.equal(schemas.length, 1, "投影出 1 个工具");
+    assert.equal(schemas[0].name, "codegraph_explore");
+    assert.ok(schemas[0].parameters, "投影 parameters 存在");
+    assert.equal(schemas[0].parameters.properties.query.type, "string");
+  });
+}
 
 // ---- install.ts ----
 {
@@ -114,7 +195,7 @@ check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents"))
       },
       // inject 强依赖：ctx.tools 直接可用（纪律工具注册；此前未 inject 导致 cordis
       // Proxy 抛 "cannot get property tools without inject" 启动失败）。
-      tools: { register: (d) => { state.tools.push(d.name); return () => {}; } },
+      tools: { register: (d) => { state.tools.push(d); return () => {}; } },
       on: () => () => {},
       effect: (fn) => { const d = fn(); state.disposers.push(d); return d; },
     };
@@ -134,6 +215,17 @@ check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents"))
     const { ctx, state } = makeCtx(); // fake ctx 无 session 字段
     await apply(ctx, {});
     assert.ok(state.disposers.length >= 1, "apply 正常完成并注册 effect disposer");
+  });
+
+  // #356 回归：apply 注册的纪律工具定义必须用 parameters（非 inputSchema）字段。
+  checkAsync("apply: 纪律工具注册定义用 parameters 字段（#356 回归）", async () => {
+    const { ctx, state } = makeCtx();
+    await apply(ctx, {});
+    assert.equal(state.tools.length, 1, "注册了 1 个工具");
+    const definition = state.tools[0];
+    assert.equal(definition.name, "codegraph_explore");
+    assert.ok(definition.parameters, "parameters 必须存在（非 inputSchema）");
+    assert.equal(definition.inputSchema, undefined, "inputSchema 不应存在");
   });
 
   // enabled:false → 不做事

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,12 @@ importers:
       '@deepseek-ai/dsh-agent':
         specifier: 'catalog:'
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-system-prompt@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-llm':
+        specifier: 'catalog:'
+        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-tools':
+        specifier: 'catalog:'
+        version: 0.1.1-rc.2(f7d8e59091784496c02afcf19f5662a6)
       '@wingsky-1/dsh-mcp-manager':
         specifier: workspace:*
         version: link:../dsh-mcp-manager


### PR DESCRIPTION
Fixes #356

## 动机

`codegraph_explore` 纪律工具注册后 schema 投影必然报错，工具在真实对话中不可见：

```
tool "codegraph_explore" parameters must be lossless JSON before schema projection
```

## 根因

`registerGuardTool` 误用 MCP 风格字段 **`inputSchema`**，而 dsh-tools 契约
（`@deepseek-ai/dsh-llm` 的 `ToolSchema`）要求 **`parameters`**。字段名错误导致
`definition.parameters === undefined`，投影时 `snapshotJsonValue(undefined)` 返回
`undefined` → 抛错。原代码用 `tools.register(d: unknown)` 断言绕过类型检查，
smoke 的 mock `tools.register` 又不触发真实投影——盲区双重放行。

## 改动

1. **`src/index.ts`**：工具定义提取为导出纯函数 `buildGuardToolDefinition()`
   （新文件 `src/tool-definition.ts`），注册定义以官方 `ToolDefinition` 类型约束
   （不再 `unknown` 断言），字段名修正为 `parameters`；
2. **`src/discipline.ts`**：`agent/pre-step` 尊重 reject 决策（不覆盖为 enter，
   参照 mcp-manager）、补 `signal.throwIfAborted()`、构造完整 `UserMessage`
   （id + content block + source），去掉 `unknown` 断言；
3. **死配置清理**：移除未接线的 `syncBeforeQuery` / `requireProjectPath`
   （声明了但 `guardedExplore` 从不消费；同 #351 移除 `requireGit` 先例），
   纪律行为固化为硬编码默认，README 配置表同步；
4. **`test/smoke.ts`**：新增 #356 回归断言——字段名契约 + 真实 dsh-tools
   注册 + `schemas()` 投影不抛错（动态解析候选：依赖树 / DSH_TOOLS_PATH /
   Volta 布局，不可解析时 warn 跳过，同 mcp-manager 先例）。

## 验证

- 全仓门禁：`pnpm build` / `pnpm test` / `pnpm contract` / `pnpm pack:check` 全绿；
- **真实投影对照**（真实 cordis + dsh-tools）：
  - 旧形态（`inputSchema`）→ `schemas()` 抛 `tool "codegraph_explore" parameters must be lossless JSON before schema projection`；
  - 修复后（`parameters`）→ 投影正常，schema 完整输出；
- **隔离 dsh web 实测**（临时 DSH_HOME + verify profile，link 本包）：
  - dsh web 正常启动，无投影报错，浏览器控制台 0 error；
  - MCP 管理器面板：codegraph 服务器「运行中 · 1 工具」；
  - `/api/dsh-mcp/servers`：`codegraph` `status=connected`，工具 `mcp__codegraph__codegraph_explore`；
  - 真实会话对话：`session.prompt` 接受，会话跑完 2 turns，`toolsTokens=7466`
    （工具 schema 完整投影进模型上下文）。

## 提交

- `fix(dsh-codegraph): codegraph_explore 工具注册字段名修正（inputSchema→parameters）+ 死配置清理与纪律注入决策修复 (#356)`
