### PR TITLE
chore(release): v0.1.14——0.1.x 收官发版准备（版本对齐 + dsh 类型层锁死 + README/release-notes 更新）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -38,7 +38,19 @@ install them all at once as a single bundle, or pick individual plugins as neede
 | `@wingsky-1/dsh-lan-proxy` | Access the dsh web UI over LAN (HTTP/HTTPS/WS forwarding + TLS + HTTP response compression, Brotli/gzip) | [README](packages/dsh-lan-proxy/README.md) | ✅ Published |
 | `@wingsky-1/dsh-mcp-manager` | MCP server manager (stdio / HTTP; per-working-directory project/global config tiers, project-level MCP collapsed via middleware — no tool flood in the model surface) | [README](packages/dsh-mcp-manager/README.md) | ✅ Published |
 | `@wingsky-1/dsh-idle-archive` | Prompt to archive idle conversations | [README](packages/dsh-idle-archive/README.md) | ✅ Published |
-| `@wingsky-1/dsh-web-file-preview` | Click conversation file links to preview in the web UI (image / text / Markdown / code / Diff) | [README](packages/dsh-web-file-preview/README.md) | ✅ Published |
+| `@wingsky-1/dsh-web-file-preview` | Click conversation file links to preview in the web UI (image / text / Markdown / code / Diff / Mermaid) | [README](packages/dsh-web-file-preview/README.md) | ✅ Published |
+| `@wingsky-1/dsh-verify-isolated` | Isolated-environment browser verification skill for DSH plugin development (temp DSH_HOME + independent profile, double isolation) | [README](packages/dsh-verify-isolated/README.md) | ✅ Published |
+| `@wingsky-1/dsh-codegraph` | codegraph local code-graph MCP + worktree development discipline (registered at runtime via mcp-manager) | [README](packages/dsh-codegraph/README.md) | ✅ Published (standalone, not in the bundle) |
+| `@wingsky-1/dsh-subagent-model-inherit` | Child agents automatically inherit parent-session model and reasoning effort | [README](packages/dsh-subagent-model-inherit/README.md) | Observation (standalone, not in the bundle) |
+
+> **Standalone note**: `@wingsky-1/dsh-codegraph` is published **standalone** and is **not
+> included in `dsh-plugins-all`**; install it separately (it registers the codegraph MCP at
+> runtime via mcp-manager, so install `dsh-mcp-manager` or the bundle first).
+>
+> **Observation note**: `@wingsky-1/dsh-subagent-model-inherit` is experimental — it changes
+> child-agent model routing (inherits the parent session). It is published **standalone** and
+> **not included in `dsh-plugins-all`**; install it separately until enough feedback decides
+> promotion into the bundle, continued standalone evolution, or retirement.
 
 > **No longer maintained**: `@wingsky-1/dsh-skill-explorer` (skill-center / skill management) is
 > **discontinued** (deprecated on npm; the plugin package and the bundle package have been removed).
@@ -158,22 +170,6 @@ Each individual package and the bundle share the same patch `id` (`ui-*`). **Ins
 results in duplicate same-name entries, and `dsh web` fails to start with a *duplicate* error
 (detectable, not corrupting). To adjust: uninstall the bundle, or uninstall the corresponding
 individual package, then restart.
-
-### Upgrading from 0.1.x (patch id migration)
-
-Since 0.1.5, individual package patch `id`s changed from the old short names (e.g. `notifier`,
-`lan-proxy`, `dsh-gzip`) to `ui-<name>` (e.g. `ui-dsh-notifier`). If you previously installed
-individual packages, your profile may still contain old `id` lines — detect and reinstall the
-affected packages to pull the new patch:
-
-```sh
-# Detect whether old ids are still referenced in the profile (home-level and profile-level)
-grep -rnE '^\s*id:\s*(dsh-gzip|dsh-idle-archive|lan-proxy|mcp-manager|notifier|opencode-usage|ui-dsh-opencode-usage)\s*$' \
-  "$DSH_HOME/cordis.patch.yml" ~/.dsh/profiles/*/cordis.patch.yml 2>/dev/null
-# If output exists → reinstall to overwrite and pull the new config (default = latest)
-dsh plugin --profile web remove @wingsky-1/<package>
-dsh plugin --profile web add @wingsky-1/<package>@latest
-```
 
 ## Related projects
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,15 @@ DSH（DeepSeek Harness）Web GUI 插件集，npm 分发：一键装全家桶，�
 | `@wingsky-1/dsh-lan-proxy` | 局域网访问 dsh web UI（HTTP/HTTPS/WS 转发 + TLS + HTTP 响应压缩，Brotli/gzip 自适应） | [README](packages/dsh-lan-proxy/README.md) | ✅ 已发布 |
 | `@wingsky-1/dsh-mcp-manager` | MCP 服务器管理器（stdio/HTTP；分工作目录维护项目级/全局两级配置，项目级 MCP 经中间层收敛、免于工具洪水） | [README](packages/dsh-mcp-manager/README.md) | ✅ 已发布 |
 | `@wingsky-1/dsh-idle-archive` | 会话闲置提醒归档 | [README](packages/dsh-idle-archive/README.md) | ✅ 已发布 |
-| `@wingsky-1/dsh-web-file-preview` | 点击对话文件链接在 web 端预览（图片/文本/Markdown/代码/Diff） | [README](packages/dsh-web-file-preview/README.md) | ✅ 已发布 |
+| `@wingsky-1/dsh-web-file-preview` | 点击对话文件链接在 web 端预览（图片/文本/Markdown/代码/Diff/Mermaid） | [README](packages/dsh-web-file-preview/README.md) | ✅ 已发布 |
+| `@wingsky-1/dsh-verify-isolated` | DSH 插件开发的隔离环境浏览器验证 skill（临时 DSH_HOME + 独立 profile 双重隔离） | [README](packages/dsh-verify-isolated/README.md) | ✅ 已发布 |
+| `@wingsky-1/dsh-codegraph` | codegraph 本地代码图谱 MCP + worktree 开发纪律（经 mcp-manager 运行时注册） | [README](packages/dsh-codegraph/README.md) | ✅ 已发布（独立发包，暂不进聚合包） |
 | `@wingsky-1/dsh-subagent-model-inherit` | 子 Agent 自动继承父会话模型与思考等级 | [README](packages/dsh-subagent-model-inherit/README.md) | 观察期（独立发包，暂不进聚合包） |
 
+> **独立发包说明**：`@wingsky-1/dsh-codegraph` 为**独立发包**、**未包含在
+> `dsh-plugins-all` 聚合包中**，需单独安装（它经 mcp-manager 运行时注册 codegraph MCP，
+> 请先装 `dsh-mcp-manager` 或聚合包再配合使用）。
+>
 > **观察期说明**：`@wingsky-1/dsh-subagent-model-inherit` 为实验性插件——它改变子 Agent
 > 的模型路由行为（继承父会话），具有全局影响。目前**独立发包**、**未包含在
 > `dsh-plugins-all` 聚合包中**，需单独安装；待收集足够使用反馈后再决定转正进聚合包、
@@ -150,21 +156,6 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-plugins-all
 同时装 `dsh-plugins-all` 与任一 `@wingsky-1/dsh-lan-proxy` 等独立包会导致同名 entry
 重复，`dsh web` 启动时报 duplicate 错误（可发现，不代表损坏）。需要调整时：
 卸载聚合包，或卸载对应独立包，重启即可。
-
-### 从 0.1.x 升级（patch id 迁移）
-
-0.1.5 起独立包 patch `id` 由旧短名（如 `notifier`、`lan-proxy`、`dsh-gzip`）统一改为
-`ui-<name>`（如 `ui-dsh-notifier`）。若你此前单独安装过独立包，profile 中可能残留旧
-`id` 行——建议确认后通过以下命令检测，并重装对应包拉取新 patch：
-
-```sh
-# 检测 profile 中是否仍引用旧 id（home 级与 profile 级）
-grep -rnE '^\s*id:\s*(dsh-gzip|dsh-idle-archive|lan-proxy|mcp-manager|notifier|opencode-usage|ui-dsh-opencode-usage)\s*$' \
-  "$DSH_HOME/cordis.patch.yml" ~/.dsh/profiles/*/cordis.patch.yml 2>/dev/null
-# 有输出 → 重装覆盖拉取新配置（默认装 latest，即当前最新版）
-dsh plugin --profile web remove @wingsky-1/<包>
-dsh plugin --profile web add @wingsky-1/<包>@latest
-```
 
 ## 相关项目
 

--- a/docs/release-notes/v0.1.14.md
+++ b/docs/release-notes/v0.1.14.md
@@ -1,0 +1,145 @@
+# dsh-plugin-hub v0.1.14 Release Notes
+
+> **[中文](#user-content-zh)** · **[English](#user-content-en)**
+
+> **⚠️ 重要声明：0.1.x 功能演进止步 + 0.2.0 预告**
+> 由于 **dsh 存在破坏性更新（breaking change）**，**v0.1.14 是 0.1.x 系列的最后一个功能版本**。后续 0.1.x 版本将只做问题修复，不再继续演进功能。如需锁定到某个 0.1.x 修复版，请参考 README 的版本安装说明：
+> - 指定版本号（@version）：<https://github.com/wingsky-1/dsh-plugin-hub/blob/main/README.md#指定版本号version>
+> 近期会发布适配 **dsh-v0.1.2-alpha.1** 的 **0.2.0** 版本，进展顺利的话将于**今日**发布。发布节奏跟随官方 npm 发布进展——在 `dsh-v0.1.2-alpha.1` 尚未发布到 npm 之前，0.2.0 仅通过 GitHub 提供下载。**0.2.0 预计包含：** 1. 适配 `dsh-v0.1.2-alpha.1`；2. 插件相关文本支持多语言能力。
+
+> **⚠️ Important notice: 0.1.x feature-freeze + 0.2.0 preview**
+> Because **dsh introduces breaking changes**, **v0.1.14 is the last feature release of the 0.1.x line**. Subsequent 0.1.x releases will ship bug fixes only, with no further feature evolution. To pin a specific 0.1.x fix release, see the README version-install sections:
+> - Pin a version (@version): <https://github.com/wingsky-1/dsh-plugin-hub/blob/main/README.en.md#pin-a-version-version>
+> We expect to ship **0.2.0** targeting **dsh-v0.1.2-alpha.1** soon, and if all goes well it lands **today**. The cadence follows the official npm release — until `dsh-v0.1.2-alpha.1` is published to npm, 0.2.0 will be downloadable from GitHub only. **0.2.0 is expected to include:** 1. Adaptation to `dsh-v0.1.2-alpha.1`; 2. Multi-language support for plugin-facing text.
+
+<a id="zh"></a><a id="user-content-zh"></a>
+## 中文
+
+### 概述
+
+v0.1.14 是 **0.1.x 功能线的收官之作**。本版主线为「能力补全 + 连接稳定性」，在 dsh 即将发生的破坏性更新前夕，把 0.1.x 的插件能力面补齐并显著加固长连接可靠性。
+
+关键新增包括：全新 **[dsh-codegraph]** 插件（codegraph MCP + worktree 开发纪律）、**[dsh-mcp-manager]** 核心化（运行时注册 MCP 服务器）与中间层能力补全、**[dsh-notifier]** 通知设置整合进官方配置页（移除侧边栏浮层）、**[dsh-web-file-preview]** 的多项预览增强（Mermaid 渲染/全屏查看器/HTML 虚拟伺服/全屏按钮）、**[dsh-provider-usage]** 图表共享库注入面与内置 zai 适配器，以及 **[ui]** 移动端/平板端适配。连接稳定性方面，notifier、provider-usage、lan-proxy、mcp-manager 的 SSE/WS 半开连接与断连传播得到系统性治理。
+
+同时，本版各插件统一将 dsh 官方类型层依赖锁定到当前支持的 **`0.1.1-rc.2`**（cordis `4.0.1`）——若你的 dsh 版本与此不匹配，安装/更新插件时 npm/pnpm 会给出明确提示，避免在 dsh 破坏性更新后出现静默的兼容性问题。
+
+建议所有用户升级到 v0.1.14，以获得最完整的 0.1.x 功能与最稳的连接体验。
+
+### 新功能
+
+- **[dsh-codegraph]** 新增插件——codegraph MCP + worktree 开发纪律（#333，#329 阶段2+3）
+- **[dsh-mcp-manager]** 核心化——ctx.mcpManager service 运行时注册 MCP 服务器（#332，#329 阶段1）
+- **[dsh-mcp-manager]** 中间层新增 ws_mcp_list / ws_mcp_detail，修复 all 模式全局可见性（#327，Fixes #312）
+- **[dsh-notifier]** 通知设置整合进官方插件配置页，移除侧边栏浮层（#340，Fixes #76）
+- **[dsh-web-file-preview]** Markdown 预览渲染 Mermaid 图（整包懒加载独立 chunk）（#283，#104）
+- **[dsh-web-file-preview]** Mermaid 全屏查看器（点击放大/缩放/平移/捏合）（#309，#293）
+- **[dsh-web-file-preview]** HTML 预览改走 serve 虚拟伺服（token 前缀路由 + iframe sandbox）（#328，Fixes #73）
+- **[dsh-web-file-preview]** 预览弹窗全屏按钮（含视口放大降级）+ 文件大小上限提至 20M（#349，#344）
+- **[dsh-provider-usage]** 图表共享库注入面 + 内置适配器 mjs 化 + 内置 zai 适配器（#307）
+- **[dsh-verify-isolated]** 隔离验证 skill 插件包（registerProvider 随装随用）+ CI 包清单单一事实源重构（#306）
+- **[ui]** 移动端/平板端适配——统一锚点/断点/z-index 可配置（#264，Refs #128）
+
+### 修复
+
+- **[dsh-codegraph]** 启动崩溃三连修——隔离实例实测（session/tools/output 契约）（#351）
+- **[dsh-codegraph]** 改回声明依赖 mcp-manager——inject 强依赖 + 类型从包引（#347，#329 评审修正）
+- **[dsh-mcp-manager]** GET /servers 恢复纯读语义，断多页面 cwd 自激循环（#326，Fixes #324）
+- **[dsh-mcp-manager]** SSE 半开连接防护——服务端 30s 心跳 + 客户端 watchdog/回前台重建（#278）
+- **[dsh-notifier]** SSE 连接表有界化 + 生命周期治理（#334，Fixes #330）
+- **[dsh-notifier]** done 通知丢失去根——安全读取 + 三态消费 + 事件契约断言（#300，#290）
+- **[dsh-notifier]** 完成判定双源订阅与跳过路径 warn 兜底，根治超长会话 done 静默（#284）
+- **[dsh-notifier]** 阶段二——done 证据面收敛 session/event 单源 push（#337，#290）
+- **[dsh-notifier]** PR#334 评审遗留 P2 清账——防御/断言/文档（#343，Fixes #335）
+- **[dsh-web-file-preview]** Mermaid 解析失败残留错误横幅——suppressErrorRendering 下发（#299，Fixes #292）
+- **[dsh-provider-usage]** 余额卡片副标题精简——来源标识折叠进 title 悬停提示（#346，Fixes #345）
+- **[dsh-provider-usage / dsh-lan-proxy]** 连接挂起修复——断连传播+锁内 signal+SSE 降级轮询+deflate 策略+断连计数（#310）
+- **[dsh-provider-usage]** 客户端 fetch 补 10s AbortSignal.timeout 兜底，半开连接不悬挂（#287，Refs #268）
+- **[dsh-provider-usage]** /stats 取数 signal 接线 + per-provider 互斥与缓存精准清（#265）
+- **[dsh-provider-usage]** harden adapter state persistence（#302）
+- **[dsh-provider-usage]** smoke 固定 sleep 竞态 flake——await async handler 读取响应（#314，Fixes #313）
+- **[dsh-lan-proxy]** WS 压缩桥接半开探活——两端独立 ping/pong 保活（#288）
+- **[dsh-lan-proxy]** 配置通道统一走 settings.register 并平稳割接自建 config.json（#267）
+- **[ui]** bottom-* 锚点移动端遮挡输入区回归修复 + z-index 与配置一致（#339，Fixes #128）
+
+### 维护与工程化
+
+- **[ci/mutation]** src 级变异矩阵 + 四班次调度（#294，#276 方案 A 全量落地）
+- **[gate]** mutate 区间机器派生——声明式分组替代人工行号维护（#280，#276 方案 B）
+- **[gate]** observe-check 适配段式报告聚合（#262，#220 B 收尾）
+- **[ci]** suite-plan 补段配置变化检测与变异工具链全量触发（#277，#220）
+- **[ci]** path-filter 补 stryker 段配置映射（#322，#336）
+- **[ci]** observe 按需基线（push 只跑变动包）+ docs 移出 ci.yml 全切片过滤面（#275，#220）
+- **[ci]** 基线快照 PR 改用 OBSERVE_PAT（#291，#220）
+- **[ci]** 快照 PR 日期闸只匹配 manifest.json 并统一 UTC 比较（#296，#276 方案 A 修正）
+- **[perf]** mcp-manager 段再均衡——s4 收窄+新增 s5（#273）；provider-usage 两段并发 8→16（#266）；mutation-gate mutate 段拆分 matrix 并行 + timeoutMS 收紧（#257，#220）
+- **[test]** 固定 sleep 等响应收敛为 await/pollUntil（mcp-manager #341 / provider-usage #338，#315 批次 A/B）
+- **[chore]** 增量变异基线例行快照多批（#320 / #318 / #303 / #297 / #285 / #282 / #281 / #279 / #261 等）
+- **[docs]** 方法论更新（#270 / #259，#220）；oss-pipeline 落 RETRO 问题1/2 规程修订（#298）；README 提炼核心优势并校正 mcp-manager 中间层描述（#274）；语言跳转锚点改双锚补位写法 + 发版纪律更新（#258）；v0.1.11/v0.1.12 发布说明锚点回修（#260）
+- **[test/mutation]** #342 二期——变异分段契约升级：弃用数字段号、按功能命名（notifier/mcp-manager/provider-usage 三包改名，provider-usage 5 段拆 6 段）（#367/#368/#369/#370）
+- **[dsh-verify-isolated]** 改为 archify 模式——复用官方 dsh-skill-filesystem 的 bundledSkillDir 注册内置 skill（#311）
+
+<a id="en"></a><a id="user-content-en"></a>
+## English
+
+### Overview
+
+v0.1.14 is the **capstone of the 0.1.x feature line**. The theme of this release is "capability completion + connection stability" — ahead of the upcoming dsh breaking changes, it rounds out the 0.1.x plugin surface and substantially hardens long-connection reliability.
+
+Key additions include the brand-new **[dsh-codegraph]** plugin (codegraph MCP + worktree development discipline), **[dsh-mcp-manager]** core-ification (runtime MCP server registration) with middle-layer completion, **[dsh-notifier]** settings folded into the official config page (sidebar overlay removed), multiple **[dsh-web-file-preview]** preview enhancements (Mermaid rendering / fullscreen viewer / HTML virtual server / fullscreen button), the **[dsh-provider-usage]** chart shared-library injection surface with a built-in zai adapter, and **[ui]** mobile/tablet adaptation. On connection stability, SSE/WS half-open connections and disconnect propagation across notifier, provider-usage, lan-proxy and mcp-manager received systematic treatment.
+
+Also, all plugins in this release lock their official dsh type-layer dependencies to the currently supported **`0.1.1-rc.2`** (cordis `4.0.1`) — if your dsh version does not match, npm/pnpm will warn explicitly when installing/updating the plugins, preventing silent compatibility issues after dsh breaking changes.
+
+We recommend all users upgrade to v0.1.14 for the most complete 0.1.x feature set and the most stable connection experience.
+
+### Features
+
+- **[dsh-codegraph]** New plugin — codegraph MCP + worktree development discipline (#333, #329 phase 2+3)
+- **[dsh-mcp-manager]** Core-ification — ctx.mcpManager service registers MCP servers at runtime (#332, #329 phase 1)
+- **[dsh-mcp-manager]** Middle layer adds ws_mcp_list / ws_mcp_detail, fixes all-mode global visibility (#327, Fixes #312)
+- **[dsh-notifier]** Notification settings folded into the official plugin config page, removing the sidebar overlay (#340, Fixes #76)
+- **[dsh-web-file-preview]** Markdown preview renders Mermaid diagrams (whole-package lazy-load as independent chunk) (#283, #104)
+- **[dsh-web-file-preview]** Mermaid fullscreen viewer (click-to-zoom / zoom / pan / pinch) (#309, #293)
+- **[dsh-web-file-preview]** HTML preview routed through serve virtual server (token-prefix routing + iframe sandbox) (#328, Fixes #73)
+- **[dsh-web-file-preview]** Preview modal fullscreen button (with viewport-zoom fallback) + file size cap raised to 20M (#349, #344)
+- **[dsh-provider-usage]** Chart shared-library injection surface + built-in adapter mjs-ified + built-in zai adapter (#307)
+- **[dsh-verify-isolated]** Isolated-verification skill plugin package (registerProvider plug-and-play) + CI package manifest single source of truth refactor (#306)
+- **[ui]** Mobile/tablet adaptation — unified anchor/breakpoint/z-index configurability (#264, Refs #128)
+
+### Bug Fixes
+
+- **[dsh-codegraph]** Startup crash triple-fix — isolated-instance verification (session/tools/output contract) (#351)
+- **[dsh-codegraph]** Revert to declared dependency on mcp-manager — inject hard dependency + types from package (#347, #329 review fix)
+- **[dsh-mcp-manager]** GET /servers restored to pure-read semantics, breaking multi-page cwd self-trigger loop (#326, Fixes #324)
+- **[dsh-mcp-manager]** SSE half-open connection guard — server 30s heartbeat + client watchdog / foreground-rebuild (#278)
+- **[dsh-notifier]** SSE connection table bounded + lifecycle governance (#334, Fixes #330)
+- **[dsh-notifier]** done notification loss root-cause — safe read + three-state consumption + event-contract assertion (#300, #290)
+- **[dsh-notifier]** Completion determination dual-source subscription + skip-path warn fallback, root-causing ultra-long-session done silence (#284)
+- **[dsh-notifier]** Phase two — done evidence surface converged to session/event single-source push (#337, #290)
+- **[dsh-notifier]** PR#334 review leftover P2 cleanup — defense / assertion / docs (#343, Fixes #335)
+- **[dsh-web-file-preview]** Mermaid parse-failure leftover error banner — suppressErrorRendering propagation (#299, Fixes #292)
+- **[dsh-provider-usage]** Balance card subtitle trimmed — source label folded into title hover hint (#346, Fixes #345)
+- **[dsh-provider-usage / dsh-lan-proxy]** Connection hang fix — disconnect propagation + in-lock signal + SSE degraded polling + deflate strategy + disconnect counter (#310)
+- **[dsh-provider-usage]** Client fetch adds 10s AbortSignal.timeout fallback, half-open connection no longer hangs (#287, Refs #268)
+- **[dsh-provider-usage]** /stats data-fetch signal wiring + per-provider mutex and precise cache invalidation (#265)
+- **[dsh-provider-usage]** Harden adapter state persistence (#302)
+- **[dsh-provider-usage]** smoke fixed-sleep race flake — await async handler to read response (#314, Fixes #313)
+- **[dsh-lan-proxy]** WS compressed bridge half-open keepalive — independent ping/pong on both ends (#288)
+- **[dsh-lan-proxy]** Config channel unified to settings.register with smooth migration off self-built config.json (#267)
+- **[ui]** bottom-* anchor mobile input-area occlusion regression fix + z-index consistency with config (#339, Fixes #128)
+
+### Maintenance
+
+- **[ci/mutation]** src-level mutation matrix + four-shift scheduling (#294, #276 plan A full rollout)
+- **[gate]** mutate range machine-derived — declarative grouping replaces manual line-number maintenance (#280, #276 plan B)
+- **[gate]** observe-check adapts to segment-style report aggregation (#262, #220 plan B wrap-up)
+- **[ci]** suite-plan adds segment config-change detection and full mutation-toolchain trigger (#277, #220)
+- **[ci]** path-filter adds stryker segment config mapping (#322, #336)
+- **[ci]** observe on-demand baseline (push runs only changed packages) + docs moved out of ci.yml full-slice filter surface (#275, #220)
+- **[ci]** baseline snapshot PR switches to OBSERVE_PAT (#291, #220)
+- **[ci]** snapshot PR date gate matches only manifest.json and unifies UTC comparison (#296, #276 plan A correction)
+- **[perf]** mcp-manager segment rebalanced — s4 narrowed + new s5 (#273); provider-usage two segments concurrency 8→16 (#266); mutation-gate mutate segment split into matrix parallel + timeoutMS tightened (#257, #220)
+- **[test]** fixed-sleep response wait converged to await/pollUntil (mcp-manager #341 / provider-usage #338, #315 batch A/B)
+- **[chore]** incremental mutation baseline routine snapshots multi-batch (#320 / #318 / #303 / #297 / #285 / #282 / #281 / #279 / #261 etc.)
+- **[docs]** methodology updates (#270 / #259, #220); oss-pipeline RETRO issues 1/2 procedure revision (#298); README distills core strengths and corrects mcp-manager middle-layer description (#274); language-jump anchor switch to dual-anchor padding + release discipline update (#258); v0.1.11/v0.1.12 release notes anchor backfix (#260)
+- **[test/mutation]** #342 phase 2 — mutation segment contract upgrade: numeric segment ids replaced by functional names (notifier/mcp-manager/provider-usage renamed; provider-usage split from 5 to 6 segments) (#367/#368/#369/#370)
+- **[dsh-verify-isolated]** switched to archify mode — reuses official dsh-skill-filesystem's bundledSkillDir to register built-in skill (#311)

--- a/packages/dsh-codegraph/package.json
+++ b/packages/dsh-codegraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-codegraph",
-  "version": "0.1.0",
+  "version": "0.1.14",
   "description": "codegraph MCP + worktree 开发纪律：探测/引导安装 codegraph CLI，经 mcp-manager 核心服务运行时注册 MCP 服务器，工具层强制「查询前 sync + projectPath」，非 git 仓不启用（#329 阶段2）",
   "type": "module",
   "main": "lib/index.js",
@@ -59,5 +59,25 @@
     "@deepseek-ai/dsh-llm": "catalog:",
     "@deepseek-ai/dsh-tools": "catalog:",
     "@wingsky-1/dsh-mcp-manager": "workspace:*"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "4.0.1",
+    "@deepseek-ai/dsh-agent": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-llm": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-tools": "0.1.1-rc.2"
+  },
+  "peerDependenciesMeta": {
+    "@deepseek-ai/cordis": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-agent": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-llm": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-tools": {
+      "optional": true
+    }
   }
 }

--- a/packages/dsh-idle-archive/package.json
+++ b/packages/dsh-idle-archive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-idle-archive",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "会话闲置自动提醒：超过 X 小时未对话的会话弹窗询问是否归档，拒绝后 Y 小时不重复提示",
   "type": "module",
   "main": "lib/index.js",
@@ -35,10 +35,18 @@
     }
   },
   "peerDependencies": {
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "@deepseek-ai/cordis": "4.0.1",
+    "@deepseek-ai/dsh-host-webserver": "0.1.1-rc.2"
   },
   "peerDependenciesMeta": {
     "react": {
+      "optional": true
+    },
+    "@deepseek-ai/cordis": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-host-webserver": {
       "optional": true
     }
   },

--- a/packages/dsh-lan-proxy/package.json
+++ b/packages/dsh-lan-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-lan-proxy",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "局域网访问 dsh web UI：在 0.0.0.0:<port> 监听，把 HTTP/HTTPS 与 WebSocket/wss 转发到回环 web 服务器（默认 127.0.0.1:3080）。重写 Host/Origin 以通过 /api 浏览器信任围栏，仅接受 IP 字面量或 localhost 的 Host 头（DNS 重绑定防护）。HTTPS 默认并存（3443），证书可配置或自动生成自签名。",
   "type": "module",
   "main": "lib/index.js",
@@ -39,10 +39,18 @@
     "schemastery": "^3.18.0"
   },
   "peerDependencies": {
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "@deepseek-ai/cordis": "4.0.1",
+    "@deepseek-ai/dsh-host-webserver": "0.1.1-rc.2"
   },
   "peerDependenciesMeta": {
     "react": {
+      "optional": true
+    },
+    "@deepseek-ai/cordis": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-host-webserver": {
       "optional": true
     }
   },

--- a/packages/dsh-mcp-manager/package.json
+++ b/packages/dsh-mcp-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-mcp-manager",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "DSH MCP 管理器：Web 侧边栏「MCP」入口，面板按状态分级展示 MCP 服务器（运行中/连接中/已配置/失败），支持快速接入（stdio / streamable-http 表单）与粘贴 mcpServers JSON 导入。已连接服务器的工具以 mcp__<server>__<tool> 注册给模型直接调用。",
   "type": "module",
   "main": "lib/index.js",
@@ -51,11 +51,12 @@
     "schemastery": "^3.18.0"
   },
   "peerDependencies": {
-    "@deepseek-ai/cordis": "*",
-    "@deepseek-ai/dsh-host-webserver": "*",
-    "@deepseek-ai/dsh-agent": "*",
-    "@deepseek-ai/dsh-tools": "*",
-    "@deepseek-ai/dsh-system-prompt": "*"
+    "@deepseek-ai/cordis": "4.0.1",
+    "@deepseek-ai/dsh-host-webserver": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-agent": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-tools": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-system-prompt": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-llm": "0.1.1-rc.2"
   },
   "peerDependenciesMeta": {
     "@deepseek-ai/cordis": {
@@ -71,6 +72,9 @@
       "optional": true
     },
     "@deepseek-ai/dsh-system-prompt": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-llm": {
       "optional": true
     }
   },

--- a/packages/dsh-notifier/package.json
+++ b/packages/dsh-notifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-notifier",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "审批/完成/错误事件通知：浏览器 Notification + 系统原生 toast（Windows PowerShell WinRT / macOS osascript / Linux notify-send，均无需额外安装）；提示音可配、每条通知独立显示不互相替换、非安全上下文自动降级横幅",
   "type": "module",
   "main": "lib/index.js",
@@ -49,10 +49,12 @@
     "@deepseek-ai/dsh-user-approval": "catalog:"
   },
   "peerDependencies": {
-    "@deepseek-ai/cordis": "*",
-    "@deepseek-ai/dsh-agent": "*",
-    "@deepseek-ai/dsh-host-webserver": "*",
-    "@deepseek-ai/dsh-session": "*"
+    "@deepseek-ai/cordis": "4.0.1",
+    "@deepseek-ai/dsh-agent": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-host-webserver": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-session": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-session-title": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-user-approval": "0.1.1-rc.2"
   },
   "peerDependenciesMeta": {
     "@deepseek-ai/cordis": {
@@ -65,6 +67,12 @@
       "optional": true
     },
     "@deepseek-ai/dsh-session": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-session-title": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-user-approval": {
       "optional": true
     }
   },

--- a/packages/dsh-plugins-all/README.md
+++ b/packages/dsh-plugins-all/README.md
@@ -56,6 +56,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-plugins-all
 | `@wingsky-1/dsh-mcp-manager` | MCP 服务器管理器（stdio/HTTP，工具注册给模型） |
 | `@wingsky-1/dsh-idle-archive` | 会话闲置提醒归档 |
 | `@wingsky-1/dsh-web-file-preview` | 点击对话文件链接在 web 端预览（图片/文本/Markdown/代码/Diff） |
+| `@wingsky-1/dsh-verify-isolated` | 插件开发隔离验证 skill（临时 DSH_HOME + 独立 profile 双重隔离） |
 
 > `@wingsky-1/dsh-gzip` 已退役：HTTP 响应压缩合并进 dsh-lan-proxy，不再随全家桶
 > 分发。此前单独安装过 dsh-gzip 的用户升级后请执行
@@ -65,6 +66,10 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-plugins-all
 >
 > `@wingsky-1/dsh-subagent-model-inherit`（子 Agent 模型继承，实验性）处于**观察期**，
 > 独立发包、暂不包含在本聚合包内；如需使用请单独安装，详见其 README。
+>
+> `@wingsky-1/dsh-codegraph`（codegraph MCP + worktree 开发纪律）为**独立发包**，
+> 暂不包含在本聚合包内；如需使用请先安装本聚合包或 `dsh-mcp-manager` 后单独安装
+> `dsh-codegraph`。
 
 ## 单独安装
 

--- a/packages/dsh-plugins-all/package.json
+++ b/packages/dsh-plugins-all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-plugins-all",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "DSH 插件全家桶聚合包：一键安装全部功能插件（idle-archive / notifier / provider-usage / mcp-manager / lan-proxy / verify-isolated / web-file-preview）。装它 = 子包 dependencies 拉齐 + 聚合 cordis patch 激活。dsh-gzip 已退役（压缩合并进 lan-proxy），不再随全家桶分发。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-provider-usage/package.json
+++ b/packages/dsh-provider-usage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-provider-usage",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "用量统计悬浮框（v2 契约）：胶囊 + 详情面板，宿主端渲染 HTML 注入；用户 mjs 适配器三函数接入任意数据源（fetchData/formatCapsule/formatPanel），宿主注入共享图表工具（utils），密钥配置链注入、按天分片 JSONL 历史、热更新可选；内置 OpenCode Go / DeepSeek 官方 / 智谱 Coding Plan (CN) 适配器",
   "type": "module",
   "main": "lib/index.js",
@@ -41,10 +41,18 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "@deepseek-ai/cordis": "4.0.1",
+    "@deepseek-ai/dsh-host-webserver": "0.1.1-rc.2"
   },
   "peerDependenciesMeta": {
     "react": {
+      "optional": true
+    },
+    "@deepseek-ai/cordis": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-host-webserver": {
       "optional": true
     }
   },

--- a/packages/dsh-subagent-model-inherit/package.json
+++ b/packages/dsh-subagent-model-inherit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-subagent-model-inherit",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "子 Agent 自动继承父会话当前模型与思考等级：agent/created 捕获父模型快照，agent/request 首次注入子请求（demo 演进包，独立发包观察期，暂不进聚合）",
   "type": "module",
   "main": "lib/index.js",
@@ -57,5 +57,25 @@
     "@deepseek-ai/dsh-agent": "catalog:",
     "@deepseek-ai/dsh-llm": "catalog:",
     "@deepseek-ai/dsh-session": "catalog:"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "4.0.1",
+    "@deepseek-ai/dsh-agent": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-llm": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-session": "0.1.1-rc.2"
+  },
+  "peerDependenciesMeta": {
+    "@deepseek-ai/cordis": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-agent": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-llm": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-session": {
+      "optional": true
+    }
   }
 }

--- a/packages/dsh-verify-isolated/package.json
+++ b/packages/dsh-verify-isolated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-verify-isolated",
-  "version": "0.1.0",
+  "version": "0.1.14",
   "description": "DSH 插件开发的隔离环境浏览器验证 skill：临时 DSH_HOME + 独立 verify_<随机> profile 双重隔离，一键拉起隔离 dsh web（自动构建/挂载/启动/清理），不污染正在使用的 web profile",
   "type": "module",
   "main": "lib/index.js",
@@ -39,5 +39,13 @@
     "skill",
     "isolated",
     "verification"
-  ]
+  ],
+  "peerDependencies": {
+    "@deepseek-ai/dsh-skill-filesystem": "0.1.1-rc.2"
+  },
+  "peerDependenciesMeta": {
+    "@deepseek-ai/dsh-skill-filesystem": {
+      "optional": true
+    }
+  }
 }

--- a/packages/dsh-web-file-preview/package.json
+++ b/packages/dsh-web-file-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-web-file-preview",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "点击对话中的文件链接在 web 端预览：宿主端按 MIME 服务会话工作区内文件（图片直出/文本 UTF-8 直出 + git diff），客户端拦截文件链接弹出预览 Modal（Markdown/代码高亮/Diff/图片灯箱）",
   "type": "module",
   "main": "lib/index.js",
@@ -76,5 +76,17 @@
     "marked": "^18.0.9",
     "mermaid": "^11.17.1",
     "untildify": "^6.0.0"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "4.0.1",
+    "@deepseek-ai/dsh-host-webserver": "0.1.1-rc.2"
+  },
+  "peerDependenciesMeta": {
+    "@deepseek-ai/cordis": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-host-webserver": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
## v0.1.14 发版准备

0.1.x 功能线收官版本。含三部分：版本对齐 + dsh 类型层锁死 + 文档更新。

### 改动

1. **版本 bump**：10 子包全部 → `0.1.14`（含新插件 dsh-codegraph / dsh-verify-isolated 首发 0.1.14；verify-version 要求全包版本 == tag）
2. **dsh 官方类型层 peer 锁死**：全包统一补 `@deepseek-ai/*` peerDependencies 并锁死到当前支持的版本——`dsh-*` `0.1.1-rc.2`、`cordis` `4.0.1`（此前为 `*`）。用户更新 dsh 后若版本不匹配，npm/pnpm 安装插件时给出明确提示，避免静默兼容性问题
3. **README（中英）**：插件表补入 `dsh-codegraph`（独立发包，暂不进聚合包）、`dsh-verify-isolated`；英文表补齐 `dsh-subagent-model-inherit`；聚合包 README 同步；移除「从 0.1.x 升级（patch id 迁移）」章节
4. **release-notes 入库**：`docs/release-notes/v0.1.14.md`（双语分节 + 双锚导航）——顶部声明 **0.1.x 功能线收官（链接 README 指定版本号章节）+ 0.2.0 预告**（适配 dsh-v0.1.2-alpha.1 + 多语言；今日可发布，npm 未同步前仅 GitHub 下载）

### 验证

- 五连门禁全绿：build / test / contract / pack:check / typecheck
- 附加：test:scripts 56/56、aggregate:check、docs:check、verify:npmlayout 全绿
- 聚合包不含 codegraph（独立发包）；含 verify-isolated（active 集）

### 发布流程

合并后由维护者推 `v0.1.14` tag 触发 release.yml（校验全包版本 == tag → 全量门禁 → publish → GitHub Release）。
