### PR TITLE
fix(dsh-mcp-manager): ws_mcp_list 输出禁用条目条件赋值，修 lossless JSON 校验失败

### DIFF
--- a/packages/dsh-mcp-manager/src/middleware-utils.ts
+++ b/packages/dsh-mcp-manager/src/middleware-utils.ts
@@ -423,10 +423,15 @@ export function listCatalog(
             break;
           }
           // 工具级禁用标注（与服务器级 disabled 并列；查询面供模型感知）。
+          // 条件赋值而非 `disabled: x || undefined`——显式 undefined 键会被宿主
+          // lossless JSON 输出校验（dsh-util-values walkJsonValue）判非法
+          // （#381：ws_mcp_list 报 "value is not lossless JSON"）。
           const rootTools = disabledTools?.get(root)?.get(serverName);
           const globalTools = root === MIDDLEWARE_GLOBAL_ROOT ? undefined : disabledTools?.get(MIDDLEWARE_GLOBAL_ROOT)?.get(serverName);
           const disabledByUser = (rootTools !== undefined && rootTools.has(toolName)) || (globalTools !== undefined && globalTools.has(toolName));
-          tools.push({ tool: toolName, description: tool.description, disabled: disabledByUser || undefined });
+          const toolEntry: ListToolEntry = { tool: toolName, description: tool.description };
+          if (disabledByUser) toolEntry.disabled = true;
+          tools.push(toolEntry);
           index += 1;
         }
         entry.tools = tools;

--- a/packages/dsh-mcp-manager/test/unit-middleware.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.test.ts
@@ -408,6 +408,34 @@ function makeHost(serversByRoot = new Map()) {
   // 常量值
   assert.equal(LIST_DEFAULT_TOOLS_PER_SERVER, 50);
   assert.equal(LIST_MAX_TOOLS_PER_SERVER, 500);
+
+  // #381 回归：未禁用工具条目**不写** disabled 键（显式 undefined 键会被宿主
+  // lossless JSON 输出校验判非法 → ws_mcp_list 报 "value is not lossless JSON"）。
+  for (const tool of ctxEntry.tools) {
+    assert.equal(Object.hasOwn(tool, "disabled"), false, `未禁用条目不写 disabled 键（${tool.tool}）`);
+  }
+  assert.equal(Object.hasOwn(offEntry, "disabled"), true, "服务器级禁用仍写 disabled 键");
+
+  // #381 回归：工具级禁用路径——禁用条目写 disabled: true，未禁用条目无键。
+  const disabledMap = new Map([[ROOT, new Map([["ctx", new Set(["t0"])]])]]);
+  const withDisabled = listCatalog(units, [ROOT], undefined, 50, "project", "empty", disabledMap);
+  const ctxWD = withDisabled.servers.find((s) => s.server === fullServerName(ROOT, "ctx"));
+  assert.equal(ctxWD.tools[0].disabled, true, "t0 被禁用 → disabled: true");
+  assert.equal(Object.hasOwn(ctxWD.tools[0], "disabled"), true);
+  assert.equal(Object.hasOwn(ctxWD.tools[1], "disabled"), false, "t1 未禁用 → 无 disabled 键");
+
+  // #381 回归：模拟宿主 lossless 校验（递归断言输出树无 undefined 值键/元素）。
+  const assertLossless = (value, path) => {
+    if (value === undefined) throw new Error(`lossless 违规：${path} 为 undefined`);
+    if (value === null || typeof value !== "object") return;
+    if (Array.isArray(value)) {
+      value.forEach((item, i) => assertLossless(item, `${path}[${i}]`));
+      return;
+    }
+    for (const [key, entry] of Object.entries(value)) assertLossless(entry, `${path}.${key}`);
+  };
+  assertLossless(listed, "listed");
+  assertLossless(withDisabled, "withDisabled");
 }
 
 // ---- findToolDetail：精确命中 / 完整 schema / 错误三分 / tool 归一化 ----


### PR DESCRIPTION
## 问题

`ws_mcp_list` 无参（或带参）调用报 `tool "ws_mcp_list" returned invalid output: value is not lossless JSON`，工具不可用。 Fixes #381。

## 根因

`listCatalog()` 工具条目以 `disabled: disabledByUser || undefined` 构造——未禁用时对象**显式携带值为 `undefined` 的键**。宿主 lossless JSON 输出校验（`@deepseek-ai/dsh-util-values` `walkJsonValue`）遍历 own enumerable 键，遇 `undefined` 值即判「无法无损序列化」→ 整个输出被拒。无参输入本身没问题（execute 已兜底），报错发生在输出校验层。

## 修复

- 条件赋值：仅禁用时写 `disabled: true`，未禁用不写键（`ListToolEntry.disabled?: boolean` 可选字段语义不变）。
- 防回归断言三组：未禁用条目 `Object.hasOwn(tool, "disabled") === false`；工具级禁用路径仍写 `true`；模拟宿主 lossless 校验递归断言输出树无 undefined。

## 测试

- `pnpm --filter @wingsky-1/dsh-mcp-manager build && pnpm --filter @wingsky-1/dsh-mcp-manager test`：all checks passed（含新增 #381 回归断言）。

Fixes #381
