### PR TITLE
fix(dsh-verify-isolated): 补 publishConfig.access=public——npm 首发 402 修复

### DIFF
--- a/packages/dsh-verify-isolated/package.json
+++ b/packages/dsh-verify-isolated/package.json
@@ -40,6 +40,9 @@
     "isolated",
     "verification"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "@deepseek-ai/dsh-skill-filesystem": "0.1.1-rc.2"
   },


### PR DESCRIPTION
## 背景

v0.1.14 发布流程（tag 已推）在 npm publish 阶段中断：`@wingsky-1/dsh-verify-isolated@0.1.14` 首发失败，npm 报 `[E402] 402 Payment Required - You must sign up for private packages`。

## 根因

`dsh-verify-isolated` 是 10 个发布包中**唯一缺 `publishConfig.access: public`** 的包（其余 9 包均有）。npm 对 scope 包首次发布默认按 private 处理（需付费），显式声明 public 才能免费发布。

## 改动

`packages/dsh-verify-isolated/package.json` 补：
```json
publishConfig: { access: public }
```

## 验证

- verify-isolated 包级 typecheck / build / smoke 全绿
- pack-check 对 verify-isolated tarball PASS（publishConfig 正确打包）
- 无源码改动，仅 package.json 字段

## 发布恢复

合并后重跑 release workflow（tag `v0.1.14` 已存在）：`publish-if-missing.ts` 幂等——已发布的 7 包自动跳过，只补发 verify-isolated / web-file-preview / plugins-all，随后创建 GitHub Release。