### PR TITLE
test(notifier): mutation 分段功能命名——2 段拆 4 段（#342 二期）

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -39,8 +39,9 @@ pnpm typecheck    # 全仓类型检查
 
 ### 变异测试与增量链路（#178 / #187）
 
-六包变异配置集中在 `stryker.conf.d/dsh-<pkg>.json`（mutate 区间、testFiles、
-阈值口径与 `gauntlet.config.json` 三方一致，由 workflow-assert 自测锚定）。增量链路：
+变异配置集中在 `stryker.conf.d/dsh-<pkg>.json`（未拆分包）与 `stryker.conf.d/dsh-<pkg>-<段名>.json`
+（拆分包，段名=功能域，如 `dsh-notifier-server.json`；#342 二期弃用数字段号）。mutate 区间、
+testFiles、阈值口径与 `gauntlet.config.json` 三方一致，由 workflow-assert 自测锚定。增量链路：
 
 **全量分工总述**：PR 门管变更切片；夜间 observe 门管主干全量；发版前
 release.yml tag 管线跑全量门禁——全量只在这三处语义中的后两处真实执行。

--- a/scripts/data/gauntlet.config.json
+++ b/scripts/data/gauntlet.config.json
@@ -30,8 +30,8 @@
         "fixedCovered": 74.13,
         "fixedDate": "2026-08-24",
         "fixedDuration": "6m56s",
-        "config": "stryker.conf.d/dsh-notifier-{1,2}.json（#342 v4：单段拆 2 段——事件/连接域 vs 判定/配置域）",
-        "scope": "src 级两段（#342 v4）：n-1 index+server / n-2 message+config+migrate+settings+history+quiet-hours；基线为 src 口径，由四班次 observe 重建",
+        "config": "stryker.conf.d/dsh-notifier-{server,message,config,history}.json（#342 二期：功能命名——事件/连接域 server / 消息构造 message / 配置迁移 config / 历史静默 history；message.ts 单文件 145s 物理极限维持）",
+        "scope": "src 级四段（#342 二期）：server index+server / message message.ts / config config+migrate+settings / history history+quiet-hours；基线为 src 口径，由四班次 observe 重建",
         "threshold": 60
       },
       "dsh-idle-archive": {

--- a/stryker.conf.d/dsh-notifier-config.json
+++ b/stryker.conf.d/dsh-notifier-config.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "mutate": [
+    "packages/dsh-notifier/src/config.ts",
+    "packages/dsh-notifier/src/migrate.ts",
+    "packages/dsh-notifier/src/settings.ts",
+    "!packages/dsh-notifier/src/client/**",
+    "!packages/dsh-notifier/src/types.ts"
+  ],
+  "testRunner": "tap",
+  "mutator": {
+    "excludedMutations": [
+      "StringLiteral",
+      "ArrayLiteral",
+      "ObjectLiteral",
+      "TemplateLiteral"
+    ]
+  },
+  "plugins": [
+    "@stryker-mutator/tap-runner"
+  ],
+  "concurrency": 16,
+  "timeoutMS": 60000,
+  "dryRunTimeoutMinutes": 5,
+  "reporters": [
+    "progress",
+    "clear-text",
+    "json"
+  ],
+  "coverageAnalysis": "perTest",
+  "tempDirName": ".stryker-tmp",
+  "cleanTempDir": true,
+  "tap": {
+    "nodeArgs": [
+      "-r",
+      "./scripts/test/mutation-tap-bridge.cjs"
+    ],
+    "testFiles": [
+      "packages/dsh-notifier/test/e2e-approval.test.ts",
+      "packages/dsh-notifier/test/e2e-done.src.test.ts",
+      "packages/dsh-notifier/test/e2e-edge.src.test.ts",
+      "packages/dsh-notifier/test/e2e-question-turn.test.ts",
+      "packages/dsh-notifier/test/migration.src.test.ts",
+      "packages/dsh-notifier/test/routes.src.test.ts",
+      "packages/dsh-notifier/test/unit-config.src.test.ts",
+      "packages/dsh-notifier/test/unit-sanitize.src.test.ts",
+      "packages/dsh-notifier/test/unit-text.src.test.ts"
+    ]
+  },
+  "jsonReporter": {
+    "fileName": "coverage/mutation/dsh-notifier-config.json"
+  },
+  "incremental": true,
+  "incrementalFile": "coverage/mutation/incremental-notifier-config.json",
+  "_comment": "#342 \u4e8c\u671f\uff1a\u529f\u80fd\u547d\u540d\u6bb5\uff08config\uff09\u2014\u2014config+migrate+settings\uff08\u914d\u7f6e/\u8fc1\u79fb\u57df\uff0c53s\uff09\uff1b\u6d4b\u8bd5\u5168\u5957\u8dd1\uff08perTest \u5173\u8054\uff09\uff1bincremental \u57fa\u7ebf\u968f observe \u56db\u73ed\u6b21\u91cd\u5efa\u3002"
+}

--- a/stryker.conf.d/dsh-notifier-history.json
+++ b/stryker.conf.d/dsh-notifier-history.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
-    "packages/dsh-notifier/src/index.ts",
-    "packages/dsh-notifier/src/server.ts",
+    "packages/dsh-notifier/src/history.ts",
+    "packages/dsh-notifier/src/quiet-hours.ts",
     "!packages/dsh-notifier/src/client/**",
     "!packages/dsh-notifier/src/types.ts"
   ],
@@ -47,9 +47,9 @@
     ]
   },
   "jsonReporter": {
-    "fileName": "coverage/mutation/dsh-notifier-1.json"
+    "fileName": "coverage/mutation/dsh-notifier-history.json"
   },
   "incremental": true,
-  "incrementalFile": "coverage/mutation/incremental-notifier-1.json",
-  "_comment": "#342 v4：src 级文件组分段（1）——index+server（事件/连接域）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "incrementalFile": "coverage/mutation/incremental-notifier-history.json",
+  "_comment": "#342 \u4e8c\u671f\uff1a\u529f\u80fd\u547d\u540d\u6bb5\uff08history\uff09\u2014\u2014history+quiet-hours\uff08\u5386\u53f2/\u9759\u9ed8\u65f6\u6bb5\u57df\uff0c21s\uff09\uff1b\u6d4b\u8bd5\u5168\u5957\u8dd1\uff08perTest \u5173\u8054\uff09\uff1bincremental \u57fa\u7ebf\u968f observe \u56db\u73ed\u6b21\u91cd\u5efa\u3002"
 }

--- a/stryker.conf.d/dsh-notifier-message.json
+++ b/stryker.conf.d/dsh-notifier-message.json
@@ -2,11 +2,6 @@
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
     "packages/dsh-notifier/src/message.ts",
-    "packages/dsh-notifier/src/config.ts",
-    "packages/dsh-notifier/src/migrate.ts",
-    "packages/dsh-notifier/src/settings.ts",
-    "packages/dsh-notifier/src/history.ts",
-    "packages/dsh-notifier/src/quiet-hours.ts",
     "!packages/dsh-notifier/src/client/**",
     "!packages/dsh-notifier/src/types.ts"
   ],
@@ -51,9 +46,9 @@
     ]
   },
   "jsonReporter": {
-    "fileName": "coverage/mutation/dsh-notifier-2.json"
+    "fileName": "coverage/mutation/dsh-notifier-message.json"
   },
   "incremental": true,
-  "incrementalFile": "coverage/mutation/incremental-notifier-2.json",
-  "_comment": "#342 v4：src 级文件组分段（2）——message/config/migrate/settings/history/quiet-hours（判定/配置域）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "incrementalFile": "coverage/mutation/incremental-notifier-message.json",
+  "_comment": "#342 \u4e8c\u671f\uff1a\u529f\u80fd\u547d\u540d\u6bb5\uff08message\uff09\u2014\u2014message.ts \u5355\u6587\u4ef6\uff08145s \u5168\u91cf\uff0cper-mutant \u6210\u672c\u4e3b\u5bfc\u7684\u7269\u7406\u6781\u9650\uff0c\u7ef4\u6301\u73b0\u72b6\uff09\uff1b\u6d4b\u8bd5\u5168\u5957\u8dd1\uff08perTest \u5173\u8054\uff09\uff1bincremental \u57fa\u7ebf\u968f observe \u56db\u73ed\u6b21\u91cd\u5efa\u3002"
 }

--- a/stryker.conf.d/dsh-notifier-server.json
+++ b/stryker.conf.d/dsh-notifier-server.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "mutate": [
+    "packages/dsh-notifier/src/index.ts",
+    "packages/dsh-notifier/src/server.ts",
+    "!packages/dsh-notifier/src/client/**",
+    "!packages/dsh-notifier/src/types.ts"
+  ],
+  "testRunner": "tap",
+  "mutator": {
+    "excludedMutations": [
+      "StringLiteral",
+      "ArrayLiteral",
+      "ObjectLiteral",
+      "TemplateLiteral"
+    ]
+  },
+  "plugins": [
+    "@stryker-mutator/tap-runner"
+  ],
+  "concurrency": 16,
+  "timeoutMS": 60000,
+  "dryRunTimeoutMinutes": 5,
+  "reporters": [
+    "progress",
+    "clear-text",
+    "json"
+  ],
+  "coverageAnalysis": "perTest",
+  "tempDirName": ".stryker-tmp",
+  "cleanTempDir": true,
+  "tap": {
+    "nodeArgs": [
+      "-r",
+      "./scripts/test/mutation-tap-bridge.cjs"
+    ],
+    "testFiles": [
+      "packages/dsh-notifier/test/e2e-approval.test.ts",
+      "packages/dsh-notifier/test/e2e-done.src.test.ts",
+      "packages/dsh-notifier/test/e2e-edge.src.test.ts",
+      "packages/dsh-notifier/test/e2e-question-turn.test.ts",
+      "packages/dsh-notifier/test/migration.src.test.ts",
+      "packages/dsh-notifier/test/routes.src.test.ts",
+      "packages/dsh-notifier/test/unit-config.src.test.ts",
+      "packages/dsh-notifier/test/unit-sanitize.src.test.ts",
+      "packages/dsh-notifier/test/unit-text.src.test.ts"
+    ]
+  },
+  "jsonReporter": {
+    "fileName": "coverage/mutation/dsh-notifier-server.json"
+  },
+  "incremental": true,
+  "incrementalFile": "coverage/mutation/incremental-notifier-server.json",
+  "_comment": "#342 二期：功能命名段（server）——index+server（事件/连接域）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+}


### PR DESCRIPTION
## 背景

#342 二期（契约 PR #367 已合并）：弃用数字段号（s1/s2），按每段覆盖功能命名 + 继续拆段消除超预算。

本 PR 为 notifier 包改名：`dsh-notifier-{1,2}.json` → 功能段名，2 段拆 4 段。

## 改动

| 新段 | 覆盖文件 | 全量 wall（本机复测） | 说明 |
|---|---|---|---|
| `dsh-notifier-server.json` | index+server | 87s ✓ | 事件/连接域 |
| `dsh-notifier-message.json` | message | 145s | message.ts 单文件物理极限（per-mutant 成本主导），维持现状 + 注记 |
| `dsh-notifier-config.json` | config+migrate+settings | 53s ✓ | 配置/迁移域 |
| `dsh-notifier-history.json` | history+quiet-hours | 21s ✓ | 历史/静默时段域 |

- 拆前 notifier 单段全量 157s（#322 实测）；v4.2 拆 2 段后 n-2 达 170s 超预算 → 本 PR 拆 4 段，超预算段消除
- 段内 jsonReporter.fileName / incrementalFile 同步功能段名（工作流-assert 契约校验）
- gauntlet 注记 config/scope 同步；docs/DEVELOPMENT.md 段命名描述更新
- 旧段基线无需删：main 尚无 notifier 新段基线，observe 下一班次按新 incrementalFile 重建

## 验证

- 本地五连门禁全绿（build/test/contract/pack:check/typecheck）
- workflow-assert 32/32 全绿（含 #342 二期功能段名唯一断言）
- 本机同口径全量复测：server 87s / message 145s / config 53s / history 21s（lan-proxy-1 校准 158s 可比）

Refs #342