### PR TITLE
fix(dsh-lan-proxy): 压缩桥接透传入站头 + 默认白名单改为 /api/remote.mux

### DIFF
--- a/packages/dsh-lan-proxy/README.md
+++ b/packages/dsh-lan-proxy/README.md
@@ -65,7 +65,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-lan-proxy
 | `httpsEnabled` | `true` | 是否并存 HTTPS |
 | `tlsCertFile` / `tlsKeyFile` | 无 | 自定义证书（mkcert 等） |
 | `wsCompressEnabled` | `true` | 是否对命中 `wsCompressPaths` 的 WebSocket 做压缩桥接 |
-| `wsCompressPaths` | `/api/events.mux, /api/events.host` | 参与 WebSocket 压缩的路径白名单 |
+| `wsCompressPaths` | `/api/remote.mux` | 参与 WebSocket 压缩的路径白名单 |
 | `httpCompressEnabled` | `true` | HTTP 响应压缩总开关（Brotli/gzip 自适应协商，合并自 dsh-gzip） |
 | `httpCompressLevel` | `1` | 压缩档位预设 0..3：`0` 默认 / `1` 低（gzip 1 / br 2，最快）· `2` 中（gzip 5 / br 5，均衡）/ `3` 高（gzip 9 / br 9，最高压缩比），对 gzip 与 Brotli **同时生效**；旧配置整数 4..9 自动迁移为 3 |
 | `injectToken` | `true` | 自动注入启动令牌（issue #380）：LAN 设备首次访问 `GET /` 由转发层自动补当前 token 铸造会话 cookie，固定设备免手工拿 token；带失效 cookie 的请求在上游 401 后自动重放自愈。安全语义见「安全模型」 |
@@ -87,10 +87,11 @@ GUI 设置入口：设置 → 插件 → 「局域网访问」卡片（保存即
 
 ## WebSocket 压缩（wss 事件流）
 
-- 对命中 `wsCompressPaths`（默认会话事件流 `/api/events.mux`、`/api/events.host`）
+- 对命中 `wsCompressPaths`（默认 `/api/remote.mux`——dsh 0.1.2 起 api-gateway
+  拥有的 Remote 流 mux 端点，取代旧 `/api/events.mux`、`/api/events.host`）
   的 WebSocket 升级，lan-proxy 做**终结 + permessage-deflate**：浏览器段压缩
   （浏览器自动协商并解压）、DSH 段明文，再双向桥接转发。
-- 收益：events.mux/events.host 是 dsh 实时事件流（会话轨迹/进度），未压缩时
+- 收益：remote.mux 承载 dsh 实时事件流与会话轨迹/进度等大流量帧，未压缩时
   经远程/慢链路访问流量大；permessage-deflate 实测约省 **75~79%**。
 - DSH 服务端即使未来自身开启 permessage-deflate，这里 DSH 段固定不协商压缩，
   两段各自独立，**不会双重压缩、不冲突**。
@@ -145,6 +146,10 @@ GUI 设置入口：设置 → 插件 → 「局域网访问」卡片（保存即
 - **凭据面**：dsh settings RPC 仅回环可读写；通过本插件访问的远程设备在
   浏览器信任围栏内可读写服务器 settings（**含凭据类数据**）——确保你的局域网
   可信，或禁用该插件
+- **桥接头透传**：WS 压缩桥接的上游连接透传入站头（Cookie 等认证凭据——dsh
+  0.1.2 起 `/api/remote.mux` 升级需 Cookie 认证，丢弃即 401 连不上），仅覆盖
+  Host/Origin 为回环目标、剥离 hop-by-hop 与 WS 握手专有头；上游被 `targetHost`
+  强制约束为回环，凭据不离开本机进程边界
 - **私钥权限**：自动生成的自签名私钥落盘 0600
 - **开放端口提醒**：0.0.0.0 监听对局域网所有设备可见
 - **HTTP 响应压缩**：压缩在转发层完成，只作用于「本插件与局域网客户端之间」
@@ -196,7 +201,7 @@ curl http://<本机局域网IP>:3081/api/dsh-lan-proxy/health
 - HTTPS 自签名证书由内置库生成，无外部命令依赖（未配置证书文件且生成失败时，HTTPS 通道自动降级关闭）
 - 换网段导致 IP 变化时，自签名证书需重新生成或更新设置（证书文件路径）
 - 命中 `wsCompressPaths` 的 WebSocket 走「终结 + 压缩桥接」（多一跳、额外压缩 CPU），
-  仅建议对 events 这类大流量路径开启；其余 WebSocket 保持透传
+  仅建议对 remote.mux 这类大流量路径开启；其余 WebSocket 保持透传
 
 ## License
 

--- a/packages/dsh-lan-proxy/src/apply.ts
+++ b/packages/dsh-lan-proxy/src/apply.ts
@@ -22,8 +22,8 @@ import { migrateFileConfig } from "./migrate.ts";
 import { ROUTES, buildConfigRoutes } from "./config-routes.ts";
 import type { ConfigRouteDeps } from "./config-routes.ts";
 
-/** WebSocket 压缩桥接默认路径白名单（会话事件流两个大流量端点）。 */
-export const DEFAULT_WSS_COMPRESS_PATHS: readonly string[] = ["/api/events.mux", "/api/events.host"];
+/** WebSocket 压缩桥接默认路径白名单（dsh 0.1.2 起 api-gateway 拥有的 Remote 流 mux 端点）。 */
+export const DEFAULT_WSS_COMPRESS_PATHS: readonly string[] = ["/api/remote.mux"];
 
 /**
  * 终端横幅输出（用户可感知信息走原生 console：cordis logger 只进内存 buffer，

--- a/packages/dsh-lan-proxy/src/client/index.ts
+++ b/packages/dsh-lan-proxy/src/client/index.ts
@@ -56,7 +56,7 @@ var CONFIG_ROUTE = "/api/dsh-lan-proxy/config";
     tlsKeyFile: "",
     printBanner: true,
     wsCompressEnabled: true,
-    wsCompressPaths: ["/api/events.mux", "/api/events.host"],
+    wsCompressPaths: ["/api/remote.mux"],
     httpCompressEnabled: true,
     httpCompressLevel: 1,
     injectToken: true,
@@ -347,7 +347,7 @@ var CONFIG_ROUTE = "/api/dsh-lan-proxy/config";
             id: "lp-set-ws-paths",
             className: "lp-set-input",
             type: "text",
-            placeholder: "/api/events.mux, /api/events.host",
+            placeholder: "/api/remote.mux",
             value: (settings.wsCompressPaths || []).join(", "),
             onChange: function (e: any) {
               const parts = e.target.value.split(",").map((s: string) => s.trim()).filter(Boolean);

--- a/packages/dsh-lan-proxy/src/config.ts
+++ b/packages/dsh-lan-proxy/src/config.ts
@@ -96,12 +96,12 @@ export const Config: z<LanProxyConfig> = z.object({
   printBanner: z.boolean().default(true),
   /**
    * WebSocket 压缩桥接总开关（默认开）：对 wsCompressPaths 命中的 WS 升级做
-   * 「终结 + permessage-deflate」——浏览器段压缩、DSH 段明文，大流量会话事件流
-   * （events.mux/events.host）经远程/慢链路访问时显著省流量。
+   * 「终结 + permessage-deflate」——浏览器段压缩、DSH 段明文，大流量 Remote 流
+   * mux 通道（remote.mux）经远程/慢链路访问时显著省流量。
    */
   wsCompressEnabled: z.boolean().default(true),
-  /** 参与 WebSocket 压缩桥接的路径白名单（默认：会话事件流两个端点）。 */
-  wsCompressPaths: z.array(z.string()).default(["/api/events.mux", "/api/events.host"]),
+  /** 参与 WebSocket 压缩桥接的路径白名单（默认：api-gateway 的 Remote 流 mux 端点）。 */
+  wsCompressPaths: z.array(z.string()).default(["/api/remote.mux"]),
   /**
    * WS 压缩协商策略（默认：浏览器段可协商，但 iPhone/iPad/iPod UA 强制不协商——
    * iOS Safari 启用 permessage-deflate 即失败，uWebSockets.js #76 实证，issue #308）。

--- a/packages/dsh-lan-proxy/src/index.ts
+++ b/packages/dsh-lan-proxy/src/index.ts
@@ -56,6 +56,6 @@ export type { ConfigRouteDeps, PatchResult } from "./config-routes.ts";
 export { apply, pluginDir, DEFAULT_WSS_COMPRESS_PATHS } from "./apply.ts";
 
 // 测试面 re-export（smoke 只依赖主入口，避免发布物保留内部模块）
-export { createLanProxy, hostnameAllowed, formatAuthority, rewriteHeaders, isLoopbackTarget, DEFAULT_OPTIONS, compressWsPath, isCompressible, resolveCompressionOptions, deflateAllowedByPolicy, DEFAULT_DEFLATE_POLICY, hasDshAuthCookie, isTokenMintCandidate, withLaunchToken } from "./proxy.ts";
+export { createLanProxy, hostnameAllowed, formatAuthority, rewriteHeaders, bridgeUpstreamHeaders, isLoopbackTarget, DEFAULT_OPTIONS, compressWsPath, isCompressible, resolveCompressionOptions, deflateAllowedByPolicy, DEFAULT_DEFLATE_POLICY, hasDshAuthCookie, isTokenMintCandidate, withLaunchToken } from "./proxy.ts";
 export type { ConnStats, DeflatePolicy, LanProxy, TokenProvider } from "./proxy.ts";
 export { ensureSelfSignedTls, certStillValid, toSanEntry, loadTlsFromFiles, SELF_SIGNED_KEY, SELF_SIGNED_CERT } from "./cert.ts";

--- a/packages/dsh-lan-proxy/src/proxy.ts
+++ b/packages/dsh-lan-proxy/src/proxy.ts
@@ -76,9 +76,10 @@ export interface LanProxyOptions {
   /**
    * WebSocket 压缩桥接：对命中 `paths` 的 WS 升级做「终结 + permessage-deflate」，
    * 浏览器段压缩、DSH 段明文；其余 WebSocket 继续由 http-proxy 做 TCP 字节透传。
-   * 默认作用于大流量的 `events.mux` / `events.host`（会话事件流）。DSH 服务端即使
+   * 默认作用于大流量的 `/api/remote.mux`（dsh 0.1.2 起 api-gateway 拥有的
+   * Remote 流 mux 通道，取代旧 events.mux/events.host）。DSH 服务端即使
    * 未来自身开启 permessage-deflate，这里 DSH 段固定不协商、浏览器段独立协商，
-   * 天然避免双重压缩。
+   * 天然避免双重压缩。桥接上游连接的入站头透传见 {@link bridgeUpstreamHeaders}。
    */
   wsCompress?: {
     enabled: boolean;
@@ -276,7 +277,8 @@ export function isLoopbackTarget(host: string): boolean {
   return host === "localhost" || bare === "127.0.0.1" || bare === "::1" || bare === "::ffff:127.0.0.1";
 }
 
-/** 为上游一跳重建请求头（Host/Origin 重写）。导出供纯函数单测锁定行为；
+/**
+ * 为上游一跳重建请求头（Host/Origin 重写）。导出供纯函数单测锁定行为；
  *  实际转发路径上作为 http-proxy 的每请求 headers 覆盖传入（前置校验不外移）。 */
 export function rewriteHeaders(headers: IncomingHttpHeaders, targetAuthority: string): IncomingHttpHeaders {
   const out = { ...headers };
@@ -349,6 +351,46 @@ export function withLaunchToken(url: string | undefined, token: string): string 
 }
 
 /**
+ * 压缩桥接上游连接剥离的入站头：hop-by-hop 头（RFC 7230 §6.1，代理不得转发）
+ * 与 WS 握手专有头（RFC 6455 §4.1，ws 库客户端按上游握手自行生成——透传浏览器段
+ * 的同名头会产生重复头，直接破坏上游握手）。
+ */
+const BRIDGE_UPSTREAM_HEADER_DENY: ReadonlySet<string> = new Set([
+  "connection", "upgrade", "keep-alive", "proxy-connection", "te", "trailer", "transfer-encoding",
+  "sec-websocket-accept", "sec-websocket-extensions", "sec-websocket-key",
+  "sec-websocket-protocol", "sec-websocket-version",
+]);
+
+/**
+ * 为压缩桥接的上游连接重建请求头（纯函数，导出供单测锁定行为）。
+ *
+ * 与 HTTP/WS 透传路径的 {@link rewriteHeaders} 不同：桥接是「终结浏览器连接 →
+ * 新建上游连接」，入站头必须显式随行转发。dsh 0.1.2 起 `/api/remote.mux` 的升级
+ * 处理在 Host/Origin 围栏之外还要校验 authority 绑定的浏览器会话 Cookie
+ * （connection.requestRejection → isAuthenticated），丢弃 Cookie 即 401 拒绝
+ * 升级、桥接表现为连不上（issue #379）。因此这里透传全部入站头（含 Cookie
+ * 等认证凭据），仅做两类例外：
+ *   - 覆盖 Host/Origin 为回环目标 authority（/api 浏览器信任围栏的校验条件，
+ *     与 rewriteHeaders 语义一致）；
+ *   - 剥离 {@link BRIDGE_UPSTREAM_HEADER_DENY} 集合中的头。
+ * @param headers 入站升级请求头。
+ * @param targetAuthority 回环目标 authority（host:port）。
+ * @returns 上游连接请求头（ws 库 headers 选项的键值面）。
+ */
+export function bridgeUpstreamHeaders(headers: IncomingHttpHeaders, targetAuthority: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    const lower = key.toLowerCase();
+    if (lower === "host" || lower === "origin" || BRIDGE_UPSTREAM_HEADER_DENY.has(lower)) continue;
+    if (value === undefined) continue;
+    out[lower] = Array.isArray(value) ? value.join(", ") : value;
+  }
+  out.host = targetAuthority;
+  out.origin = `http://${targetAuthority}`;
+  return out;
+}
+
+/**
  * 默认配置（单一事实源）：schema 默认值、resolve 兜底、createLanProxy 参数
  * 默认值统一引用本常量，避免默认端口/主机多处硬编码漂移。
  * 注意：cordis.patch.yml 中的 port: 3081 属 bundle 层显式配置，与默认值
@@ -362,7 +404,7 @@ const MAX_UPSTREAM_SOCKETS = 64;
 /**
  * 判断某 WS 升级请求路径是否命中「需压缩桥接」白名单。
  * 仅比较 pathname（忽略查询串）。导出供纯函数单测锁定行为。
- * @param paths 压缩白名单（默认含 /api/events.mux、/api/events.host）。
+ * @param paths 压缩白名单（默认含 /api/remote.mux）。
  * @param url 原始请求 URL（可能带查询串）。
  * @returns 是否命中。
  */
@@ -475,10 +517,13 @@ export function bridgeCompressedWs(
   });
   wss.handleUpgrade(req, socket, head, (browserWs) => {
     // DSH 段：明文（本机/内网），固定不协商 permessage-deflate。
+    // 入站头透传（Cookie 等认证凭据；issue #379——0.1.2 起 /api/remote.mux 升级
+    // 需 Cookie 认证），Host/Origin 覆盖为回环目标，hop-by-hop 与 sec-websocket-*
+    // 剥离（ws 库自生成）。
     const upstreamUrl = `ws://${target.targetHost}:${target.targetPort}${req.url}`;
     const upstreamWs = new WsClient(upstreamUrl, {
       perMessageDeflate: false,
-      headers: { origin: `http://${target.targetHost}:${target.targetPort}` },
+      headers: bridgeUpstreamHeaders(req.headers, formatAuthority(target.targetHost, target.targetPort)),
     });
     // 半开探活：两端独立计时（各自 pong 判定），probeIntervalMs=0 显式关闭。
     const probeIntervalMs = target.probeIntervalMs ?? DEFAULT_WS_PROBE_INTERVAL_MS;

--- a/packages/dsh-lan-proxy/test/smoke.ts
+++ b/packages/dsh-lan-proxy/test/smoke.ts
@@ -642,27 +642,27 @@ const main = async () => {
   });
 
   console.log("unit: WebSocket 压缩桥接配置");
-  // 默认白名单包含会话事件流两个端点。
-  check("默认压缩白名单含 events.mux / events.host", () => {
-    assert.deepEqual(DEFAULT_WSS_COMPRESS_PATHS, ["/api/events.mux", "/api/events.host"]);
+  // 默认白名单为 api-gateway 的 Remote 流 mux 端点（dsh 0.1.2 起取代 events.mux/events.host）。
+  check("默认压缩白名单为 remote.mux", () => {
+    assert.deepEqual(DEFAULT_WSS_COMPRESS_PATHS, ["/api/remote.mux"]);
   });
   // compressWsPath：命中 / 未命中 / 查询串忽略 / 传入 undefined 拒绝。
   check("compressWsPath 命中默认 path 忽略查询串", () =>
-    assert.equal(compressWsPath(DEFAULT_WSS_COMPRESS_PATHS, "/api/events.mux?days=30"), true));
+    assert.equal(compressWsPath(DEFAULT_WSS_COMPRESS_PATHS, "/api/remote.mux?x=1"), true));
   check("compressWsPath 命中非默认 path", () => {
     assert.equal(compressWsPath(["/api/events.mux", "/api/events.host"], "/api/events.host"), true);
     assert.equal(compressWsPath(["/custom/ws"], "/custom/ws"), true);
   });
   check("compressWsPath 未命中 / 空列表 / undefined", () => {
     assert.equal(compressWsPath(DEFAULT_WSS_COMPRESS_PATHS, "/api/other"), false);
-    assert.equal(compressWsPath([], "/api/events.mux"), false);
-    assert.equal(compressWsPath(undefined, "/api/events.mux"), false);
+    assert.equal(compressWsPath([], "/api/remote.mux"), false);
+    assert.equal(compressWsPath(undefined, "/api/remote.mux"), false);
     assert.equal(compressWsPath(DEFAULT_WSS_COMPRESS_PATHS, undefined), false);
   });
   // sanitize：接受 wsCompressEnabled / wsCompressPaths（字符串数组），非法整体拒绝。
   check("sanitize 接受 ws 压缩配置", () => {
-    const out = sanitizeSettings({ wsCompressEnabled: false, wsCompressPaths: ["/api/events.mux"] });
-    assert.deepEqual(out, { wsCompressEnabled: false, wsCompressPaths: ["/api/events.mux"] });
+    const out = sanitizeSettings({ wsCompressEnabled: false, wsCompressPaths: ["/api/remote.mux"] });
+    assert.deepEqual(out, { wsCompressEnabled: false, wsCompressPaths: ["/api/remote.mux"] });
   });
   check("sanitize 拒绝非字符串数组 paths", () =>
     assert.equal(sanitizeSettings({ wsCompressPaths: [1, 2] }), null));

--- a/packages/dsh-lan-proxy/test/unit-apply.src.test.ts
+++ b/packages/dsh-lan-proxy/test/unit-apply.src.test.ts
@@ -751,7 +751,7 @@ const { createServer } = await import("node:http");
   assert.equal(defaults.wsCompressEnabled, true, "wsCompressEnabled 默认 true");
   assert.equal(defaults.httpCompressEnabled, true, "httpCompressEnabled 默认 true");
   assert.equal(defaults.httpCompressLevel, 1, "httpCompressLevel 默认低档 1");
-  assert.deepEqual(defaults.wsCompressPaths, ["/api/events.mux", "/api/events.host"], "ws 压缩路径默认两会话端点");
+  assert.deepEqual(defaults.wsCompressPaths, ["/api/remote.mux"], "ws 压缩路径默认 Remote 流 mux 端点");
   // 端口上界 65535 由 schema max 强制
   assert.throws(() => Config({ port: 65536 }), "port 超 schema 上界抛错");
   assert.throws(() => Config({ httpsPort: -1 }), "httpsPort 负数抛错");

--- a/packages/dsh-lan-proxy/test/unit-apply.test.ts
+++ b/packages/dsh-lan-proxy/test/unit-apply.test.ts
@@ -751,7 +751,7 @@ const { createServer } = await import("node:http");
   assert.equal(defaults.wsCompressEnabled, true, "wsCompressEnabled 默认 true");
   assert.equal(defaults.httpCompressEnabled, true, "httpCompressEnabled 默认 true");
   assert.equal(defaults.httpCompressLevel, 1, "httpCompressLevel 默认低档 1");
-  assert.deepEqual(defaults.wsCompressPaths, ["/api/events.mux", "/api/events.host"], "ws 压缩路径默认两会话端点");
+  assert.deepEqual(defaults.wsCompressPaths, ["/api/remote.mux"], "ws 压缩路径默认 Remote 流 mux 端点");
   // 端口上界 65535 由 schema max 强制
   assert.throws(() => Config({ port: 65536 }), "port 超 schema 上界抛错");
   assert.throws(() => Config({ httpsPort: -1 }), "httpsPort 负数抛错");

--- a/packages/dsh-lan-proxy/test/unit-proxy.src.test.ts
+++ b/packages/dsh-lan-proxy/test/unit-proxy.src.test.ts
@@ -20,7 +20,7 @@ import { X509Certificate, createHash } from "node:crypto";
 import { constants as zlibConstants } from "node:zlib";
 
 import {
-  hostnameAllowed, formatAuthority, rewriteHeaders, createLanProxy, isLoopbackTarget,
+  hostnameAllowed, formatAuthority, rewriteHeaders, bridgeUpstreamHeaders, createLanProxy, isLoopbackTarget,
   DEFAULT_OPTIONS, compressWsPath, isCompressible, resolveCompressionOptions,
   ensureSelfSignedTls, deflateAllowedByPolicy, DEFAULT_DEFLATE_POLICY,
   hasDshAuthCookie, isTokenMintCandidate, withLaunchToken,
@@ -101,6 +101,38 @@ assert.deepEqual(rewriteHeaders({ host: ["a", "b"], origin: ["http://a"] }, "127
   const src = { host: "old:1" };
   rewriteHeaders(src, "127.0.0.1:2");
   assert.equal(src.host, "old:1", "入参 headers 不被就地修改");
+}
+
+// bridgeUpstreamHeaders（issue #379：压缩桥接上游连接入站头透传）
+assert.deepEqual(bridgeUpstreamHeaders({
+  host: "192.168.1.50:3081",
+  origin: "http://192.168.1.50:3081",
+  cookie: "dsh-auth-x=v1.aaa",
+  "x-custom": "v",
+  connection: "Upgrade",
+  upgrade: "websocket",
+  "sec-websocket-key": "AAA=",
+  "sec-websocket-version": "13",
+  "sec-websocket-extensions": "permessage-deflate",
+}, "127.0.0.1:3080"), {
+  cookie: "dsh-auth-x=v1.aaa",
+  "x-custom": "v",
+  host: "127.0.0.1:3080",
+  origin: "http://127.0.0.1:3080",
+}, "透传认证/自定义头，重写 Host/Origin，剥离 hop-by-hop 与 WS 握手专有头");
+assert.deepEqual(bridgeUpstreamHeaders({}, "127.0.0.1:3080"), {
+  host: "127.0.0.1:3080",
+  origin: "http://127.0.0.1:3080",
+}, "空头仍产出回环 Host/Origin（无条件带 origin 与桥接既有行为一致）");
+assert.deepEqual(bridgeUpstreamHeaders({ cookie: ["a=1", "b=2"] }, "127.0.0.1:1"), {
+  cookie: "a=1, b=2",
+  host: "127.0.0.1:1",
+  origin: "http://127.0.0.1:1",
+}, "多值头（string[]）合并为逗号串");
+{
+  const src = { cookie: "c=1" };
+  bridgeUpstreamHeaders(src, "127.0.0.1:2");
+  assert.deepEqual(src, { cookie: "c=1" }, "入参 headers 不被就地修改");
 }
 
 // compressWsPath
@@ -329,11 +361,11 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 
   const proxy = createLanProxy({
     host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
-    wsCompress: { enabled: true, paths: ["/api/events.mux", "/api/events.host"] },
+    wsCompress: { enabled: true, paths: ["/api/remote.mux"] },
   });
   const { httpPort } = await proxy.listen();
 
-  const browserWs = new WsClient(`ws://127.0.0.1:${httpPort}/api/events.mux`);
+  const browserWs = new WsClient(`ws://127.0.0.1:${httpPort}/api/remote.mux`);
   const received = [];
   browserWs.on("message", (data) => { received.push(data.toString()); });
   await new Promise((r, j) => { browserWs.on("open", r); browserWs.on("error", j); });
@@ -343,6 +375,63 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 
   assert.ok(received.includes("hello-via-ws-bridge"),
     `WS 压缩桥接双向转发：上游回显到浏览器端（收到 ${JSON.stringify(received)}）`);
+
+  await proxy.close();
+  wss.close();
+  upServer.close();
+}
+
+// ===== 桥接上游连接入站头透传（issue #379 端到端） =====
+// dsh 0.1.2 起 /api/remote.mux 升级处理需 Cookie 认证（connection.requestRejection
+// → isAuthenticated），桥接若丢弃入站头即 401 拒绝升级、表现为连不上。
+// 上游记录 upgrade 请求头；浏览器端模拟真实浏览器（带 cookie + 自定义头 +
+// 协商 permessage-deflate）连压缩路径，断言：cookie/自定义头原样透传、
+// Host/Origin 重写为回环目标、浏览器段 WS 握手头不透传（无重复头）、
+// 浏览器段压缩帧经桥接解压后上游回显可达（压缩与认证互不干扰）。
+{
+  const { WebSocketServer, WebSocket: WsClient } = await import("ws");
+
+  const upPort = 19850 + Math.floor(Math.random() * 100);
+  const upServer = createServer();
+  const wss = new WebSocketServer({ noServer: true });
+  let upgradeHeaders = null;
+  upServer.on("upgrade", (req, socket, head) => {
+    upgradeHeaders = req.headers;
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      ws.on("message", (data, isBinary) => ws.send(data, { binary: isBinary }));
+    });
+  });
+  await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+
+  const proxy = createLanProxy({
+    host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
+    wsCompress: { enabled: true, paths: ["/api/remote.mux"], probeIntervalMs: 0 },
+  });
+  const { httpPort } = await proxy.listen();
+
+  const browserWs = new WsClient(`ws://127.0.0.1:${httpPort}/api/remote.mux`, {
+    perMessageDeflate: { threshold: 0 }, // 真实浏览器默认协商压缩：强制每一帧都走压缩路径
+    headers: {
+      cookie: "dsh-auth-test=v1.issue379",
+      "x-lan-proxy-probe": "issue-379",
+    },
+  });
+  const echoed = new Promise((resolve) => browserWs.once("message", (d) => resolve(d.toString())));
+  await new Promise((r, j) => { browserWs.on("open", r); browserWs.on("error", j); });
+  browserWs.send("headers-probe");
+  assert.equal(await echoed, "headers-probe", "带认证头的桥接连接双向可达（压缩帧解压后转发）");
+  browserWs.close();
+
+  assert.ok(upgradeHeaders, "上游已收到桥接的升级请求");
+  assert.equal(upgradeHeaders.cookie, "dsh-auth-test=v1.issue379",
+    "cookie 原样透传到上游（认证凭据不丢，issue #379 核心语义）");
+  assert.equal(upgradeHeaders["x-lan-proxy-probe"], "issue-379", "自定义头同样透传");
+  assert.equal(upgradeHeaders.host, `127.0.0.1:${upPort}`, "host 重写为回环目标 authority");
+  assert.equal(upgradeHeaders.origin, `http://127.0.0.1:${upPort}`, "origin 重写为回环 http 目标");
+  assert.equal(typeof upgradeHeaders["sec-websocket-key"], "string",
+    "sec-websocket-key 为 ws 库自生成的单一字符串（浏览器段握手头已剥离、无重复头）");
+  assert.equal(upgradeHeaders["sec-websocket-extensions"], undefined,
+    "浏览器段 permessage-deflate 协商头不透传（DSH 段固定明文，避免双重压缩）");
 
   await proxy.close();
   wss.close();

--- a/packages/dsh-lan-proxy/test/unit-proxy.test.ts
+++ b/packages/dsh-lan-proxy/test/unit-proxy.test.ts
@@ -19,7 +19,7 @@ import { X509Certificate, createHash } from "node:crypto";
 import { constants as zlibConstants } from "node:zlib";
 
 import {
-  hostnameAllowed, formatAuthority, rewriteHeaders, createLanProxy, isLoopbackTarget,
+  hostnameAllowed, formatAuthority, rewriteHeaders, bridgeUpstreamHeaders, createLanProxy, isLoopbackTarget,
   DEFAULT_OPTIONS, compressWsPath, isCompressible, resolveCompressionOptions,
   ensureSelfSignedTls,
 } from "../lib/index.js";
@@ -101,6 +101,38 @@ assert.deepEqual(rewriteHeaders({ host: ["a", "b"], origin: ["http://a"] }, "127
   assert.equal(src.host, "old:1", "入参 headers 不被就地修改");
 }
 
+// bridgeUpstreamHeaders（issue #379：压缩桥接上游连接入站头透传）
+assert.deepEqual(bridgeUpstreamHeaders({
+  host: "192.168.1.50:3081",
+  origin: "http://192.168.1.50:3081",
+  cookie: "dsh-auth-x=v1.aaa",
+  "x-custom": "v",
+  connection: "Upgrade",
+  upgrade: "websocket",
+  "sec-websocket-key": "AAA=",
+  "sec-websocket-version": "13",
+  "sec-websocket-extensions": "permessage-deflate",
+}, "127.0.0.1:3080"), {
+  cookie: "dsh-auth-x=v1.aaa",
+  "x-custom": "v",
+  host: "127.0.0.1:3080",
+  origin: "http://127.0.0.1:3080",
+}, "透传认证/自定义头，重写 Host/Origin，剥离 hop-by-hop 与 WS 握手专有头");
+assert.deepEqual(bridgeUpstreamHeaders({}, "127.0.0.1:3080"), {
+  host: "127.0.0.1:3080",
+  origin: "http://127.0.0.1:3080",
+}, "空头仍产出回环 Host/Origin（无条件带 origin 与桥接既有行为一致）");
+assert.deepEqual(bridgeUpstreamHeaders({ cookie: ["a=1", "b=2"] }, "127.0.0.1:1"), {
+  cookie: "a=1, b=2",
+  host: "127.0.0.1:1",
+  origin: "http://127.0.0.1:1",
+}, "多值头（string[]）合并为逗号串");
+{
+  const src = { cookie: "c=1" };
+  bridgeUpstreamHeaders(src, "127.0.0.1:2");
+  assert.deepEqual(src, { cookie: "c=1" }, "入参 headers 不被就地修改");
+}
+
 // compressWsPath
 assert.equal(compressWsPath(["/a", "/b"], "/a?query=1"), true, "带查询串命中");
 assert.equal(compressWsPath(["/a", "/b"], "/c"), false, "未命中");
@@ -146,11 +178,11 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 
   const proxy = createLanProxy({
     host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
-    wsCompress: { enabled: true, paths: ["/api/events.mux", "/api/events.host"] },
+    wsCompress: { enabled: true, paths: ["/api/remote.mux"] },
   });
   const { httpPort } = await proxy.listen();
 
-  const browserWs = new WsClient(`ws://127.0.0.1:${httpPort}/api/events.mux`);
+  const browserWs = new WsClient(`ws://127.0.0.1:${httpPort}/api/remote.mux`);
   const received = [];
   browserWs.on("message", (data) => { received.push(data.toString()); });
   await new Promise((r, j) => { browserWs.on("open", r); browserWs.on("error", j); });
@@ -160,6 +192,63 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 
   assert.ok(received.includes("hello-via-ws-bridge"),
     `WS 压缩桥接双向转发：上游回显到浏览器端（收到 ${JSON.stringify(received)}）`);
+
+  await proxy.close();
+  wss.close();
+  upServer.close();
+}
+
+// ===== 桥接上游连接入站头透传（issue #379 端到端） =====
+// dsh 0.1.2 起 /api/remote.mux 升级处理需 Cookie 认证（connection.requestRejection
+// → isAuthenticated），桥接若丢弃入站头即 401 拒绝升级、表现为连不上。
+// 上游记录 upgrade 请求头；浏览器端模拟真实浏览器（带 cookie + 自定义头 +
+// 协商 permessage-deflate）连压缩路径，断言：cookie/自定义头原样透传、
+// Host/Origin 重写为回环目标、浏览器段 WS 握手头不透传（无重复头）、
+// 浏览器段压缩帧经桥接解压后上游回显可达（压缩与认证互不干扰）。
+{
+  const { WebSocketServer, WebSocket: WsClient } = await import("ws");
+
+  const upPort = 19850 + Math.floor(Math.random() * 100);
+  const upServer = createServer();
+  const wss = new WebSocketServer({ noServer: true });
+  let upgradeHeaders = null;
+  upServer.on("upgrade", (req, socket, head) => {
+    upgradeHeaders = req.headers;
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      ws.on("message", (data, isBinary) => ws.send(data, { binary: isBinary }));
+    });
+  });
+  await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+
+  const proxy = createLanProxy({
+    host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
+    wsCompress: { enabled: true, paths: ["/api/remote.mux"], probeIntervalMs: 0 },
+  });
+  const { httpPort } = await proxy.listen();
+
+  const browserWs = new WsClient(`ws://127.0.0.1:${httpPort}/api/remote.mux`, {
+    perMessageDeflate: { threshold: 0 }, // 真实浏览器默认协商压缩：强制每一帧都走压缩路径
+    headers: {
+      cookie: "dsh-auth-test=v1.issue379",
+      "x-lan-proxy-probe": "issue-379",
+    },
+  });
+  const echoed = new Promise((resolve) => browserWs.once("message", (d) => resolve(d.toString())));
+  await new Promise((r, j) => { browserWs.on("open", r); browserWs.on("error", j); });
+  browserWs.send("headers-probe");
+  assert.equal(await echoed, "headers-probe", "带认证头的桥接连接双向可达（压缩帧解压后转发）");
+  browserWs.close();
+
+  assert.ok(upgradeHeaders, "上游已收到桥接的升级请求");
+  assert.equal(upgradeHeaders.cookie, "dsh-auth-test=v1.issue379",
+    "cookie 原样透传到上游（认证凭据不丢，issue #379 核心语义）");
+  assert.equal(upgradeHeaders["x-lan-proxy-probe"], "issue-379", "自定义头同样透传");
+  assert.equal(upgradeHeaders.host, `127.0.0.1:${upPort}`, "host 重写为回环目标 authority");
+  assert.equal(upgradeHeaders.origin, `http://127.0.0.1:${upPort}`, "origin 重写为回环 http 目标");
+  assert.equal(typeof upgradeHeaders["sec-websocket-key"], "string",
+    "sec-websocket-key 为 ws 库自生成的单一字符串（浏览器段握手头已剥离、无重复头）");
+  assert.equal(upgradeHeaders["sec-websocket-extensions"], undefined,
+    "浏览器段 permessage-deflate 协商头不透传（DSH 段固定明文，避免双重压缩）");
 
   await proxy.close();
   wss.close();


### PR DESCRIPTION
Closes #379

## 问题

dsh 0.1.2 起 `/api/remote.mux`（dsh-api-gateway 拥有的 Remote 流 mux WebSocket）取代了 `/api/events.mux` / `/api/events.host`，其升级处理在 Host/Origin 围栏之外还需校验 authority 绑定的浏览器会话 Cookie（`connection.requestRejection` → `isAuthenticated`）。

lan-proxy 的 WS 压缩桥接是「终结浏览器连接 → 新建上游连接」，原实现新建上游 `WsClient` 时仅携带 `origin` 头，入站头（含 Cookie）全部丢失 → 上游 401 拒绝升级 → 桥接 terminate 浏览器段。表现为：把 `/api/remote.mux` 加入压缩白名单即无法连接（close 1006，桥接日志 `upstream error: Unexpected server response: 401`）。旧 events 端点只查围栏，故当年桥接可工作。

## 修复

1. **`proxy.ts` 新增 `bridgeUpstreamHeaders` 纯函数**：压缩桥接上游连接透传全部入站头（Cookie 等认证凭据），仅两类例外——
   - 覆盖 Host/Origin 为回环目标 authority（/api 浏览器信任围栏的校验条件，与透传路径 `rewriteHeaders` 语义一致）；
   - 剥离 hop-by-hop 头与 `sec-websocket-*` 握手专有头（ws 库客户端自生成，透传会产生重复头破坏上游握手）。
2. **默认压缩白名单改为 `["/api/remote.mux"]`**（同步 4 处）：`apply.ts` 的 `DEFAULT_WSS_COMPRESS_PATHS`、`config.ts` schema 默认值、客户端 `DEFAULTS` 与输入框 placeholder。旧 events 路径在 0.1.2 已不存在，属死路径。

## 测试

- `unit-proxy` 双形态（src/lib）新增：
  - `bridgeUpstreamHeaders` 纯函数断言（透传认证/自定义头、重写 Host/Origin、剥离 hop-by-hop 与 WS 握手头、多值头合并、入参不被就地修改）；
  - 「桥接头透传」端到端用例：浏览器端模拟真实浏览器（带 cookie + 自定义头 + 协商 permessage-deflate）连压缩路径，断言 cookie/自定义头原样到达上游、Host/Origin 重写、`sec-websocket-key` 为单一字符串（无重复头）、浏览器段 `sec-websocket-extensions` 不透传（DSH 段固定明文）、压缩帧经桥接解压后双向可达。
- `smoke` / `unit-apply` 双形态：默认白名单断言更新为 remote.mux。

## 门禁与隔离实证

- `pnpm build && pnpm test && pnpm contract && pnpm pack:check` 全绿。
- 隔离实例实证（临时 `DSH_HOME` + 真实 dsh 0.1.2-alpha.2 + worktree 构建的真身转发层）：

| 场景 | 修复前 | 修复后 |
|---|---|---|
| remote.mux 经压缩桥接（带 cookie） | open 后 3ms 被杀（401 → close 1006） | 稳定建连（跨 2s 心跳多周期，close 1000 正常收口） |
| 直连 / 透传路径（带 cookie） | 稳定 | 稳定（不变） |
| 无 cookie 直连（对照） | 401 | 401（判据有效） |

## 文档

README：压缩白名单默认值与收益段（remote.mux）、安全模型补「桥接头透传」语义（凭据不离开本机进程边界——上游被 targetHost 强制约束为回环）、已知限制文案同步。
