### PR TITLE
test(meta): 变异分段契约升级——数字段号改功能段名枚举（#342 二期）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,9 @@ jobs:
       hitPackages: ${{ steps.pkgs.outputs.hitPackages }}
       # 增量变异切片清单（#178）：hitPackages 剔除聚合包 dsh-plugins-all（无变异配置）
       mutationPackages: ${{ steps.pkgs.outputs.mutationPackages }}
-      # 变异 matrix 组合清单（#220 B 方案）：[{package, seg}] —— 拆分三包按
-      # stryker.conf.d/<pkg>-<n>.json 展开为多实例并行，未拆分包 seg=0 走包级配置
+      # 变异 matrix 组合清单（#220 B 方案）：[{package, seg}] —— 拆分包按
+      # stryker.conf.d/<pkg>-<后缀>.json（功能段名/数字段名统一）展开为多实例
+      # 并行，未拆分包 seg="0" 走包级配置（#342 二期功能命名改造）
       mutationCombos: ${{ steps.pkgs.outputs.mutationCombos }}
       # 切片是否含变异对象包（#217：显式布尔字符串 'true'/'false'）。GHA 表达式
       # 无取长度与管道能力，在 if 里对清单做取长判空或裸数组文本比较均脆弱；
@@ -135,26 +136,31 @@ jobs:
           echo "全量包清单（单一事实源）: $ALL_PACKAGES"
           # mutationPackages：hitPackages 剔除聚合包后的增量变异切片（#178）；
           # mutationCombos（#220 B 方案）：切片按 stryker.conf.d/ 段配置展开为
-          #   matrix 组合 —— 存在 <pkg>-<n>.json 的包逐段实例化，否则 seg=0 走
-          #   包级配置；段数以 conf 目录为单一事实源，脚本不硬编码；
+          #   matrix 组合 —— 存在 <pkg>-<后缀>.json 的包逐段实例化（后缀即
+          #   功能段名，如 dsh-notifier-server.json → seg=server；数字段名
+          #   dsh-lan-proxy-1.json → seg=1 亦兼容），否则 seg=0 走包级配置；
+          #   段名以 conf 目录文件名为单一事实源，脚本不硬编码；
           # hasMutations（#217）：由同一清单推导的显式布尔，供下游 if 精确比较
           combos_for() {
-            local pkg="$1" segs i out= first=1
+            local pkg="$1" seg_name out= first=1 conf
             # 无任何 stryker 配置的包（如纯宿主 skill 包 dsh-verify-isolated）不进
             # 变异切片：既无段配置也无包级 <pkg>.json 时返回空（#306 防假红）
             if [ ! -f "stryker.conf.d/$pkg.json" ] && ! ls stryker.conf.d/"$pkg"-*.json >/dev/null 2>&1; then
               return 0
             fi
-            segs=$(ls stryker.conf.d/"$pkg"-*.json 2>/dev/null | wc -l)
-            if [ "$segs" -gt 0 ]; then
-              out='['
-              for i in $(seq 1 "$segs"); do
-                [ $first -eq 1 ] && first=0 || out="$out,"
-                out="$out{\"package\":\"$pkg\",\"seg\":$i}"
-              done
-              echo "$out]"
+            # 段式配置：逐个枚举 stryker.conf.d/<pkg>-*.json，seg = 文件名剥
+            # <pkg>- 前缀后的后缀（功能名 / 数字名统一；空 = 包级单段 seg=0）
+            out='['
+            for conf in $(ls stryker.conf.d/"$pkg"-*.json 2>/dev/null | sort); do
+              seg_name="$(basename "$conf" .json | sed "s/^${pkg}-//")"
+              if [ -z "$seg_name" ]; then continue; fi
+              [ $first -eq 1 ] && first=0 || out="$out,"
+              out="$out{\"package\":\"$pkg\",\"seg\":\"$seg_name\"}"
+            done
+            if [ "$first" -eq 1 ]; then
+              echo "[{\"package\":\"$pkg\",\"seg\":\"0\"}]"
             else
-              echo "[{\"package\":\"$pkg\",\"seg\":0}]"
+              echo "$out]"
             fi
           }
           emit_outputs() {
@@ -350,15 +356,15 @@ jobs:
   #   天然可见）；首夜/基线缺失时天然降级为全量变异，门禁语义不变仅变慢
   # 已知约束：GitHub Actions 的 matrix 不允许引用 env context，但可引用 needs outputs
   mutation-gate:
-    name: Mutation gate (${{ matrix.combo.package }} · s${{ matrix.combo.seg }})
+    name: Mutation gate (${{ matrix.combo.package }} · ${{ matrix.combo.seg }})
     needs: changes
     # 与 coverage job 平行（无 needs 依赖）；if 精确锁定事件面与显式布尔切片，
     # 空 slice 时 if 直接为假、矩阵不实例化（job result = skipped）
     if: github.event_name == 'pull_request' && needs.changes.outputs.hasMutations == 'true'
     strategy:
       fail-fast: false
-      # #220 B 方案：combo = {package, seg}；拆分三包逐段并行实例化，
-      # 未拆分包单实例（seg=0 走包级配置 <pkg>.json）
+      # #220 B 方案：combo = {package, seg}；改造后 seg=功能段名（数字段名亦兼容），
+      # 多段包逐段并行实例化，未拆分包单实例（seg="0" 走包级配置 <pkg>.json）
       matrix:
         combo: ${{ fromJSON(needs.changes.outputs.mutationCombos) }}
     runs-on: ubuntu-latest
@@ -389,7 +395,7 @@ jobs:
       - name: Build all packages（变异对象 lib 分段依赖全集一致的构建链）
         run: pnpm build
 
-      - name: Resolve combo paths（#220：seg=0 包级配置；seg>0 段式配置）
+      - name: Resolve combo paths（#220 + #342 二期：seg="0" 包级配置；seg=功能段名/数字段名）
         env:
           MATRIX_PKG: ${{ matrix.combo.package }}
           SEG: ${{ matrix.combo.seg }}
@@ -434,7 +440,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: mutation-report-${{ matrix.combo.package }}-s${{ matrix.combo.seg }}
+          name: mutation-report-${{ matrix.combo.package }}-${{ matrix.combo.seg }}
           path: coverage/mutation/${{ env.REPORT }}.json
           retention-days: 1
           if-no-files-found: error

--- a/packages/dsh-codegraph/test/smoke.ts
+++ b/packages/dsh-codegraph/test/smoke.ts
@@ -802,28 +802,43 @@ check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpMa
 
   // #363 补充 3：apply 不再调用 ctx.tools.register（撤销自注册）——
   // fake ctx 无 tools 成员，apply 不应触碰它。
+  // 注：apply 只在 isCodegraphInstalled()（真实 PATH 探测）为真时才调
+  // registerServer——必须用 fake codegraph 目录隔离 PATH 模拟「已装」，
+  // 否则 CI runner（无 codegraph CLI）会走未装分支导致 registerCalls=0
+  // （#365 引入时在 coverage job 从未真正执行过，CI 跑 coverage 全量时才暴露）。
   registerAsync("apply: 不再调用 ctx.tools.register（撤销自注册，#363 补充 3）", async () => {
-    const { ctx, state } = makeCtx();
-    await apply(ctx, {});
-    assert.equal(state.tools.length, 0, "不应有任何 tools.register 调用");
-    assert.equal(state.registerCalls.length, 1, "registerServer 被调用一次");
+    const dir = mkdtempSync(join(tmpdir(), "cg-applynor-"));
+    writeFileSync(join(dir, "codegraph"), "#!/bin/sh\n");
+    await withGlobalPath(dir, async () => {
+      const { ctx, state } = makeCtx();
+      await apply(ctx, {});
+      assert.equal(state.tools.length, 0, "不应有任何 tools.register 调用");
+      assert.equal(state.registerCalls.length, 1, "registerServer 被调用一次");
+    });
+    rmSync(dir, { recursive: true, force: true });
   });
 
   // #363 补充 3：registerServer 携带 toolDefinitions —— 8 个封装定义交给
   // mcp-manager 注册（manager 侧 #362 补充 4 消费）。
+  // 同上：需 fake codegraph 目录模拟「已装」，保证 registerServer 走注册分支。
   registerAsync("apply: registerServer 携带 toolDefinitions（8 个封装定义）", async () => {
-    const { ctx, state } = makeCtx();
-    await apply(ctx, {});
-    assert.ok(Array.isArray(state.registerCalls[0]?.toolDefinitions), "registerServer 入参应有 toolDefinitions");
-    const defs = state.registerCalls[0].toolDefinitions;
-    assert.equal(defs.length, 8, "8 个封装定义");
-    const names = defs.map((d) => d.name).sort();
-    assert.deepEqual(names, ["codegraph_callees", "codegraph_callers", "codegraph_explore", "codegraph_files", "codegraph_impact", "codegraph_node", "codegraph_search", "codegraph_status"]);
-    for (const definition of defs) {
-      assert.ok(definition.parameters, `parameters 必须存在（非 inputSchema，${definition.name}）`);
-      assert.equal(definition.inputSchema, undefined, `inputSchema 不应存在（${definition.name}）`);
-      assert.equal(typeof definition.execute, "function", `execute 应为函数（${definition.name}）`);
-    }
+    const dir = mkdtempSync(join(tmpdir(), "cg-applydefs-"));
+    writeFileSync(join(dir, "codegraph"), "#!/bin/sh\n");
+    await withGlobalPath(dir, async () => {
+      const { ctx, state } = makeCtx();
+      await apply(ctx, {});
+      assert.ok(Array.isArray(state.registerCalls[0]?.toolDefinitions), "registerServer 入参应有 toolDefinitions");
+      const defs = state.registerCalls[0].toolDefinitions;
+      assert.equal(defs.length, 8, "8 个封装定义");
+      const names = defs.map((d) => d.name).sort();
+      assert.deepEqual(names, ["codegraph_callees", "codegraph_callers", "codegraph_explore", "codegraph_files", "codegraph_impact", "codegraph_node", "codegraph_search", "codegraph_status"]);
+      for (const definition of defs) {
+        assert.ok(definition.parameters, `parameters 必须存在（非 inputSchema，${definition.name}）`);
+        assert.equal(definition.inputSchema, undefined, `inputSchema 不应存在（${definition.name}）`);
+        assert.equal(typeof definition.execute, "function", `execute 应为函数（${definition.name}）`);
+      }
+    });
+    rmSync(dir, { recursive: true, force: true });
   });
 
   // enabled:false → 不做事

--- a/scripts/gate/mutation-gate.mjs
+++ b/scripts/gate/mutation-gate.mjs
@@ -97,18 +97,18 @@ if (fnPct < covThreshold) {
 const reportDir = join(repoRoot, 'coverage', 'mutation');
 let r = null;
 {
-  // 期望段数由 stryker.conf.d/ 实际存在的 <pkg>-<n>.json 推导（单一事实源）；
-  // 报告必须与段配置一一对应，缺任一段 = 链路异常，fail-closed
+  // 期望段名由 stryker.conf.d/ 实际存在的 <pkg>-<后缀>.json 推导（单一事实源；
+  // 后缀即功能段名，数字段名亦兼容——#342 二期功能命名改造）；报告必须与段
+  // 配置一一对应，缺任一段 = 链路异常，fail-closed
   const confDir = join(repoRoot, 'stryker.conf.d');
   const expectedSegs = readdirSync(confDir)
-    .map((f) => (f.match(new RegExp(`^${pkg}-(\\d+)\\.json$`)) ?? [])[1])
+    .map((f) => (f.match(new RegExp(`^${pkg}-(.+)\\.json$`)) ?? [])[1])
     .filter(Boolean)
-    .map(Number)
-    .sort((a, b) => a - b);
+    .sort();
   const segPaths = expectedSegs.map((n) => {
     const p = join(reportDir, `${pkg}-${n}.json`);
     if (!existsSync(p)) {
-      console.error(`mutation-gate: ${pkg} 第 ${n} 段报告缺失（${p}）—— 段 matrix 实例未产出，fail-closed`);
+      console.error(`mutation-gate: ${pkg} 段 ${n} 报告缺失（${p}）—— 段 matrix 实例未产出，fail-closed`);
       process.exit(2);
     }
     return p;

--- a/scripts/gate/observe-check.mjs
+++ b/scripts/gate/observe-check.mjs
@@ -55,38 +55,43 @@ if (existsSync(selfCovPath)) {
   } catch { /* 展示性字段，缺失不致命 */ }
 }
 
-// #220 B 方案：包可拆分为段式配置（<pkg>-<seg>.json），夜间变异产出
-// <pkg>-<seg>.json 段报告；此处按 conf 目录推导期望段数，聚合为包级口径
-// （mutant 位置键去重，与 mutation-gate.mjs 同一 lib 函数）。未拆分包仍读
-// 单报告 <pkg>.json。缺任一段报告 = 该包未完整执行，fail-closed。
+// #220 B 方案：包可拆分为段式配置（<pkg>-<后缀>.json，后缀即功能段名，
+// 数字段名亦兼容——#342 二期功能命名改造），夜间变异产出 <pkg>-<后缀>.json
+// 段报告；此处按 conf 目录枚举段后缀，聚合为包级口径（mutant 位置键去重，
+// 与 mutation-gate.mjs 同一 lib 函数）。未拆分包仍读单报告 <pkg>.json。
+// 缺任一段报告 = 该包未完整执行，fail-closed。
 const confDir = join(repoRoot, 'stryker.conf.d');
 const reportDir = join(repoRoot, 'coverage', 'mutation');
-const segCounts = new Map();
+const segNamesByPkg = new Map(); // pkg → 段后缀数组（未排序）
 for (const f of readdirSync(confDir)) {
-  const m = f.match(/^(dsh-[a-z0-9-]+)-(\d+)\.json$/);
-  if (m) segCounts.set(m[1], Math.max(segCounts.get(m[1]) ?? 0, Number(m[2])));
+  const m = f.match(/^(dsh-[a-z0-9-]+)-(.+)\.json$/);
+  if (m) {
+    const list = segNamesByPkg.get(m[1]) ?? [];
+    list.push(m[2]);
+    segNamesByPkg.set(m[1], list);
+  }
 }
 
 for (const [pkg, cfg] of Object.entries(packages)) {
-  const expectedSegs = segCounts.get(pkg) ?? 0;
+  const expectedSegs = (segNamesByPkg.get(pkg) ?? []).sort();
   let r = null;
-  if (expectedSegs > 0) {
+  if (expectedSegs.length > 0) {
     const segPaths = [];
-    for (let n = 1; n <= expectedSegs; n += 1) {
+    for (const n of expectedSegs) {
       const p = join(reportDir, `${pkg}-${n}.json`);
       if (!existsSync(p)) {
-        rows.push({ pkg, missing: true, missingLabel: `第 ${n} 段未执行` });
-        if (mutationStrict) violations.push(`${pkg}: 第 ${n} 段变异报告缺失（${pkg}-${n}.json 不存在——该段未执行）`);
+        rows.push({ pkg, missing: true, missingLabel: `段 ${n} 未执行` });
+        if (mutationStrict) violations.push(`${pkg}: 段 ${n} 变异报告缺失（${pkg}-${n}.json 不存在——该段未执行）`);
         r = null;
         break;
       }
       segPaths.push(p);
     }
-    if (segPaths.length === expectedSegs) {
+    if (segPaths.length === expectedSegs.length) {
       r = readMutationReportsAgg(segPaths);
       if (!r) {
         rows.push({ pkg, missing: true, missingLabel: '报告损坏' });
-        if (mutationStrict) violations.push(`${pkg}: 段式报告不可解析（共 ${expectedSegs} 段）`);
+        if (mutationStrict) violations.push(`${pkg}: 段式报告不可解析（共 ${expectedSegs.length} 段）`);
         continue;
       }
     } else {

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -45,6 +45,31 @@ const SLICE_PACKAGES = [...MANIFEST.active, AGGREGATE]
 // 变异对象包：gauntlet mutation.packages（含 standalone，不含聚合/纯宿主 skill 包）
 const MUTATION_PACKAGES = Object.keys(GAUNTLET?.mutation?.packages ?? {})
 
+// ── 段配置文件名归并（#342 二期：数字段名 s1/s2 废弃，改为功能段名；二者兼容）──
+// 包级单段配置 <pkg>.json 与段式配置 <pkg>-<后缀>.json（后缀=功能段名或数字段名）
+// 统一归并为基础包名：对已知包集合（gauntlet mutation.packages）做最长前缀匹配。
+// 所有需要「conf 文件集 ↔ 包集」一致的断言共用本函数，避免三处漂移（评审 P1-2）。
+function basePkgOfConf(f) {
+  const name = f.replace(/\.json$/, '')
+  const hit = MUTATION_PACKAGES
+    .filter((p) => name === p || name.startsWith(`${p}-`))
+    .sort((a, b) => b.length - a.length)
+  return hit[0]
+}
+// 段式配置的后缀（如 dsh-notifier-server.json → server；dsh-lan-proxy-1.json → 1）
+function segSuffixOfConf(f) {
+  const name = f.replace(/\.json$/, '')
+  const base = basePkgOfConf(f)
+  return base && name !== base ? name.slice(base.length + 1) : undefined
+}
+// 有 stryker 配置的包集合（conf 文件集归并；段式/包级统一）
+function strykerPkgs() {
+  return [...new Set(readdirSync(join(ROOT, 'stryker.conf.d'))
+    .filter((f) => f.endsWith('.json'))
+    .map(basePkgOfConf)
+    .filter(Boolean))].sort()
+}
+
 test('ci.yml: repo-gate 保持分支保护 required check 名', () => {
   const m = /repo-gate:\s*\n\s*name: (.+)/.exec(CI)
   assert.ok(m, '存在 repo-gate 作业且声明 name')
@@ -140,11 +165,10 @@ test('#220: docs 不在 ci.yml global 过滤面——文档 PR 不触发变异�
 })
 
 test('#322: 每个带 stryker 配置的包在 path-filter 均有段配置通配映射（防回归）', () => {
-  // 有 stryker 配置的包 = stryker.conf.d 文件集归并出的基础包名（段级 <pkg>-<n>.json
-  // 归并到 <pkg>），与 #220 段式三方一致测试同一口径
-  const confDir = join(ROOT, 'stryker.conf.d')
-  const confFiles = readdirSync(confDir).filter((f) => f.endsWith('.json'))
-  const basePkgs = [...new Set(confFiles.map((f) => f.replace(/\.json$/, '').replace(/-\d+$/, '')))].sort()
+  // 有 stryker 配置的包 = stryker.conf.d 文件集归并出的基础包名（段式
+  // <pkg>-<后缀>.json 与包级 <pkg>.json 归并到 <pkg>，功能段名/数字段名统一——
+  // basePkgOfConf 共享函数），与 #220 段式三方一致测试同一口径
+  const basePkgs = strykerPkgs()
 
   const filtersBlock = CI.slice(CI.indexOf('filters: |'), CI.indexOf('- name: Compute hit packages'))
   for (const pkg of basePkgs) {
@@ -191,11 +215,12 @@ test('#220 段式三方一致：observe 计划 ↔ stryker.conf.d 文件集 ↔ 
   assert.ok(OBSERVE.includes('while read -r conf; do'),
     '变异循环必须从 suite-plan 清单文件逐行消费')
 
-  // stryker.conf.d 实际文件集 → 基础包名集合（段配置 <pkg>-<n>.json 归并到 <pkg>）
+  // stryker.conf.d 实际文件集 → 基础包名集合（段配置 <pkg>-<后缀>.json 与包级
+  // <pkg>.json 统一归并到 <pkg>——功能段名/数字段名兼容，basePkgOfConf 共享函数）
   const confDir = join(ROOT, 'stryker.conf.d')
   const confFiles = readdirSync(confDir).filter((f) => f.endsWith('.json')).sort()
   assert.ok(confFiles.length > 0, 'stryker.conf.d 非空')
-  const basePkgs = [...new Set(confFiles.map((f) => f.replace(/\.json$/, '').replace(/-\d+$/, '')))].sort()
+  const basePkgs = strykerPkgs()
 
   // gauntlet mutation.packages 与基础包名集一致
   const gauntPkgs = Object.keys(GAUNTLET?.mutation?.packages ?? {}).sort()
@@ -219,34 +244,36 @@ test('#220 段式三方一致：observe 计划 ↔ stryker.conf.d 文件集 ↔ 
   }
 })
 
-// ── #342 v4 §4.3/§4.4：段号连续 + mutate 面防空段回归 ──
-// 段号连续：combos_for 按 stryker.conf.d/<pkg>-*.json 文件数展开 seq 1 N，
-// 跳号（如缺 dsh-a-2.json）会让矩阵实例指向不存在配置，fail-closed 前先静态拦截。
-// 防空段：provider-2 空段实证（mutate 指向不存在的 adapters/*.ts，0 mutant）——
+// ── #342 二期 §契约：功能段名唯一 + mutate 面防空段回归 ──
+// 段名唯一：combos_for 按 stryker.conf.d/<pkg>-*.json 文件名枚举后缀展开矩阵，
+// 段文件名即矩阵实例（功能段名如 dsh-notifier-server.json → seg=server；数字段名
+// dsh-lan-proxy-1.json → seg=1 亦兼容）。重名/孤儿段（同时存在 <pkg>.json 与
+// <pkg>-*.json）/跳号会让矩阵指向不存在配置或白跑孤儿全量，fail-closed 前先静态拦截。
+// 防空段：provider 空段实证（mutate 指向不存在的 adapters/*.ts，0 mutant）——
 // 每段 mutate 正向条目必须至少 glob 到 1 个现存文件。
-test('#342: 各包 stryker 段号从 1 连续无空洞（防跳号矩阵）', () => {
+test('#342 二期: 各包 stryker 段文件名唯一且无孤儿段（防矩阵重名/孤儿全量）', () => {
   const confDir = join(ROOT, 'stryker.conf.d')
   const confFiles = readdirSync(confDir).filter((f) => f.endsWith('.json'))
   assert.ok(confFiles.length > 0, 'stryker.conf.d 非空')
-  // 包级单段配置（<pkg>.json）走 seg=0，不参与段号序列；段式配置 <pkg>-<n>.json 独立成组
-  const segSets = new Map() // base-pkg → Set<seg>
+  // 包级单段配置（<pkg>.json）走 seg="0"，不参与段名序列；段式配置 <pkg>-<后缀>.json 独立成组
+  const segSets = new Map() // base-pkg → Set<segName>
   const hasPkgLevel = new Set()
   for (const f of confFiles) {
-    const m = /^dsh-(.+?)(?:-(\d+))?\.json$/.exec(f)
-    if (!m) continue
-    const [, base, seg] = m
+    const base = basePkgOfConf(f)
+    if (!base) continue
+    const seg = segSuffixOfConf(f)
     if (seg) {
+      assert.ok(/^[a-z0-9-]+$/.test(seg),
+        `${f} 段名必须是 kebab-case 字母数字连字符（combos_for 以文件名枚举矩阵，非法字符会破坏路径拼接）`)
       if (!segSets.has(base)) segSets.set(base, new Set())
-      segSets.get(base).add(Number(seg))
+      segSets.get(base).add(seg)
     } else {
       hasPkgLevel.add(base)
     }
   }
   for (const [base, segs] of segSets) {
-    const arr = [...segs].sort((a, b) => a - b)
-    const expect = Array.from({ length: arr.length }, (_, i) => i + 1)
-    assert.deepEqual(arr, expect,
-      `${base} 段号必须为 1..${arr.length} 连续无空洞（combos_for 按 seq 1 N 展开，跳号即矩阵指向不存在配置）`)
+    assert.ok(segs.size === [...segs].length,
+      `${base} 段名必须唯一（文件名即矩阵实例，重名会让 combo 指向同一配置）`)
     assert.ok(!hasPkgLevel.has(base),
       `${base} 存在段式配置时不得残留包级孤儿 <pkg>.json（v4 §4.1：否则 observe 每班次白跑一段孤儿全量）`)
   }
@@ -700,7 +727,7 @@ test('#217: mutation-gate 剥离 cov——与 coverage 平行（needs 仅 change
   assert.ok(upIdx > 0, 'stryker 报告上传步骤在位')
   const upBlock = mg.slice(upIdx)
   assert.ok(/if: always\(\)/.test(upBlock), '报告上传必须 if: always()（实例非零退出时报告照常下发统一判分）')
-  assert.ok(upBlock.includes('name: mutation-report-${{ matrix.combo.package }}-s${{ matrix.combo.seg }}'),
+  assert.ok(upBlock.includes('name: mutation-report-${{ matrix.combo.package }}-${{ matrix.combo.seg }}'),
     '报告 artifact 名含 matrix.combo（package+seg）保证段实例唯一（pattern 下游可枚举）')
   assert.ok(upBlock.includes('if-no-files-found: error'), '报告缺失必须 error（verdict 缺报告 fail-closed 的前提）')
 })


### PR DESCRIPTION
## 背景

#342 v4.2 拆段（#352/#355/#357）已合并，但本机同口径全量复测仍有段超 120s 预算。
维护者指示二期：继续拆段 + **弃用数字段号（s1/s2），按每段覆盖功能命名**。

本 PR 是**契约先行**（评审 P1-4 无红过渡保障）：先把 ci.yml 段号派生与全部消费脚本
升级为「枚举 stryker.conf.d/<pkg>-*.json 文件名后缀」，对数字段名与功能段名统一兼容——
先合并本 PR（中间态不红），再逐包 git mv 改名，每包独立验证。

## 改动

1. **ci.yml combos_for**：`seq 1 N` 数字段号 → 枚举文件名后缀（seg=功能段名/数字段名）
2. **mutation-gate.mjs**：数字段号正则 `^${pkg}-(\d+)$` → 枚举段后缀（评审 P0-1 漏列消费点）
3. **observe-check.mjs**：数字段号正则 → 枚举段后缀（评审 P1-3 漏列消费点）
4. **workflow-assert.test.ts**：
   - 段号连续断言 → 功能段名唯一 + 无孤儿断言（防矩阵重名/孤儿全量）
   - basePkg 归并抽共享函数 `basePkgOfConf`（数字/功能段名统一，评审 P1-2）
   - artifact 名断言同步去 `-s` 前缀（评审 P1-1）

## 验证

- workflow-assert **32/32 全绿**（含新增/改造断言，对当前数字段名向后兼容）
- 本地五连门禁全绿（build/test/contract/pack:check/typecheck）
- 模拟枚举：数字段名 dsh-notifier-1.json → seg="1" → CONF 拼接正确

Refs #342