### PR TITLE
fix(mcp-manager,codegraph): 运行时注入的 MCP 服务器进能力目录 + 纪律注入迁移 systemPrompt 段 (#359)

### DIFF
--- a/packages/dsh-codegraph/README.md
+++ b/packages/dsh-codegraph/README.md
@@ -14,8 +14,9 @@ codegraph MCP + worktree 开发纪律 —— 把 [codegraph](https://github.com/
   worktree，自动不了则拒绝并提示）。杜绝「worktree 索引静默过期」与「漏传 projectPath
   查错对象」。
 - **agent 纪律钩子**：`agent/created` + 会话 cwd 判定，git 仓（主 checkout / worktree）会话
-  才注入 worktree 开发纪律（~200 tokens/次）；非 git 仓（日常维护/讨论空间）不注入——
-  多工作空间天然区分（按会话 cwd 判定，无需配置）。
+  才注入 worktree 开发纪律——以 systemPrompt 段注入（order 161，恒在 mcp-manager
+  能力目录段之后，agent scope 注册沿 scope 链自动继承给子 agent）；非 git 仓
+  （日常维护/讨论空间）不注入——多工作空间天然区分（按会话 cwd 判定，无需配置）。
 
 ## 安装
 

--- a/packages/dsh-codegraph/package.json
+++ b/packages/dsh-codegraph/package.json
@@ -57,6 +57,7 @@
     "@deepseek-ai/cordis": "catalog:",
     "@deepseek-ai/dsh-agent": "catalog:",
     "@deepseek-ai/dsh-llm": "catalog:",
+    "@deepseek-ai/dsh-system-prompt": "catalog:",
     "@deepseek-ai/dsh-tools": "catalog:",
     "@wingsky-1/dsh-mcp-manager": "workspace:*"
   }

--- a/packages/dsh-codegraph/src/discipline.ts
+++ b/packages/dsh-codegraph/src/discipline.ts
@@ -1,29 +1,48 @@
 /**
- * agent 纪律钩子——按会话 cwd 条件注入 worktree 开发纪律。
+ * agent 纪律钩子——按会话 cwd 条件注入 worktree 开发纪律（#359 迁移）。
  *
  * 载体：agent/created（dsh-agent 无「子 agent 启动」专用事件，评审④核实；
  * 仓库先例 dsh-subagent-model-inherit 用 agent/created + inject:["agents"]）。
+ * 注入方式：**systemPrompt.section（官方有序提示段）**，不再用 agent/pre-step
+ * 拼 user 消息——system prompt 段每次请求都在（不随消息轮次丢失）、注册天然
+ * 唯一（无重复注入）、order 精确控制位置、随 agent scope 自动清理。
+ *
+ * 顺序（#359）：mcp-manager 能力目录段 order=160（plugin:dsh-mcp-manager），
+ * 本纪律段 order=161 恒在其后——先看到"有哪些 MCP 服务器"，再看"codegraph
+ * 怎么用"。agent scope 注册沿 scope 链向下继承，子 agent 自动继承纪律。
+ *
  * 判定：agent.session.header.cwd（dsh-session 类型，mcp-manager 中间层已实证
  * 可得）→ 沿 cwd 找 .git 标记（findGitRoot）：
- * - 是 git 仓（主 checkout / worktree）→ 注入纪律（~200 tokens/次，非每 step）；
- * - 非 git 仓（日常维护/讨论空间）→ 不注入（静默跳过，agent 正常讨论无噪声）。
+ * - 是 git 仓（主 checkout / worktree）→ 注册纪律段（~200 tokens/次，非每 step）；
+ * - 非 git 仓（日常维护/讨论空间）→ 不注册（静默跳过，agent 正常讨论无噪声）。
  * 多工作空间天然区分：每个会话独立判定，互不影响。
  */
 import type { Context } from "@deepseek-ai/cordis";
-import type { UserMessage } from "@deepseek-ai/dsh-llm";
 import type {} from "@deepseek-ai/dsh-agent";
-import { randomUUID } from "node:crypto";
 import { findGitRoot } from "./guard.ts";
 
-/** 注入给 agent 的 worktree 开发纪律文案（~200 tokens，保持精简）。 */
+/** 纪律段 order：mcp-manager 目录段（160）之后，工具带（100-199）内靠后。 */
+export const DISCIPLINE_SECTION_ORDER = 161;
+
+/** 纪律段唯一名（systemPrompt.section name 唯一，重复注册抛错）。 */
+export const DISCIPLINE_SECTION_NAME = "plugin:dsh-codegraph";
+
+/** 注入给 agent 的 worktree 开发纪律文案（~200 tokens，保持精简）。
+ * 只保留目录注入覆盖不到的**差异化纪律**（#359 去重）：
+ * - 用裸 codegraph_explore（纪律工具：自动补全 projectPath + 强制 sync），
+ *   不是 mcp__codegraph__codegraph_explore（官方 MCP 工具要手动传 projectPath）；
+ * - 自动 sync 语义（worktree 索引新鲜度）；
+ * - 无索引时返回引导（init 由 agent/用户决策）。
+ * "codegraph 可用"等能力声明由 mcp-manager 能力目录（<available_mcp_servers>）
+ * 承担，不在此重复。 */
 export const DISCIPLINE_TEXT = [
-  "【codegraph 开发纪律】本会话工作目录是 git 仓库（主 checkout 或 worktree），",
-  "codegraph 代码图谱可用：",
-  "- 结构类查询（X 被谁调用/依赖关系/符号位置）优先用 codegraph_explore，",
-  "  它会自动先 sync 再查，返回的源码视为已读，不必再 grep 复核；",
+  "【codegraph 开发纪律】结构类查询（X 被谁调用/依赖关系/符号位置）优先用",
+  "`codegraph_explore`（裸名，不是 mcp__codegraph__ 前缀的官方工具）——它会",
+  "自动补全 projectPath 为当前会话 worktree 并先 sync 再查，返回的源码视为已读，",
+  "不必再 grep 复核；",
   "- worktree 内新建/改动文件需 sync 后才进索引——查询结果以工具自动 sync 为准；",
   "- 正在编辑的文件一律 Read 原文，不依赖图谱；",
-  "- 没有 .codegraph 索引的目录会返回引导，索引与否是用户决定。",
+  "- 没有 .codegraph 索引的目录会返回引导（codegraph init <path>），索引与否是用户决定。",
 ].join("\n");
 
 /** 按会话 cwd 判定是否注入纪律（纯函数，便于单测）。 */
@@ -31,38 +50,19 @@ export function shouldInject(cwd: string | undefined): boolean {
   return findGitRoot(cwd) !== undefined;
 }
 
-/** 构造纪律注入消息（完整 UserMessage 契约：id + content block + source）。 */
-function disciplineMessage(): UserMessage {
-  return {
-    id: randomUUID() as UserMessage["id"],
-    role: "user",
-    content: [{ type: "text", text: DISCIPLINE_TEXT }],
-    source: { kind: "plugin", plugin: "codegraph", form: "instructions" },
-  };
-}
-
 /** 注册 agent/created 钩子（按 cwd 条件注入纪律）。返回 disposer。 */
 export function registerDisciplineHook(ctx: Context): () => void {
   const disposer = ctx.on("agent/created", ({ agent }) => {
     // 提取会话 cwd（agent.session.header.cwd；防御缺省）。
     const cwd = (agent.session as unknown as { header?: { cwd?: string } })?.header?.cwd;
+    // 非 git 仓 → 不注册（零注入；agent scope 沿链继承也不会带出纪律）。
     if (!shouldInject(cwd)) return;
-    // 在子 agent 自己的 scope 注册 pre-step：首轮向 messages 追加纪律文本
-    // （~200 tokens/次，非每 step），随 scope 自动清理。
-    let injected = false;
-    agent.ctx.on("agent/pre-step", async ({ messages, signal }, next) => {
-      const decision = await next();
-      signal.throwIfAborted();
-      // 尊重 reject 决策（如其他监听器拒绝进入本轮 step），不覆盖为 enter；
-      // 已注入过 → 原样放行（幂等，防重复注入）。
-      if (decision.kind === "reject" || injected) return decision;
-      injected = true;
-      // 不可变注入：返回新数组（不动传入 messages 引用），符合 PreStepDecision
-      // 契约——mcp-manager 的 resolveCatalogInjection 同款构造式返回。
-      const nextMessages = Array.isArray(messages)
-        ? [...messages, disciplineMessage()]
-        : messages;
-      return { kind: "enter", messages: nextMessages };
+    // git 仓 → 在 agent 自己的 scope 注册纪律段（order 161，恒在 MCP 目录段
+    // 160 之后；随 agent scope 自动清理，子 agent 沿 scope 链继承）。
+    (agent.ctx as unknown as { systemPrompt?: { section(opts: Record<string, unknown>): () => void } }).systemPrompt?.section({
+      name: DISCIPLINE_SECTION_NAME,
+      order: DISCIPLINE_SECTION_ORDER,
+      text: DISCIPLINE_TEXT,
     });
   });
   return disposer;

--- a/packages/dsh-codegraph/src/index.ts
+++ b/packages/dsh-codegraph/src/index.ts
@@ -35,13 +35,14 @@ import { buildGuardToolDefinition } from "./tool-definition.ts";
 export const name = "codegraph";
 
 /** 需要的宿主服务：agents（agent/created 事件）、mcpManager（MCP 注册/管理/使用）、
- *  tools（纪律工具注册）。均经 inject 强依赖声明——缺失时 cordis 内核自动停用本插件。 */
-export const inject = ["agents", "mcpManager", "tools"];
+ *  tools（纪律工具注册）、systemPrompt（纪律段注册）。均经 inject 强依赖声明——
+ *  缺失时 cordis 内核自动停用本插件。 */
+export const inject = ["agents", "mcpManager", "tools", "systemPrompt"];
 
 // 内部模块 re-export（公共测试面 + 其他插件可复用纯函数）。
 export { isCodegraphInstalled, installGuidance, runInstall } from "./install.ts";
 export { findGitRoot, isGitRepo, syncCodegraph, exploreCodegraph, guardedExplore } from "./guard.ts";
-export { shouldInject, DISCIPLINE_TEXT, registerDisciplineHook } from "./discipline.ts";
+export { shouldInject, DISCIPLINE_TEXT, DISCIPLINE_SECTION_NAME, DISCIPLINE_SECTION_ORDER, registerDisciplineHook } from "./discipline.ts";
 export { buildGuardToolDefinition } from "./tool-definition.ts";
 
 /** 插件配置。 */

--- a/packages/dsh-codegraph/test/smoke.ts
+++ b/packages/dsh-codegraph/test/smoke.ts
@@ -182,7 +182,7 @@ check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents"))
 // ---- apply ----
 {
   const makeCtx = (overrides = {}) => {
-    const state = { disposers: [], registered: [], hooks: [], logs: [], tools: [] };
+    const state = { disposers: [], registered: [], hooks: [], logs: [], tools: [], sections: [], createdCbs: [] };
     const ctx = {
       logger: { warn: (m) => state.logs.push(`warn:${m}`), info: (m) => state.logs.push(`info:${m}`) },
       // inject 强依赖：ctx.mcpManager 直接可用（不再 get 探测）。
@@ -196,14 +196,16 @@ check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents"))
       // inject 强依赖：ctx.tools 直接可用（纪律工具注册；此前未 inject 导致 cordis
       // Proxy 抛 "cannot get property tools without inject" 启动失败）。
       tools: { register: (d) => { state.tools.push(d); return () => {}; } },
-      on: () => () => {},
+      // inject 强依赖：ctx.systemPrompt（纪律段注册，agent scope 继承）。
+      systemPrompt: { section: (opts) => { state.sections.push(opts); return () => {}; } },
+      on: (event, cb) => { if (event === "agent/created") state.createdCbs.push(cb); return () => {}; },
       effect: (fn) => { const d = fn(); state.disposers.push(d); return d; },
     };
     return { ctx, state };
   };
 
-  check("契约: inject 含 agents/mcpManager/tools（强依赖声明）", () => {
-    for (const svc of ["agents", "mcpManager", "tools"]) {
+  check("契约: inject 含 agents/mcpManager/tools/systemPrompt（强依赖声明）", () => {
+    for (const svc of ["agents", "mcpManager", "tools", "systemPrompt"]) {
       assert.ok(inject.includes(svc), `inject 应含 ${svc}，实际 ${JSON.stringify(inject)}`);
     }
   });
@@ -278,6 +280,49 @@ check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents"))
     assert.equal(registered, true, "registerServer 被调用");
     rmSync(dir, { recursive: true, force: true });
   });
+
+  // #359：纪律注入迁移到 systemPrompt.section（order 161，agent scope 注册，
+  // 非 git 不注册）——替代原 pre-step user 消息注入。
+  {
+    // 模拟 agent/created：git 仓会话 → 注册纪律段；非 git 会话 → 不注册。
+    // 注意：目录在 checkAsync 内部自建自删（防 flake 纪律——共享外层目录 +
+    // 未 await 的异步断言会在 finally 清理后执行 findGitRoot 而失败）。
+    const emitCreated = (state, cwd) => {
+      for (const cb of state.createdCbs) {
+        cb({ agent: { session: { header: { cwd } }, ctx: { systemPrompt: { section: (opts) => { state.sections.push(opts); return () => {}; } } } } });
+      }
+    };
+    checkAsync("discipline: git 仓会话注册纪律段（order 161，MCP 目录段之后）", async () => {
+      const dir = mkdtempSync(join(tmpdir(), "cg-disc-git-"));
+      mkdirSync(join(dir, "repo", ".git"), { recursive: true });
+      try {
+        const { ctx, state } = makeCtx();
+        const { registerDisciplineHook, DISCIPLINE_SECTION_NAME, DISCIPLINE_SECTION_ORDER } = await import(pathToFileURL(join(pkgDir, "lib/index.js")).href);
+        registerDisciplineHook(ctx);
+        emitCreated(state, join(dir, "repo"));
+        assert.equal(state.sections.length, 1, "git 仓注册 1 个纪律段");
+        assert.equal(state.sections[0].name, DISCIPLINE_SECTION_NAME);
+        assert.equal(state.sections[0].order, DISCIPLINE_SECTION_ORDER);
+        assert.ok(state.sections[0].order > 160, "纪律段必须在 MCP 目录段（160）之后");
+        assert.ok(typeof state.sections[0].text === "string" && state.sections[0].text.includes("codegraph_explore"));
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+    checkAsync("discipline: 非 git 会话不注册纪律段（零注入）", async () => {
+      const dir = mkdtempSync(join(tmpdir(), "cg-disc-nongit-"));
+      mkdirSync(join(dir, "nongit"), { recursive: true });
+      try {
+        const { ctx, state } = makeCtx();
+        const { registerDisciplineHook } = await import(pathToFileURL(join(pkgDir, "lib/index.js")).href);
+        registerDisciplineHook(ctx);
+        emitCreated(state, join(dir, "nongit"));
+        assert.equal(state.sections.length, 0, "非 git 不注册纪律段");
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  }
 }
 
 if (failures.length > 0) {

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -294,12 +294,22 @@ export class McpManager {
    * 连接状态、跟随"当前工作区"）——切换工作区会断开/连接项目级服务器，导致
    * 别的会话的目录集合抖动、每次抖动注入一条目录更新消息。按 cwd 计算后：
    * 工作区 MCP 没变化 → digest 不变 → 不重新注入。
+   *
+   * 运行时注入（registerServer 的 runtimeRegistry，内存态）同样并入目录数据源
+   * （#359）：dsh-codegraph 等插件经运行时注入注册的服务器，连接成功、工具可用，
+   * 但此前不在目录里——模型看不到能力，只能自己翻 CLI。同名 runtime 优先
+   * （与 reconcile 双轨一致）。
    */
   async catalogServersFor(cwd: string | undefined): Promise<Map<string, { server: ServerConfig; scope: string }>> {
     const servers = new Map<string, { server: ServerConfig; scope: string }>();
     for (const server of this.store.data.servers) {
       if (server.enabled === false) continue;
       servers.set(server.name, { server, scope: SCOPE_GLOBAL });
+    }
+    // 运行时注入（registerServer 内存态）：并入目录数据源，同名 runtime 优先。
+    for (const [name, server] of this.runtimeRegistry) {
+      if (server.enabled === false) continue;
+      servers.set(name, { server, scope: SCOPE_GLOBAL });
     }
     const root = cwd === undefined || cwd === null || cwd === "" ? undefined : await this.findProjectRoot(cwd);
     const store = root === undefined ? undefined : await this.projectStoreFor(root);

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -1077,6 +1077,19 @@ const main = async () => {
         assert.equal(manager.projectStore, current);
       });
 
+      // #359：运行时注入（registerServer 的 runtimeRegistry）并入目录数据源——
+      // dsh-codegraph 等插件运行时注册的服务器必须在 <available_mcp_servers> 里。
+      // 放在块尾：避免注入污染前面用例对"仅 store"目录的断言。
+      await checkAsync("运行时注入（runtimeRegistry）并入目录数据源（#359）", async () => {
+        await manager.registerServer(normalizeServer({ name: "rt1", transport: "stdio", command: "true", ...noReconnect }));
+        const names = [...(await manager.catalogServersFor("")).keys()];
+        assert.deepEqual(names, ["g1", "rt1"]);
+        // 同名 runtime 优先于 store（与 reconcile 双轨一致）——目录仍含该名。
+        await manager.registerServer(normalizeServer({ name: "g1", transport: "stdio", command: "true", ...noReconnect }));
+        const g1 = (await manager.catalogServersFor("")).get("g1");
+        assert.equal(g1 !== undefined && g1.server !== undefined, true, "g1 仍在目录中");
+      });
+
       await manager.dispose();
     } finally {
       rmSync(base, { recursive: true, force: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@deepseek-ai/dsh-llm':
         specifier: 'catalog:'
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-system-prompt':
+        specifier: 'catalog:'
+        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-tools':
         specifier: 'catalog:'
         version: 0.1.1-rc.2(f7d8e59091784496c02afcf19f5662a6)


### PR DESCRIPTION
Fixes #359

## 动机

实测发现两个关联问题：

1. **运行时注入的 MCP 服务器不进能力目录**：dsh-codegraph 经 `registerServer()`
   运行时注入的 codegraph 服务器，连接成功、工具可用（`mcp__codegraph__codegraph_explore`），
   但 `<available_mcp_servers>` 目录注入里没有它——模型不知道 codegraph 可用，
   只能自己翻 CLI 用法。

2. **dsh-codegraph 纪律注入与目录注入重叠 + 位置不可控**：纪律用 pre-step 注入
   （user 消息），与 mcp-manager 的目录注入内容重叠（都宣称"codegraph 可用"），
   且顺序不可控。

## 根因

`catalogServersFor()`（manager.ts）只读持久化 store（`store.data.servers` + 项目
store），不含运行时注入表 `runtimeRegistry`（`registerServer()` 写入的内存态注册表）。

## 改动

### mcp-manager
- `catalogServersFor()` 并入 `runtimeRegistry`（同名 runtime 优先，与 reconcile
  双轨一致）——运行时注入的服务器进能力目录；

### dsh-codegraph
- 纪律注入从 `agent/pre-step` 迁移到 `systemPrompt.section()`：
  - `order: 161`（恒在 mcp-manager 目录段 160 之后）；
  - agent scope 注册（`agent.ctx`），沿 scope 链自动继承给子 agent，随 agent
    销毁自动清理；
  - `agent/created` 里按 `shouldInject(cwd)` 判定，git 仓才注册，非 git 零注入
    （保留原边界）；
- 纪律文本去重精简：删除与目录重复的"codegraph 可用"表述，保留差异化纪律
  （裸 `codegraph_explore` 而非 `mcp__` 前缀、自动 sync、无索引返回引导）；
- `inject` 加 `"systemPrompt"`；

### smoke
- mcp-manager：补 `runtimeRegistry` 并入目录断言（#359 回归）；
- dsh-codegraph：补 discipline section 注册断言（git 注册 order 161 / 非 git
  零注入），inject 契约加 systemPrompt。

## 验证

- 全仓门禁：`pnpm build` / `pnpm test` / `pnpm contract` / `pnpm pack:check` 全绿；
- 隔离 dsh web 实测（临时 DSH_HOME + verify profile，link 两个包）：
  - 目录注入含 codegraph：`<available_mcp_servers>` 列出 `codegraph`（mcp-catalog
    事件，带官方能力描述）；
  - 纪律段在目录段之后：system prompt 内 mcp 目录在 6254、纪律段在 6612
    （order 161 > 160 生效）；
  - 纪律内容去重：无"codegraph 可用"重复表述，保留差异化指引；
  - 非 git 会话不注入（smoke 断言）。

## 提交

- `fix(mcp-manager,codegraph): 运行时注入的 MCP 服务器进能力目录 + 纪律注入迁移 systemPrompt 段 (#359)`
