### PR TITLE
test(provider-usage): mutation 分段功能命名——5 段拆 6 段（#342 二期）

### DIFF
--- a/scripts/data/gauntlet.config.json
+++ b/scripts/data/gauntlet.config.json
@@ -91,10 +91,10 @@
         "baselineDate": "2026-08-25",
         "baselineDuration": "4m30s",
         "baselineScope": "packages/dsh-provider-usage/lib/index.js:1372-2769+2805-3696（self-written 两段：contracts/registry/adapters-opencode-go/core-guards/sanitize/pipeline-v2/history/provider-config/hotreload 与 path-resolve/client-logic/index；排除 esbuild 垫片、cosmokit/schemastery/async-mutex/untildify 内联 vendor、shared 契约层内联副本与纯 import 提升段）",
-        "config": "stryker.conf.d/dsh-provider-usage-{1..5}.json（#342 v4：重排为 p-1..p-5，删除 adapters 空段，charts.ts 纳入修复变异盲区）",
+        "config": "stryker.conf.d/dsh-provider-usage-{entry,apply,contracts,sanitize,registry,pipeline}.json（#342 二期：功能命名——入口 entry / 主流程 apply / 契约 contracts / 净化 sanitize / 注册表 registry / 管线 pipeline；apply.ts 单文件 120s 贴线维持）",
         "hardeningNote": "#150 变异加固轮一阶段（PR #169）：covered 由 31.80% 提升至 52.87%；二阶段（PR #183）：提升至 67.28% ≥60 达标，全局 strict 随之开启",
         "threshold": 60,
-        "scope": "src 级五段（#342 v4）：p-1 index+user-adapters+ui-config+config / p-2 apply 单列 / p-3 contracts+core/guards / p-4 sanitize+registry / p-5 history+v2+hotreload+placement-math+path-resolve+client-logic+provider-config+charts；基线为 src 口径，由四班次 observe 重建"
+        "scope": "src 级六段（#342 二期）：entry index+user-adapters+ui-config+config / apply apply.ts / contracts contracts+core/guards / sanitize sanitize.ts / registry registry.ts / pipeline history+v2+hotreload+placement-math+path-resolve+client-logic+provider-config+charts；基线为 src 口径，由四班次 observe 重建"
       },
       "dsh-lan-proxy": {
         "baselineScore": 52.43,

--- a/stryker.conf.d/dsh-provider-usage-apply.json
+++ b/stryker.conf.d/dsh-provider-usage-apply.json
@@ -44,9 +44,9 @@
     ]
   },
   "jsonReporter": {
-    "fileName": "coverage/mutation/dsh-provider-usage-2.json"
+    "fileName": "coverage/mutation/dsh-provider-usage-apply.json"
   },
   "incremental": true,
-  "incrementalFile": "coverage/mutation/incremental-provider-usage-2.json",
-  "_comment": "#342 v4：src 级文件组分段（2）——apply 单列（#316 拆分后最重文件独立成段）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "incrementalFile": "coverage/mutation/incremental-provider-usage-apply.json",
+  "_comment": "#342 v4\uff1asrc \u7ea7\u6587\u4ef6\u7ec4\u5206\u6bb5\uff082\uff09\u2014\u2014apply \u5355\u5217\uff08#316 \u62c6\u5206\u540e\u6700\u91cd\u6587\u4ef6\u72ec\u7acb\u6210\u6bb5\uff09\uff1b\u6d4b\u8bd5\u5168\u5957\u8dd1\uff08perTest \u5173\u8054\uff09\uff1bincremental \u57fa\u7ebf\u968f observe \u56db\u73ed\u6b21\u91cd\u5efa\u3002"
 }

--- a/stryker.conf.d/dsh-provider-usage-contracts.json
+++ b/stryker.conf.d/dsh-provider-usage-contracts.json
@@ -45,9 +45,9 @@
     ]
   },
   "jsonReporter": {
-    "fileName": "coverage/mutation/dsh-provider-usage-3.json"
+    "fileName": "coverage/mutation/dsh-provider-usage-contracts.json"
   },
   "incremental": true,
-  "incrementalFile": "coverage/mutation/incremental-provider-usage-3.json",
-  "_comment": "#342 v4：src 级文件组分段（3）——contracts+core/guards（契约面）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "incrementalFile": "coverage/mutation/incremental-provider-usage-contracts.json",
+  "_comment": "#342 v4\uff1asrc \u7ea7\u6587\u4ef6\u7ec4\u5206\u6bb5\uff083\uff09\u2014\u2014contracts+core/guards\uff08\u5951\u7ea6\u9762\uff09\uff1b\u6d4b\u8bd5\u5168\u5957\u8dd1\uff08perTest \u5173\u8054\uff09\uff1bincremental \u57fa\u7ebf\u968f observe \u56db\u73ed\u6b21\u91cd\u5efa\u3002"
 }

--- a/stryker.conf.d/dsh-provider-usage-entry.json
+++ b/stryker.conf.d/dsh-provider-usage-entry.json
@@ -47,9 +47,9 @@
     ]
   },
   "jsonReporter": {
-    "fileName": "coverage/mutation/dsh-provider-usage-1.json"
+    "fileName": "coverage/mutation/dsh-provider-usage-entry.json"
   },
   "incremental": true,
-  "incrementalFile": "coverage/mutation/incremental-provider-usage-1.json",
-  "_comment": "#342 v4：src 级文件组分段（1）——index+user-adapters+ui-config+config（配置/入口面）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "incrementalFile": "coverage/mutation/incremental-provider-usage-entry.json",
+  "_comment": "#342 v4\uff1asrc \u7ea7\u6587\u4ef6\u7ec4\u5206\u6bb5\uff081\uff09\u2014\u2014index+user-adapters+ui-config+config\uff08\u914d\u7f6e/\u5165\u53e3\u9762\uff09\uff1b\u6d4b\u8bd5\u5168\u5957\u8dd1\uff08perTest \u5173\u8054\uff09\uff1bincremental \u57fa\u7ebf\u968f observe \u56db\u73ed\u6b21\u91cd\u5efa\u3002"
 }

--- a/stryker.conf.d/dsh-provider-usage-pipeline.json
+++ b/stryker.conf.d/dsh-provider-usage-pipeline.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "mutate": [
+    "packages/dsh-provider-usage/src/core/history.ts",
+    "packages/dsh-provider-usage/src/pipeline/v2.ts",
+    "packages/dsh-provider-usage/src/hotreload.ts",
+    "packages/dsh-provider-usage/src/placement-math.ts",
+    "packages/dsh-provider-usage/src/path-resolve.ts",
+    "packages/dsh-provider-usage/src/client-logic.ts",
+    "packages/dsh-provider-usage/src/provider-config.ts",
+    "packages/dsh-provider-usage/src/charts.ts",
+    "!packages/dsh-provider-usage/src/client/**",
+    "!packages/dsh-provider-usage/src/types.ts"
+  ],
+  "testRunner": "tap",
+  "mutator": {
+    "excludedMutations": [
+      "StringLiteral",
+      "ArrayLiteral",
+      "ObjectLiteral",
+      "TemplateLiteral"
+    ]
+  },
+  "plugins": [
+    "@stryker-mutator/tap-runner"
+  ],
+  "concurrency": 16,
+  "timeoutMS": 60000,
+  "dryRunTimeoutMinutes": 5,
+  "reporters": [
+    "progress",
+    "clear-text",
+    "json"
+  ],
+  "coverageAnalysis": "perTest",
+  "tempDirName": ".stryker-tmp",
+  "cleanTempDir": true,
+  "tap": {
+    "nodeArgs": [
+      "-r",
+      "./scripts/test/mutation-tap-bridge.cjs"
+    ],
+    "testFiles": [
+      "packages/dsh-provider-usage/test/unit-apply.src.test.ts",
+      "packages/dsh-provider-usage/test/unit-config.src.test.ts",
+      "packages/dsh-provider-usage/test/unit-contract.src.test.ts",
+      "packages/dsh-provider-usage/test/unit-deepseek-official.src.test.ts",
+      "packages/dsh-provider-usage/test/unit-history.src.test.ts",
+      "packages/dsh-provider-usage/test/unit-signal-lock.src.test.ts",
+      "packages/dsh-provider-usage/test/unit-v1.src.test.ts"
+    ]
+  },
+  "jsonReporter": {
+    "fileName": "coverage/mutation/dsh-provider-usage-pipeline.json"
+  },
+  "incremental": true,
+  "incrementalFile": "coverage/mutation/incremental-provider-usage-pipeline.json",
+  "_comment": "#342 v4\uff1asrc \u7ea7\u6587\u4ef6\u7ec4\u5206\u6bb5\uff085\uff09\u2014\u2014history/v2/hotreload/placement-math/path-resolve/client-logic/provider-config/charts\uff08\u5386\u53f2/\u7ba1\u7ebf/\u70ed\u66f4/\u56fe\u8868\u9762\uff1bcharts \u7eb3\u5165\u4fee\u590d\u53d8\u5f02\u76f2\u533a\uff09\uff1b\u6d4b\u8bd5\u5168\u5957\u8dd1\uff08perTest \u5173\u8054\uff09\uff1bincremental \u57fa\u7ebf\u968f observe \u56db\u73ed\u6b21\u91cd\u5efa\u3002"
+}

--- a/stryker.conf.d/dsh-provider-usage-registry.json
+++ b/stryker.conf.d/dsh-provider-usage-registry.json
@@ -1,14 +1,7 @@
 {
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
-    "packages/dsh-provider-usage/src/core/history.ts",
-    "packages/dsh-provider-usage/src/pipeline/v2.ts",
-    "packages/dsh-provider-usage/src/hotreload.ts",
-    "packages/dsh-provider-usage/src/placement-math.ts",
-    "packages/dsh-provider-usage/src/path-resolve.ts",
-    "packages/dsh-provider-usage/src/client-logic.ts",
-    "packages/dsh-provider-usage/src/provider-config.ts",
-    "packages/dsh-provider-usage/src/charts.ts",
+    "packages/dsh-provider-usage/src/registry.ts",
     "!packages/dsh-provider-usage/src/client/**",
     "!packages/dsh-provider-usage/src/types.ts"
   ],
@@ -51,9 +44,9 @@
     ]
   },
   "jsonReporter": {
-    "fileName": "coverage/mutation/dsh-provider-usage-5.json"
+    "fileName": "coverage/mutation/dsh-provider-usage-registry.json"
   },
   "incremental": true,
-  "incrementalFile": "coverage/mutation/incremental-provider-usage-5.json",
-  "_comment": "#342 v4：src 级文件组分段（5）——history/v2/hotreload/placement-math/path-resolve/client-logic/provider-config/charts（历史/管线/热更/图表面；charts 纳入修复变异盲区）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "incrementalFile": "coverage/mutation/incremental-provider-usage-registry.json",
+  "_comment": "#342 \u4e8c\u671f\uff1a\u529f\u80fd\u547d\u540d\u6bb5\uff08registry\uff09\u2014\u2014registry\uff08\u6ce8\u518c\u8868\u57df\uff0c25s\uff09\uff1b\u6d4b\u8bd5\u5168\u5957\u8dd1\uff08perTest \u5173\u8054\uff09\uff1bincremental \u57fa\u7ebf\u968f observe \u56db\u73ed\u6b21\u91cd\u5efa\u3002"
 }

--- a/stryker.conf.d/dsh-provider-usage-sanitize.json
+++ b/stryker.conf.d/dsh-provider-usage-sanitize.json
@@ -2,7 +2,6 @@
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
     "packages/dsh-provider-usage/src/sanitize.ts",
-    "packages/dsh-provider-usage/src/registry.ts",
     "!packages/dsh-provider-usage/src/client/**",
     "!packages/dsh-provider-usage/src/types.ts"
   ],
@@ -45,9 +44,9 @@
     ]
   },
   "jsonReporter": {
-    "fileName": "coverage/mutation/dsh-provider-usage-4.json"
+    "fileName": "coverage/mutation/dsh-provider-usage-sanitize.json"
   },
   "incremental": true,
-  "incrementalFile": "coverage/mutation/incremental-provider-usage-4.json",
-  "_comment": "#342 v4：src 级文件组分段（4）——sanitize+registry（净化与注册面）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "incrementalFile": "coverage/mutation/incremental-provider-usage-sanitize.json",
+  "_comment": "#342 \u4e8c\u671f\uff1a\u529f\u80fd\u547d\u540d\u6bb5\uff08sanitize\uff09\u2014\u2014sanitize\uff08\u6570\u636e\u51c0\u5316\u57df\uff0c115s\uff09\uff1b\u6d4b\u8bd5\u5168\u5957\u8dd1\uff08perTest \u5173\u8054\uff09\uff1bincremental \u57fa\u7ebf\u968f observe \u56db\u73ed\u6b21\u91cd\u5efa\u3002"
 }


### PR DESCRIPTION
## 背景

#342 二期（契约 PR #367 已合并）：弃用数字段号，按每段覆盖功能命名 + 继续拆段消除超预算。

本 PR 为 provider-usage 包改名 + 拆段：`dsh-provider-usage-{1..5}.json` → 功能段名，5 段拆 6 段。

## 改动

| 新段 | 覆盖文件 | 全量 wall（本机复测） | 说明 |
|---|---|---|---|
| `dsh-provider-usage-entry.json` | index+user-adapters+ui-config+config | 53s ✓ | 入口/适配器装载/UI 配置/配置域 |
| `dsh-provider-usage-apply.json` | apply | 120s ✓ | apply.ts 单文件（856 行）物理极限，贴线维持 |
| `dsh-provider-usage-contracts.json` | contracts+core/guards | 59s ✓ | 契约/守卫域 |
| `dsh-provider-usage-sanitize.json` | sanitize | 115s ✓ | 净化域（自 dsh-provider-usage-4 拆出） |
| `dsh-provider-usage-registry.json` | registry | 25s ✓ | 注册表域（自 dsh-provider-usage-4 拆出） |
| `dsh-provider-usage-pipeline.json` | history+v2+hotreload+placement-math+path-resolve+client-logic+provider-config+charts | 60s ✓ | 管线/历史/重载/路径/客户端逻辑/图表域 |

- 拆前 p-4（sanitize+registry 双文件）超预算 → 拆 sanitize/registry 两段后消除；其余段改名不变
- 段内 jsonReporter.fileName / incrementalFile 同步功能段名（workflow-assert 契约校验）
- gauntlet 注记 config/scope 同步
- 旧段基线无需删：main 尚无 provider 新段基线，observe 下一班次按新 incrementalFile 重建

## 验证

- 本地五连门禁全绿（build/test/contract/pack:check/typecheck）；workflow-assert 32/32 全绿
- rebase origin/main（含 #368/#369）后 workflow-assert 复测 32/32 仍全绿
- 本机同口径全量复测：entry 53s / apply 120s / contracts 59s / sanitize 115s / registry 25s / pipeline 60s

Refs #342
