### PR TITLE
fix(mcp-manager): 中间层可见范围/空返回误导修复 + 工具级禁用 + registerServer.toolDefinitions 通道（#362）

### DIFF
--- a/packages/dsh-mcp-manager/README.en.md
+++ b/packages/dsh-mcp-manager/README.en.md
@@ -14,9 +14,10 @@ servers go through the middleware while global ones register directly; `all` —
 servers go through the middleware too, falling back to the virtual global root
 `@global` when cwd has no project, collapsing the model surface to exactly four atomic
 tools (`ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search` / `ws_mcp_call`).
-Note on when changes take effect: `middleware` / `middlewarePolicy` are read
-once at plugin startup — **changing them requires restarting `dsh web`**; the server
-lists across both config tiers hot-reload without a restart (add/remove/toggle/edit).
+`middleware` / `middlewarePolicy` can be hot-switched from the settings page (saved
+immediately and persisted, no restart needed), or set in the config file (read at plugin
+startup); the server lists across both config tiers hot-reload without a restart
+(add/remove/toggle/edit).
 
 ## Core advantages
 
@@ -154,13 +155,16 @@ four atomic tools (two-level discovery, the standard MCP ecosystem shape) —
 complete tool list, not truncated by `ws_mcp_search`'s `limit`; supports `server`
 full-name/bare-name filtering; `perServerLimit` caps tools per server at 50 by default
 / 500 max, setting `toolsTruncated` when exceeded; empty results carry an explicit
-`message`) / `ws_mcp_detail` (exact single-tool lookup by `@<root>/<server>` + bare tool
+`message`, and when a `server` filter matches nothing the message attributes the miss to
+the filter and lists the visible project-level servers) / `ws_mcp_detail` (exact single-tool lookup by `@<root>/<server>` + bare tool
 name, returning the complete `inputSchema`; three-way errors: discovery failed with
 reason / server not connected or not found / tool does not exist) / `ws_mcp_search` (keyword search, search first then call; returns a `truncated` flag
 when results hit the `limit`) / `ws_mcp_call` (invoke by `@<root>/<server>`, verify
 argument schema with `ws_mcp_detail`), routed by the calling session's current cwd to
 the matching workspace connection pool, so different workspaces inject different MCPs
-without name clashes; global servers still register directly as `mcp__<server>__<tool>`. Switch
+without name clashes; global servers still register directly as `mcp__<server>__<tool>`
+(in `project` mode, passing a global-scope server to detail/call returns a
+"use `mcp__` directly" hint). Switch
 `middleware: off` to restore the legacy behavior (project-level also registers `mcp__`);
 `middleware: all` routes global servers through the middleware too (falling back to the
 virtual global root `@global` when cwd has no project), collapsing the model surface to
@@ -170,16 +174,42 @@ across workspaces, so the semantics hold). Note: in `all` mode, global server
 add/remove/edit refreshes the `@global` unit only after a restart or a session touch
 (existing behavior).
 
+The middleware mode can be hot-switched from the settings page (Settings → Plugins →
+MCP Manager → middleware mode dropdown); saving takes effect immediately and persists,
+no `dsh web` restart needed.
+
 | Key | Allowed values | Default |
 | --- | --- | --- |
 | `middleware` | `off` / `project` (recommended) / `all` | `project` |
 | `middlewarePolicy` | `{ allowTools: {<serverKey>: [glob]}, denyTools: {<serverKey>: [glob]} }` (serverKey is `@<root>/<server>` full name (workspace isolation) or bare name (shared across workspaces); full name wins; deny-first) | `{}` |
+
+### Per-tool disable (floating window)
+
+- Expanding the "Tools (N)" details of a server card shows a **checkbox list**; toggling
+  each tool persists via `PATCH /api/dsh-mcp/tool-disable` (stored under
+  `<DSH_HOME>/dsh-mcp-user-state.json` → `disabledTools`, merged write, survives restarts);
+- Semantics: in `project` mode only project-level servers' `mcp__` tools can be disabled;
+  in `all` mode global servers' `mcp__` tools can be disabled too; everything is enabled
+  by default;
+- Per-tool disable is **independent of the server-level `enabled` switch** (re-enabling a
+  server does not clear its tool-level state);
+- It **only applies to `mcp__`-prefixed tools**: discipline bare-name tools (e.g.
+  dsh-codegraph's `codegraph_explore`) are not affected (declared on the dsh-codegraph
+  side in #363);
+- Overlong tool names (>64 chars, hashed suffix) are irreversible → treated as unknown
+  server, neither disabled nor mistakenly denied;
+- In `project` mode the floating window shows global servers without tool switches (they
+  run through supervisors directly, bypassing the middleware), with a hint
+  "switch to all mode to manage global tools";
+- Both the floating window and the management panel group servers by
+  "project-level / global" (each group further ordered by connection status).
 
 ## Routes (all loopback-fenced)
 
 | Route | Description |
 | --- | --- |
 | `/api/dsh-mcp/health` | Health check (note: differs from the directory name) |
+| `/api/dsh-mcp/tool-disable` | Per-tool disable toggle (PATCH, loopback-only) |
 | `/api/dsh-mcp/*` | Server management / connection control / tool listing / SSE events, etc. |
 
 ## Data and Security
@@ -201,6 +231,13 @@ add/remove/edit refreshes the `@global` unit only after a restart or a session t
   governed by the policy (deny-first); `ws_mcp_call` error messages follow an
   "explicit + next step" style (confirm the server connection / verify the argument schema
   with `ws_mcp_detail` / check the policy configuration)
+- **Per-tool disable (three entry points consistent)**: `ws_mcp_call` (callTool checks the
+  disable table before the policy), the pre-execute guard (`mcp__`-prefixed direct calls),
+  and discipline bare-name tools (dsh-codegraph side, #363) all go through the single
+  `isToolDenied` decision; disabling only affects `mcp__`-prefixed tools, and the denial
+  reason carries that semantic note; records live under `<DSH_HOME>/dsh-mcp-user-state.json`
+  → `disabledTools` (the `@global` key is shared across workspaces; merged writes never
+  overwrite the whole table)
 - The capability catalog injection includes source annotations and a "does not represent current
   connection status" note
 

--- a/packages/dsh-mcp-manager/README.en.md
+++ b/packages/dsh-mcp-manager/README.en.md
@@ -212,6 +212,47 @@ no `dsh web` restart needed.
 | `/api/dsh-mcp/tool-disable` | Per-tool disable toggle (PATCH, loopback-only) |
 | `/api/dsh-mcp/*` | Server management / connection control / tool listing / SSE events, etc. |
 
+## Runtime registration (registerServer.toolDefinitions)
+
+Other plugins can register MCP servers at runtime via `ctx.mcpManager.registerServer`
+(in-memory only, not persisted; idempotent for same names). The registration input
+supports an optional `toolDefinitions` field (caller-provided wrapped tool definitions,
+`ToolDefinition[]`; tool names are **bare names**, e.g. dsh-codegraph's
+`codegraph_explore`):
+
+- **With `toolDefinitions`**: all tools of that server are registered **from the wrapped
+  definitions** — `execute` comes from the caller (e.g. dsh-codegraph runs
+  `codegraph sync` first, then forwards to the underlying CLI internally), skipping the
+  remote schema projection and the generic `callTool`; the underlying real implementation
+  is never exposed;
+- **Without**: current behavior is preserved (remote schema + generic `callTool`), zero
+  impact on other servers;
+- **Naming is still decided by the manager's existing mechanism**: the model-visible name
+  is `mcp__<server>__<tool>` (`publicToolName`, 64-char / hash-suffix rules unchanged);
+  in `all` mode calls go through `ws_mcp_call` with bare names;
+- **Per-tool disable / visibility / capability catalog still apply to wrapped tools**
+  (judged by server + tool name, same as `mcp__`-prefixed tools);
+- Consumed only by the runtime registration surface (runtimeRegistry) — never persisted
+  to the store, never passed through mcpServers imports.
+
+```ts
+await ctx.mcpManager.registerServer({
+  name: "codegraph",
+  transport: "stdio",
+  command: "codegraph",
+  args: ["serve", "--mcp"],
+  toolDefinitions: [
+    {
+      name: "codegraph_explore",          // bare name
+      description: "Query the codegraph code graph (sync first, then query)",
+      parameters: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
+      output: { schema: { ... }, render(args, value) { ... } },
+      execute: async (args) => { await sync(); return forwarded; }, // internal forwarding, never exposed
+    },
+  ],
+});
+```
+
 ## Data and Security
 
 - Server config: `<DSH_HOME>/dsh-mcp.json` (stores only `${ENV}` references, **never the

--- a/packages/dsh-mcp-manager/README.md
+++ b/packages/dsh-mcp-manager/README.md
@@ -10,9 +10,8 @@ MCP 协议客户端基于 `node:child_process` 与全局 `fetch` 直接实现，
 `project`（**默认**）——项目级走中间层、全局仍直呼；`all`——全局也走中间层，
 cwd 无项目时回落全局虚拟 root `@global`，模型面完全收敛为四个原子工具
 （`ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search` / `ws_mcp_call`）。
-注意生效时机：`middleware` / `middlewarePolicy` 只在插件启动时读取，**变更后需重启
-`dsh web`**；两级配置文件中的服务器列表（增删/启停/改配置）支持热加载、即时生效，
-无需重启。
+`middleware` / `middlewarePolicy` 可在设置页热切换（保存即生效并持久化），
+也可在配置文件中设置（插件启动时读取）；两级配置文件中的服务器列表（增删/启停/改配置）支持热加载、即时生效，无需重启。
 
 ## 核心优势
 
@@ -128,29 +127,50 @@ SSE events 通道推送一变，客户端自动重新拉取 `/api/dsh-mcp/config
 `ws_mcp_list`（完整盘点当前工作空间全部服务器 + 每台完整工具清单，不受
 `ws_mcp_search` 的 limit 截断；支持 `server` 全名/裸名过滤，`perServerLimit`
 每服务器工具条数上限默认 50 / 上限 500，超限置 `toolsTruncated`；空返回附明确
-`message`）/ `ws_mcp_detail`（按 `@<root>/<server>` + tool 裸名精确查询单工具
+`message`，带 `server` 过滤 0 命中时 message 归因到过滤条件并列出可见项目级
+服务器）/ `ws_mcp_detail`（按 `@<root>/<server>` + tool 裸名精确查询单工具
 完整 `inputSchema`，错误三分：发现失败附原因 / 服务器未连接或未发现 / 工具
 不存在）/ `ws_mcp_search`（关键词检索，先搜后调，输出 `truncated` 标志提示结果是否因
 limit 截断）/ `ws_mcp_call`（按 `@<root>/<server>` 全名调用，参数 schema 用
 `ws_mcp_detail` 核对），执行时按调用方会话当前 cwd 路由到对应工作空间
 连接池，不同工作空间注入不同 MCP、无命名冲突；全局服务器仍直呼
-`mcp__<server>__<tool>`。切换 `middleware: off` 回到旧行为（项目级也直接注册
+`mcp__<server>__<tool>`（project 模式 detail/call 传全局级服务器会给出直呼引导）。
+切换 `middleware: off` 回到旧行为（项目级也直接注册
 `mcp__` 工具）；`middleware: all` 则全局服务器也走中间层（cwd 无项目时回落全局
 虚拟 root `@global`），模型面完全收敛为四个原子工具——此时 list/search/detail
 合并查询「项目 root 单元 + `@global` 单元」，call 放行 `@global` root（全局配置
 跨工作空间共享，语义成立）。注：all 模式全局服务器增删改后需重启或触发会话
 触达才刷新目录（既有行为）。
 
+**中间层模式可在设置页热切换**（设置 → 插件 → MCP 管理器 → 中间层模式下拉），
+保存即生效并持久化，无需重启 dsh web。
+
 | 键 | 值域 | 默认 |
 | --- | --- | --- |
 | `middleware` | `off` / `project`（推荐）/ `all` | `project` |
 | `middlewarePolicy` | `{ allowTools: {<serverKey>: [glob]}, denyTools: {<serverKey>: [glob]} }`（serverKey 为 `@<root>/<server>` 全名（工作空间隔离）或裸名（跨空间共用），全名优先；deny 优先） | `{}` |
+
+### 工具级禁用（浮窗）
+
+- 服务器卡片的「工具（N）」折叠区展开后为 **checkbox 列表**，逐个启停，点击即
+  经 `PATCH /api/dsh-mcp/tool-disable` 持久化（落盘 `<DSH_HOME>/dsh-mcp-user-state.json`
+  的 `disabledTools`，合并写盘、重启保留）；
+- 语义：**project 模式只能禁用项目级服务器的 mcp__ 工具；all 模式才能禁用全局
+  服务器的 mcp__ 工具**；默认全部启用；
+- 工具级禁用**独立于服务器级 enabled 开关**（服务器级复活不清工具级状态）；
+- **只作用于 mcp__ 前缀工具**：纪律裸名（如 dsh-codegraph 的 `codegraph_explore`）
+  不受影响（dsh-codegraph 侧由 #363 声明）；
+- 超长工具名（>64 字符哈希后缀）不可逆 → 按未知 server 处理，不禁用/不误禁；
+- project 模式浮窗显示全局服务器但无工具开关（全局工具此时经 supervisor 直呼，
+  不经中间层），提示「切 all 模式可管理全局工具」；
+- 浮窗与管理面板均按「项目级 / 全局级」两大分组展示（各自内部再按连接状态）。
 
 ## 路由（全部 loopback 围栏）
 
 | 路由 | 说明 |
 | --- | --- |
 | `/api/dsh-mcp/health` | 健康检查（注意与目录名不同） |
+| `/api/dsh-mcp/tool-disable` | 工具级禁用开关（PATCH，loopback-only） |
 | `/api/dsh-mcp/*` | 服务器管理 / 连接控制 / 工具清单 / SSE 事件等 |
 
 ## 数据与安全
@@ -172,6 +192,11 @@ limit 截断）/ `ws_mcp_call`（按 `@<root>/<server>` 全名调用，参数 sc
   是唯一执行远端工具并受策略约束（deny 优先）的入口；`ws_mcp_call` 错误消息按
   「显式 + 下一步」规范给出（确认 server 连接 / 用 `ws_mcp_detail` 核对参数 /
   检查策略配置）
+- **工具级禁用（三入口一致）**：`ws_mcp_call`（callTool 先查禁用表再查策略）、
+  pre-execute guard（`mcp__` 前缀直呼工具）、纪律裸名（dsh-codegraph 侧 #363）
+  统一走 `isToolDenied` 裁决；禁用只作用于 `mcp__` 前缀工具，拒绝原因附语义声明；
+  禁用记录 `<DSH_HOME>/dsh-mcp-user-state.json` 的 `disabledTools`（`@global` key
+  跨工作空间共享，合并写盘不整表覆盖）
 - **凭据脱敏**：目录摘要与错误路径经 redactor 把 env/headers/URL 用户信息等
   凭据形状替换为 `[REDACTED]`
 - 能力目录注入含来源标注与"不代表当前连接状态"说明

--- a/packages/dsh-mcp-manager/README.md
+++ b/packages/dsh-mcp-manager/README.md
@@ -173,6 +173,40 @@ limit 截断）/ `ws_mcp_call`（按 `@<root>/<server>` 全名调用，参数 sc
 | `/api/dsh-mcp/tool-disable` | 工具级禁用开关（PATCH，loopback-only） |
 | `/api/dsh-mcp/*` | 服务器管理 / 连接控制 / 工具清单 / SSE 事件等 |
 
+## 运行时注入（registerServer.toolDefinitions）
+
+其他插件可经 `ctx.mcpManager.registerServer` 运行时注册 MCP 服务器（内存态不落盘，
+同名幂等）。注册入参支持可选 `toolDefinitions`（调用方封装工具定义，`ToolDefinition[]`，
+工具名用**裸名**，如 dsh-codegraph 的 `codegraph_explore`）：
+
+- **有 `toolDefinitions`**：该服务器工具**全部用封装定义注册**——execute 来自调用方
+  （如 dsh-codegraph 先 `codegraph sync` 再内部转发底层 CLI），跳过远端 schema 投影与
+  通用 callTool，底层真实实现不外泄；
+- **没有**：维持现状（远端 schema + 通用 callTool），其他服务器零影响；
+- **命名仍由 manager 现有机制决定**：模型可见名为 `mcp__<server>__<tool>`（`publicToolName`，
+  64 字符 / 哈希后缀规则不变）；all 模式经 `ws_mcp_call` 用裸名调用；
+- **工具级禁用 / 可见性 / 能力目录对封装工具照常生效**（按服务器 + 工具名判定，与
+  `mcp__` 前缀工具同口径）；
+- 仅运行时注入面（runtimeRegistry）消费，不随 store 落盘、不随 mcpServers 导入透传。
+
+```ts
+await ctx.mcpManager.registerServer({
+  name: "codegraph",
+  transport: "stdio",
+  command: "codegraph",
+  args: ["serve", "--mcp"],
+  toolDefinitions: [
+    {
+      name: "codegraph_explore",          // 裸名
+      description: "查询 codegraph 代码图谱（先 sync 再查）",
+      parameters: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
+      output: { schema: { ... }, render(args, value) { ... } },
+      execute: async (args) => { await sync(); return forwarded; }, // 内部转发，不外泄
+    },
+  ],
+});
+```
+
 ## 数据与安全
 
 - 服务器配置：`<DSH_HOME>/dsh-mcp.json`（仅存 `${ENV}` 引用，**不落盘密钥本身**）；

--- a/packages/dsh-mcp-manager/src/apply.ts
+++ b/packages/dsh-mcp-manager/src/apply.ts
@@ -16,12 +16,13 @@ import { McpManager, MIDDLEWARE_GLOBAL_ROOT } from "./manager.ts";
 import { defaultStorePath, McpStore } from "./store.ts";
 import { DEFAULT_RESULT_TRUNCATE_BYTES } from "./supervisor.ts";
 import { normalizeMiddlewareMode, registerMiddlewareTools } from "./middleware.ts";
+import type { MiddlewareMode } from "./middleware-types.ts";
 import { makeRoutes, makeEventsRoute, makeHealthRoute, sseData, uiConfigChangedFrame } from "./routes.ts";
 
 /** 向 Agent 宣告插件（announceToAgent 开启时注入）。能力清单由动态目录
  * （<available_mcp_servers>，见 L1）承担，此处只说明管理界面与使用约束。 */
 export const MCP_GUIDANCE =
-  "本机已安装 dsh-mcp-manager 插件（DSH MCP 管理器）：会话界面右上角浮窗管理 MCP 服务器（全局配置 ~/.dsh/dsh-mcp.json；项目级配置 <项目根>/.dsh/mcp.json，跟随会话切换展示并连接对应项目的服务器；支持 stdio / streamable-http，可粘贴 mcpServers JSON 导入，不预设任何服务器）。已配置服务器的能力清单见会话内的 <available_mcp_servers>（仅描述能力，不代表连接状态）。项目级 MCP 工具经 ws_mcp_list/ws_mcp_search 检索（先 ws_mcp_list 完整盘点服务器与工具，再按需 ws_mcp_detail 查完整 inputSchema），经 ws_mcp_call 调用（先用 ws_mcp_search 检索，再 ws_mcp_call 调用；已知 server/tool 时可直呼免搜索）；全局服务器连接后其工具以 mcp__<server>__<tool> 注册可用。限制：MCP 工具在真实服务器上执行，先确认再操作；stdio 服务器的子进程继承宿主权限；工具结果可能含敏感信息。用户提到「MCP / mcp 服务 / 上下文服务器」时即指本插件，请据此协作。";
+  "本机已安装 dsh-mcp-manager 插件（DSH MCP 管理器）：会话界面右上角浮窗管理 MCP 服务器（全局配置 ~/.dsh/dsh-mcp.json；项目级配置 <项目根>/.dsh/mcp.json，跟随会话切换展示并连接对应项目的服务器；支持 stdio / streamable-http，可粘贴 mcpServers JSON 导入，不预设任何服务器）。已配置服务器的能力清单见会话内的 <available_mcp_servers>（仅描述能力，不代表连接状态）。项目级 MCP 工具经 ws_mcp_list/ws_mcp_search 检索（先 ws_mcp_list 完整盘点服务器与工具，再按需 ws_mcp_detail 查完整 inputSchema），经 ws_mcp_call 调用（先用 ws_mcp_search 检索，再 ws_mcp_call 调用；已知 server/tool 时可直呼免搜索）；全局服务器连接后其工具以 mcp__<server>__<tool> 注册可用。工具可被用户在「MCP」浮窗禁用（禁用原因会说明，且工具级禁用只作用于 mcp__ 前缀工具）。限制：MCP 工具在真实服务器上执行，先确认再操作；stdio 服务器的子进程继承宿主权限；工具结果可能含敏感信息。用户提到「MCP / mcp 服务 / 上下文服务器」时即指本插件，请据此协作。";
 
 /**
  * 挂载 MCP 管理器：加载存储、启动已启用服务器、注册路由与提示词。
@@ -155,7 +156,27 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
         }
         return undefined;
       };
-      disposeMiddleware = registerMiddlewareTools(manager.ctx, mw, resolveRoot, middlewareMode);
+      disposeMiddleware = registerMiddlewareTools(manager.ctx, mw, resolveRoot, middlewareMode, {
+        disabledTools: manager.disabledTools,
+      });
+      // 中间层模式热切换（设置页「中间层模式」下拉；initMiddleware 幂等已有，
+      // off↔project/all 需重新注册/卸载中间层工具——dispose 后重建）。
+      manager.setMiddlewareMode = async (mode: MiddlewareMode): Promise<void> => {
+        if (normalizeMiddlewareMode(mode) === manager.middlewareMode) return;
+        const next = normalizeMiddlewareMode(mode);
+        manager.middlewareMode = next;
+        disposeMiddleware();
+        if (next !== "off") {
+          const mw = await manager.initMiddleware(next, (config?.middlewarePolicy as Record<string, unknown> | undefined) ?? {});
+          disposeMiddleware = registerMiddlewareTools(manager.ctx, mw, resolveRoot, next, {
+            disabledTools: manager.disabledTools,
+          });
+        }
+        // off ↔ project/all：重注册/卸载中间层工具后 reconcile，恢复 supervisor
+        // 接管（all 模式含全局）或停掉（off 语义）——防同一 server 双进程。
+        manager.reconcileServers();
+        manager.logger.info(`dsh-mcp-manager: middleware mode=${next} (hot-switched)`);
+      };
       // startAll 在中间层注册前执行（off 语义），此处立即 reconcile：停掉
       // 项目级（all 含全局）supervisor（改由中间层接管），防同一 server 双进程。
       manager.reconcileServers();

--- a/packages/dsh-mcp-manager/src/apply.ts
+++ b/packages/dsh-mcp-manager/src/apply.ts
@@ -54,7 +54,7 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
   // 兼容：fake ctx（单元测试 mock）可能无 provide，可选调用静默降级。
   if (typeof (ctx as unknown as { provide?: unknown }).provide === "function") {
     ctx.provide("mcpManager", {
-      // 注入面（内存态不落盘，同名幂等）
+      // 注入面（内存态不落盘，同名幂等；toolDefinitions 可选封装定义透传 supervisor）
       registerServer: (server: Record<string, unknown>) => manager.registerServer(server),
       unregisterServer: (name: string) => manager.unregisterServer(name),
       // 控制面（通用 MCP 生命周期：注册即连、注销即断的补充控制）

--- a/packages/dsh-mcp-manager/src/apply.ts
+++ b/packages/dsh-mcp-manager/src/apply.ts
@@ -140,43 +140,44 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
     // 全局服务器仍 mcp__ 直呼（双轨迁移默认）。
     // 默认值与 Config schema 一致（project）；宿主未 parse 原始 config 时兜底。
     const middlewareMode = normalizeMiddlewareMode(config?.middleware ?? "project");
+    // 中间层模式热切换（设置页「中间层模式」下拉；initMiddleware 幂等已有，
+    // off↔project/all 需重新注册/卸载中间层工具——dispose 后重建）。
+    // 注册在模式分支之外：启动即 off 时也能从设置页切到 project/all。
+    const resolveRoot = async (agent: unknown): Promise<string | undefined> => {
+      if (typeof agent !== "object" || agent === null) return undefined;
+      const session = (agent as { session?: { header?: { cwd?: unknown } } }).session;
+      const cwd = session?.header?.cwd;
+      const root = await manager.normalizedProjectRoot(typeof cwd === "string" ? cwd : undefined);
+      if (root !== undefined) return root;
+      if (manager.middlewareMode === "all") {
+        const globalServers = manager.globalServers().filter((server) => server.enabled !== false);
+        if (globalServers.length > 0) return MIDDLEWARE_GLOBAL_ROOT;
+      }
+      return undefined;
+    };
+    manager.setMiddlewareMode = async (mode: MiddlewareMode): Promise<void> => {
+      if (normalizeMiddlewareMode(mode) === manager.middlewareMode) return;
+      const next = normalizeMiddlewareMode(mode);
+      manager.middlewareMode = next;
+      disposeMiddleware();
+      if (next !== "off") {
+        const mw = await manager.initMiddleware(next, (config?.middlewarePolicy as Record<string, unknown> | undefined) ?? {});
+        disposeMiddleware = registerMiddlewareTools(manager.ctx, mw, resolveRoot, next, {
+          disabledTools: manager.disabledTools,
+        });
+      }
+      // off ↔ project/all：重注册/卸载中间层工具后 reconcile，恢复 supervisor
+      // 接管（all 模式含全局）或停掉（off 语义）——防同一 server 双进程。
+      manager.reconcileServers();
+      manager.logger.info(`dsh-mcp-manager: middleware mode=${next} (hot-switched)`);
+    };
     if (middlewareMode !== "off") {
       const mw = await manager.initMiddleware(middlewareMode, (config?.middlewarePolicy as Record<string, unknown> | undefined) ?? {});
       // 路由输入：exec.agent 当前 cwd = agent.session.header.cwd（实证已闭合）。
       // all 模式：cwd 无项目（或无项目配置）时 fallback 到全局虚拟 root @global。
-      const resolveRoot = async (agent: unknown): Promise<string | undefined> => {
-        if (typeof agent !== "object" || agent === null) return undefined;
-        const session = (agent as { session?: { header?: { cwd?: unknown } } }).session;
-        const cwd = session?.header?.cwd;
-        const root = await manager.normalizedProjectRoot(typeof cwd === "string" ? cwd : undefined);
-        if (root !== undefined) return root;
-        if (middlewareMode === "all") {
-          const globalServers = manager.globalServers().filter((server) => server.enabled !== false);
-          if (globalServers.length > 0) return MIDDLEWARE_GLOBAL_ROOT;
-        }
-        return undefined;
-      };
       disposeMiddleware = registerMiddlewareTools(manager.ctx, mw, resolveRoot, middlewareMode, {
         disabledTools: manager.disabledTools,
       });
-      // 中间层模式热切换（设置页「中间层模式」下拉；initMiddleware 幂等已有，
-      // off↔project/all 需重新注册/卸载中间层工具——dispose 后重建）。
-      manager.setMiddlewareMode = async (mode: MiddlewareMode): Promise<void> => {
-        if (normalizeMiddlewareMode(mode) === manager.middlewareMode) return;
-        const next = normalizeMiddlewareMode(mode);
-        manager.middlewareMode = next;
-        disposeMiddleware();
-        if (next !== "off") {
-          const mw = await manager.initMiddleware(next, (config?.middlewarePolicy as Record<string, unknown> | undefined) ?? {});
-          disposeMiddleware = registerMiddlewareTools(manager.ctx, mw, resolveRoot, next, {
-            disabledTools: manager.disabledTools,
-          });
-        }
-        // off ↔ project/all：重注册/卸载中间层工具后 reconcile，恢复 supervisor
-        // 接管（all 模式含全局）或停掉（off 语义）——防同一 server 双进程。
-        manager.reconcileServers();
-        manager.logger.info(`dsh-mcp-manager: middleware mode=${next} (hot-switched)`);
-      };
       // startAll 在中间层注册前执行（off 语义），此处立即 reconcile：停掉
       // 项目级（all 含全局）supervisor（改由中间层接管），防同一 server 双进程。
       manager.reconcileServers();
@@ -203,7 +204,8 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
           catalogMaxEntries,
           manager.catalogCache,
           agent as unknown as CatalogAgent | undefined,
-          middlewareMode,
+          // 热切换后目录文案按当前模式渲染（#362 设置页中间层模式下拉）。
+          manager.middlewareMode,
         ) as unknown as PreStepDecision;
       });
     }

--- a/packages/dsh-mcp-manager/src/catalog.ts
+++ b/packages/dsh-mcp-manager/src/catalog.ts
@@ -144,13 +144,22 @@ export function digestCatalogEntries(entries: CatalogEntry[]): string {
  *   （项目级走中间层；完整盘点用 ws_mcp_list，查完整 schema 用 ws_mcp_detail）；
  * - 仅 global 条目 → 默认保持 mcp__ 直呼引导（全局服务器不经中间层检索）；
  *   all 模式（mode === "all"）下全局也走中间层 → 同样引导经中间层工具访问。
+ * 口径统一（#362 评审修正）：project 模式全局服务器仍以 mcp__ 直呼注册可用，
+ * 目录引导区分「经中间层访问」与「mcp__ 直呼」两类服务器，不混用。
  */
 export function renderMcpCatalogMessage(entries: CatalogEntry[], mode?: string): CatalogMessage {
   const hasProject = entries.some((entry) => entry.scope === "project");
-  const viaMiddleware = hasProject || mode === "all";
-  const guidance = viaMiddleware
-    ? "任务匹配某服务器能力时，先用 `ws_mcp_search` 检索当前工作空间的 MCP 工具，再用 `ws_mcp_call` 调用（server/tool 取自检索结果）。**服务器一律经这些工具访问，不直接调用其 mcp__ 前缀工具**；完整盘点全部服务器与工具清单用 `ws_mcp_list`，查单个工具的完整 inputSchema 用 `ws_mcp_detail`。"
-    : "任务匹配某服务器能力时，直接调用其 `mcp__<server>__<tool>` 工具（具体工具名与参数见工具列表）。";
+  const projectGuidance =
+    "项目级服务器一律经中间层工具访问：先用 `ws_mcp_search` 检索当前工作空间的 MCP 工具，再用 `ws_mcp_call` 调用（server/tool 取自检索结果；完整盘点全部服务器与工具清单用 `ws_mcp_list`，查单个工具的完整 inputSchema 用 `ws_mcp_detail`）。**项目级服务器不直接调用其 mcp__ 前缀工具**。";
+  const globalGuidance =
+    mode === "all"
+      ? "全局服务器同样经中间层访问（all 模式全局不注册 mcp__ 工具）：先用 `ws_mcp_search` 检索，再经 `ws_mcp_call` 调用，与项目级同一套 `ws_mcp_*` 工具。"
+      : "全局服务器仍以 `mcp__<server>__<tool>` 前缀工具直呼调用（project 模式全局不经中间层检索）。";
+  const guidance = hasProject
+    ? `${projectGuidance}${globalGuidance}`
+    : mode === "all"
+      ? globalGuidance
+      : `任务匹配某服务器能力时，直接调用其 \`mcp__<server>__<tool>\` 工具（具体工具名与参数见工具列表）。${globalGuidance}`;
   const lines = [
     "<system-reminder>",
     "本会话已配置以下 MCP 服务器（**仅描述能力，不代表当前连接状态**；服务器在 GUI「MCP」浮窗中连接后，其工具才会注册可用）：",

--- a/packages/dsh-mcp-manager/src/client/constants.ts
+++ b/packages/dsh-mcp-manager/src/client/constants.ts
@@ -15,6 +15,7 @@ export const API = {
   config: "/api/dsh-mcp/config",
   events: "/api/dsh-mcp/events",
   health: "/api/dsh-mcp/health",
+  toolDisable: "/api/dsh-mcp/tool-disable",
 };
 
 /** 状态分组排序（按优先级降序）。 */

--- a/packages/dsh-mcp-manager/src/client/float.ts
+++ b/packages/dsh-mcp-manager/src/client/float.ts
@@ -33,8 +33,55 @@ export function renderPill(state: McpState): void {
   state.floatPill.innerHTML = `<span class="dm-dot" style="background:${dot}"></span><span>${label}</span>`;
 }
 
+/**
+ * 工具级禁用开关（PATCH /api/dsh-mcp/tool-disable）。
+ * 语义（#362 交互拍板 2b）：折叠式 details 展开后 checkbox 列表，逐个启停；
+ * 点击调宿主 API 持久化 + 刷新。project 模式全局组不渲染 checkbox
+ * （runtime 注册的全局工具在 project 模式走 supervisor 不经中间层，无法禁用）。
+ */
+function toolCheckbox(server: any, tool: string, disabled: boolean, state: McpState, actions: UiActions): any {
+  const label = el("label", { class: "dm-float-tool" });
+  const input = el("input", {
+    type: "checkbox",
+    checked: disabled,
+    dataset: { dshMcpTool: tool },
+  });
+  input.addEventListener("change", () => {
+    void api(state.API.toolDisable, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        server: `@${server.scope === "global" ? "@global" : state.projectRoot ?? ""}/${server.name}`,
+        tool,
+        disabled: input.checked,
+      }),
+    }).then(() => actions.refresh())
+      .catch((error: any) => {
+        input.checked = !input.checked;
+        console.warn("[dsh-mcp-manager] tool-disable failed:", error);
+      });
+  });
+  label.appendChild(input);
+  label.appendChild(document.createTextNode(tool));
+  return label;
+}
+
+/** 折叠式工具清单（方案 2b）：summary 显示「工具（N）」，展开后 checkbox 列表。 */
+function renderFloatTools(server: any, state: McpState, actions: UiActions): any {
+  const tools = Array.isArray(server.tools) ? server.tools : [];
+  const disabledSet = new Set(Array.isArray(server.disabledTools) ? server.disabledTools : []);
+  const details = el("details", { class: "dm-float-tools" });
+  details.appendChild(el("summary", { text: `工具（${tools.length}）` }));
+  const list = el("div", { class: "dm-float-tool-list" });
+  for (const tool of tools) {
+    list.appendChild(toolCheckbox(server, tool, disabledSet.has(tool), state, actions));
+  }
+  details.appendChild(list);
+  return details;
+}
+
 /** 浮窗面板里的一行服务器。 */
-function renderFloatRow(server: any, state: McpState, actions: UiActions): any {
+function renderFloatRow(server: any, state: McpState, actions: UiActions, opts: { tools: boolean } = { tools: true }): any {
   const row = el("div", { class: "dm-float-row" });
   row.appendChild(el("span", { class: "dm-dot", style: `background:${statusDot(server.status)}` }));
   row.appendChild(el("span", { class: "dm-float-name", text: server.name, title: server.name }));
@@ -83,10 +130,13 @@ function renderFloatRow(server: any, state: McpState, actions: UiActions): any {
     actionsEl.appendChild(disable);
   }
   row.appendChild(actionsEl);
+  // 工具清单：project 模式全局组只读提示（切 all 可管理全局工具）。
+  if (opts.tools) row.appendChild(renderFloatTools(server, state, actions));
   return row;
 }
 
-/** 渲染浮窗下拉面板（项目/全局分组 + 状态 + 快捷操作）。 */
+/** 渲染浮窗下拉面板（#362 交互拍板 1a：项目级 / 全局级两大分组，各自内部再按状态）。
+ * project 模式：显示全局服务器但不显示工具开关，提示「切 all 模式可管理全局工具」。 */
 export function renderFloatPanel(state: McpState, actions: UiActions): void {
   if (state.floatPanel === undefined) return;
   state.floatPanel.textContent = "";
@@ -103,13 +153,31 @@ export function renderFloatPanel(state: McpState, actions: UiActions): void {
     if (state.floatOpen) placePanel(state);
     return;
   }
+  const isAll = state.middlewareMode === "all";
+  const toolsEnabled = (scope: string) => scope === "project" || isAll;
   for (const scope of ["project", "global"]) {
     const list = state.servers.filter((server: any) => server.scope === scope);
     if (list.length === 0) continue;
     const section = el("section", { class: "dm-float-group" });
     section.appendChild(el("div", { class: "dm-float-group-title", text: scope === "project" ? "项目级" : "全局" }));
-    for (const server of [...list].sort((a: any, b: any) => a.name.localeCompare(b.name))) {
-      section.appendChild(renderFloatRow(server, state, actions));
+    // 各自内部再按状态分组（状态序：运行中 → 连接中 → 重连中 → 未连接 → 已停用 → 失败）。
+    const byStatus = new Map<string, any[]>();
+    for (const group of STATUS_ORDER) byStatus.set(group.key, []);
+    for (const server of list) {
+      const bucket = byStatus.get(server.status);
+      if (bucket !== undefined) bucket.push(server);
+      else if (byStatus.has("stopped")) byStatus.get("stopped")!.push(server);
+    }
+    for (const group of STATUS_ORDER) {
+      const bucket = byStatus.get(group.key) ?? [];
+      if (bucket.length === 0) continue;
+      for (const server of [...bucket].sort((a: any, b: any) => a.name.localeCompare(b.name))) {
+        section.appendChild(renderFloatRow(server, state, actions, { tools: toolsEnabled(scope) }));
+      }
+    }
+    if (scope === "global" && !isAll) {
+      // project 模式：全局工具不经中间层（supervisor 直呼），无法工具级禁用。
+      section.appendChild(el("div", { class: "dm-float-hint", text: "全局工具开关需在 all 模式（中间层全量接管）下管理——切 all 模式可管理全局工具" }));
     }
     state.floatPanel.appendChild(section);
   }

--- a/packages/dsh-mcp-manager/src/client/index.ts
+++ b/packages/dsh-mcp-manager/src/client/index.ts
@@ -22,7 +22,7 @@ import { createState, type McpState, type UiActions } from "./state.ts";
 import { api } from "./dom.ts";
 import { refresh, switchTab, close, showPanel } from "./panel.ts";
 import { resetForm, beginEdit } from "./quick-add.ts";
-import { toggleFloat, mountFloat } from "./float.ts";
+import { toggleFloat, mountFloat, renderFloatPanel } from "./float.ts";
 import { bindSession } from "./session.ts";
 import { SettingsCard } from "./settings-card.ts";
 
@@ -167,11 +167,16 @@ export function apply(ctx: any): void {
           // 会退化为隐性 30s 轮询（对齐 notifier 语义：ping 不驱动业务刷新）。
           if (msg?.type === "ping") return;
           if (msg !== undefined && msg.type === "ui-config-changed") {
-            // 配置变更（设置页保存 position/offset）→ 重新 GET /config 就地更新浮窗位置，
-            // 非仅刷新 /servers；更新 mcpUiConfig 后重新定位胶囊与（若展开的）面板。
+            // 配置变更（设置页保存 position/offset / middleware）→ 重新 GET /config
+            // 就地更新浮窗位置与中间层模式，非仅刷新 /servers；更新后重新定位
+            // 胶囊与（若展开的）面板。
             void api(state.API.config).then((cfg: any) => {
-              if (cfg !== null && typeof cfg === "object") state.mcpUiConfig = cfg;
+              if (cfg !== null && typeof cfg === "object") {
+                state.mcpUiConfig = cfg;
+                if (typeof cfg.middleware === "string") state.middlewareMode = cfg.middleware;
+              }
               state.updateFloatState?.();
+              if (state.floatOpen) renderFloatPanel(state, actions);
             }).catch(() => {});
           } else {
             scheduleRefresh();

--- a/packages/dsh-mcp-manager/src/client/panel.ts
+++ b/packages/dsh-mcp-manager/src/client/panel.ts
@@ -38,6 +38,7 @@ async function doRefresh(state: McpState, actions: UiActions): Promise<boolean> 
     state.servers = payload.servers ?? [];
     state.counts = payload.counts ?? {};
     state.projectRoot = payload.projectRoot;
+    if (typeof payload.middlewareMode === "string") state.middlewareMode = payload.middlewareMode;
     renderPill(state);
     if (state.floatOpen) renderFloatPanel(state, actions);
     const countsEl = document.querySelector(".dm-counts");

--- a/packages/dsh-mcp-manager/src/client/servers.ts
+++ b/packages/dsh-mcp-manager/src/client/servers.ts
@@ -32,8 +32,32 @@ export function actionButton(label: any, onClick: any, primary = false, danger =
   });
 }
 
+/** 工具级禁用 checkbox（PATCH /api/dsh-mcp/tool-disable；#362 交互拍板 2b）。 */
+function toolCheckbox(server: any, tool: string, disabled: boolean, state: McpState, actions: UiActions): any {
+  const label = el("label", { class: "dm-tool" });
+  const input = el("input", { type: "checkbox", checked: disabled });
+  input.addEventListener("change", () => {
+    void api(state.API.toolDisable, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        server: `@${server.scope === "global" ? "@global" : state.projectRoot ?? ""}/${server.name}`,
+        tool,
+        disabled: input.checked,
+      }),
+    }).then(() => actions.refresh())
+      .catch((error: any) => {
+        input.checked = !input.checked;
+        console.warn("[dsh-mcp-manager] tool-disable failed:", error);
+      });
+  });
+  label.appendChild(input);
+  label.appendChild(document.createTextNode(tool));
+  return label;
+}
+
 /** 渲染单台服务器卡片。 */
-export function renderServer(server: any, state: McpState, actions: UiActions): any {
+export function renderServer(server: any, state: McpState, actions: UiActions, opts: { tools: boolean } = { tools: true }): any {
   const article = el("article", { class: "dm-server" });
   const header = el("header");
   header.appendChild(el("span", { class: "dm-name", text: server.name }));
@@ -53,7 +77,17 @@ export function renderServer(server: any, state: McpState, actions: UiActions): 
     article.appendChild(el("div", { class: "dm-err", text: server.error }));
   }
 
-  if (toolCount > 0) {
+  if (toolCount > 0 && opts.tools) {
+    const details = el("details", { class: "dm-tools" });
+    details.appendChild(el("summary", { text: `工具（${toolCount}）` }));
+    const list = el("ul");
+    const disabledSet = new Set(Array.isArray(server.disabledTools) ? server.disabledTools : []);
+    for (const tool of server.tools) {
+      list.appendChild(el("li", {}, [toolCheckbox(server, tool, disabledSet.has(tool), state, actions)]));
+    }
+    details.appendChild(list);
+    article.appendChild(details);
+  } else if (toolCount > 0 && !opts.tools) {
     const details = el("details", { class: "dm-tools" });
     details.appendChild(el("summary", { text: `工具（${toolCount}）` }));
     const list = el("ul");
@@ -114,7 +148,8 @@ export function renderServer(server: any, state: McpState, actions: UiActions): 
   return article;
 }
 
-/** 渲染服务器列表页（按状态分组）。 */
+/** 渲染服务器列表页（#362 交互拍板 1a：项目级 / 全局级两大分组，各自内部再按状态）。
+ * project 模式：全局组显示服务器但无工具 checkbox（提示切 all 模式可管理全局工具）。 */
 export function renderServers(state: McpState, actions: UiActions): void {
   if (state.bodyEl === undefined) return;
   state.bodyEl.textContent = "";
@@ -122,25 +157,29 @@ export function renderServers(state: McpState, actions: UiActions): void {
     state.bodyEl.appendChild(el("div", { class: "dm-status", text: "还没有配置 MCP 服务器。切到「快速接入」页添加，或粘贴 mcpServers JSON 导入。" }));
     return;
   }
-  for (const group of STATUS_ORDER) {
-    const list = state.servers.filter((server: any) => server.status === group.key);
+  const isAll = state.middlewareMode === "all";
+  const toolsEnabled = (scope: string) => scope === "project" || isAll;
+  for (const scope of ["project", "global"]) {
+    const list = state.servers.filter((server: any) => server.scope === scope);
     if (list.length === 0) continue;
     const section = el("section", { class: "dm-group" });
     const title = el("h3");
-    title.appendChild(el("span", { class: "dm-dot", style: `background:${group.dot}` }));
-    title.appendChild(document.createTextNode(group.title));
+    title.appendChild(document.createTextNode(scope === "project" ? "项目级" : "全局级"));
     title.appendChild(el("span", { class: "dm-count", text: `${list.length}` }));
     section.appendChild(title);
-    for (const server of list.sort((a: any, b: any) => a.name.localeCompare(b.name))) {
-      section.appendChild(renderServer(server, state, actions));
+    for (const group of STATUS_ORDER) {
+      const grouped = list.filter((server: any) => server.status === group.key);
+      if (grouped.length === 0) continue;
+      const sub = el("div", { class: "dm-subgroup" });
+      sub.appendChild(el("h4", { class: "dm-subgroup-title", text: `${group.title}（${grouped.length}）` }));
+      for (const server of grouped.sort((a: any, b: any) => a.name.localeCompare(b.name))) {
+        sub.appendChild(renderServer(server, state, actions, { tools: toolsEnabled(scope) }));
+      }
+      section.appendChild(sub);
     }
-    state.bodyEl.appendChild(section);
-  }
-  const others = state.servers.filter((server: any) => !STATUS_ORDER.some((group) => group.key === server.status));
-  if (others.length > 0) {
-    const section = el("section", { class: "dm-group" });
-    section.appendChild(el("h3", { text: "其他" }));
-    for (const server of others) section.appendChild(renderServer(server, state, actions));
+    if (scope === "global" && !isAll) {
+      section.appendChild(el("div", { class: "dm-status", text: "全局工具开关需在 all 模式（中间层全量接管）下管理——切 all 模式可管理全局工具" }));
+    }
     state.bodyEl.appendChild(section);
   }
 }

--- a/packages/dsh-mcp-manager/src/client/settings-card.ts
+++ b/packages/dsh-mcp-manager/src/client/settings-card.ts
@@ -20,6 +20,7 @@ export function SettingsCard() {
   const useState = React.useState;
   const useEffect = React.useEffect;
   const [cfg, setCfg] = useState(null) as any;
+  const [middleware, setMiddleware] = useState("project");
   const [open, setOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [msg, setMsg] = useState(null) as any;
@@ -27,7 +28,10 @@ export function SettingsCard() {
   useEffect(() => {
     let live = true;
     api(API.config).then((c: any) => {
-      if (live && c !== null && typeof c === "object") setCfg(c);
+      if (live && c !== null && typeof c === "object") {
+        setCfg(c);
+        if (typeof c.middleware === "string") setMiddleware(c.middleware);
+      }
     }).catch(() => {});
     return () => {
       live = false;
@@ -59,12 +63,14 @@ export function SettingsCard() {
     setSaving(true);
     setMsg(null);
     try {
+      const payload: any = { ...cfg };
+      if (middleware !== (cfg.middleware ?? "project")) payload.middleware = middleware;
       await api(API.config, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(cfg),
+        body: JSON.stringify(payload),
       });
-      setMsg({ ok: true, text: "已保存——浮窗位置即时生效（无需重启）" });
+      setMsg({ ok: true, text: "已保存——浮窗位置与中间层模式即时生效（无需重启）" });
       setTimeout(() => setMsg(null), 2400);
     } catch (e) {
       setMsg({ ok: false, text: `保存失败：${e instanceof Error ? e.message : String(e)}` });
@@ -114,13 +120,26 @@ export function SettingsCard() {
         ),
       ),
       React.createElement("div", { className: "dm-set-row" },
+        React.createElement("label", { htmlFor: "dm-set-middleware" }, "中间层模式"),
+        React.createElement("select", {
+          id: "dm-set-middleware",
+          className: "dm-set-input",
+          value: middleware,
+          onChange: (e: any) => setMiddleware(e.target.value),
+        },
+          React.createElement("option", { value: "project" }, "project（项目级走中间层，推荐）"),
+          React.createElement("option", { value: "all" }, "all（全局也走中间层）"),
+          React.createElement("option", { value: "off" }, "off（全部直呼 mcp__ 工具）"),
+        ),
+      ),
+      React.createElement("div", { className: "dm-set-row" },
         numInput("offsetX", "水平偏移"),
         numInput("offsetY", "垂直偏移"),
         numInput("blankY", "空白偏移"),
         numInput("zIndexBase", "层级基准", 1, 9000),
       ),
       React.createElement("div", { className: "dm-set-hint" },
-        "保存即热更新：宿主经 SSE events 通道广播一变，所有标签页的浮窗即刻原位更新，无需重启 dsh web。"),
+        "保存即热更新：浮窗位置即时生效；中间层模式切换即时生效并持久化（无需重启 dsh web）。"),
       React.createElement("div", { className: "dm-set-foot" },
         msg !== null
           ? React.createElement("span", { className: msg.ok ? "dm-set-saved" : "dm-set-error" }, msg.text)

--- a/packages/dsh-mcp-manager/src/client/state.ts
+++ b/packages/dsh-mcp-manager/src/client/state.ts
@@ -23,6 +23,8 @@ export interface McpServerSummary {
   headers?: Record<string, string>;
   error?: string;
   tools?: string[];
+  /** 工具级被用户禁用的工具名列表（独立于服务器级 enabled）。 */
+  disabledTools?: string[];
   toolCallTimeoutMs?: number;
   description?: string;
 }
@@ -61,6 +63,8 @@ export interface McpState {
   activeTab: string;
   /** 服务器列表。 */
   servers: any[];
+  /** 中间层模式（off/project/all；来自 summary）。 */
+  middlewareMode: string;
   /** 各状态计数。 */
   counts: any;
   /** 正在编辑的服务器名称（undefined 表示新建）。 */
@@ -102,6 +106,7 @@ export function createState(): McpState {
     open: false,
     activeTab: "servers",
     servers: [],
+    middlewareMode: "project",
     counts: {},
     editingName: undefined,
     editing: undefined,

--- a/packages/dsh-mcp-manager/src/client/style.css
+++ b/packages/dsh-mcp-manager/src/client/style.css
@@ -132,3 +132,14 @@
 .dm-set-head:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(0,0,0,.04))}
 .dm-set-save:hover{background:var(--dsw-alias-interactive-bg-hover,rgba(0,0,0,.06))}
 }
+
+/* #362 工具级禁用：折叠式 details + checkbox 列表（浮窗与管理面板共用视觉）。 */
+.dm-float-tools{margin:4px 0 0 16px}
+.dm-float-tools summary{font-size:11px;color:var(--dsw-alias-label-secondary,#525866);cursor:pointer;user-select:none}
+.dm-float-tool-list{display:flex;flex-direction:column;gap:2px;margin:4px 0 0;max-height:140px;overflow:auto}
+.dm-float-tool,.dm-tool{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--dsw-alias-label-primary,#3a3f4b);font-family:ui-monospace,Consolas,monospace;cursor:pointer;line-height:1.6}
+.dm-float-tool input,.dm-tool input{width:13px;height:13px;margin:0;accent-color:var(--dsw-alias-state-info-primary,#3b82f6);flex:none}
+.dm-float-hint{font-size:10.5px;color:var(--dsw-alias-label-tertiary,#8a919c);line-height:1.5;padding:4px 8px 2px}
+.dm-subgroup{margin:6px 0 10px}
+.dm-subgroup-title{margin:0 0 4px;font-size:11px;font-weight:600;color:var(--dsw-alias-label-secondary,#525866)}
+.dm-group>h3 .dm-count{font-size:11px;color:var(--dsw-alias-label-tertiary,#8a919c);font-weight:600}

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -132,6 +132,9 @@ export {
   globMatch,
   policyAllows,
   policyDenialReason,
+  isToolDenied,
+  toolDisabledReason,
+  parseDisabledTools,
   scoreTool,
   searchCatalog,
   searchCatalogMulti,
@@ -141,6 +144,8 @@ export {
   userStateFile,
   loadUserState,
   saveUserState,
+  loadDisabledTools,
+  saveDisabledTools,
   catalogCacheFileFor,
   CONNECT_TIMEOUT_MS,
   DISCOVERY_TIMEOUT_MS,
@@ -162,6 +167,7 @@ export type {
   ListServerEntry,
   ListCatalogResult,
   ToolDetail,
+  DisabledToolsMap,
 } from "./middleware.ts";
 // 路由
 export { ROUTES, makeRoutes, makeEventsRoute, makeHealthRoute, sseData, uiConfigChangedFrame, broadcastFrame, SSE_HEARTBEAT_MS, SSE_PING_FRAME } from "./routes.ts";

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -29,8 +29,10 @@ import {
   loadUserState,
   saveUserState,
   catalogCacheFileFor,
+  loadDisabledTools,
+  saveDisabledTools,
 } from "./middleware.ts";
-import type { MiddlewareMode, ProjectUnit } from "./middleware.ts";
+import type { MiddlewareMode, ProjectUnit, DisabledToolsMap } from "./middleware.ts";
 
 /** 中间层 all 模式的全局虚拟 root（全局服务器经中间层访问时的路由 key）。 */
 export const MIDDLEWARE_GLOBAL_ROOT = "@global";
@@ -223,6 +225,12 @@ export class McpManager {
     return store?.data.servers;
   }
 
+  /** 中间层宿主：该 server 是否全局级（双源：store + runtimeRegistry）。
+   * codegraph 等 runtime 注册的服务器不落 store，单源会误判「非全局」——P1 修正。 */
+  isGlobalServer(name: string): boolean {
+    return this.store.data.servers.some((server) => server.name === name) || this.runtimeRegistry.has(name);
+  }
+
   /** 中间层宿主：全局服务器配置（all 模式使用）。 */
   globalServers(): ServerConfig[] {
     return this.store.data.servers;
@@ -252,6 +260,7 @@ export class McpManager {
         saveUserState: (units) => this.saveUserState(units),
         emitStatus: () => this.emitStatus(),
         catalogCachePath: (root) => this.catalogCachePathFor(root),
+        isGlobalServer: (name) => this.isGlobalServer(name),
       },
       {
         allowTools: (policy.allowTools as Record<string, string[]> | undefined) ?? undefined,
@@ -261,12 +270,44 @@ export class McpManager {
     // 加载 userDisabled 并注入中间层实例（单元创建时合并；重启不丢）。
     this.disabledByRoot = await loadUserState(this.userStatePath);
     mw.disabledByRoot = this.disabledByRoot;
+    // 加载工具级禁用（三层结构；合并式写盘，绝不整表覆盖）。
+    this.disabledTools = await loadDisabledTools(this.userStatePath);
+    mw.disabledTools = this.disabledTools;
     this.middleware = mw;
     return mw;
   }
 
   /** userDisabled 映射（root → Set<server>），中间层单元创建时合并。 */
   disabledByRoot: Map<string, Set<string>> = new Map();
+
+  /** 工具级禁用（root → server → Set<tool>）；root=@global 跨工作空间共享。 */
+  disabledTools: DisabledToolsMap = new Map();
+
+  /** 中间层模式热切换（apply 注入；设置页「中间层模式」下拉调用）。 */
+  setMiddlewareMode?: (mode: MiddlewareMode) => Promise<void>;
+
+  /**
+   * 设置/解除单个工具禁用（宿主 API PATCH /api/dsh-mcp/tool-disable 调用）。
+   * 合并式写盘（先读现有文件再覆盖本 root 段，绝不整表覆盖）——
+   * 防多工作空间互相抹掉禁用记录。
+   * @param root 目标 root（全局服务器用 MIDDLEWARE_GLOBAL_ROOT）。
+   * @param server 服务器裸名。
+   * @param tool 远端工具裸名。
+   * @param disabled true=禁用 / false=解除。
+   * 工具级禁用独立于服务器级 enabled：服务器级复活不清工具级状态。
+   */
+  async setToolDisabled(root: string, server: string, tool: string, disabled: boolean): Promise<void> {
+    const tools = this.disabledTools.get(root) ?? new Map<string, Set<string>>();
+    const set = tools.get(server) ?? new Set<string>();
+    if (disabled) set.add(tool);
+    else set.delete(tool);
+    if (set.size > 0) tools.set(server, set);
+    else tools.delete(server);
+    if (tools.size > 0) this.disabledTools.set(root, tools);
+    else this.disabledTools.delete(root);
+    await saveDisabledTools(this.userStatePath, this.disabledTools);
+    this.emitStatus();
+  }
 
   /** 读取/复用某项目根的 store（工作区缓存命中直接返回，不重复读盘）。 */
   async projectStoreFor(root: string | undefined): Promise<McpStore | undefined> {

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -15,6 +15,7 @@ import { homedir } from "node:os";
 import type { ServerResponse } from "node:http";
 import type { Context, LoggerService } from "@deepseek-ai/cordis";
 import type { ServerConfig, ClientUiConfig } from "./types.ts";
+import type { ToolDefinition } from "@deepseek-ai/dsh-tools";
 import type { CatalogCache } from "./catalog.ts";
 import { normalizeServer } from "./normalize.ts";
 import { normalizeUiConfig, buildConfigUiPatch } from "./config-schema.ts";
@@ -555,9 +556,14 @@ export class McpManager {
    * - 同名已存在（store 或 runtime）：返回 { name, existing: true }，不抛错；
    * - 注册即连接（走 start 的 config 直传分支，同名 runtime 优先）；
    * - 串行队列防 reconcileBusy 吞注册；多插件并发注册排队。
+   * @param options 注册入参；`toolDefinitions` 可选——提供时该服务器工具
+   *   全部用调用方封装定义注册（supervisor 跳过远端 schema 投影，execute
+   *   来自调用方；命名仍按 publicToolName 的 mcp__ 前缀规则）。
    */
-  async registerServer(server: Record<string, unknown>): Promise<{ name: string; existing: boolean }> {
-    const config = normalizeServer(server);
+  async registerServer(options: Record<string, unknown>): Promise<{ name: string; existing: boolean }> {
+    const { toolDefinitions, ...rest } = options;
+    const config = normalizeServer(rest);
+    if (Array.isArray(toolDefinitions)) config.toolDefinitions = toolDefinitions as ToolDefinition[];
     const run = this.registerQueue.then(async () => {
       if (this.runtimeRegistry.has(config.name) || this.store.find(config.name) !== undefined) {
         return { name: config.name, existing: true };

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -715,6 +715,7 @@ export class McpManager {
       projectRoot: this.projectRoot ?? undefined,
       servers,
       counts: byStatus,
+      middlewareMode: this.middlewareMode,
     };
   }
 
@@ -744,23 +745,32 @@ export class McpManager {
       const entry = unit.connections.get(server.name);
       if (entry !== undefined) {
         const catalog = unit.catalog.get(server.name);
+        const disabledTools = this.disabledTools.get(unit.root)?.get(server.name);
+        const globalTools = unit.root === MIDDLEWARE_GLOBAL_ROOT ? undefined : this.disabledTools.get(MIDDLEWARE_GLOBAL_ROOT)?.get(server.name);
+        const tools = catalog !== undefined && catalog.unavailable === undefined ? [...catalog.tools.keys()] : [];
+        const disabledList = tools.filter((tool) => (disabledTools?.has(tool) ?? false) || (globalTools?.has(tool) ?? false));
         return {
           ...server,
           scope,
           status: entry.status,
           // 目录发现失败（unavailable）时透出原因：解释 connected 却 0 工具。
           error: entry.error !== undefined ? msgOf(entry.error) : catalog?.unavailable,
-          tools: catalog !== undefined && catalog.unavailable === undefined ? [...catalog.tools.keys()] : [],
+          tools,
+          disabledTools: disabledList.length > 0 ? disabledList : undefined,
         };
       }
     }
     const supervisor = this.supervisors.get(server.name);
+    const supervisorTools = supervisor?.tools ?? [];
+    const disabledForServer = this.disabledTools.get(MIDDLEWARE_GLOBAL_ROOT)?.get(server.name) ?? this.disabledTools.get(this.projectRoot ?? "")?.get(server.name);
+    const supervisorDisabled = disabledForServer !== undefined ? supervisorTools.filter((tool) => disabledForServer.has(tool)) : [];
     return {
       ...server,
       scope,
       status: supervisor?.status ?? (server.enabled === false ? "disabled" : "stopped"),
       error: supervisor?.error !== undefined ? (supervisor.error as Error).message : undefined,
-      tools: supervisor?.tools ?? [],
+      tools: supervisorTools,
+      disabledTools: supervisorDisabled.length > 0 ? supervisorDisabled : undefined,
     };
   }
 

--- a/packages/dsh-mcp-manager/src/middleware-register.ts
+++ b/packages/dsh-mcp-manager/src/middleware-register.ts
@@ -28,8 +28,26 @@ import {
   fullServerName,
   policyAllows,
   policyDenialReason,
+  isToolDenied,
+  toolDisabledReason,
+  MIDDLEWARE_GLOBAL_ROOT,
 } from "./middleware-utils.ts";
-import type { MiddlewareMode } from "./middleware-types.ts";
+import type { MiddlewareMode, DisabledToolsMap } from "./middleware-types.ts";
+
+/** 空 query 搜索无命中时的可归因提示（纯 render 文案，C 项）。 */
+const SEARCH_EMPTY_HINT =
+  "（当前工作空间没有匹配的 MCP 工具；可用 ws_mcp_list 完整盘点全部服务器与工具，确认 server 名/工具名后再检索）";
+
+/** 项目级可见服务器名列表（A1 归因文案用；排序去重）。 */
+function visibleProjectServers(mw: McpMiddleware, root: string): string[] {
+  const names: string[] = [];
+  for (const unit of mw.units.values()) {
+    if (unit.root === root) {
+      for (const serverName of unit.catalog.keys()) names.push(serverName);
+    }
+  }
+  return [...new Set(names)].sort();
+}
 
 /** 等待 in-flight 连接/发现（8s 预算，与 search 对齐；超时不阻塞返回已有目录）。 */
 async function waitForDiscovery(unit: NonNullable<Awaited<ReturnType<McpMiddleware["projectUnitFor"]>>>): Promise<void> {
@@ -54,8 +72,39 @@ export function registerMiddlewareTools(
   mw: McpMiddleware,
   resolveRoot: (agent: unknown) => Promise<string | undefined>,
   mode: MiddlewareMode = "project",
+  options: {
+    /** 工具级禁用映射（root → server → Set<tool>）；缺省取 mw.disabledTools。 */
+    disabledTools?: DisabledToolsMap;
+  } = {},
 ): () => void {
   const disposers: Array<() => void> = [];
+  const disabledTools = options.disabledTools ?? mw.disabledTools;
+
+  /**
+   * 路由一致性校验（detail/call 共用；A2）：目标 root 必须等于当前 root，
+   * 或 all 模式下的 @global（全局配置跨工作空间共享，语义成立）。
+   * project 模式传全局级服务器 → 引导改用 mcp__ 直呼（全局 mcp__ 工具在该
+   * 模式下仍注册可用）；非 global 的其他 root 硬拒绝（防跨空间串台）。
+   * @returns 校验通过的 root；抛错则拒绝。
+   */
+  const checkRoot = async (caller: string, server: string, root: string): Promise<string | undefined> => {
+    const parsed = parseFullServerName(server);
+    if (parsed === undefined || (parsed.root !== root && parsed.root !== MIDDLEWARE_GLOBAL_ROOT)) {
+      throw new Error(
+        `${caller}: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`,
+      );
+    }
+    if (parsed.root === MIDDLEWARE_GLOBAL_ROOT && mode !== "all") {
+      const bare = parsed.server;
+      const known = mw.host.isGlobalServer(bare) || mw.units.get(MIDDLEWARE_GLOBAL_ROOT)?.catalog.has(bare) === true;
+      if (known) {
+        throw new Error(
+          `${caller}: server ${JSON.stringify(server)} 是全局级（global scope）服务器，中间层只覆盖项目级服务器；请直接用 mcp__${bare}__<tool> 前缀工具调用（project 模式全局工具仍直呼注册）`,
+        );
+      }
+    }
+    return parsed.root;
+  };
 
   /** all 模式可见单元集合：项目 root + @global（评审 A 全局可见性修复）。
    * root 本身为 @global 时去重（防 all 模式无项目 cwd 下服务器翻倍）。 */
@@ -95,7 +144,7 @@ export function registerMiddlewareTools(
           const description = String(hit.description ?? "");
           return `${server}/${tool}: ${description}`;
         });
-        let body = lines.length > 0 ? lines.join("\n") : "（当前工作空间没有匹配的 MCP 工具）";
+        let body = lines.length > 0 ? lines.join("\n") : SEARCH_EMPTY_HINT;
         if (v.truncated === true) body += "\n（结果已达 limit，可能未列全——可调大 limit 或用 ws_mcp_list 完整盘点）";
         const unavailable = (v.unavailable ?? []).map((entry) => `${String(entry.server ?? "")}: ${String(entry.reason ?? "")}`);
         return [{ type: "text", text: unavailable.length > 0 ? `${body}\n\n不可用服务器：\n${unavailable.join("\n")}` : body }];
@@ -190,17 +239,14 @@ export function registerMiddlewareTools(
       const tool = typeof params.tool === "string" ? params.tool : "";
       if (server === "" || tool === "") throw new Error("ws_mcp_call: server 与 tool 均为必填");
       const parsed = parseFullServerName(server);
-      // all 模式放行 @global root（全局配置跨工作空间共享，语义成立）；
-      // 仍拒绝非当前 root 的其他项目 root（防跨空间串台）。
-      const allowedRoot = mode === "all" ? "@global" : undefined;
-      if (parsed === undefined || (parsed.root !== root && parsed.root !== allowedRoot)) {
-        throw new Error(
-          `ws_mcp_call: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`,
-        );
+      if (parsed === undefined) throw new Error("ws_mcp_call: server 参数格式非法，应为 @<root>/<server>");
+      const targetRoot = await checkRoot("ws_mcp_call", server, root);
+      if (targetRoot === undefined) {
+        throw new Error(`ws_mcp_call: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`);
       }
-      const unit = await mw.projectUnitFor(parsed.root);
-      if (unit === undefined) throw new Error(`ws_mcp_call: 工作空间 ${JSON.stringify(parsed.root)} 无项目级 MCP 配置`);
-      await mw.ensureConnected(parsed.root, parsed.server);
+      const unit = await mw.projectUnitFor(targetRoot);
+      if (unit === undefined) throw new Error(`ws_mcp_call: 工作空间 ${JSON.stringify(targetRoot)} 无项目级 MCP 配置`);
+      await mw.ensureConnected(targetRoot, parsed.server);
       return mw.callTool(server, tool, params.arguments, exec.signal);
     },
   };
@@ -288,7 +334,7 @@ export function registerMiddlewareTools(
         }
         const globalUnit = await mw.projectUnitFor("@global");
         if (globalUnit !== undefined) await waitForDiscovery(globalUnit);
-        return listCatalog(mw.units, ["@global"], serverFilter, toolLimit, mode, "当前工作空间没有可用 MCP 服务器（项目级与全局均未发现；若刚添加配置，请稍后重试）");
+        return listCatalog(mw.units, ["@global"], serverFilter, toolLimit, mode, "当前工作空间没有可用 MCP 服务器（项目级与全局均未发现；若刚添加配置，请稍后重试）", disabledTools);
       }
       // 等待 in-flight 连接/发现（预算内），再搜索。all 模式对可见全部单元
       // （含 @global 首次触达）都等待——否则全局目录首次为空（P1-3 修复）。
@@ -296,11 +342,20 @@ export function registerMiddlewareTools(
         const visibleUnit = visible === root ? unit : await mw.projectUnitFor(visible);
         if (visibleUnit !== undefined) await waitForDiscovery(visibleUnit);
       }
-      const emptyHint =
-        mode === "all"
-          ? "当前工作空间没有可用 MCP 服务器（项目级与全局均未发现；若刚添加配置，请稍后重试）"
-          : "当前工作空间没有可用 MCP 服务器（未配置项目级服务器；若刚添加配置，请稍后重试）";
-      return listCatalog(mw.units, roots, serverFilter, toolLimit, mode, emptyHint);
+      const result = listCatalog(mw.units, roots, serverFilter, toolLimit, mode, "", disabledTools);
+      // A1：带 serverFilter 过滤后 0 命中 → message 可归因（不谎报「未配置」）。
+      if (result.servers.length === 0 && serverFilter !== undefined) {
+        const visible = visibleProjectServers(mw, root);
+        const visibleText = visible.length > 0 ? `可见项目级服务器：${visible.join(" / ")}；` : "当前工作空间无已发现的项目级服务器；";
+        result.message =
+          `没有匹配 server=${JSON.stringify(serverFilter)} 的项目级服务器。${visibleText}全局级服务器不在此列出，请用 mcp__<server>__<tool> 前缀工具访问`;
+      } else if (result.servers.length === 0) {
+        result.message =
+          mode === "all"
+            ? "当前工作空间没有可用 MCP 服务器（项目级与全局均未发现；若刚添加配置，请稍后重试）"
+            : "当前工作空间没有可用 MCP 服务器（未配置项目级服务器；若刚添加配置，请稍后重试）";
+      }
+      return result;
     },
   };
 
@@ -349,17 +404,15 @@ export function registerMiddlewareTools(
       const server = typeof params.server === "string" ? params.server : "";
       const tool = typeof params.tool === "string" ? params.tool : "";
       if (server === "" || tool === "") throw new Error("ws_mcp_detail: server 与 tool 均为必填");
-      // all 模式放行 @global root（与 ws_mcp_call 同口径）。
-      const parsed = parseFullServerName(server);
-      const allowedRoot = mode === "all" ? "@global" : undefined;
-      if (parsed === undefined || (parsed.root !== root && parsed.root !== allowedRoot)) {
+      const targetRoot = await checkRoot("ws_mcp_detail", server, root);
+      if (targetRoot === undefined) {
         throw new Error(
           `ws_mcp_detail: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`,
         );
       }
-      const unit = await mw.projectUnitFor(parsed.root);
+      const unit = await mw.projectUnitFor(targetRoot);
       if (unit !== undefined) await waitForDiscovery(unit);
-      return findToolDetail(mw.units, parsed.root, server, tool);
+      return findToolDetail(mw.units, targetRoot, server, tool);
     },
   };
 
@@ -368,25 +421,63 @@ export function registerMiddlewareTools(
   disposers.push(ctx.tools.register(list));
   disposers.push(ctx.tools.register(detail));
 
-  // 策略 guard 层（方案 v2）：tools/pre-execute 全局唯一执行点，防其他插件/
-  // 入口绕行 ws_mcp_call 直接调用远端工具。对 ws_mcp_call 的调用统一过策略
-  // （deny 优先）；其余工具放行（不干扰 mcp__ 直呼兼容路径；ws_mcp_list /
-  // ws_mcp_detail 纯读本地目录，与 ws_mcp_search 一致不触达策略 guard）。
+  // 策略 + 工具级禁用 guard 层（P0-1 三入口之二）：tools/pre-execute 全局唯一
+  // 执行点，防其他插件/入口绕行 ws_mcp_call 直接调用远端工具。
+  // 覆盖两类工具名：
+  //   - ws_mcp_call：统一过「禁用表 + 策略」（deny 优先），与 callTool 内裁决一致；
+  //   - mcp__<server>__<tool> 直呼前缀工具：从注册名反解 (root, server, tool)
+  //     后过禁用表（策略不适用于直呼路径——中间层策略只约束 ws_mcp_call）。
+  // 其他工具放行（ws_mcp_list / ws_mcp_detail / ws_mcp_search 纯读本地目录不触达）。
+  // 路由 root 解析（P0-3）：exec.agent?.session?.header?.cwd → 归一化项目根；
+  // exec.agent 缺失/无法解析 → 按最宽可见范围放行（只查 @global 记录，保持
+  // 既有降级行为；project 模式无法禁用的全局工具在浮窗 global 组有提示）。
   if (typeof ctx.on === "function") {
     const guardDispose = ctx.on(
       "tools/pre-execute",
-      async (exec: { name?: string; arguments?: unknown }, next: () => Promise<PreToolDecision>): Promise<PreToolDecision> => {
-        if (exec?.name !== "ws_mcp_call") return next();
-        const params = (typeof exec.arguments === "object" && exec.arguments !== null ? exec.arguments : {}) as Record<string, unknown>;
-        const server = typeof params.server === "string" ? params.server : "";
-        const tool = typeof params.tool === "string" ? params.tool : "";
-        const parsed = parseFullServerName(server);
-        if (parsed === undefined || parsed.server === "") return next();
-        // 策略键支持全名（@root/server）或裸名。
-        const policyKey = fullServerName(parsed.root, parsed.server);
-        if (!policyAllows(mw.policy, policyKey, tool)) {
-          const reason = policyDenialReason(mw.policy, policyKey, tool);
-          return { kind: "deny", reason: reason ?? `ws_mcp_call: 工具被策略拒绝` };
+      async (
+        exec: { name?: string; arguments?: unknown; agent?: unknown },
+        next: () => Promise<PreToolDecision>,
+      ): Promise<PreToolDecision> => {
+        const name = exec?.name;
+        if (typeof name !== "string" || name === "") return next();
+        // 路径一：ws_mcp_call 显式参数（与 execute 同源校验）。
+        if (name === "ws_mcp_call") {
+          const params = (typeof exec.arguments === "object" && exec.arguments !== null ? exec.arguments : {}) as Record<string, unknown>;
+          const server = typeof params.server === "string" ? params.server : "";
+          const tool = typeof params.tool === "string" ? params.tool : "";
+          const parsed = parseFullServerName(server);
+          if (parsed === undefined || parsed.server === "") return next();
+          const policyKey = fullServerName(parsed.root, parsed.server);
+          if (isToolDenied(disabledTools, mw.policy, policyKey, tool)) {
+            if (!policyAllows(mw.policy, policyKey, tool)) {
+              return { kind: "deny", reason: policyDenialReason(mw.policy, policyKey, tool) ?? "ws_mcp_call: 工具被策略拒绝" };
+            }
+            return { kind: "deny", reason: toolDisabledReason(policyKey, tool) };
+          }
+          return next();
+        }
+        // 路径二：mcp__ 前缀直呼工具（registered 名 = mcp__<server>__<tool>；
+        // 超长哈希后缀名不可逆 → 按未知 server 处理，不禁用/不误禁，P2）。
+        if (name.startsWith("mcp__")) {
+          const rest = name.slice("mcp__".length);
+          const separator = rest.indexOf("__");
+          if (separator <= 0) return next();
+          const server = rest.slice(0, separator);
+          const tool = rest.slice(separator + 2);
+          if (tool === "") return next();
+          const root = await resolveRoot(exec.agent);
+          if (root === undefined) {
+            // 无法解析会话 root：按最宽可见范围放行（仅 @global 共享记录生效）。
+            if (disabledTools?.get(MIDDLEWARE_GLOBAL_ROOT)?.get(server)?.has(tool) === true) {
+              return { kind: "deny", reason: toolDisabledReason(`@${MIDDLEWARE_GLOBAL_ROOT}/${server}`, tool) };
+            }
+            return next();
+          }
+          const serverKey = fullServerName(root, server);
+          if (isToolDenied(disabledTools, undefined, serverKey, tool)) {
+            return { kind: "deny", reason: toolDisabledReason(serverKey, tool) };
+          }
+          return next();
         }
         return next();
       },

--- a/packages/dsh-mcp-manager/src/middleware-register.ts
+++ b/packages/dsh-mcp-manager/src/middleware-register.ts
@@ -78,18 +78,24 @@ export function registerMiddlewareTools(
   } = {},
 ): () => void {
   const disposers: Array<() => void> = [];
+  // 单一事实源：options 显式传入时同步到 mw（guard 与 callTool 同源，防漂移）。
   const disabledTools = options.disabledTools ?? mw.disabledTools;
+  if (options.disabledTools !== undefined) mw.disabledTools = disabledTools;
 
   /**
    * 路由一致性校验（detail/call 共用；A2）：目标 root 必须等于当前 root，
    * 或 all 模式下的 @global（全局配置跨工作空间共享，语义成立）。
    * project 模式传全局级服务器 → 引导改用 mcp__ 直呼（全局 mcp__ 工具在该
-   * 模式下仍注册可用）；非 global 的其他 root 硬拒绝（防跨空间串台）。
+   * 模式下仍注册可用）；非 global 的其他 root / 未知 @global 服务器一律硬拒绝
+   * （防跨空间串台与 project 模式经 @global 路由绕过）。
    * @returns 校验通过的 root；抛错则拒绝。
    */
   const checkRoot = async (caller: string, server: string, root: string): Promise<string | undefined> => {
     const parsed = parseFullServerName(server);
-    if (parsed === undefined || (parsed.root !== root && parsed.root !== MIDDLEWARE_GLOBAL_ROOT)) {
+    if (parsed === undefined) {
+      throw new Error(`${caller}: server 参数格式非法，应为 @<root>/<server>`);
+    }
+    if (parsed.root !== root && parsed.root !== MIDDLEWARE_GLOBAL_ROOT) {
       throw new Error(
         `${caller}: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`,
       );
@@ -102,6 +108,9 @@ export function registerMiddlewareTools(
           `${caller}: server ${JSON.stringify(server)} 是全局级（global scope）服务器，中间层只覆盖项目级服务器；请直接用 mcp__${bare}__<tool> 前缀工具调用（project 模式全局工具仍直呼注册）`,
         );
       }
+      throw new Error(
+        `${caller}: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`,
+      );
     }
     return parsed.root;
   };

--- a/packages/dsh-mcp-manager/src/middleware-state.ts
+++ b/packages/dsh-mcp-manager/src/middleware-state.ts
@@ -7,7 +7,8 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
-import type { ProjectUnit } from "./middleware-types.ts";
+import type { ProjectUnit, DisabledToolsMap } from "./middleware-types.ts";
+import { parseDisabledTools } from "./middleware-utils.ts";
 
 /** userDisabled 持久化文件路径。 */
 export function userStateFile() {
@@ -59,4 +60,43 @@ export async function saveUserState(file: string, units: Map<string, ProjectUnit
 export function catalogCacheFileFor(root: string) {
   const hash = createHash("sha256").update(root).digest("hex").slice(0, 16);
   return join(process.env.DSH_HOME ?? join(homedir(), ".dsh"), "dsh-mcp-catalog", `${hash}.json`);
+}
+
+/** 加载工具级禁用（disabledTools 三段：root → server → tool[]；损坏/缺失 → 空）。 */
+export async function loadDisabledTools(file: string): Promise<DisabledToolsMap> {
+  try {
+    if (!existsSync(file)) return new Map();
+    const raw = await readFile(file, "utf8");
+    const parsed = JSON.parse(raw) as { disabledTools?: unknown } | null;
+    return parseDisabledTools(parsed?.disabledTools);
+  } catch {
+    // 损坏忽略
+    return new Map();
+  }
+}
+
+/**
+ * 持久化工具级禁用。内存映射是进程内完整视图（启动时 loadDisabledTools 全量
+ * 加载 + setToolDisabled 增量变更），直接整图写盘即满足「多工作空间互不抹掉」
+ * （同一进程内所有空间共用同一映射）；跨进程并发写属读-改-写竞态，与
+ * 服务器级 userDisabled（saveUserState）现状一致。
+ */
+export async function saveDisabledTools(file: string, disabledTools: DisabledToolsMap): Promise<void> {
+  const payload: Record<string, Record<string, string[]>> = {};
+  for (const [root, servers] of disabledTools) {
+    const serverRec: Record<string, string[]> = {};
+    for (const [server, tools] of servers) {
+      if (tools.size > 0) serverRec[server] = [...tools].sort();
+    }
+    if (Object.keys(serverRec).length > 0) payload[root] = serverRec;
+  }
+  try {
+    const dir = dirname(file);
+    if (!existsSync(dir)) await mkdir(dir, { recursive: true });
+    const tmp = `${file}.${process.pid}.${Date.now().toString(36)}.tmp`;
+    await writeFile(tmp, JSON.stringify({ version: 1, disabledTools: payload }, null, 2), "utf8");
+    await rename(tmp, file);
+  } catch {
+    // 落盘失败不阻塞主流程
+  }
 }

--- a/packages/dsh-mcp-manager/src/middleware-types.ts
+++ b/packages/dsh-mcp-manager/src/middleware-types.ts
@@ -13,6 +13,9 @@ import type { ServerConfig } from "./types.ts";
 /** 中间层模式：off = 直呼（默认兼容）；project = 项目级走中间层；all = 全部走中间层。 */
 export type MiddlewareMode = "off" | "project" | "all";
 
+/** 用户已禁用的工具集合（root → server → tool 列表）。root 为 @global 时跨工作空间共享。 */
+export type DisabledToolsMap = Map<string, Map<string, Set<string>>>;
+
 /** 策略过滤模式。 */
 export interface MiddlewarePolicy {
   /** server 名（裸名，不含 @root 前缀）→ 允许的工具 glob（空 = 全部允许）。 */
@@ -84,6 +87,8 @@ export interface SearchHit {
 export interface ListToolEntry {
   tool: string;
   description: string;
+  /** 工具级被用户禁用（独立于服务器级 enabled；仅在禁用时置位）。 */
+  disabled?: boolean;
 }
 
 /** ws_mcp_list 的单个服务器条目。 */
@@ -144,4 +149,6 @@ export interface MiddlewareHost {
   emitStatus(): void;
   /** 目录缓存文件路径（last-good 持久化）。 */
   catalogCachePath(root: string): string;
+  /** 该 server 是否全局级（双源：store.data.servers + runtimeRegistry；codegraph 为 runtime 注册）。 */
+  isGlobalServer(name: string): boolean;
 }

--- a/packages/dsh-mcp-manager/src/middleware-utils.ts
+++ b/packages/dsh-mcp-manager/src/middleware-utils.ts
@@ -15,6 +15,7 @@ import type {
   ProjectUnit,
   SearchHit,
   ToolDetail,
+  DisabledToolsMap,
 } from "./middleware-types.ts";
 import type { ServerConfig } from "./types.ts";
 
@@ -23,6 +24,26 @@ import type { ServerConfig } from "./types.ts";
 /** server 全局唯一名：@<root>/<server>。 */
 export function fullServerName(root: string, server: string): string {
   return `@${root}/${server}`;
+}
+
+/** 中间层全局虚拟 root（全局服务器经中间层访问时的路由 key；与 manager 常量同值）。 */
+export const MIDDLEWARE_GLOBAL_ROOT = "@global";
+
+/** 从持久化载荷解析 disabledTools 三层结构（损坏/缺失 → 空；容错不抛）。 */
+export function parseDisabledTools(raw: unknown): DisabledToolsMap {
+  const out: DisabledToolsMap = new Map();
+  if (typeof raw !== "object" || raw === null) return out;
+  for (const [root, servers] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof servers !== "object" || servers === null) continue;
+    const serverMap = new Map<string, Set<string>>();
+    for (const [server, tools] of Object.entries(servers as Record<string, unknown>)) {
+      if (!Array.isArray(tools)) continue;
+      const set = new Set<string>(tools.filter((tool): tool is string => typeof tool === "string" && tool !== ""));
+      if (set.size > 0) serverMap.set(server, set);
+    }
+    if (serverMap.size > 0) out.set(root, serverMap);
+  }
+  return out;
 }
 
 /** 解析 @<root>/<server> 全名 → { root, server }；非法返回 undefined。
@@ -164,6 +185,49 @@ export function bareServerName(name: string): string {
   return parsed?.server ?? name;
 }
 
+/**
+ * 单一裁决：工具是否被用户禁用（工具级禁用，独立于服务器级 enabled）。
+ *
+ * 三入口统一调用（P0-1）：ws_mcp_call（callTool，先查禁用再查策略）、
+ * pre-execute guard（mcp__ 前缀工具）、纪律裸名（dsh-codegraph 侧声明语义）。
+ *
+ * 语义（P0-2 方案 A，零耦合）：禁用**只作用于 mcp-manager 管辖的 mcp__ 前缀
+ * 工具**；纪律裸名（如 codegraph_explore）不受影响，由 dsh-codegraph 侧（#363）
+ * 自行声明。禁用原因文案与浮窗 UI 均需同步声明该语义。
+ *
+ * 判定（P1 三层结构 + P2 超长名）：
+ * 1. 目标 root 直接命中 → 查该 root 记录（project 模式按会话 root 隔离）；
+ * 2. 未命中且目标 root 非 @global → 回落 @global 共享记录（全局工具跨工作空间
+ *    key=@global；对项目 root 的查询是「该 root 无记录」的探测，永不误禁）；
+ * 3. 哈希后缀名（>64 字符或含非法字符）不可逆 → 按「未知 server」处理：
+ *    不禁用、不误禁（publicToolName 无法反解出 (server, tool)）。
+ *
+ * @param disabledTools 禁用映射（root → server → Set<tool>）。
+ * @param policy 中间层策略（allowTools/denyTools；工具级禁用之外的第二道闸，
+ *    仅 ws_mcp_call 路径检查，与既有语义一致）。
+ * @param serverKey @<root>/<server> 全名或裸名（策略键；与 policyAllows 同形态）。
+ * @param tool 远端工具裸名。
+ * @returns true = 拒绝执行（被禁用或策略 deny）。
+ */
+export function isToolDenied(
+  disabledTools: DisabledToolsMap | undefined,
+  policy: MiddlewarePolicy | undefined,
+  serverKey: string,
+  tool: string,
+): boolean {
+  const parsed = parseFullServerName(serverKey);
+  if (parsed !== undefined) {
+    const server = parsed.server;
+    const set = disabledTools?.get(parsed.root)?.get(server);
+    if (set !== undefined && set.size > 0 && set.has(tool)) return true;
+    if (parsed.root !== MIDDLEWARE_GLOBAL_ROOT) {
+      const globalSet = disabledTools?.get(MIDDLEWARE_GLOBAL_ROOT)?.get(server);
+      if (globalSet !== undefined && globalSet.size > 0 && globalSet.has(tool)) return true;
+    }
+  }
+  return !policyAllows(policy, serverKey, tool);
+}
+
 /** 策略拒绝原因（供 denialReason 提示）。 */
 export function policyDenialReason(policy: MiddlewarePolicy | undefined, serverKey: string, tool: string): string | undefined {
   if (policyAllows(policy, serverKey, tool)) return undefined;
@@ -172,6 +236,11 @@ export function policyDenialReason(policy: MiddlewarePolicy | undefined, serverK
     return `ws_mcp_call: 工具 ${JSON.stringify(`${serverKey}/${tool}`)} 被 denyTools 策略拒绝`;
   }
   return `ws_mcp_call: 工具 ${JSON.stringify(`${serverKey}/${tool}`)} 不在 allowTools 白名单内，被策略拒绝`;
+}
+
+/** 工具级禁用的拒绝原因文案（三入口统一；P0-2 语义声明）。 */
+export function toolDisabledReason(serverKey: string, tool: string): string {
+  return `ws_mcp_call: 工具 ${JSON.stringify(`${serverKey}/${tool}`)} 已被用户在「MCP」浮窗禁用；工具级禁用只作用于 mcp__ 前缀工具，纪律裸名不受影响（如需恢复请到浮窗重新勾选）`;
 }
 
 // ------------------------------------------------------------ 目录检索
@@ -296,6 +365,8 @@ export function searchCatalogMulti(
  * @param serverFilter 可选：@<root>/<server> 全名或裸名过滤。
  * @param toolLimit 每服务器工具条数上限（>0；超过置 toolsTruncated）。
  * @param emptyHint 空返回时的 message（按模式区分场景）。
+ * @param disabledTools 用户工具级禁用映射（root → server → Set<tool>）；
+ *    命中条目在工具行标注禁用（供模型感知）。
  * @throws 全名 root 不属于当前 roots → 路由一致性错误（与 ws_mcp_call 口径一致）。
  */
 export function listCatalog(
@@ -305,6 +376,7 @@ export function listCatalog(
   toolLimit: number,
   mode: string,
   emptyHint: string,
+  disabledTools?: DisabledToolsMap,
 ): ListCatalogResult {
   const safeLimit = Number.isFinite(toolLimit) && toolLimit > 0 ? Math.floor(toolLimit) : LIST_DEFAULT_TOOLS_PER_SERVER;
   let rootSet: Set<string> | undefined;
@@ -343,7 +415,11 @@ export function listCatalog(
             truncated = true;
             break;
           }
-          tools.push({ tool: toolName, description: tool.description });
+          // 工具级禁用标注（与服务器级 disabled 并列；查询面供模型感知）。
+          const rootTools = disabledTools?.get(root)?.get(serverName);
+          const globalTools = root === MIDDLEWARE_GLOBAL_ROOT ? undefined : disabledTools?.get(MIDDLEWARE_GLOBAL_ROOT)?.get(serverName);
+          const disabledByUser = (rootTools !== undefined && rootTools.has(toolName)) || (globalTools !== undefined && globalTools.has(toolName));
+          tools.push({ tool: toolName, description: tool.description, disabled: disabledByUser || undefined });
           index += 1;
         }
         entry.tools = tools;

--- a/packages/dsh-mcp-manager/src/middleware-utils.ts
+++ b/packages/dsh-mcp-manager/src/middleware-utils.ts
@@ -47,12 +47,19 @@ export function parseDisabledTools(raw: unknown): DisabledToolsMap {
 }
 
 /** 解析 @<root>/<server> 全名 → { root, server }；非法返回 undefined。
- * root 是绝对路径（以 / 开头），故从最后一个 `/` 分割（server 名不含 `/`）。 */
+ * root 是绝对路径（以 / 开头），故从最后一个 `/` 分割（server 名不含 `/`）。
+ * 特殊形态兼容：`@global/<server>`（单 @，人类/文档/A2 指引形态）归一化为
+ * root=`@global`（MIDDLEWARE_GLOBAL_ROOT）；`@@global/<server>`（双 @，内部
+ * fullServerName 产物）同样归一化为 `@global`——两种输入等价，杜绝「单 @ 被
+ * 路由拒绝、双 @ 放行」的语义分裂（隔离验证 P0 发现，smoke 双 @ 掩盖单 @ 被拒）。 */
 export function parseFullServerName(name: string): { root: string; server: string } | undefined {
   if (!name.startsWith("@")) return undefined;
   const slash = name.lastIndexOf("/");
   if (slash <= 1 || slash === name.length - 1) return undefined;
-  return { root: name.slice(1, slash), server: name.slice(slash + 1) };
+  const rawRoot = name.slice(1, slash);
+  // @global/<s> → rawRoot="global"；@@global/<s> → rawRoot="@global"。
+  const root = rawRoot === "global" || rawRoot === "@global" ? MIDDLEWARE_GLOBAL_ROOT : rawRoot;
+  return { root, server: name.slice(slash + 1) };
 }
 
 /** 归一化中间层工具的 tool 参数（模型可能传 mcp__<server>__<tool> 全名）。

--- a/packages/dsh-mcp-manager/src/middleware.ts
+++ b/packages/dsh-mcp-manager/src/middleware.ts
@@ -44,6 +44,8 @@ import {
   policyAllows,
   policyDenialReason,
   fullServerName,
+  isToolDenied,
+  toolDisabledReason,
 } from "./middleware-utils.ts";
 import type {
   MiddlewareHost,
@@ -51,6 +53,7 @@ import type {
   MiddlewarePolicy,
   ConnectionEntry,
   CatalogTool,
+  DisabledToolsMap,
 } from "./middleware-types.ts";
 
 
@@ -69,6 +72,8 @@ export class McpMiddleware {
   policy: MiddlewarePolicy;
   /** 用户禁用映射（root → Set<server>），单元创建时合并。 */
   disabledByRoot: Map<string, Set<string>> = new Map();
+  /** 工具级禁用（root → server → Set<tool>；root=@global 跨工作空间共享）。 */
+  disabledTools: DisabledToolsMap = new Map();
 
   constructor(host: MiddlewareHost, policy: MiddlewarePolicy = {}) {
     this.host = host;
@@ -365,11 +370,15 @@ export class McpMiddleware {
       throw new Error(`ws_mcp_call: server ${JSON.stringify(fullName)} 连接仍在进行，请稍后重试；连接完成后再调用`);
     }
     const tool = normalizeToolName(parsed.server, toolRaw);
-    // 策略键支持全名（@root/server，工作空间隔离）或裸名（跨空间共用）。
+    // 工具级禁用（先查禁用表再查策略；P0-1 三入口统一走 isToolDenied）。
     const policyKey = fullServerName(parsed.root, parsed.server);
-    if (!policyAllows(this.policy, policyKey, tool)) {
-      const reason = policyDenialReason(this.policy, policyKey, tool);
-      throw new Error(`${reason ?? `ws_mcp_call: 工具 ${JSON.stringify(`${policyKey}/${tool}`)} 被策略拒绝`}；如需放行请调整 middlewarePolicy 配置`);
+    if (isToolDenied(this.disabledTools, this.policy, policyKey, tool)) {
+      // 策略拒绝与禁用拒绝文案区分（策略拒绝附「调整 middlewarePolicy 配置」下一步）。
+      if (!policyAllows(this.policy, policyKey, tool)) {
+        const reason = policyDenialReason(this.policy, policyKey, tool);
+        throw new Error(`${reason ?? `ws_mcp_call: 工具 ${JSON.stringify(`${policyKey}/${tool}`)} 被策略拒绝`}；如需放行请调整 middlewarePolicy 配置`);
+      }
+      throw new Error(toolDisabledReason(policyKey, tool));
     }
     const catalog = unit.catalog.get(parsed.server);
     const stale =
@@ -492,14 +501,18 @@ export {
   policyAllows,
   bareServerName,
   policyDenialReason,
+  isToolDenied,
+  toolDisabledReason,
+  parseDisabledTools,
   scoreTool,
   searchCatalog,
   searchCatalogMulti,
   listCatalog,
   findToolDetail,
+  MIDDLEWARE_GLOBAL_ROOT,
 } from "./middleware-utils.ts";
 // 状态持久化
-export { userStateFile, loadUserState, saveUserState, catalogCacheFileFor } from "./middleware-state.ts";
+export { userStateFile, loadUserState, saveUserState, catalogCacheFileFor, loadDisabledTools, saveDisabledTools } from "./middleware-state.ts";
 // 工具注册
 export { registerMiddlewareTools } from "./middleware-register.ts";
 // 类型
@@ -516,5 +529,6 @@ export type {
   ListCatalogResult,
   ToolDetail,
   MiddlewareHost,
+  DisabledToolsMap,
 } from "./middleware-types.ts";
 

--- a/packages/dsh-mcp-manager/src/routes.ts
+++ b/packages/dsh-mcp-manager/src/routes.ts
@@ -13,6 +13,8 @@ import { isLoopbackRequest } from "../../../shared/loopback.js";
 import { writeJson, readJsonBody } from "../../../shared/host-utils.js";
 import { parseClaudeJson } from "./import.ts";
 import { SCOPE_PROJECT, normalizeScope } from "./scope.ts";
+import { parseFullServerName, MIDDLEWARE_GLOBAL_ROOT } from "./middleware-utils.ts";
+import { normalizeMiddlewareMode } from "./middleware-const.ts";
 import type { ServerConfig } from "./types.ts";
 import type { ClientUiConfig } from "./index.ts";
 import type { WebRoute } from "@deepseek-ai/dsh-host-webserver";
@@ -32,8 +34,16 @@ export interface RoutesManager {
   connect(name: string, scope?: string): Promise<void>;
   disconnect(name: string): Promise<void>;
   reconnect(name: string, scope?: string): Promise<void>;
+  /** 设置/解除单个工具禁用（工具级，独立于服务器级 enabled）。 */
+  setToolDisabled?(root: string, server: string, tool: string, disabled: boolean): Promise<void>;
+  /** 中间层模式热切换（apply 注入；缺省不可用）。 */
+  setMiddlewareMode?(mode: string): Promise<void>;
   projectStoreOrThrow(): Promise<McpStore>;
   store: McpStore;
+  /** 当前会话项目根（tool-disable 路由一致性校验用）。 */
+  projectRoot?: string;
+  /** 设置命名空间写入 sink（apply 注入；config 写路由落盘用）。 */
+  uiUpdate?: (patch: Record<string, unknown>) => Promise<unknown>;
   sseConnections?: Set<ServerResponse>;
   /**
    * SSE 心跳定时器的逐连接清理函数（makeEventsRoute 注册；close 时自删）。
@@ -61,6 +71,7 @@ export const ROUTES = {
   importJson: "/api/dsh-mcp/import/json",
   events: "/api/dsh-mcp/events",
   health: "/api/dsh-mcp/health",
+  toolDisable: "/api/dsh-mcp/tool-disable",
 };
 
 const MAX_JSON_BODY_BYTES = 2 * 1024 * 1024;
@@ -99,16 +110,17 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
       kind: "exact",
       path: ROUTES.config,
       handler: async (req, res) => {
-        // GET：只读 UI 配置（允许非 loopback，供远程页面读取非敏感的展示配置）。
+        // GET：只读 UI 配置 + 中间层模式（允许非 loopback，供远程页面读取非敏感的展示配置）。
         if (req.method === "GET") {
           try {
-            writeJson(res, 200, manager.uiConfig());
+            writeJson(res, 200, { ...manager.uiConfig(), middleware: manager.middlewareMode ?? "off" });
           } catch (error) {
             handleError(res, error);
           }
           return;
         }
-        // POST：写入浮窗 UI 配置（position / offset）。写操作只对 loopback 开放；
+        // POST：写入浮窗 UI 配置（position / offset），或热切换中间层模式
+        // （middleware: off/project/all）。写操作只对 loopback 开放；
         // 经设置命名空间落盘（Config.ui），触发 scope.watch → onChange → SSE 广播一帧，
         // 客户端收到后重新 GET /config 就地更新浮窗位置，无需重启/轮询。
         if (req.method === "POST") {
@@ -128,6 +140,18 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
             return;
           }
           try {
+            const rec = body as Record<string, unknown>;
+            if (typeof rec.middleware === "string") {
+              // 中间层模式热切换：先热生效（当前进程立即切换），再落盘（重启保留）。
+              if (typeof manager.setMiddlewareMode === "function") {
+                await manager.setMiddlewareMode(rec.middleware);
+              }
+              if (typeof manager.uiUpdate === "function") {
+                await manager.uiUpdate({ middleware: normalizeMiddlewareMode(rec.middleware) });
+              }
+              writeJson(res, 200, { ...manager.uiConfig(), middleware: manager.middlewareMode ?? "off" });
+              return;
+            }
             writeJson(res, 200, await manager.updateUiConfig(body));
           } catch (error) {
             handleError(res, error);
@@ -321,6 +345,52 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
           return;
         }
         writeJson(res, 200, { imported, skipped, summary: manager.summary() });
+      },
+    },
+    {
+      kind: "exact",
+      path: ROUTES.toolDisable,
+      handler: async (req, res) => {
+        if (!guard(req, res, "PATCH")) return;
+        const url = new URL(req.url ?? "/", "http://localhost");
+        const body = await readJsonBody(req);
+        if (body === undefined || typeof body !== "object" || body === null) {
+          writeJson(res, 400, { error: "invalid JSON body" });
+          return;
+        }
+        const rec = body as Record<string, unknown>;
+        const server = typeof rec.server === "string" ? rec.server : "";
+        const tool = typeof rec.tool === "string" ? rec.tool : "";
+        const disabled = rec.disabled === true;
+        if (server === "" || tool === "") {
+          writeJson(res, 400, { error: "server 与 tool 均为必填" });
+          return;
+        }
+        // 路由一致性：server 全名 root 必须属于当前工作空间（或 all 模式 @global）。
+        const parsed = parseFullServerName(server);
+        if (parsed === undefined) {
+          writeJson(res, 400, { error: "server 格式非法，应为 @<root>/<server>" });
+          return;
+        }
+        const root = parsed.root === MIDDLEWARE_GLOBAL_ROOT ? parsed.root : parsed.root;
+        const cwdParam = queryParam(url, "cwd");
+        if (cwdParam !== undefined && cwdParam !== "") await manager.setSession(cwdParam);
+        const sessionRoot = manager.projectRoot;
+        const allowed = root === MIDDLEWARE_GLOBAL_ROOT || root === sessionRoot;
+        if (!allowed) {
+          writeJson(res, 400, { error: `server ${JSON.stringify(server)} 不属于当前工作空间；路由一致性校验失败（防跨空间串台）` });
+          return;
+        }
+        if (typeof manager.setToolDisabled !== "function") {
+          writeJson(res, 400, { error: "tool-disable not writable: middleware unavailable" });
+          return;
+        }
+        try {
+          await manager.setToolDisabled(root, parsed.server, tool, disabled);
+          writeJson(res, 200, { ok: true, summary: manager.summary() });
+        } catch (error) {
+          handleError(res, error);
+        }
       },
     },
   ];

--- a/packages/dsh-mcp-manager/src/supervisor.ts
+++ b/packages/dsh-mcp-manager/src/supervisor.ts
@@ -426,28 +426,54 @@ export class ConnectionSupervisor {
     this.reconnectTimer.unref?.();
   }
 
-  /** 拉取工具列表并整体替换注册（代际安全：先取后换）。 */
+  /**
+   * 拉取工具列表并整体替换注册（代际安全：先取后换）。
+   * 封装定义路径（registerServer.toolDefinitions）：服务器配置带 toolDefinitions
+   * 时**全部用调用方封装定义注册**——execute 来自调用方（先 sync → 内部转发底层
+   * 实现），跳过远端 schema 投影与通用 callTool；模型可见名仍按 publicToolName
+   * （mcp__ 前缀），禁用/可见性/能力目录按服务器+工具名判定照常生效（#362）。
+   * 无 toolDefinitions：现状不变（远端 schema + 通用 callTool）。
+   */
   async syncTools(client: MCPClient, startup: boolean): Promise<void> {
     const definitions = new Map<string, ToolDefinition>();
     const toolMeta = new Map<string, { description?: unknown }>();
-    let cursor;
-    do {
-      const response = await client.listTools(cursor);
-      const responseObj = response as { tools?: unknown[]; nextCursor?: unknown } | undefined;
-      const tools = responseObj?.tools ?? [];
-      for (const tool of tools) {
-        const publicName = publicToolName(this.server.name, (tool as Record<string, unknown>).name as string);
-        if (definitions.has(publicName)) {
-          throw new Error(`server "${this.server.name}" listed tool "${(tool as Record<string, unknown>).name}" more than once — invalid tool list`);
+    const wrapped = this.server.toolDefinitions;
+    if (Array.isArray(wrapped) && wrapped.length > 0) {
+      // 封装定义路径：裸名 → 公开名（mcp__ 前缀）；重复名抛错（与远端路径一致）。
+      for (const definition of wrapped) {
+        const rawName = typeof definition?.name === "string" ? definition.name : "";
+        if (rawName === "") {
+          throw new Error(`server "${this.server.name}" has a toolDefinition without a name — invalid wrapped tool list`);
         }
-        definitions.set(publicName, buildToolDefinition(client, tool as Record<string, unknown>, this.server, this.manager.enhancement));
-        // 工具描述元数据（保留供 GUI 展示；不再用于能力目录——目录是纯静态数据源，
-        // 聚合连接后数据会让 digest 随连接状态抖动而反复注入）。
-        toolMeta.set(publicName, { description: (tool as Record<string, unknown>).description ?? "" });
+        const publicName = publicToolName(this.server.name, rawName);
+        if (definitions.has(publicName)) {
+          throw new Error(`server "${this.server.name}" has duplicate wrapped tool "${rawName}" — invalid wrapped tool list`);
+        }
+        // 复制并改写 name 为公开名（mcp__ 前缀）：ctx.tools.register 按
+        // definition.name 注册，调用方封装定义本身保持裸名不被改动。
+        definitions.set(publicName, { ...definition, name: publicName });
+        // 描述元数据（保留供 GUI 展示；与远端路径同口径）。
+        toolMeta.set(publicName, { description: definition.description ?? "" });
       }
-      cursor = responseObj?.nextCursor as string | undefined;
-    } while (cursor !== undefined && cursor !== null && cursor !== "");
-
+    } else {
+      let cursor;
+      do {
+        const response = await client.listTools(cursor);
+        const responseObj = response as { tools?: unknown[]; nextCursor?: unknown } | undefined;
+        const tools = responseObj?.tools ?? [];
+        for (const tool of tools) {
+          const publicName = publicToolName(this.server.name, (tool as Record<string, unknown>).name as string);
+          if (definitions.has(publicName)) {
+            throw new Error(`server "${this.server.name}" listed tool "${(tool as Record<string, unknown>).name}" more than once — invalid tool list`);
+          }
+          definitions.set(publicName, buildToolDefinition(client, tool as Record<string, unknown>, this.server, this.manager.enhancement));
+          // 工具描述元数据（保留供 GUI 展示；不再用于能力目录——目录是纯静态数据源，
+          // 聚合连接后数据会让 digest 随连接状态抖动而反复注入）。
+          toolMeta.set(publicName, { description: (tool as Record<string, unknown>).description ?? "" });
+        }
+        cursor = responseObj?.nextCursor as string | undefined;
+      } while (cursor !== undefined && cursor !== null && cursor !== "");
+    }
     for (const dispose of this.toolDisposers.values()) dispose();
     const disposers = new Map<string, () => void>();
     try {

--- a/packages/dsh-mcp-manager/src/types.ts
+++ b/packages/dsh-mcp-manager/src/types.ts
@@ -6,6 +6,8 @@
  * （type-only，编译期擦除）。
  */
 
+import type { ToolDefinition } from "@deepseek-ai/dsh-tools";
+
 /** MCP 服务器配置（归一化后）。 */
 export interface ServerConfig {
   name: string;
@@ -17,6 +19,14 @@ export interface ServerConfig {
   reconnect?: Record<string, unknown>;
   /** 能力目录的自定义描述（用户手写）。 */
   description?: string;
+  /**
+   * 调用方封装工具定义（registerServer 运行时注入面专用，如 dsh-codegraph）：
+   * 提供时该服务器工具**全部用封装定义注册**（execute 来自调用方，跳过远端
+   * schema 投影与通用 callTool）；缺省走现状（远端 schema + 通用 callTool）。
+   * 工具名为裸名；模型可见名仍由 publicToolName（mcp__ 前缀）决定。
+   * 仅内存态（runtimeRegistry）消费，不随 store 落盘、不随 import 透传。
+   */
+  toolDefinitions?: ToolDefinition[];
   // stdio 传输字段
   command?: string;
   args?: string[];

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -572,6 +572,26 @@ const main = async () => {
     assert.ok(clientSrc.includes("settings.plugin.item"), "settings.plugin.item 卡已注册");
     assert.ok(clientSrc.includes("dsh-mcp-manager"), "卡片 key/id 引用宿主命名空间 dsh-mcp-manager");
   });
+  check("#362 客户端：工具级禁用 checkbox + scope 分组 + project 全局提示 + middleware 下拉", () => {
+    const clientSrc = readFileSync(new URL("../lib/client.js", import.meta.url), "utf8");
+    // 工具 checkbox 经 tool-disable API 持久化。
+    assert.ok(clientSrc.includes("tool-disable"), "客户端含 tool-disable API 调用");
+    assert.ok(clientSrc.includes('type: "checkbox"'), "工具开关为 checkbox");
+    assert.ok(clientSrc.includes("dm-float-tools"), "浮窗折叠式工具清单存在");
+    assert.ok(clientSrc.includes("切 all 模式可管理全局工具"), "project 模式全局组提示文案");
+    assert.ok(clientSrc.includes("dm-set-middleware"), "设置页中间层模式下拉存在");
+    // 浮窗与管理面板均按 scope 分组。
+    assert.ok(clientSrc.includes("dm-float-group-title"), "浮窗 scope 分组标题存在");
+    assert.ok(clientSrc.includes("项目级") && clientSrc.includes("全局"), "scope 分组文案存在");
+  });
+  check("#362 无游离 css：style.css 全部内联进 client.js（无独立样式请求）", () => {
+    const clientSrc = readFileSync(new URL("../lib/client.js", import.meta.url), "utf8");
+    const css = readFileSync(new URL("../src/client/style.css", import.meta.url), "utf8");
+    const probe = css.split("\n").filter((line) => line.trim() !== "").pop() ?? "";
+    // 样式文件末尾规则应整体出现在 client.js 产物中（text-loader 原样内联）。
+    assert.ok(clientSrc.includes(probe.slice(0, 40)), "style.css 尾部规则已内联进 client.js");
+    assert.ok(!clientSrc.includes('rel="stylesheet"'), "无独立样式表请求");
+  });
 
   console.log("SSE 半开连接防护（#268：服务端心跳 + 客户端 watchdog + 回前台重建）");
   check("客户端 watchdog：60s 失活重建 + 建连前先关旧（0.1.8 同款防泄漏）", () => {

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -395,6 +395,178 @@ const main = async () => {
     assert.ok(foundAfterWait.results.some((hit) => hit.server === fullServerName(MIDDLEWARE_GLOBAL_ROOT, "gctx")), "search 等待 in-flight 后命中 @global");
     dispose();
   });
+  await checkAsync("#362 A2：project 模式 detail/call 传全局级服务器 → 引导 mcp__ 直呼（不再谎报不属于工作空间）", async () => {
+    const { registerMiddlewareTools, McpMiddleware, fullServerName, MIDDLEWARE_GLOBAL_ROOT } = await import("../lib/index.js");
+    const registered = [];
+    const ctx = { tools: { register: (def) => { registered.push(def); return () => {}; } } };
+    const host = {
+      ctx,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      projectServersFor: async (root) => (root === MIDDLEWARE_GLOBAL_ROOT ? [{ name: "gctx", transport: "stdio", command: "npx", enabled: true }] : undefined),
+      globalServers: () => [{ name: "gctx", transport: "stdio", command: "npx", enabled: true }],
+      normalizedProjectRoot: async (cwd) => (cwd === "/proj" ? "/proj" : undefined),
+      saveUserState: async () => {},
+      emitStatus: () => {},
+      catalogCachePath: () => "/tmp/cache.json",
+      isGlobalServer: (name) => name === "gctx",
+    };
+    const mw = new McpMiddleware(host, {});
+    const dispose = registerMiddlewareTools(ctx, mw, async (agent) => agent?.session?.header?.cwd === "/proj" ? "/proj" : undefined, "project");
+    const detailDef = registered.find((d) => d.name === "ws_mcp_detail");
+    const callDef = registered.find((d) => d.name === "ws_mcp_call");
+    const agent = { session: { header: { cwd: "/proj" } } };
+    // detail 全局服务器 → 引导（project 模式全局 mcp__ 直呼可用）。
+    await assert.rejects(
+      () => detailDef.execute({ server: fullServerName(MIDDLEWARE_GLOBAL_ROOT, "gctx"), tool: "use_g" }, { agent }),
+      /全局级|mcp__gctx__/,
+      "project 模式 detail 全局服务器给出直呼引导",
+    );
+    // call 全局服务器 → 同样引导。
+    await assert.rejects(
+      () => callDef.execute({ server: fullServerName(MIDDLEWARE_GLOBAL_ROOT, "gctx"), tool: "use_g" }, { agent }),
+      /全局级|mcp__gctx__/,
+      "project 模式 call 全局服务器给出直呼引导",
+    );
+    // 非 global 其他 root 仍硬拒绝（防跨空间串台，不回归）。
+    await assert.rejects(
+      () => detailDef.execute({ server: fullServerName("/other", "ctx"), tool: "use_ctx" }, { agent }),
+      /不属于当前工作空间/,
+    );
+    dispose();
+  });
+  await checkAsync("#362 isGlobalServer 双源：runtime 注册的 codegraph 判全局（P1 修正）", async () => {
+    const { McpManager, McpStore, MIDDLEWARE_GLOBAL_ROOT } = await import("../lib/index.js");
+    const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-manager-global-"));
+    try {
+      const store = new McpStore(join(dir, "mcp.json"));
+      store.data = { version: 1, servers: [] };
+      const manager = new McpManager({ logger: { warn: () => {}, info: () => {} } }, store);
+      // runtime 注册（不落 store）→ isGlobalServer 必须返回 true。
+      await manager.registerServer({ name: "codegraph", transport: "stdio", command: "echo", args: ["x"], enabled: false });
+      assert.equal(manager.isGlobalServer("codegraph"), true, "runtime 注册判全局（双源）");
+      // store 持久化条目 → 全局。
+      store.upsert({ name: "ctx", transport: "stdio", command: "echo", enabled: false });
+      assert.equal(manager.isGlobalServer("ctx"), true, "store 条目判全局");
+      assert.equal(manager.isGlobalServer("ghost"), false, "未注册不判全局");
+      await manager.dispose();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  await checkAsync("#362 A1：ws_mcp_list 带 serverFilter 过滤 0 命中 → message 可归因（不谎报未配置）", async () => {
+    const { registerMiddlewareTools, McpMiddleware, fullServerName, parseFullServerName } = await import("../lib/index.js");
+    const registered = [];
+    const ctx = { tools: { register: (def) => { registered.push(def); return () => {}; } } };
+    const host = {
+      ctx,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      projectServersFor: async () => [{ name: "ctx", transport: "stdio", command: "npx", enabled: true }],
+      globalServers: () => [],
+      normalizedProjectRoot: async (cwd) => (cwd === "/proj" ? "/proj" : undefined),
+      saveUserState: async () => {},
+      emitStatus: () => {},
+      catalogCachePath: () => "/tmp/cache.json",
+      isGlobalServer: () => false,
+    };
+    const mw = new McpMiddleware(host, {});
+    // 预置目录（模拟 last-good 已发现；不 spawn 子进程）。
+    mw.units.set("/proj", {
+      root: "/proj",
+      connections: new Map(),
+      catalog: new Map([["ctx", { discoveredAt: Date.now(), tools: new Map([["use_ctx", { description: "项目工具", inputSchema: {} }]]) }]]),
+      userDisabled: new Set(),
+      lastTouchedAt: Date.now(),
+      inFlight: new Map(),
+    });
+    const dispose = registerMiddlewareTools(ctx, mw, async (agent) => agent?.session?.header?.cwd === "/proj" ? "/proj" : undefined, "project");
+    const listDef = registered.find((d) => d.name === "ws_mcp_list");
+    const agent = { session: { header: { cwd: "/proj" } } };
+    // 过滤不存在的 server → 0 命中 + 可归因 message。
+    const out = await listDef.execute({ server: "nope" }, { agent });
+    assert.equal(out.totalServers, 0);
+    assert.match(out.message, /没有匹配 server="nope" 的项目级服务器/, "A1：message 归因到过滤条件");
+    assert.match(out.message, /可见项目级服务器：ctx/, "A1：列出可见项目级服务器");
+    assert.match(out.message, /全局级服务器不在此列出/, "A1：提示全局级不列出");
+    // 不带过滤的真实空目录 → 原有空返回提示（不回归）。
+    const out2 = await listDef.execute({}, { agent });
+    assert.equal(out2.totalServers, 1, "不带过滤正常列出");
+    dispose();
+  });
+  await checkAsync("#362 P0-1：工具级禁用三入口一致（callTool / pre-execute guard / mcp__ 直呼）", async () => {
+    const { registerMiddlewareTools, McpMiddleware, fullServerName, MIDDLEWARE_GLOBAL_ROOT, parseDisabledTools, isToolDenied, toolDisabledReason } = await import("../lib/index.js");
+    // 1) isToolDenied 纯函数：项目 root 命中 + @global 回落 + 哈希超长名不误禁。
+    const map = parseDisabledTools({ "/proj": { ctx: ["use_ctx"] }, "@global": { gctx: ["use_g"] } });
+    assert.equal(isToolDenied(map, undefined, fullServerName("/proj", "ctx"), "use_ctx"), true, "项目 root 记录命中");
+    assert.equal(isToolDenied(map, undefined, fullServerName("/proj", "ctx"), "other"), false, "未禁用工具放行");
+    assert.equal(isToolDenied(map, undefined, fullServerName("/proj", "gctx"), "use_g"), true, "@global 共享记录回落命中");
+    assert.equal(isToolDenied(map, undefined, fullServerName("@global", "gctx"), "use_g"), true, "@global root 自身记录命中");
+    assert.equal(isToolDenied(map, undefined, "mcp__ctx__use_ctx_hash123456", "x"), false, "哈希超长名不可逆 → 不误禁");
+    assert.equal(isToolDenied(new Map(), { denyTools: { ctx: ["evil"] } }, fullServerName("/proj", "ctx"), "evil"), true, "策略 deny 仍生效");
+    // 2) registerMiddlewareTools 的 pre-execute guard：mcp__ 直呼被 deny。
+    const registered = [];
+    const ctx = { tools: { register: (def) => { registered.push(def); return () => {}; } }, on: (event, handler) => { guards.set(event, handler); return () => {}; } };
+    const guards = new Map();
+    const host = {
+      ctx,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      projectServersFor: async () => [],
+      globalServers: () => [],
+      normalizedProjectRoot: async (cwd) => (cwd === "/proj" ? "/proj" : undefined),
+      saveUserState: async () => {},
+      emitStatus: () => {},
+      catalogCachePath: () => "/tmp/cache.json",
+      isGlobalServer: () => false,
+    };
+    const mw = new McpMiddleware(host, {});
+    const dispose = registerMiddlewareTools(ctx, mw, async (agent) => agent?.session?.header?.cwd === "/proj" ? "/proj" : undefined, "project", { disabledTools: map });
+    const guard = guards.get("tools/pre-execute");
+    assert.ok(typeof guard === "function", "pre-execute guard 已注册");
+    const deny = await guard({ name: "mcp__ctx__use_ctx", agent: { session: { header: { cwd: "/proj" } } } }, async () => ({ kind: "allow" }));
+    assert.equal(deny.kind, "deny", "mcp__ 直呼被禁用表 deny");
+    assert.match(deny.reason, /已被用户在「MCP」浮窗禁用/, "拒绝原因含禁用语义声明");
+    const allow = await guard({ name: "mcp__ctx__other", agent: { session: { header: { cwd: "/proj" } } } }, async () => ({ kind: "allow" }));
+    assert.equal(allow.kind, "allow", "未禁用工具放行");
+    // agent-less → 按最宽可见范围放行（@global 记录仍生效）。
+    const gDeny = await guard({ name: "mcp__gctx__use_g" }, async () => ({ kind: "allow" }));
+    assert.equal(gDeny.kind, "deny", "agent-less 时 @global 共享记录仍 deny");
+    // 超长哈希名（含非法字符被替换）→ 不误禁。
+    const hashed = await guard({ name: "mcp__ctx__use_ctx_0123456789ab" }, async () => ({ kind: "allow" }));
+    assert.equal(hashed.kind, "allow", "哈希后缀名按未知 server 放行");
+    // ws_mcp_call guard：禁用命中 → deny。
+    const callDeny = await guard({ name: "ws_mcp_call", arguments: { server: fullServerName("/proj", "ctx"), tool: "use_ctx" } }, async () => ({ kind: "allow" }));
+    assert.equal(callDeny.kind, "deny", "ws_mcp_call guard 查禁用表");
+    assert.equal(toolDisabledReason(fullServerName("/proj", "ctx"), "use_ctx").includes("mcp__ 前缀"), true, "禁用原因声明只作用于 mcp__ 前缀");
+    dispose();
+  });
+  await checkAsync("#362 P1：disabledTools 持久化（合并式写盘 + 重启保留）", async () => {
+    const { McpManager, McpStore, loadDisabledTools, saveDisabledTools, parseDisabledTools, MIDDLEWARE_GLOBAL_ROOT } = await import("../lib/index.js");
+    const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-manager-tools-"));
+    try {
+      const file = join(dir, "dsh-mcp-user-state.json");
+      // 预置磁盘记录（模拟另一工作空间已禁用），并让 manager 加载（等价
+      // initMiddleware 的 loadDisabledTools 路径——进程内完整视图）。
+      await saveDisabledTools(file, parseDisabledTools({ "/other": { s2: ["t2"] } }));
+      const manager = new McpManager({ logger: { warn: () => {}, info: () => {} } }, new McpStore(join(dir, "mcp.json")));
+      manager.userStatePath = file;
+      manager.disabledTools = await loadDisabledTools(file);
+      // 多空间共存：新增 /proj 记录，/other 记录保留（不整表覆盖）。
+      await manager.setToolDisabled("/proj", "ctx", "use_ctx", true);
+      await manager.setToolDisabled(MIDDLEWARE_GLOBAL_ROOT, "gctx", "use_g", true);
+      const reloaded = await loadDisabledTools(file);
+      assert.equal(reloaded.get("/proj")?.get("ctx")?.has("use_ctx"), true, "/proj 记录落盘");
+      assert.equal(reloaded.get("@global")?.get("gctx")?.has("use_g"), true, "@global 记录落盘");
+      assert.equal(reloaded.get("/other")?.get("s2")?.has("t2"), true, "既有 /other 记录保留（合并式，绝不整表覆盖）");
+      // 解除禁用 → 记录清除；其他记录保留。
+      await manager.setToolDisabled("/proj", "ctx", "use_ctx", false);
+      const after = await loadDisabledTools(file);
+      const projTools = after.get("/proj")?.get("ctx");
+      assert.equal(projTools === undefined || !projTools.has("use_ctx"), true, "解除后记录清除");
+      assert.equal(after.get("/other")?.get("s2")?.has("t2"), true, "解除不影响其他记录");
+      await manager.dispose();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
   check("client 注册 settings.plugin.item 卡（id/key = 宿主命名空间 dsh-mcp-manager）", () => {
     const clientSrc = readFileSync(new URL("../lib/client.js", import.meta.url), "utf8");
     assert.ok(clientSrc.includes("settings.plugin.item"), "settings.plugin.item 卡已注册");
@@ -1182,6 +1354,7 @@ const main = async () => {
         logger: { warn: () => {}, info: () => {}, error: () => {} },
         summary: () => ({ servers: [], counts: {} }),
         uiConfig: () => uiCfg,
+        middlewareMode: "project",
         updateUiConfig: async (raw) => {
           uiCfg = normalizeUiConfig(raw);
           return uiCfg;
@@ -1216,8 +1389,8 @@ const main = async () => {
       const routes = makeRoutes(manager, process.cwd());
       const find = (path) => routes.find((route) => route.path === path);
 
-      check("注册 7 条 exact 路由", () => {
-        assert.equal(routes.length, 7);
+      check("注册 8 条 exact 路由（含 tool-disable）", () => {
+        assert.equal(routes.length, 8);
         for (const route of routes) assert.equal(route.kind, "exact");
       });
 
@@ -1281,7 +1454,7 @@ const main = async () => {
         await find(ROUTES.servers).handler(fakeFenceBroken("GET", ROUTES.servers), res);
         assert.equal(res.state.status, 403);
       });
-      await checkAsync("config GET → 200 读回（默认 top-right/8/8/40）", async () => {
+      await checkAsync("config GET → 200 读回（默认 top-right/8/8/40 + middleware 字段）", async () => {
         const res = fakeRes();
         await find(ROUTES.config).handler(fakeReq("GET", ROUTES.config), res);
         assert.equal(res.state.status, 200);
@@ -1290,6 +1463,7 @@ const main = async () => {
         assert.equal(body.offsetX, 8);
         assert.equal(body.offsetY, 8);
         assert.equal(body.blankY, 40);
+        assert.equal(body.middleware, "project", "config GET 附带中间层模式");
       });
       await checkAsync("config 非 loopback GET → 200（只读 UI 配置放开）", async () => {
         const res = fakeRes();
@@ -1313,7 +1487,16 @@ const main = async () => {
         const read = fakeRes();
         await find(ROUTES.config).handler(fakeReq("GET", ROUTES.config), read);
         const readBack = JSON.parse(read.state.body);
-        assert.deepEqual(readBack, { position: "bottom-right", offsetX: 12, offsetY: 20, blankY: 60, zIndexBase: 10 });
+        assert.deepEqual(readBack, { position: "bottom-right", offsetX: 12, offsetY: 20, blankY: 60, zIndexBase: 10, middleware: "project" });
+      });
+      await checkAsync("config POST middleware → 热切换 + 落盘（读回 middleware 变化）", async () => {
+        const write = fakeRes();
+        await find(ROUTES.config).handler(fakeReq("POST", ROUTES.config, { middleware: "off" }), write);
+        assert.equal(write.state.status, 200);
+        const read = fakeRes();
+        await find(ROUTES.config).handler(fakeReq("GET", ROUTES.config), read);
+        const readBack = JSON.parse(read.state.body);
+        assert.equal(readBack.middleware, "project", "fake manager 无 setMiddlewareMode → 模式不变（读回原值）");
       });
       await checkAsync("config POST 非 loopback → 403（写操作不开放远程页面）", async () => {
         const res = fakeRes();
@@ -1363,6 +1546,31 @@ const main = async () => {
           res,
         );
         assert.equal(res.state.status, 400);
+      });
+      await checkAsync("tool-disable 围栏：非 loopback → 403 / GET → 405", async () => {
+        const res403 = fakeRes();
+        await find(ROUTES.toolDisable).handler(
+          fakeFenceBroken("PATCH", ROUTES.toolDisable, { server: "@x/s", tool: "t", disabled: true }),
+          res403,
+        );
+        assert.equal(res403.state.status, 403);
+        const res405 = fakeRes();
+        await find(ROUTES.toolDisable).handler(fakeReq("GET", ROUTES.toolDisable), res405);
+        assert.equal(res405.state.status, 405);
+      });
+      await checkAsync("tool-disable：缺 server/tool → 400；root 不属于工作空间 / setToolDisabled 未挂 → 400", async () => {
+        const res1 = fakeRes();
+        await find(ROUTES.toolDisable).handler(
+          fakeReq("PATCH", ROUTES.toolDisable, { tool: "t", disabled: true }),
+          res1,
+        );
+        assert.equal(res1.state.status, 400);
+        const res2 = fakeRes();
+        await find(ROUTES.toolDisable).handler(
+          fakeReq("PATCH", ROUTES.toolDisable, { server: "@x/s", tool: "t", disabled: true }),
+          res2,
+        );
+        assert.equal(res2.state.status, 400, "root 不属于工作空间或不可写 → 400");
       });
       await checkAsync("POST session {cwd} → 200 并记录会话", async () => {
         const res = fakeRes();
@@ -1416,7 +1624,7 @@ const main = async () => {
     const ctx = fakeCtx();
     try {
       await apply(ctx, { enabled: true, storePath: join(dir, "dsh-mcp.json") });
-      assert.equal(ctx.routes.length, 9); // 7 条业务路由 + 1 条 SSE events + 1 条 health
+      assert.equal(ctx.routes.length, 10); // 8 条业务路由 + 1 条 SSE events + 1 条 health
       assert.ok(ctx.routes.some((route) => route.path === ROUTES.events), "SSE events 路由已注册");
       assert.equal(ctx.sections.length, 1);
       assert.equal(ctx.sections[0].name, "plugin:dsh-mcp-manager");

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -257,6 +257,11 @@ const main = async () => {
     // server 全名解析往返
     const full = fullServerName("/proj", "ctx");
     assert.deepEqual(parseFullServerName(full), { root: "/proj", server: "ctx" });
+    // @global 单 @ / 双 @ 等价（隔离验证 P0：smoke 双 @ 掩盖单 @ 被拒）
+    const { MIDDLEWARE_GLOBAL_ROOT } = await import("../lib/index.js");
+    assert.deepEqual(parseFullServerName("@global/gctx"), { root: MIDDLEWARE_GLOBAL_ROOT, server: "gctx" }, "单 @ @global/ 归一化为 @global");
+    assert.deepEqual(parseFullServerName("@@global/gctx"), { root: MIDDLEWARE_GLOBAL_ROOT, server: "gctx" }, "双 @ @@global/ 归一化为 @global");
+    assert.deepEqual(parseFullServerName(fullServerName(MIDDLEWARE_GLOBAL_ROOT, "gctx")), { root: MIDDLEWARE_GLOBAL_ROOT, server: "gctx" }, "fullServerName(@global) 往返一致");
     dispose();
   });
   await checkAsync("search 早退分支（unit undefined）返回 truncated=false（P1-1）", async () => {

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -432,6 +432,12 @@ const main = async () => {
       () => detailDef.execute({ server: fullServerName("/other", "ctx"), tool: "use_ctx" }, { agent }),
       /不属于当前工作空间/,
     );
+    // project 模式未知 @global 服务器（非全局级）→ 硬拒绝（防经 @global 路由绕过）。
+    await assert.rejects(
+      () => detailDef.execute({ server: fullServerName(MIDDLEWARE_GLOBAL_ROOT, "ghost"), tool: "x" }, { agent }),
+      /不属于当前工作空间/,
+      "project 模式未知 @global 服务器拒绝",
+    );
     dispose();
   });
   await checkAsync("#362 isGlobalServer 双源：runtime 注册的 codegraph 判全局（P1 修正）", async () => {
@@ -536,6 +542,24 @@ const main = async () => {
     const callDeny = await guard({ name: "ws_mcp_call", arguments: { server: fullServerName("/proj", "ctx"), tool: "use_ctx" } }, async () => ({ kind: "allow" }));
     assert.equal(callDeny.kind, "deny", "ws_mcp_call guard 查禁用表");
     assert.equal(toolDisabledReason(fullServerName("/proj", "ctx"), "use_ctx").includes("mcp__ 前缀"), true, "禁用原因声明只作用于 mcp__ 前缀");
+    // 3) callTool（ws_mcp_call 执行路径）：禁用工具 → 显式抛错（验收 14：三入口一致）。
+    const callUnit = {
+      root: "/proj",
+      connections: new Map([["ctx", { server: { name: "ctx", transport: "stdio", command: "x", enabled: true }, status: "connected", error: undefined, client: { callTool: async () => ({ content: [] }) }, reconnectTimer: undefined, disposed: false, failedAttempts: 0 }]]),
+      catalog: new Map([["ctx", { discoveredAt: Date.now(), tools: new Map([["use_ctx", { description: "d", inputSchema: {} }]]) }]]),
+      userDisabled: new Set(),
+      lastTouchedAt: Date.now(),
+      inFlight: new Map(),
+    };
+    mw.units.set("/proj", callUnit);
+    await assert.rejects(
+      () => mw.callTool(fullServerName("/proj", "ctx"), "use_ctx", {}, undefined),
+      /已被用户在「MCP」浮窗禁用/,
+      "callTool 先查禁用表（三入口一致）",
+    );
+    // 未禁用工具正常放行到调用。
+    const okValue = await mw.callTool(fullServerName("/proj", "ctx"), "other", {}, undefined);
+    assert.deepEqual(okValue.content, [], "未禁用工具正常调用");
     dispose();
   });
   await checkAsync("#362 P1：disabledTools 持久化（合并式写盘 + 重启保留）", async () => {

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -2303,6 +2303,135 @@ const main = async () => {
     }
   }
 
+  // ---- #362 补充 4：registerServer.toolDefinitions（调用方封装定义注册）----
+  // 带 toolDefinitions → 该服务器工具全部用封装定义注册（execute 来自调用方，
+  // 命名仍按 publicToolName mcp__ 前缀）；不带 → 现状回归（远端 schema + 通用
+  // callTool）。工具级禁用/可见性/能力目录按服务器+工具名判定照常生效。
+
+  {
+    const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-manager-wrapped-"));
+    try {
+      const store = new McpStore(join(dir, "mcp.json"));
+      store.data = { version: 1, servers: [] };
+      const manager = new McpManager({ logger: { warn: () => {}, info: () => {} } }, store);
+
+      // 封装定义（裸名；模拟 dsh-codegraph 侧 codegraph_explore 形态）。
+      const wrappedExecCalls = [];
+      const wrapped = [
+        {
+          name: "codegraph_explore",
+          description: "封装定义：查询前强制 sync + projectPath（#362 补充 4）",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" } },
+            required: ["query"],
+          },
+          output: {
+            schema: { type: "object", properties: { text: { type: "string" } }, required: ["text"] },
+            render(_args, value) {
+              return [{ type: "text", text: value && typeof value === "object" && "text" in value ? String(value.text) : "" }];
+            },
+          },
+          async execute(args) {
+            wrappedExecCalls.push(args);
+            return { text: `wrapped:${args && typeof args === "object" ? String(args.query ?? "") : ""}` };
+          },
+        },
+        {
+          name: "codegraph_status",
+          description: "封装定义：状态查询",
+          parameters: { type: "object", properties: {} },
+          output: {
+            schema: { type: "object", properties: { text: { type: "string" } }, required: ["text"] },
+            render(_args, value) {
+              return [{ type: "text", text: value && typeof value === "object" && "text" in value ? String(value.text) : "" }];
+            },
+          },
+          execute: async () => ({ text: "ok" }),
+        },
+      ];
+      const registered = [];
+      const sup = new ConnectionSupervisor(
+        {
+          ctx: { tools: { register: (definition) => { registered.push(definition); return () => {}; } } },
+          logger: { warn: () => {}, info: () => {}, error: () => {} },
+          enhancement: {},
+          emitStatus() {},
+          recordCatalogTools: async () => {},
+        },
+        normalizeServer({ name: "codegraph", transport: "stdio", command: "true" }),
+      );
+      sup.server.toolDefinitions = wrapped;
+      // 挂入 manager.supervisors：summarize 的禁用投影按 supervisor 工具列表判定。
+      manager.supervisors.set("codegraph", sup);
+
+      await checkAsync("toolDefinitions：封装定义注册（execute 来自调用方，mcp__ 前缀命名）", async () => {
+        // 封装路径不触达远端 schema 投影：伪造 listTools 抛错证明未走远端路径。
+        await sup.syncTools({ listTools: async () => { throw new Error("must not reach remote schema"); } }, true);
+        assert.deepEqual(sup.tools, ["mcp__codegraph__codegraph_explore", "mcp__codegraph__codegraph_status"], "公共名排序");
+        assert.equal(registered.length, 2);
+        assert.equal(registered[0].name, "mcp__codegraph__codegraph_explore", "命名仍按 publicToolName（mcp__ 前缀）");
+        assert.equal(registered[0].description, "封装定义：查询前强制 sync + projectPath（#362 补充 4）", "自定义 description 被采用");
+        // execute 来自调用方封装（不经通用 callTool）。
+        const value = await registered[0].execute({ query: "X 被谁调用" }, { signal: undefined });
+        assert.equal(value.text, "wrapped:X 被谁调用", "execute 来自封装定义");
+        assert.equal(wrappedExecCalls.length, 1);
+      });
+
+      // 工具级禁用对封装工具照常生效（#362 既有机制：isToolDenied 按服务器+工具
+      // 裸名判定；封装工具注册名仍是 mcp__ 前缀，guard 反解裸名查表与普通工具同路径）。
+      const { isToolDenied, fullServerName, parseDisabledTools, MIDDLEWARE_GLOBAL_ROOT } = await import("../lib/index.js");
+      const denyMap = parseDisabledTools({ "@global": { codegraph: ["codegraph_explore"] } });
+      assert.equal(
+        isToolDenied(denyMap, undefined, fullServerName(MIDDLEWARE_GLOBAL_ROOT, "codegraph"), "codegraph_explore"),
+        true,
+        "封装工具按服务器+裸名禁用命中（既有 isToolDenied 机制）",
+      );
+      assert.equal(
+        isToolDenied(denyMap, undefined, fullServerName(MIDDLEWARE_GLOBAL_ROOT, "codegraph"), "codegraph_status"),
+        false,
+        "未禁用封装工具放行",
+      );
+      // 可见性/能力目录：summary 工具列表为 mcp__ 公开名（与普通工具同口径）。
+      const sum = manager.summarize(sup.server, SCOPE_GLOBAL);
+      assert.deepEqual(sum.tools, ["mcp__codegraph__codegraph_explore", "mcp__codegraph__codegraph_status"], "summary 工具列表为公开名");
+
+      // 不带 toolDefinitions → 现状回归：远端 schema + 通用 callTool 路径不变。
+      const plainRegistered = [];
+      const supPlain = new ConnectionSupervisor(
+        {
+          ctx: { tools: { register: (definition) => { plainRegistered.push(definition); return () => {}; } } },
+          logger: { warn: () => {}, info: () => {}, error: () => {} },
+          enhancement: {},
+          emitStatus() {},
+          recordCatalogTools: async () => {},
+        },
+        normalizeServer({ name: "mini", transport: "stdio", command: "true" }),
+      );
+      const plainExecCalls = [];
+      const plainClient = {
+        listTools: async () => ({ tools: [{ name: "echo", description: "echo back", inputSchema: { type: "object", properties: { text: { type: "string" } } } }] }),
+        callTool: async (rawName, args) => {
+          plainExecCalls.push([rawName, args]);
+          return { content: [{ type: "text", text: `echo:${String(args.text ?? "")}` }] };
+        },
+      };
+      await checkAsync("不带 toolDefinitions → 现状回归（远端 schema + 通用 callTool）", async () => {
+        await supPlain.syncTools(plainClient, true);
+        assert.deepEqual(supPlain.tools, ["mcp__mini__echo"]);
+        assert.equal(plainRegistered.length, 1);
+        // 通用 callTool 路径：execute 经 client.callTool 转发远端。
+        const value = await plainRegistered[0].execute({ text: "hi" }, { signal: undefined });
+        assert.deepEqual(value.content, [{ type: "text", text: "echo:hi" }]);
+        assert.deepEqual(plainExecCalls, [["echo", { text: "hi" }]], "通用 callTool 转发远端");
+      });
+
+      console.log("  ok   封装定义注册: toolDefinitions 采用 / 现状回归 / 禁用按公开名");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
   if (failures.length > 0) {
     console.error(`\n${failures.length} check(s) failed: ${failures.join(", ")}`);
     process.exit(1);

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -1616,6 +1616,32 @@ const main = async () => {
         );
         assert.equal(res2.state.status, 400, "root 不属于工作空间或不可写 → 400");
       });
+      await checkAsync("tool-disable：合法请求 → 200 且调用 setToolDisabled（scope=global → @global root）", async () => {
+        const calls = [];
+        const tdManager = {
+          ...manager,
+          projectRoot: "/proj",
+          setToolDisabled: async (root, server, tool, disabled) => {
+            calls.push({ root, server, tool, disabled });
+          },
+        };
+        const tdRoutes = makeRoutes(tdManager, process.cwd());
+        const tdRoute = tdRoutes.find((route) => route.path === ROUTES.toolDisable);
+        const res = fakeRes();
+        await tdRoute.handler(
+          fakeReq("PATCH", ROUTES.toolDisable, { server: "@/proj/ctx", tool: "use_ctx", disabled: true }),
+          res,
+        );
+        assert.equal(res.state.status, 200);
+        assert.deepEqual(calls, [{ root: "/proj", server: "ctx", tool: "use_ctx", disabled: true }]);
+        // 全局 root：scope=global 的服务器以 @global 为 key。
+        const resG = fakeRes();
+        await tdRoute.handler(
+          fakeReq("PATCH", ROUTES.toolDisable, { server: "@/proj/gctx", tool: "use_g", disabled: true }),
+          resG,
+        );
+        assert.equal(resG.state.status, 200, "global 服务器（store 条目）以项目 root 为 key 可写");
+      });
       await checkAsync("POST session {cwd} → 200 并记录会话", async () => {
         const res = fakeRes();
         await find(ROUTES.session).handler(fakeReq("POST", ROUTES.session, { cwd: "C:/proj" }), res);
@@ -1673,6 +1699,50 @@ const main = async () => {
       assert.equal(ctx.sections.length, 1);
       assert.equal(ctx.sections[0].name, "plugin:dsh-mcp-manager");
       assert.match(ctx.sections[0].text, /dsh-mcp-manager/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  await checkAsync("#362 中间层模式热切换：off 启动也可切到 project（设置页下拉路径）", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-manager-hotswitch-"));
+    const ctx = fakeCtx();
+    try {
+      await apply(ctx, { enabled: true, middleware: "off", storePath: join(dir, "dsh-mcp.json") });
+      // off 启动：不注册中间层工具，但 setMiddlewareMode 已挂。
+      const toolNames = ctx.registeredTools.map((def) => def.name);
+      assert.ok(!toolNames.includes("ws_mcp_call"), "off 启动不注册中间层工具");
+      const configRoute = ctx.routes.find((route) => route.path === ROUTES.config);
+      assert.ok(configRoute, "config 路由已注册");
+      // POST middleware=project → 热切换生效：中间层工具注册。
+      const res = fakeRes();
+      const req = {
+        method: "POST",
+        url: ROUTES.config,
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: { host: "localhost:3080", origin: "http://localhost:3080", "sec-fetch-site": "same-origin" },
+        async *[Symbol.asyncIterator]() {
+          yield Buffer.from(JSON.stringify({ middleware: "project" }));
+        },
+      };
+      await configRoute.handler(req, res);
+      assert.equal(res.state.status, 200);
+      const body = JSON.parse(res.state.body);
+      assert.equal(body.middleware, "project", "热切换后 config 读回 project");
+      assert.ok(ctx.registeredTools.some((def) => def.name === "ws_mcp_call"), "热切换后注册中间层工具");
+      // 再切回 off：中间层工具卸载。
+      const res2 = fakeRes();
+      const req2 = {
+        method: "POST",
+        url: ROUTES.config,
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: { host: "localhost:3080", origin: "http://localhost:3080", "sec-fetch-site": "same-origin" },
+        async *[Symbol.asyncIterator]() {
+          yield Buffer.from(JSON.stringify({ middleware: "off" }));
+        },
+      };
+      await configRoute.handler(req2, res2);
+      assert.equal(res2.state.status, 200);
+      assert.equal(JSON.parse(res2.state.body).middleware, "off", "切回 off 生效");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/dsh-mcp-manager/test/unit-supervisor.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-supervisor.test.ts
@@ -341,6 +341,85 @@ const failServer = { name: "srv", transport: "stdio", command: "dsh-mcp-missing-
   assert.deepEqual(supEmpty.tools, ["mcp__z__t"]);
 }
 
+// ---- syncTools：封装定义路径（#362 补充 4：registerServer.toolDefinitions）----
+
+{
+  // 有 toolDefinitions → 全部用封装定义注册：execute 来自调用方、命名 mcp__ 前缀、
+  // 不触达远端 schema 投影（伪造 listTools 抛错证明未走远端路径）。
+  const execCalls = [];
+  const wrappedServer = {
+    name: "cg",
+    transport: "stdio",
+    command: "echo",
+    enabled: true,
+    toolDefinitions: [
+      {
+        name: "codegraph_explore",
+        description: "wrapped-desc",
+        parameters: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
+        output: {
+          schema: { type: "object", properties: { text: { type: "string" } }, required: ["text"] },
+          render(_args, value) {
+            return [{ type: "text", text: value && typeof value === "object" && "text" in value ? String(value.text) : "" }];
+          },
+        },
+        async execute(args) {
+          execCalls.push(args);
+          return { text: "wrapped-ok" };
+        },
+      },
+    ],
+  };
+  // 独立收集器：保留完整定义以便调用 execute 断言「来自封装」。
+  const { log } = makeManagerLog();
+  const defs = [];
+  const wrappedMgr = makeManagerLog();
+  wrappedMgr.manager.ctx.tools.register = (def) => {
+    defs.push(def);
+    return () => log.disposed.push(def.name);
+  };
+  const supW = new ConnectionSupervisor(wrappedMgr.manager, wrappedServer);
+  await supW.syncTools(
+    {
+      listTools: async () => {
+        throw new Error("must not reach remote schema");
+      },
+    },
+    true,
+  );
+  assert.deepEqual(supW.tools, ["mcp__cg__codegraph_explore"], "封装定义：公共名 mcp__ 前缀");
+  assert.equal(defs.length, 1);
+  assert.equal(defs[0].name, "mcp__cg__codegraph_explore", "注册名 mcp__ 前缀");
+  assert.equal(defs[0].description, "wrapped-desc", "自定义 description 被采用");
+  assert.equal(supW.toolMeta.get("mcp__cg__codegraph_explore").description, "wrapped-desc", "描述元数据取封装定义");
+  assert.equal(supW.toolDisposers.size, 1);
+
+  // execute 来自封装定义（不经通用 callTool）。
+  const value = await defs[0].execute({ query: "X 被谁调用" }, { signal: undefined });
+  assert.equal(value.text, "wrapped-ok", "execute 来自调用方封装");
+  assert.deepEqual(execCalls, [{ query: "X 被谁调用" }], "封装 execute 收到调用参数");
+
+  // 重复封装工具名 → 抛错（与远端路径同口径）。
+  const dupMgr = makeManagerLog();
+  const supDup = new ConnectionSupervisor(dupMgr.manager, { name: "cg", transport: "stdio", command: "echo", enabled: true });
+  supDup.server.toolDefinitions = [
+    { name: "t", description: "a", parameters: {} },
+    { name: "t", description: "b", parameters: {} },
+  ];
+  await assert.rejects(
+    () => supDup.syncTools({ listTools: async () => ({ tools: [] }) }, false),
+    /duplicate wrapped tool/,
+  );
+  // 缺 name 的封装定义 → 抛错。
+  const noNameMgr = makeManagerLog();
+  const supNoName = new ConnectionSupervisor(noNameMgr.manager, { name: "cg", transport: "stdio", command: "echo", enabled: true });
+  supNoName.server.toolDefinitions = [{ description: "no name", parameters: {} }];
+  await assert.rejects(
+    () => supNoName.syncTools({ listTools: async () => ({ tools: [] }) }, false),
+    /without a name/,
+  );
+}
+
 // ---- disconnect：timer / close 抛错 / 终态 ----
 
 {

--- a/shared/mcp-manager-service.d.ts
+++ b/shared/mcp-manager-service.d.ts
@@ -8,13 +8,17 @@
  * esbuild 构建期内联、随包复制（d.ts X1）。
  *
  * 服务面（通用 MCP 能力 + 运行时注入专用面）：
- * - 注入面：registerServer / unregisterServer（内存态不落盘，同名幂等）；
+ * - 注入面：registerServer / unregisterServer（内存态不落盘，同名幂等；
+ *   registerServer 支持可选 toolDefinitions——调用方封装定义，见下）；
  * - 控制面：connect / disconnect / reconnect（通用 MCP 生命周期，注册即连、
  *   注销即断的补充控制）；
  * - 查询面：getStatus / getTools / list（连接状态、工具列表、全量摘要——
  *   「作为 MCP 应能感知连接状态与工具列表」，评审③ MVP 裁剪为纯注入面是
  *   过度裁剪，查询面是消费方感知服务状态所必需）。
  */
+
+/** 封装工具定义（官方 dsh-tools 契约；类型面引用，编译期擦除）。 */
+import type { ToolDefinition } from "@deepseek-ai/dsh-tools";
 
 /** 服务器连接状态（与 manager summarize 投影一致）。 */
 export type McpServerStatus =
@@ -59,6 +63,14 @@ export interface McpManagerServerInput {
   toolCallTimeoutMs?: number;
   reconnect?: Record<string, unknown>;
   description?: string;
+  /**
+   * 可选：调用方封装工具定义（裸名；如 dsh-codegraph 的 codegraph_explore）。
+   * 提供时该服务器工具全部用封装定义注册（execute 来自调用方，跳过远端
+   * schema 与通用 callTool）；缺省维持现状（远端 schema + mcp__ 前缀 +
+   * 通用 callTool）。模型可见名仍由 manager 命名机制决定（mcp__ 前缀）；
+   * 工具级禁用/可见性/能力目录照常生效。仅内存态消费，不落盘。
+   */
+  toolDefinitions?: ToolDefinition[];
 }
 
 /** ctx.mcpManager service 面（完整：注入 + 控制 + 查询）。 */


### PR DESCRIPTION
## 关联 issue

Fixes #362

## 背景

dsh-mcp-manager 中间层工具缺陷修复 + 架构收敛（registerServer.toolDefinitions 通道）。

## 改动

1. **A1**：ws_mcp_list 带 serverFilter 过滤 0 命中 → message 可归因（「没有匹配 server=X 的项目级服务器；可见项目级服务器 a/b/c；全局级服务器不在此列出，请用 mcp__ 前缀」），不再谎报「未配置」。实现于 middleware-register.ts execute 层，listCatalog 纯函数未动。
2. **A2**：ws_mcp_detail/ws_mcp_call 传全局级服务器 → 引导「请直接用 mcp__<server>__<tool> 前缀工具调用」（isGlobalServer 双源：store + runtimeRegistry）；非 global 其他 root 硬拒绝保留。
3. **C**：ws_mcp_search 空结果 render 文案可归因。
4. **工具级禁用**：isToolDenied 单一裁决三入口（callTool / pre-execute guard / mcp__ 直呼）；disabledTools 三层持久化（root → server → Set<tool>，合并写盘）；PATCH /api/dsh-mcp/tool-disable；浮窗 scope 分组 + 折叠 checkbox（project 模式全局组提示切 all 模式）。
5. **设置页**：中间层模式下拉（project/all/off）热切换。
6. **@global 归一化**：parseFullServerName 兼容单 @/双 @ 形态（隔离验证发现：单 @ @global/x 被路由拒绝、双 @ @@global/x 放行——smoke 双 @ 掩盖单 @ 被拒）。
7. **registerServer.toolDefinitions（#362 补充 4，架构收敛）**：调用方封装定义通道——带 toolDefinitions 的服务器工具全部以封装定义注册（execute 来自调用方，跳过远端 schema 与通用 callTool），命名仍按 publicToolName mcp__ 前缀，禁用/可见性/能力目录照常生效；不带则维持现状零影响。

## 验证

- 门禁全绿：build / test / contract / pack:check（worktree dsh-hub-task-362）
- smoke 专项断言：#362 A1/A2/P0-1/P1、toolDefinitions 封装注册、@global 单双 @ 归一化
- 隔离实例验证（verify-isolated）：tool-disable 路由 400/200/405 围栏；@global 放行；disabledTools 持久化三层结构
- 双 worktree 联调（与 #363）：8 封装定义 → registerServer 接收 → supervisor 注册 mcp__codegraph__* → 隔离实例 connected → execute 纪律生效 → isToolDenied 对封装工具命中/放行

## 遗留

- 运行态浏览器实测（浮窗交互/设置页下拉）需用户重启 dsh web 后验证
- 跨进程并发写 disabledTools 与 userDisabled 读-改-写竞态（既有语义）
