### PR TITLE
fix(dsh-codegraph): 纪律注入改回 pre-step 消息型（面板可见）+ 幂等查会话历史 + 内容正交化 (#359)

### DIFF
--- a/packages/dsh-codegraph/README.md
+++ b/packages/dsh-codegraph/README.md
@@ -13,10 +13,11 @@ codegraph MCP + worktree 开发纪律 —— 把 [codegraph](https://github.com/
   （新鲜度硬保证，worktree 索引不过期）+ 校验/补全 `projectPath`（缺省补全为当前会话
   worktree，自动不了则拒绝并提示）。杜绝「worktree 索引静默过期」与「漏传 projectPath
   查错对象」。
-- **agent 纪律钩子**：`agent/created` + 会话 cwd 判定，git 仓（主 checkout / worktree）会话
-  才注入 worktree 开发纪律——以 systemPrompt 段注入（order 161，恒在 mcp-manager
-  能力目录段之后，agent scope 注册沿 scope 链自动继承给子 agent）；非 git 仓
-  （日常维护/讨论空间）不注入——多工作空间天然区分（按会话 cwd 判定，无需配置）。
+- **agent 纪律钩子**：`agent/pre-step` + 会话 cwd 判定，git 仓（主 checkout / worktree）会话
+  才注入 worktree 开发纪律——以 pre-step user 消息注入（官方 dsh-tool-skill 同款载体，
+  出现在 GUI「上下文注入」面板，幂等查会话历史）；非 git 仓（日常维护/讨论空间）不注入——
+  多工作空间天然区分（按会话 cwd 判定，无需配置）。纪律内容与 mcp 能力目录正交
+  （纪律讲工具用法，目录讲服务器清单），无先后依赖。
 
 ## 安装
 

--- a/packages/dsh-codegraph/package.json
+++ b/packages/dsh-codegraph/package.json
@@ -57,7 +57,6 @@
     "@deepseek-ai/cordis": "catalog:",
     "@deepseek-ai/dsh-agent": "catalog:",
     "@deepseek-ai/dsh-llm": "catalog:",
-    "@deepseek-ai/dsh-system-prompt": "catalog:",
     "@deepseek-ai/dsh-tools": "catalog:",
     "@wingsky-1/dsh-mcp-manager": "workspace:*"
   }

--- a/packages/dsh-codegraph/src/discipline.ts
+++ b/packages/dsh-codegraph/src/discipline.ts
@@ -1,40 +1,38 @@
 /**
- * agent 纪律钩子——按会话 cwd 条件注入 worktree 开发纪律（#359 迁移）。
+ * agent 纪律钩子——按会话 cwd 条件注入 worktree 开发纪律（#359 三轮，B2）。
  *
- * 载体：agent/created（dsh-agent 无「子 agent 启动」专用事件，评审④核实；
- * 仓库先例 dsh-subagent-model-inherit 用 agent/created + inject:["agents"]）。
- * 注入方式：**systemPrompt.section（官方有序提示段）**，不再用 agent/pre-step
- * 拼 user 消息——system prompt 段每次请求都在（不随消息轮次丢失）、注册天然
- * 唯一（无重复注入）、order 精确控制位置、随 agent scope 自动清理。
+ * 注入方式：**agent/pre-step user 消息注入**（与 dsh-tool-skill / dsh-time-context
+ * 官方插件同款载体，出现在 GUI「上下文注入」面板）。
  *
- * 顺序（#359）：mcp-manager 能力目录段 order=160（plugin:dsh-mcp-manager），
- * 本纪律段 order=161 恒在其后——先看到"有哪些 MCP 服务器"，再看"codegraph
- * 怎么用"。agent scope 注册沿 scope 链向下继承，子 agent 自动继承纪律。
+ * 幂等（官方模式）：查**会话历史** `agent.session.events` 是否已注入过本插件的
+ * 纪律消息（source.kind=plugin && source.plugin=codegraph）——与 dsh-time-context
+ * 的 `latestInjectionTime(agent)` 同款（pre-step 的 messages 不含历史注入，
+ * 不能靠查 messages 判重）。compaction/resume 后历史被压缩 → 重新注入（幂等自愈）。
  *
- * 判定：agent.session.header.cwd（dsh-session 类型，mcp-manager 中间层已实证
- * 可得）→ 沿 cwd 找 .git 标记（findGitRoot）：
- * - 是 git 仓（主 checkout / worktree）→ 注册纪律段（~200 tokens/次，非每 step）；
- * - 非 git 仓（日常维护/讨论空间）→ 不注册（静默跳过，agent 正常讨论无噪声）。
+ * 内容正交（B2：#360 曾与 mcp 能力目录排先后，实测脆弱且耦合——目录讲
+ * "有哪些 MCP 服务器"，纪律讲 "codegraph_explore 工具怎么用"，本就不该有
+ * 先后依赖）。纪律只保留工具层差异化信息（裸工具名、自动 sync、无索引引导）。
+ *
+ * 判定：payload.agent.session.header.cwd（dsh-session 类型，mcp-manager 中间层
+ * 已实证可得）→ 沿 cwd 找 .git 标记（findGitRoot）：
+ * - 是 git 仓（主 checkout / worktree）→ 注入纪律（~200 tokens/次，非每 step）；
+ * - 非 git 仓（日常维护/讨论空间）→ 不注入（静默跳过，agent 正常讨论无噪声）。
  * 多工作空间天然区分：每个会话独立判定，互不影响。
  */
 import type { Context } from "@deepseek-ai/cordis";
+import type { UserMessage } from "@deepseek-ai/dsh-llm";
 import type {} from "@deepseek-ai/dsh-agent";
+import { randomUUID } from "node:crypto";
 import { findGitRoot } from "./guard.ts";
 
-/** 纪律段 order：mcp-manager 目录段（160）之后，工具带（100-199）内靠后。 */
-export const DISCIPLINE_SECTION_ORDER = 161;
-
-/** 纪律段唯一名（systemPrompt.section name 唯一，重复注册抛错）。 */
-export const DISCIPLINE_SECTION_NAME = "plugin:dsh-codegraph";
-
 /** 注入给 agent 的 worktree 开发纪律文案（~200 tokens，保持精简）。
- * 只保留目录注入覆盖不到的**差异化纪律**（#359 去重）：
+ * 只保留目录注入覆盖不到的**差异化纪律**（B2 正交化）：
  * - 用裸 codegraph_explore（纪律工具：自动补全 projectPath + 强制 sync），
  *   不是 mcp__codegraph__codegraph_explore（官方 MCP 工具要手动传 projectPath）；
  * - 自动 sync 语义（worktree 索引新鲜度）；
  * - 无索引时返回引导（init 由 agent/用户决策）。
  * "codegraph 可用"等能力声明由 mcp-manager 能力目录（<available_mcp_servers>）
- * 承担，不在此重复。 */
+ * 承担，不在此重复；与目录**无先后依赖**（内容正交）。 */
 export const DISCIPLINE_TEXT = [
   "【codegraph 开发纪律】结构类查询（X 被谁调用/依赖关系/符号位置）优先用",
   "`codegraph_explore`（裸名，不是 mcp__codegraph__ 前缀的官方工具）——它会",
@@ -50,20 +48,48 @@ export function shouldInject(cwd: string | undefined): boolean {
   return findGitRoot(cwd) !== undefined;
 }
 
-/** 注册 agent/created 钩子（按 cwd 条件注入纪律）。返回 disposer。 */
+/** 构造纪律注入消息（完整 UserMessage 契约：id + content block + source）。
+ * source.kind=plugin → 出现在 GUI「上下文注入」面板（与 dsh-tool-skill 同载体）。 */
+function disciplineMessage(): UserMessage {
+  return {
+    id: randomUUID() as UserMessage["id"],
+    role: "user",
+    content: [{ type: "text", text: DISCIPLINE_TEXT }],
+    source: { kind: "plugin", plugin: "codegraph", form: "instructions" },
+  };
+}
+
+/** 会话历史里是否已注入过纪律消息（官方模式：查 agent.session.events，仿
+ * dsh-time-context 的 latestInjectionTime）。compaction 后历史不可见 → false
+ * → 重新注入（幂等自愈）。 */
+function alreadyInjected(agent: { session?: { events?: unknown[] } }): boolean {
+  const events = agent.session?.events;
+  if (!Array.isArray(events)) return false;
+  return events.some((event) => {
+    const e = event as { type?: string; data?: { source?: { kind?: string; plugin?: string } } };
+    return e.type === "user/message"
+      && e.data?.source?.kind === "plugin"
+      && e.data.source.plugin === "codegraph";
+  });
+}
+
+/** 注册纪律注入（根 ctx pre-step 监听器，按 agent cwd 条件注入）。返回 disposer。 */
 export function registerDisciplineHook(ctx: Context): () => void {
-  const disposer = ctx.on("agent/created", ({ agent }) => {
-    // 提取会话 cwd（agent.session.header.cwd；防御缺省）。
+  const disposer = ctx.on("agent/pre-step", async ({ agent, signal }, next) => {
+    const decision = await next();
+    signal.throwIfAborted();
+    // 尊重 reject 决策（如其他监听器拒绝进入本轮 step），不覆盖为 enter。
+    if (decision.kind === "reject") return decision;
+    // 按会话 cwd 判定：非 git 仓 → 零注入（静默跳过）。
     const cwd = (agent.session as unknown as { header?: { cwd?: string } })?.header?.cwd;
-    // 非 git 仓 → 不注册（零注入；agent scope 沿链继承也不会带出纪律）。
-    if (!shouldInject(cwd)) return;
-    // git 仓 → 在 agent 自己的 scope 注册纪律段（order 161，恒在 MCP 目录段
-    // 160 之后；随 agent scope 自动清理，子 agent 沿 scope 链继承）。
-    (agent.ctx as unknown as { systemPrompt?: { section(opts: Record<string, unknown>): () => void } }).systemPrompt?.section({
-      name: DISCIPLINE_SECTION_NAME,
-      order: DISCIPLINE_SECTION_ORDER,
-      text: DISCIPLINE_TEXT,
-    });
+    if (!shouldInject(cwd)) return decision;
+    // 幂等：会话历史已注入过 → 原样放行。
+    if (alreadyInjected(agent as unknown as { session?: { events?: unknown[] } })) return decision;
+    // 不可变注入：追加纪律消息（内容与 mcp 能力目录正交，无先后依赖）。
+    const nextMessages = Array.isArray(decision.messages)
+      ? [...decision.messages, disciplineMessage()]
+      : decision.messages;
+    return { kind: "enter", messages: nextMessages };
   });
   return disposer;
 }

--- a/packages/dsh-codegraph/src/index.ts
+++ b/packages/dsh-codegraph/src/index.ts
@@ -10,10 +10,10 @@
  * - **纪律工具**（工具层硬纪律，核心价值）：codegraph_explore 封装——查询前
  *   强制 sync + 校验/补全 projectPath（自动补全 + 拒绝兜底），杜绝「worktree
  *   索引静默过期」与「漏传 projectPath 查错对象」；
- * - **agent 钩子**：agent/created + 会话 cwd 判定，git 仓（主 checkout /
- *   worktree）才注入纪律（~200 tokens/次）；非 git 仓（日常维护/讨论空间）
- *   不注入——多工作空间天然区分（按会话 cwd 判定，由 discipline/guard 承担，
- *   不在 apply 阶段读取 ctx.session——apply 无会话概念）。
+ * - **agent 钩子**：agent/pre-step + 会话 cwd 判定，git 仓（主 checkout /
+ *   worktree）才注入纪律（~200 tokens/次，根 ctx 注册保证在 mcp 目录注入之后）；
+ *   非 git 仓（日常维护/讨论空间）不注入——多工作空间天然区分（按会话 cwd 判定，
+ *   由 discipline/guard 承担，不在 apply 阶段读取 ctx.session——apply 无会话概念）。
  *
  * 安全模型（详见 README「安全模型」一节）：不自动执行第三方安装命令（默认）、
  * stdio 子进程继承宿主权限、索引为本地 SQLite 无加密、工具在真实服务器上执行。
@@ -34,15 +34,14 @@ import { buildGuardToolDefinition } from "./tool-definition.ts";
 /** Stable cordis plugin name. */
 export const name = "codegraph";
 
-/** 需要的宿主服务：agents（agent/created 事件）、mcpManager（MCP 注册/管理/使用）、
- *  tools（纪律工具注册）、systemPrompt（纪律段注册）。均经 inject 强依赖声明——
- *  缺失时 cordis 内核自动停用本插件。 */
-export const inject = ["agents", "mcpManager", "tools", "systemPrompt"];
+/** 需要的宿主服务：mcpManager（MCP 注册/管理/使用）、tools（纪律工具注册）。
+ *  均经 inject 强依赖声明——缺失时 cordis 内核自动停用本插件。 */
+export const inject = ["mcpManager", "tools"];
 
 // 内部模块 re-export（公共测试面 + 其他插件可复用纯函数）。
 export { isCodegraphInstalled, installGuidance, runInstall } from "./install.ts";
 export { findGitRoot, isGitRepo, syncCodegraph, exploreCodegraph, guardedExplore } from "./guard.ts";
-export { shouldInject, DISCIPLINE_TEXT, DISCIPLINE_SECTION_NAME, DISCIPLINE_SECTION_ORDER, registerDisciplineHook } from "./discipline.ts";
+export { shouldInject, DISCIPLINE_TEXT, registerDisciplineHook } from "./discipline.ts";
 export { buildGuardToolDefinition } from "./tool-definition.ts";
 
 /** 插件配置。 */

--- a/packages/dsh-codegraph/test/smoke.ts
+++ b/packages/dsh-codegraph/test/smoke.ts
@@ -80,7 +80,7 @@ async function checkAsync(label, fn) {
 
 // ---- 契约 ----
 check("契约: name = codegraph", () => assert.equal(name, "codegraph"));
-check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents")));
+check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpManager")));
 
 // ---- 工具注册定义（#356 回归）----
 // 根因：注册定义误用 MCP 风格字段 inputSchema，而 dsh-tools 契约要求 parameters，
@@ -182,7 +182,7 @@ check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents"))
 // ---- apply ----
 {
   const makeCtx = (overrides = {}) => {
-    const state = { disposers: [], registered: [], hooks: [], logs: [], tools: [], sections: [], createdCbs: [] };
+    const state = { disposers: [], registered: [], hooks: [], logs: [], tools: [], preStepCbs: [] };
     const ctx = {
       logger: { warn: (m) => state.logs.push(`warn:${m}`), info: (m) => state.logs.push(`info:${m}`) },
       // inject 强依赖：ctx.mcpManager 直接可用（不再 get 探测）。
@@ -196,16 +196,14 @@ check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents"))
       // inject 强依赖：ctx.tools 直接可用（纪律工具注册；此前未 inject 导致 cordis
       // Proxy 抛 "cannot get property tools without inject" 启动失败）。
       tools: { register: (d) => { state.tools.push(d); return () => {}; } },
-      // inject 强依赖：ctx.systemPrompt（纪律段注册，agent scope 继承）。
-      systemPrompt: { section: (opts) => { state.sections.push(opts); return () => {}; } },
-      on: (event, cb) => { if (event === "agent/created") state.createdCbs.push(cb); return () => {}; },
+      on: (event, cb) => { if (event === "agent/pre-step") state.preStepCbs.push(cb); return () => {}; },
       effect: (fn) => { const d = fn(); state.disposers.push(d); return d; },
     };
     return { ctx, state };
   };
 
-  check("契约: inject 含 agents/mcpManager/tools/systemPrompt（强依赖声明）", () => {
-    for (const svc of ["agents", "mcpManager", "tools", "systemPrompt"]) {
+  check("契约: inject 含 mcpManager/tools（强依赖声明）", () => {
+    for (const svc of ["mcpManager", "tools"]) {
       assert.ok(inject.includes(svc), `inject 应含 ${svc}，实际 ${JSON.stringify(inject)}`);
     }
   });
@@ -281,43 +279,62 @@ check("契约: inject 包含 agents", () => assert.ok(inject.includes("agents"))
     rmSync(dir, { recursive: true, force: true });
   });
 
-  // #359：纪律注入迁移到 systemPrompt.section（order 161，agent scope 注册，
-  // 非 git 不注册）——替代原 pre-step user 消息注入。
+  // #359 三轮（B2）：纪律注入为根 ctx pre-step user 消息型（面板可见，同官方
+  // dsh-tool-skill 载体）；git 仓注入、非 git 不注入；幂等查会话历史
+  // （agent.session.events，官方 dsh-time-context 模式）。内容与 mcp 目录正交。
   {
-    // 模拟 agent/created：git 仓会话 → 注册纪律段；非 git 会话 → 不注册。
-    // 注意：目录在 checkAsync 内部自建自删（防 flake 纪律——共享外层目录 +
-    // 未 await 的异步断言会在 finally 清理后执行 findGitRoot 而失败）。
-    const emitCreated = (state, cwd) => {
-      for (const cb of state.createdCbs) {
-        cb({ agent: { session: { header: { cwd } }, ctx: { systemPrompt: { section: (opts) => { state.sections.push(opts); return () => {}; } } } } });
+    const runPreStep = async (state, messages, cwd, events = []) => {
+      const next = async () => ({ kind: "enter", messages });
+      let result;
+      for (const cb of state.preStepCbs ?? []) {
+        result = await cb({ agent: { id: "a1", session: { header: { cwd }, events } }, messages, signal: { throwIfAborted: () => {} } }, next);
       }
+      return result;
     };
-    checkAsync("discipline: git 仓会话注册纪律段（order 161，MCP 目录段之后）", async () => {
+    checkAsync("discipline: git 仓会话 pre-step 注入纪律消息（面板可见）", async () => {
       const dir = mkdtempSync(join(tmpdir(), "cg-disc-git-"));
       mkdirSync(join(dir, "repo", ".git"), { recursive: true });
       try {
         const { ctx, state } = makeCtx();
-        const { registerDisciplineHook, DISCIPLINE_SECTION_NAME, DISCIPLINE_SECTION_ORDER } = await import(pathToFileURL(join(pkgDir, "lib/index.js")).href);
+        const { registerDisciplineHook } = await import(pathToFileURL(join(pkgDir, "lib/index.js")).href);
         registerDisciplineHook(ctx);
-        emitCreated(state, join(dir, "repo"));
-        assert.equal(state.sections.length, 1, "git 仓注册 1 个纪律段");
-        assert.equal(state.sections[0].name, DISCIPLINE_SECTION_NAME);
-        assert.equal(state.sections[0].order, DISCIPLINE_SECTION_ORDER);
-        assert.ok(state.sections[0].order > 160, "纪律段必须在 MCP 目录段（160）之后");
-        assert.ok(typeof state.sections[0].text === "string" && state.sections[0].text.includes("codegraph_explore"));
+        assert.equal((state.preStepCbs ?? []).length, 1, "注册了 pre-step 监听器");
+        const decision = await runPreStep(state, [{ id: "m1", role: "user", content: [{ type: "text", text: "hi" }], source: { kind: "user" } }], join(dir, "repo"));
+        assert.equal(decision.kind, "enter");
+        assert.equal(decision.messages.length, 2, "追加 1 条纪律消息");
+        const injected = decision.messages[1];
+        assert.equal(injected.role, "user");
+        assert.equal(injected.source.kind, "plugin", "source.kind=plugin → GUI 上下文注入面板可见");
+        assert.equal(injected.source.plugin, "codegraph");
+        assert.ok(injected.content[0].text.includes("codegraph_explore"), "纪律文本含工具名");
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }
     });
-    checkAsync("discipline: 非 git 会话不注册纪律段（零注入）", async () => {
+    checkAsync("discipline: 会话历史已注入 → 不重复注入（幂等）", async () => {
+      const dir = mkdtempSync(join(tmpdir(), "cg-disc-idem-"));
+      mkdirSync(join(dir, "repo", ".git"), { recursive: true });
+      try {
+        const { ctx, state } = makeCtx();
+        const { registerDisciplineHook } = await import(pathToFileURL(join(pkgDir, "lib/index.js")).href);
+        registerDisciplineHook(ctx);
+        // 会话历史已有纪律消息（source.kind=plugin && plugin=codegraph）
+        const events = [{ type: "user/message", data: { source: { kind: "plugin", plugin: "codegraph" } } }];
+        const decision = await runPreStep(state, [{ id: "m1", role: "user", content: [{ type: "text", text: "hi" }], source: { kind: "user" } }], join(dir, "repo"), events);
+        assert.equal(decision.messages.length, 1, "历史已注入 → 不再追加");
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+    checkAsync("discipline: 非 git 会话不注入纪律（零注入）", async () => {
       const dir = mkdtempSync(join(tmpdir(), "cg-disc-nongit-"));
       mkdirSync(join(dir, "nongit"), { recursive: true });
       try {
         const { ctx, state } = makeCtx();
         const { registerDisciplineHook } = await import(pathToFileURL(join(pkgDir, "lib/index.js")).href);
         registerDisciplineHook(ctx);
-        emitCreated(state, join(dir, "nongit"));
-        assert.equal(state.sections.length, 0, "非 git 不注册纪律段");
+        const decision = await runPreStep(state, [{ id: "m1", role: "user", content: [{ type: "text", text: "hi" }], source: { kind: "user" } }], join(dir, "nongit"));
+        assert.equal(decision.messages.length, 1, "非 git 不注入纪律");
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,9 +86,6 @@ importers:
       '@deepseek-ai/dsh-llm':
         specifier: 'catalog:'
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-system-prompt':
-        specifier: 'catalog:'
-        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-tools':
         specifier: 'catalog:'
         version: 0.1.1-rc.2(f7d8e59091784496c02afcf19f5662a6)


### PR DESCRIPTION
Fixes #359（第二轮）

## 动机

#360 把纪律注入迁移到 `systemPrompt.section` 后，实测发现 GUI「上下文注入」面板
不显示它（面板只列 user/message 型注入，如 mcp-catalog / skill-catalog）——用户
误以为"没注入"。改回消息型注入时又发现两个坑：

1. **顺序依赖 bundle 配置**：消息型注入的 waterfall 按监听器注册顺序执行 = 插件
   apply 顺序 = profile bundles 顺序。要纪律在 mcp 目录之后，必须保证 mcp-manager
   先加载——脆弱；
2. **幂等失效**：pre-step 的 `messages` 不含历史注入消息，靠查 messages 判重
   实测每轮重复注入。

## 修复（B2，参照官方插件）

- **注入改回根 ctx `agent/pre-step` user 消息型**（官方 dsh-tool-skill /
  dsh-time-context 同款载体）→ 出现在 GUI「上下文注入」面板；
- **幂等查会话历史** `agent.session.events`（source.kind=plugin &&
  plugin=codegraph；官方 dsh-time-context 的 `latestInjectionTime` 同款）→ 可靠防重复；
- **内容正交化**：纪律只讲 `codegraph_explore` 工具用法（裸工具名、自动 sync、
  无索引引导），mcp 能力目录讲服务器清单——**去掉先后依赖**（不再检查
  mcp-catalog 注入顺序，bundle 顺序无关）；
- `inject` 去掉 `agents`（不再用 agent/created + agent.ctx），去掉
  `dsh-system-prompt` devDep；
- smoke：注入 / 幂等（会话历史已注入不重复）/ 非 git 零注入三用例。

## 验证

- 全仓门禁：`pnpm build` / `pnpm test` / `pnpm contract` / `pnpm pack:check` 全绿；
- 隔离 dsh web 实测（**codegraph 故意放 bundle 最前**，验证无顺序依赖）：
  - codegraph 纪律**恰好注入 1 次**（seq=11，两轮对话后无重复）——幂等正确；
  - `source.kind=plugin && plugin=codegraph` → **面板可见**；
  - mcp 能力目录正常注入（seq=12），内容正交无冲突。

## 提交

- `fix(dsh-codegraph): 纪律注入改回 pre-step 消息型（面板可见），幂等查会话历史，内容与 mcp 目录正交 (#359)`
