### PR TITLE
fix(provider-usage): 胶囊跟随会话 provider——投影字段改读拍平 projectionValues（#383）

### DIFF
--- a/packages/dsh-provider-usage/src/client/core.ts
+++ b/packages/dsh-provider-usage/src/client/core.ts
@@ -100,11 +100,14 @@ export interface ModelSelectionProjectionLike {
   next?: ModelSelectionLike | null;
 }
 
-/** 会话行投影 hints（宿主 list 快照 per-session 投影，0.1.2-alpha.2 SessionProjectionHints）。 */
-export interface SessionRowProjectionsLike {
-  values?: {
-    modelSelection?: ModelSelectionProjectionLike;
-  };
+/**
+ * 会话行投影值（#383：0.1.2 客户端 list 快照行 SessionSummary.projectionValues——
+ * 对象层把 per-session ProjectionValueStore.values() 拍平挂回行，键=投影键）。
+ * 注意与 wire session.list 原始行的 `projections: {asOfSeq, values}` baseline block
+ * 形状区分：store 行只有拍平的 projectionValues，不存在 projections 字段。
+ */
+export interface SessionRowProjectionValuesLike {
+  modelSelection?: ModelSelectionProjectionLike;
 }
 
 /**
@@ -131,8 +134,8 @@ export interface SessionListRowLike {
    */
   parentId?: string;
   parentSessionId?: string;
-  /** per-session modelSelection 投影（0.1.2-alpha.2 SessionProjectionHints）。 */
-  projections?: SessionRowProjectionsLike;
+  /** per-session 投影值 map（0.1.2 list 行 SessionSummary.projectionValues；键=投影键，#383）。 */
+  projectionValues?: SessionRowProjectionValuesLike;
 }
 
 /** sessions.list 快照形态（{current, ids, byId}，与宿主 client-runtime 一致）。 */
@@ -191,12 +194,12 @@ export function sessionAncestryChain(
 }
 
 /**
- * 从会话行读取 per-session modelSelection 投影的 provider（0.1.2-alpha.2 投影面）：
- * lastUsed 优先（上次实际使用），next 次之（待确认意图）；均缺失返回 undefined。
- * 纯同步快照读取，不触发任何 RPC。
+ * 从会话行读取 per-session modelSelection 投影的 provider（0.1.2 投影面，#383 修正）：
+ * 读 list 快照行拍平的 projectionValues.modelSelection（lastUsed 优先 = 上次实际使用，
+ * next 次之 = 待确认意图）；均缺失返回 undefined。纯同步快照读取，不触发任何 RPC。
  */
 function providerFromProjection(row: SessionListRowLike | undefined): string | undefined {
-  const ms = row?.projections?.values?.modelSelection;
+  const ms = row?.projectionValues?.modelSelection;
   const sel = ms?.lastUsed ?? ms?.next;
   return typeof sel?.provider === "string" && sel.provider.length > 0 ? sel.provider : undefined;
 }

--- a/packages/dsh-provider-usage/test/client-revalidate.worker.mjs
+++ b/packages/dsh-provider-usage/test/client-revalidate.worker.mjs
@@ -247,7 +247,7 @@ function makeFakeServices(initialProvider) {
               id,
               proj === undefined
                 ? base
-                : { ...base, projections: { values: { modelSelection: { lastUsed: proj } } } },
+                : { ...base, projectionValues: { modelSelection: { lastUsed: proj } } },
             ];
           }),
         ),

--- a/packages/dsh-provider-usage/test/unit-detect.test.ts
+++ b/packages/dsh-provider-usage/test/unit-detect.test.ts
@@ -1,10 +1,11 @@
 // @ts-nocheck
 /**
- * dsh-provider-usage — unit：provider 检测链（issue #69，0.1.2 适配）。
+ * dsh-provider-usage — unit：provider 检测链（issue #69；#383 投影形状修正）。
  *
- * 覆盖：per-session modelSelection 投影（0.1.2-alpha.2）读取 provider —— 子代理会话
- * 自身投影缺失时沿 parentId 上溯父会话投影取 provider、上溯深度封顶与环防御、
- * 全链投影缺失回落 ctx.remote.session.modelCatalog().default 兜底、
+ * 覆盖：per-session modelSelection 投影（0.1.2 list 行拍平 projectionValues）读取
+ * provider —— 子代理会话自身投影缺失时沿 parentId 上溯父会话投影取 provider、
+ * 上溯深度封顶与环防御、全链投影缺失回落 ctx.remote.session.modelCatalog().default
+ * 兜底、wire 形状（projections.values）不得被误读（#383 反向断言）、
  * 全链失败保持上次检测 + 「提供商未识别」标注决策、无任何会话维持原回落行为
  * （回归防护）、ordinary 会话直连解析回归。
  *
@@ -54,7 +55,7 @@ function makeSessions(byId, current) {
 }
 
 /**
- * 行投影小工具：构造 SessionSummary 防御式行。
+ * 行投影小工具：构造 SessionSummary 防御式行（#383：拍平 projectionValues 形状）。
  * provider 缺省 → 行无 modelSelection 投影（模拟子代理/未解析会话）。
  */
 function row(provider, opts = {}) {
@@ -64,13 +65,11 @@ function row(provider, opts = {}) {
   if (parentSessionId !== undefined) r.parentSessionId = parentSessionId;
   if (origin !== undefined) r.origin = origin;
   if (provider !== undefined) {
-    r.projections = {
-      values: {
-        modelSelection: {
-          // 默认写入 lastUsed；slot:"next" 时只写 next（模拟待确认意图）
-          ...(slot === "next" ? {} : { lastUsed: { provider, model: "model-x" } }),
-          ...(slot === "next" ? { next: { provider, model: "model-x" } } : {}),
-        },
+    r.projectionValues = {
+      modelSelection: {
+        // 默认写入 lastUsed；slot:"next" 时只写 next（模拟待确认意图）
+        ...(slot === "next" ? {} : { lastUsed: { provider, model: "model-x" } }),
+        ...(slot === "next" ? { next: { provider, model: "model-x" } } : {}),
       },
     };
   }
@@ -122,16 +121,14 @@ function makeRemote(providerByDefault) {
 }
 
 {
-  // lastUsed 优先于 next：两者并存时取 lastUsed
+  // lastUsed 优先于 next：两者并存时取 lastUsed（#383：拍平 projectionValues 形状）
   const sessions = makeSessions(
     {
       own: {
-        projections: {
-          values: {
-            modelSelection: {
-              lastUsed: { provider: "last-p", model: "a" },
-              next: { provider: "next-p", model: "b" },
-            },
+        projectionValues: {
+          modelSelection: {
+            lastUsed: { provider: "last-p", model: "a" },
+            next: { provider: "next-p", model: "b" },
           },
         },
       },
@@ -140,6 +137,24 @@ function makeRemote(providerByDefault) {
   );
   const got = await resolveProviderFromSession(sessions, makeRemote());
   assert.equal(got, "last-p", "lastUsed 优先于 next");
+}
+
+{
+  // #383 反向断言：wire 形状（projections.values）不得被误读——store 行只认拍平的
+  // projectionValues；仅携带 wire 形状的行必须视为无投影 → 走 modelCatalog 兜底
+  const sessions = makeSessions(
+    {
+      own: {
+        projections: {
+          asOfSeq: 7,
+          values: { modelSelection: { lastUsed: { provider: "wire-p", model: "a" } } },
+        },
+      },
+    },
+    "own",
+  );
+  const got = await resolveProviderFromSession(sessions, makeRemote("catalog-fallback"));
+  assert.equal(got, "catalog-fallback", "wire 形状（projections.values）不被读取 → 落兜底");
 }
 
 // ---------------------------------------------------------------- 2) 全链投影缺失：保持上次检测 + 未识别标注 / modelCatalog 兜底
@@ -260,4 +275,4 @@ function makeRemote(providerByDefault) {
   assert.equal(got, "prov-k", "首个解析成功者胜");
 }
 
-console.log("[unit-detect] 全部断言通过 ✓ (#69 provider 检测链，0.1.2-alpha.2 投影面)");
+console.log("[unit-detect] 全部断言通过 ✓ (#69 检测链；#383 projectionValues 形状修正)");


### PR DESCRIPTION
Closes #383

## 问题

dsh 0.1.2-alpha.2 适配（#323，527a459）后，用量胶囊恒显示全局默认 provider（opencode-go）的用量/未配置态，切换会话、会话内切模型均不跟随。

## 根因

#323 适配把 provider 检测迁到 sessions.list 快照投影面时，将 **wire 行形状**误当 **store 行形状**：

- `core.ts` 读 `row.projections.values.modelSelection`（wire session.list 原始行的 baseline block 形状）；
- 客户端 store 的 list 快照行（0.1.2-alpha.2 `SessionSummary` + 发布物 `buildListSnapshot()` 实装）投影字段是**拍平的 `projectionValues`**（`Partial<SessionProjectionMap>`，键直接为 `modelSelection`）。

主判据恒 undefined → 每次检测落 `remote.session.modelCatalog()` 兜底（全局默认）→ 胶囊永不跟随。原单测 mock 与被测同用错误形状，门禁绿但线上失效（假阳性）。

## 修复

- `providerFromProjection` 改读 `row.projectionValues.modelSelection`；类型与注释同步修正，不做旧形状兼容（0.1.1/0.1.2 store 行均无 projections 字段）；
- `unit-detect` 行构造与 `client-revalidate.worker` mock 改拍平形状；新增反向断言：仅携带 wire 形状的行必须视为无投影落兜底。

## 验证

- worktree 全门禁：`pnpm build && pnpm test && pnpm contract && pnpm pack:check` 全绿（含新增反向断言）；
- 改动仅客户端 `core.ts`，build 后刷新页面即生效，无需重启 dsh web；merge 后实机验证胶囊跟随行为。