### PR TITLE
test(mcp-manager): mutation 分段功能命名——5 段拆 6 段（#342 二期）

### DIFF
--- a/scripts/data/gauntlet.config.json
+++ b/scripts/data/gauntlet.config.json
@@ -74,10 +74,10 @@
         "baselineDate": "2026-08-24",
         "baselineDuration": "3m0s",
         "baselineScope": "packages/dsh-mcp-manager/lib/index.js:8610-8696+17322-17456+19271-19915+19964-21027（self-written 四段：store、transport+scope、protocol/supervisor/catalog、import/routes/index；排除 esbuild 垫片、zod/@modelcontextprotocol/sdk/ajv 等大段内联 vendor、shared 契约层内联副本与纯 import 提升段）",
-        "config": "stryker.conf.d/dsh-mcp-manager-{1..5}.json（#342 v4：s1/s2/s3 全拆重排为 m-1..m-5；types.ts / service.ts type-only 显式排除）",
+        "config": "stryker.conf.d/dsh-mcp-manager-{manager,entry,supervisor,middleware,routes,runtime}.json（#342 二期：功能命名——核心 manager / 入口 entry / 监督 supervisor / 中间件 middleware / 路由 routes / 运行时 runtime；manager.ts 单文件 134s 物理极限维持）",
         "hardeningNote": "#148 变异加固轮：6 个单测 commit 将 covered 由 29.37% 提升至 74.66%；耗时优化（#173）零杀伤 testFiles 移除 + conc8，3m52s→3m0s",
         "threshold": 60,
-        "scope": "src 级五段（#342 v4）：m-1 manager+index+normalize+import / m-2 supervisor+middleware-state+store+scope / m-3 middleware+middleware-utils+middleware-const / m-4 middleware-register+routes / m-5 catalog+apply+transport+placement-math+config-schema+protocol+middleware-types；基线为 src 口径，由四班次 observe 重建"
+        "scope": "src 级六段（#342 二期）：manager manager.ts / entry index+normalize+import / supervisor supervisor+middleware-state+store+scope / middleware middleware+middleware-utils+middleware-const / routes middleware-register+routes / runtime catalog+apply+transport+placement-math+config-schema+protocol+middleware-types；基线为 src 口径，由四班次 observe 重建"
       },
       "dsh-provider-usage": {
         "baselineScore": 67.28,

--- a/stryker.conf.d/dsh-mcp-manager-entry.json
+++ b/stryker.conf.d/dsh-mcp-manager-entry.json
@@ -1,13 +1,9 @@
 {
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
-    "packages/dsh-mcp-manager/src/catalog.ts",
-    "packages/dsh-mcp-manager/src/apply.ts",
-    "packages/dsh-mcp-manager/src/transport.ts",
-    "packages/dsh-mcp-manager/src/placement-math.ts",
-    "packages/dsh-mcp-manager/src/config-schema.ts",
-    "packages/dsh-mcp-manager/src/protocol.ts",
-    "packages/dsh-mcp-manager/src/middleware-types.ts",
+    "packages/dsh-mcp-manager/src/index.ts",
+    "packages/dsh-mcp-manager/src/normalize.ts",
+    "packages/dsh-mcp-manager/src/import.ts",
     "!packages/dsh-mcp-manager/src/client/**",
     "!packages/dsh-mcp-manager/src/types.ts",
     "!packages/dsh-mcp-manager/src/service.ts"
@@ -54,9 +50,9 @@
     ]
   },
   "jsonReporter": {
-    "fileName": "coverage/mutation/dsh-mcp-manager-5.json"
+    "fileName": "coverage/mutation/dsh-mcp-manager-entry.json"
   },
   "incremental": true,
-  "incrementalFile": "coverage/mutation/incremental-mcp-manager-5.json",
-  "_comment": "#342 v4：src 级文件组分段（5）——catalog+apply+transport+placement-math+config-schema+protocol+middleware-types；types.ts / service.ts（type-only）显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "incrementalFile": "coverage/mutation/incremental-mcp-manager-entry.json",
+  "_comment": "#342 \u4e8c\u671f\uff1a\u529f\u80fd\u547d\u540d\u6bb5\uff08entry\uff09\u2014\u2014index+normalize+import\uff08\u5165\u53e3/\u5f52\u4e00\u5316/\u5bfc\u5165\u57df\uff0c28s\uff09\uff1btypes.ts / service.ts\uff08type-only\uff09\u663e\u5f0f\u6392\u9664\uff1b\u6d4b\u8bd5\u5168\u5957\u8dd1\uff08perTest \u5173\u8054\uff09\uff1bincremental \u57fa\u7ebf\u968f observe \u56db\u73ed\u6b21\u91cd\u5efa\u3002"
 }

--- a/stryker.conf.d/dsh-mcp-manager-manager.json
+++ b/stryker.conf.d/dsh-mcp-manager-manager.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "mutate": [
+    "packages/dsh-mcp-manager/src/manager.ts",
+    "!packages/dsh-mcp-manager/src/client/**",
+    "!packages/dsh-mcp-manager/src/types.ts",
+    "!packages/dsh-mcp-manager/src/service.ts"
+  ],
+  "testRunner": "tap",
+  "mutator": {
+    "excludedMutations": [
+      "StringLiteral",
+      "ArrayLiteral",
+      "ObjectLiteral",
+      "TemplateLiteral"
+    ]
+  },
+  "plugins": [
+    "@stryker-mutator/tap-runner"
+  ],
+  "concurrency": 16,
+  "timeoutMS": 60000,
+  "dryRunTimeoutMinutes": 5,
+  "reporters": [
+    "progress",
+    "clear-text",
+    "json"
+  ],
+  "coverageAnalysis": "perTest",
+  "tempDirName": ".stryker-tmp",
+  "cleanTempDir": true,
+  "tap": {
+    "nodeArgs": [
+      "-r",
+      "./scripts/test/mutation-tap-bridge.cjs"
+    ],
+    "testFiles": [
+      "packages/dsh-mcp-manager/test/unit-apply.src.test.ts",
+      "packages/dsh-mcp-manager/test/unit-catalog.src.test.ts",
+      "packages/dsh-mcp-manager/test/unit-hotspot.src.test.ts",
+      "packages/dsh-mcp-manager/test/unit-manager.src.test.ts",
+      "packages/dsh-mcp-manager/test/unit-manager2.src.test.ts",
+      "packages/dsh-mcp-manager/test/unit-middleware.src.test.ts",
+      "packages/dsh-mcp-manager/test/unit-routes-sse.src.test.ts",
+      "packages/dsh-mcp-manager/test/unit-store.src.test.ts",
+      "packages/dsh-mcp-manager/test/unit-supervisor.src.test.ts",
+      "packages/dsh-mcp-manager/test/unit-transport.src.test.ts"
+    ]
+  },
+  "jsonReporter": {
+    "fileName": "coverage/mutation/dsh-mcp-manager-manager.json"
+  },
+  "incremental": true,
+  "incrementalFile": "coverage/mutation/incremental-mcp-manager-manager.json",
+  "_comment": "#342 \u4e8c\u671f\uff1a\u529f\u80fd\u547d\u540d\u6bb5\uff08manager\uff09\u2014\u2014manager.ts \u5355\u6587\u4ef6\uff08742 \u884c\uff0c134s \u5168\u91cf\uff0cper-mutant \u6210\u672c\u4e3b\u5bfc\u7684\u7269\u7406\u6781\u9650\uff0c\u7ef4\u6301\u73b0\u72b6\uff09\uff1btypes.ts / service.ts\uff08type-only\uff09\u663e\u5f0f\u6392\u9664\uff1b\u6d4b\u8bd5\u5168\u5957\u8dd1\uff08perTest \u5173\u8054\uff09\uff1bincremental \u57fa\u7ebf\u968f observe \u56db\u73ed\u6b21\u91cd\u5efa\u3002"
+}

--- a/stryker.conf.d/dsh-mcp-manager-middleware.json
+++ b/stryker.conf.d/dsh-mcp-manager-middleware.json
@@ -1,8 +1,9 @@
 {
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
-    "packages/dsh-mcp-manager/src/middleware-register.ts",
-    "packages/dsh-mcp-manager/src/routes.ts",
+    "packages/dsh-mcp-manager/src/middleware.ts",
+    "packages/dsh-mcp-manager/src/middleware-utils.ts",
+    "packages/dsh-mcp-manager/src/middleware-const.ts",
     "!packages/dsh-mcp-manager/src/client/**",
     "!packages/dsh-mcp-manager/src/types.ts",
     "!packages/dsh-mcp-manager/src/service.ts"
@@ -49,9 +50,9 @@
     ]
   },
   "jsonReporter": {
-    "fileName": "coverage/mutation/dsh-mcp-manager-4.json"
+    "fileName": "coverage/mutation/dsh-mcp-manager-middleware.json"
   },
   "incremental": true,
-  "incrementalFile": "coverage/mutation/incremental-mcp-manager-4.json",
-  "_comment": "#342 v4：src 级文件组分段（4）——middleware-register+routes；types.ts / service.ts（type-only）显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "incrementalFile": "coverage/mutation/incremental-mcp-manager-middleware.json",
+  "_comment": "#342 \u4e8c\u671f\uff1asrc \u7ea7\u6587\u4ef6\u7ec4\u529f\u80fd\u547d\u540d\u6bb5\uff08middleware\uff09\u2014\u2014middleware+middleware-utils+middleware-const\uff1btypes.ts / service.ts\uff08type-only\uff09\u663e\u5f0f\u6392\u9664\uff1b\u6d4b\u8bd5\u5168\u5957\u8dd1\uff08perTest \u5173\u8054\uff09\uff1bincremental \u57fa\u7ebf\u968f observe \u56db\u73ed\u6b21\u91cd\u5efa\u3002"
 }

--- a/stryker.conf.d/dsh-mcp-manager-routes.json
+++ b/stryker.conf.d/dsh-mcp-manager-routes.json
@@ -1,10 +1,8 @@
 {
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
-    "packages/dsh-mcp-manager/src/manager.ts",
-    "packages/dsh-mcp-manager/src/index.ts",
-    "packages/dsh-mcp-manager/src/normalize.ts",
-    "packages/dsh-mcp-manager/src/import.ts",
+    "packages/dsh-mcp-manager/src/middleware-register.ts",
+    "packages/dsh-mcp-manager/src/routes.ts",
     "!packages/dsh-mcp-manager/src/client/**",
     "!packages/dsh-mcp-manager/src/types.ts",
     "!packages/dsh-mcp-manager/src/service.ts"
@@ -51,9 +49,9 @@
     ]
   },
   "jsonReporter": {
-    "fileName": "coverage/mutation/dsh-mcp-manager-1.json"
+    "fileName": "coverage/mutation/dsh-mcp-manager-routes.json"
   },
   "incremental": true,
-  "incrementalFile": "coverage/mutation/incremental-mcp-manager-1.json",
-  "_comment": "#342 v4：src 级文件组分段（1）——manager+index+normalize+import；types.ts / service.ts（type-only）显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "incrementalFile": "coverage/mutation/incremental-mcp-manager-routes.json",
+  "_comment": "#342 \u4e8c\u671f\uff1asrc \u7ea7\u6587\u4ef6\u7ec4\u529f\u80fd\u547d\u540d\u6bb5\uff08routes\uff09\u2014\u2014middleware-register+routes\uff1btypes.ts / service.ts\uff08type-only\uff09\u663e\u5f0f\u6392\u9664\uff1b\u6d4b\u8bd5\u5168\u5957\u8dd1\uff08perTest \u5173\u8054\uff09\uff1bincremental \u57fa\u7ebf\u968f observe \u56db\u73ed\u6b21\u91cd\u5efa\u3002"
 }

--- a/stryker.conf.d/dsh-mcp-manager-runtime.json
+++ b/stryker.conf.d/dsh-mcp-manager-runtime.json
@@ -1,9 +1,13 @@
 {
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
-    "packages/dsh-mcp-manager/src/middleware.ts",
-    "packages/dsh-mcp-manager/src/middleware-utils.ts",
-    "packages/dsh-mcp-manager/src/middleware-const.ts",
+    "packages/dsh-mcp-manager/src/catalog.ts",
+    "packages/dsh-mcp-manager/src/apply.ts",
+    "packages/dsh-mcp-manager/src/transport.ts",
+    "packages/dsh-mcp-manager/src/placement-math.ts",
+    "packages/dsh-mcp-manager/src/config-schema.ts",
+    "packages/dsh-mcp-manager/src/protocol.ts",
+    "packages/dsh-mcp-manager/src/middleware-types.ts",
     "!packages/dsh-mcp-manager/src/client/**",
     "!packages/dsh-mcp-manager/src/types.ts",
     "!packages/dsh-mcp-manager/src/service.ts"
@@ -50,9 +54,9 @@
     ]
   },
   "jsonReporter": {
-    "fileName": "coverage/mutation/dsh-mcp-manager-3.json"
+    "fileName": "coverage/mutation/dsh-mcp-manager-runtime.json"
   },
   "incremental": true,
-  "incrementalFile": "coverage/mutation/incremental-mcp-manager-3.json",
-  "_comment": "#342 v4：src 级文件组分段（3）——middleware+middleware-utils+middleware-const；types.ts / service.ts（type-only）显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "incrementalFile": "coverage/mutation/incremental-mcp-manager-runtime.json",
+  "_comment": "#342 \u4e8c\u671f\uff1asrc \u7ea7\u6587\u4ef6\u7ec4\u529f\u80fd\u547d\u540d\u6bb5\uff08runtime\uff09\u2014\u2014catalog+apply+transport+placement-math+config-schema+protocol+middleware-types\uff1btypes.ts / service.ts\uff08type-only\uff09\u663e\u5f0f\u6392\u9664\uff1b\u6d4b\u8bd5\u5168\u5957\u8dd1\uff08perTest \u5173\u8054\uff09\uff1bincremental \u57fa\u7ebf\u968f observe \u56db\u73ed\u6b21\u91cd\u5efa\u3002"
 }

--- a/stryker.conf.d/dsh-mcp-manager-supervisor.json
+++ b/stryker.conf.d/dsh-mcp-manager-supervisor.json
@@ -51,9 +51,9 @@
     ]
   },
   "jsonReporter": {
-    "fileName": "coverage/mutation/dsh-mcp-manager-2.json"
+    "fileName": "coverage/mutation/dsh-mcp-manager-supervisor.json"
   },
   "incremental": true,
-  "incrementalFile": "coverage/mutation/incremental-mcp-manager-2.json",
-  "_comment": "#342 v4：src 级文件组分段（2）——supervisor+middleware-state+store+scope；types.ts / service.ts（type-only）显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "incrementalFile": "coverage/mutation/incremental-mcp-manager-supervisor.json",
+  "_comment": "#342 \u4e8c\u671f\uff1asrc \u7ea7\u6587\u4ef6\u7ec4\u529f\u80fd\u547d\u540d\u6bb5\uff08supervisor\uff09\u2014\u2014supervisor+middleware-state+store+scope\uff1btypes.ts / service.ts\uff08type-only\uff09\u663e\u5f0f\u6392\u9664\uff1b\u6d4b\u8bd5\u5168\u5957\u8dd1\uff08perTest \u5173\u8054\uff09\uff1bincremental \u57fa\u7ebf\u968f observe \u56db\u73ed\u6b21\u91cd\u5efa\u3002"
 }


### PR DESCRIPTION
## 背景

#342 二期（契约 PR #367 已合并）：弃用数字段号，按每段覆盖功能命名 + 继续拆段消除超预算。

本 PR 为 mcp-manager 包改名：`dsh-mcp-manager-{1..5}.json` → 功能段名，5 段拆 6 段。

## 改动

| 新段 | 覆盖文件 | 全量 wall（本机复测） | 说明 |
|---|---|---|---|
| `dsh-mcp-manager-manager.json` | manager | 134s | manager.ts 单文件（742 行）物理极限，维持现状 + 注记 |
| `dsh-mcp-manager-entry.json` | index+normalize+import | 28s ✓ | 入口/归一化/导入域 |
| `dsh-mcp-manager-supervisor.json` | supervisor+middleware-state+store+scope | 82s ✓ | 监督/状态/存储/作用域 |
| `dsh-mcp-manager-middleware.json` | middleware+middleware-utils+middleware-const | 101s ✓ | 中间件族 |
| `dsh-mcp-manager-routes.json` | middleware-register+routes | 33s ✓ | 注册/路由域 |
| `dsh-mcp-manager-runtime.json` | catalog+apply+transport+placement-math+config-schema+protocol+middleware-types | 87s ✓ | 目录/运行时域 |

- 拆前 mcp-1（manager+index+normalize+import）148s 超预算 → 拆 manager/entry 两段后消除；其余段改名不变
- 段内 jsonReporter.fileName / incrementalFile 同步功能段名（工作流-assert 契约校验）
- gauntlet 注记 config/scope 同步
- 旧段基线无需删：main 尚无 mcp 新段基线，observe 下一班次按新 incrementalFile 重建

## 验证

- 本地五连门禁全绿；workflow-assert 32/32 全绿
- 本机同口径全量复测：manager 134s / entry 28s / supervisor 82s / middleware 101s / routes 33s / runtime 87s

Refs #342