### PR TITLE
feat(dsh-lan-proxy): injectToken 自动注入启动令牌，含 401 重放自愈（#380）

### DIFF
--- a/packages/dsh-lan-proxy/README.md
+++ b/packages/dsh-lan-proxy/README.md
@@ -68,6 +68,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-lan-proxy
 | `wsCompressPaths` | `/api/events.mux, /api/events.host` | 参与 WebSocket 压缩的路径白名单 |
 | `httpCompressEnabled` | `true` | HTTP 响应压缩总开关（Brotli/gzip 自适应协商，合并自 dsh-gzip） |
 | `httpCompressLevel` | `1` | 压缩档位预设 0..3：`0` 默认 / `1` 低（gzip 1 / br 2，最快）· `2` 中（gzip 5 / br 5，均衡）/ `3` 高（gzip 9 / br 9，最高压缩比），对 gzip 与 Brotli **同时生效**；旧配置整数 4..9 自动迁移为 3 |
+| `injectToken` | `true` | 自动注入启动令牌（issue #380）：LAN 设备首次访问 `GET /` 由转发层自动补当前 token 铸造会话 cookie，固定设备免手工拿 token；带失效 cookie 的请求在上游 401 后自动重放自愈。安全语义见「安全模型」 |
 
 GUI 设置入口：设置 → 插件 → 「局域网访问」卡片（保存即热更新）。
 
@@ -152,6 +153,30 @@ GUI 设置入口：设置 → 插件 → 「局域网访问」卡片（保存即
   对**直连回环 web** 的请求生效；经本插件转发的请求按设计视为受信（见凭据面）。
   注意：health 响应携带的诊断元数据——`configDir` 绝对路径与压缩协商计数——
   会随转发原样到达局域网设备，对其可见
+- **injectToken 自动注入（issue #380）**：dsh web 的浏览器会话认证（launch token
+  + 持久签名 cookie）无法关闭，token 每次重启变化且只打印在本机终端——固定
+  局域网设备拿不到实时 token。本插件经官方 connection 服务的**公开 API**
+  `authenticatedUrl()` 动态读取当前 token，仅在铸造入口（`GET /`、无会话 cookie）
+  自动补上：LAN 设备零操作进入。安全取舍与缓解：
+  - **等效「信任整个局域网」**：开启后任何能网络到达本端口的客户端都免 token
+    获得完整 dsh 控制权（bash 直通宿主机）。仅在可信家庭/办公内网开启；
+    不可信网段务必关闭（设置卡片开关）。
+  - **默认开启（维护者决策）**：业界同类先例（Home Assistant `trusted_networks`
+    认证 provider、qBittorrent WebUI 「Bypass authentication for clients」）默认
+    需显式配置；本插件按家用固定内网场景默认开启，以「启动横幅警示行 + 设置
+    卡片常驻警示 + 本节说明」作缓解。
+  - **关闭不吊销已发 cookie**：会话 cookie 有效期内（默认 30 天）已登录设备
+    在关闭后仍可直接进入；需立即收回访问时清空 dsh credentials 存储。
+  - **失效 cookie 自愈**：cookie 失效（credentials 重置等）的设备原本会陷入
+    401 死锁（Max-Age 内浏览器不删 cookie、又拿不到新 token）；转发层在检测到
+    上游 401 后自动带 token 重放一次，上游直接重铸 cookie，设备无感恢复。
+  - **cross-site 残余面**：公网恶意页面对 `http://<LAN-IP>:3081/` 发起的跨站
+    GET 可被白铸 cookie，但读不到响应（CORS opaque）、后续请求因
+    `SameSite=Strict` 不携带 cookie、`POST /api` 被 sec-fetch-site 围栏拒绝——
+    链条闭合；token 与 cookie 均不出现在浏览器地址栏/历史。
+  - **不注入范围**：仅 `GET /` 且无 token 参数的请求；WebSocket、非根路径、
+    已带 token 的请求、provider 不可用时全部原样透传（行为与未开启一致）。
+    自建口令页（信任收窄为「知道口令」）为后续演进方向。
 
 ## 验证
 

--- a/packages/dsh-lan-proxy/src/apply.ts
+++ b/packages/dsh-lan-proxy/src/apply.ts
@@ -98,8 +98,63 @@ export function apply(ctx: Context, config: LanProxyConfig = {}): void {
       wsDeflatePolicy: value.wsDeflatePolicy ?? DEFAULT_DEFLATE_POLICY,
       httpCompressEnabled: value.httpCompressEnabled ?? true,
       httpCompressLevel: value.httpCompressLevel ?? 1,
+      injectToken: value.injectToken ?? true,
     };
   };
+
+  // ---- injectToken（issue #380）：launch token 动态提供者 ----
+  // 官方 connection 服务（@deepseek-ai/dsh-client-connection）以 cordis 服务
+  // "connection" 提供；公开方法 authenticatedUrl(baseUrl) 返回带当前 launch
+  // token 的 URL。token 进程内恒定、跨重启变化——getter 每次现读不缓存，重启
+  // 后自动跟随新值。服务晚于转发器 attach 是常态：getter 在 attach 前返回
+  // undefined，逐请求降级为不注入（与未开启一致），attach 后自动生效。
+  /** 官方 connection 服务最小类型面（公开 API；仅取 token 所需）。 */
+  interface ConnectionLike {
+    authenticatedUrl(baseUrl: string): string;
+  }
+  /** connection 内层 attach 后就绪的 token 读取器（未 attach 前 undefined）。 */
+  let readLaunchToken: (() => string | undefined) | undefined;
+  /** 提供者状态（absent/ready/error），变化时各 warn 一次——不造节流器。 */
+  let tokenProviderState: "absent" | "ready" | "error" = "absent";
+  const setTokenProviderState = (next: "ready" | "error"): void => {
+    if (tokenProviderState === next) return;
+    tokenProviderState = next;
+    if (next === "error") {
+      out.warn("injectToken: 读取 dsh web launch token 失败 — 自动注入逐请求降级关闭（官方行为面变更？请按 dsh-upgrade 流程复核）");
+    } else {
+      out.info("injectToken: launch token 提供者就绪 — LAN 设备首次访问将自动铸造会话");
+    }
+  };
+  /** 转发器消费的提供者：转发器随配置重建，getter 引用保持同一份（禁快照）。 */
+  const tokenProvider = { getToken: (): string | undefined => readLaunchToken?.() ?? undefined };
+  if (typeof (ctx as unknown as { inject?: unknown })?.inject === "function") {
+    (ctx as unknown as { inject: (services: string[], fn: (c: unknown) => void) => void }).inject(
+      ["connection"],
+      (connectionCtx: unknown) => {
+        const connection = (connectionCtx as { connection?: ConnectionLike } | undefined)?.connection;
+        if (connection === undefined || typeof connection.authenticatedUrl !== "function") {
+          setTokenProviderState("error");
+          return;
+        }
+        readLaunchToken = () => {
+          try {
+            // 官方公开 API：返回「根 URL + ?token=当前 launch token」。
+            const mint = connection.authenticatedUrl("http://lan-proxy.local");
+            const token = new URL(mint).searchParams.get("token");
+            if (token === null || token === "") {
+              setTokenProviderState("error");
+              return undefined;
+            }
+            setTokenProviderState("ready");
+            return token;
+          } catch {
+            setTokenProviderState("error");
+            return undefined;
+          }
+        };
+      },
+    );
+  }
 
   /**
    * HTTP 压缩运行快照（issue #33 子项 3）：health 与 GET /config 共用的单一来源，
@@ -179,6 +234,9 @@ export function apply(ctx: Context, config: LanProxyConfig = {}): void {
           enabled: httpCompressEnabled,
           level: value.httpCompressLevel,
         },
+        // 自动注入启动令牌（issue #380）：仅开关开启时交给转发器；提供者 getter
+        // 跨重建共享（connection 服务 attach 前返回 undefined，逐请求降级）。
+        injectToken: value.injectToken ? tokenProvider : undefined,
       },
       ctx.logger,
     );
@@ -197,6 +255,11 @@ export function apply(ctx: Context, config: LanProxyConfig = {}): void {
         }
         for (const ip of lanIpv4Addresses()) {
           lines.push(`LAN access http://${ip}:${httpPort}${httpsPort !== undefined ? ` · https://${ip}:${httpsPort}` : ""}`);
+        }
+        // injectToken 开启警示（issue #380）：开启 = LAN 内设备免 token 直入，
+        // 横幅每次监听结果变化都带此行，保持可感知。
+        if (value.injectToken) {
+          lines.push("injectToken: ON — 局域网设备免 token 直接进入（等效信任整个 LAN，关闭见 设置 → 插件 → dsh-lan-proxy）");
         }
         const banner = lines.map((line) => `  ${line}`).join("\n");
         if (value.printBanner !== false && banner !== lastBanner) {

--- a/packages/dsh-lan-proxy/src/client/index.ts
+++ b/packages/dsh-lan-proxy/src/client/index.ts
@@ -38,7 +38,7 @@ const NS = "settings.lanProxy";
 
 var CONFIG_ROUTE = "/api/dsh-lan-proxy/config";
   var STYLE_ID = "dsh-lan-proxy-style";
-  var CSS_VERSION = "3";
+  var CSS_VERSION = "4";
 
   /** i18n 翻译函数（apply 时由 ctx.locale.bind(NS) 装配；未装配回落 key 本体，行为零变化）。 */
   var t: any = function (key: string, params?: any) {
@@ -59,6 +59,7 @@ var CONFIG_ROUTE = "/api/dsh-lan-proxy/config";
     wsCompressPaths: ["/api/events.mux", "/api/events.host"],
     httpCompressEnabled: true,
     httpCompressLevel: 1,
+    injectToken: true,
   };
 
   var disposed = false;
@@ -377,6 +378,18 @@ var CONFIG_ROUTE = "/api/dsh-lan-proxy/config";
             React.createElement("option", { value: "3" }, t("level3")),
           ),
         ),
+        // injectToken（issue #380）：默认开启——LAN 设备免 token 直入；开启态
+        // 持久显示安全警示（评审要求：横幅一次性警示不足，卡片常驻提醒）。
+        React.createElement("div", { className: "lp-set-row" },
+          React.createElement("label", { htmlFor: "lp-set-inject-token" }, t("injectToken")),
+          React.createElement("input", {
+            id: "lp-set-inject-token",
+            type: "checkbox",
+            checked: settings.injectToken,
+            onChange: function (e: any) { patch({ injectToken: e.target.checked }); },
+          }),
+        ),
+        settings.injectToken ? React.createElement("div", { className: "lp-set-warn" }, t("injectTokenOnHint")) : null,
         React.createElement("div", { className: "lp-set-hint" }, t("bodyHint")),
         (function () {
           var compressLine = compressStatusLine(compress);

--- a/packages/dsh-lan-proxy/src/client/locales.ts
+++ b/packages/dsh-lan-proxy/src/client/locales.ts
@@ -30,6 +30,9 @@ export const zh = {
   level1: "低（最快：gzip 1 / br 2）",
   level2: "中（均衡：gzip 5 / br 5）",
   level3: "高（最高压缩比：gzip 9 / br 9）",
+  injectToken: "局域网免 token 直入",
+  injectTokenOnHint:
+    "已开启：局域网内任何能访问该端口的设备都无需登录 token 即可完整控制 dsh（含终端命令执行），等效信任整个局域网。仅在可信家庭/办公内网开启；关闭后已登录设备的会话在有效期内仍然有效（约 30 天），不即时吊销。",
   bodyHint:
     "保存即热更新（配置写入宿主统一设置存储，无需重启 dsh web）。修改后内网设备访问新端口，旧端口立即失效。",
   // HTTP 压缩状态行
@@ -73,6 +76,9 @@ export const en: Record<LanProxyLocaleKey, string> = {
   level1: "Low (fastest: gzip 1 / br 2)",
   level2: "Medium (balanced: gzip 5 / br 5)",
   level3: "High (best ratio: gzip 9 / br 9)",
+  injectToken: "Token-free LAN access",
+  injectTokenOnHint:
+    "On: any device that can reach this port on the LAN gets full control of dsh (including terminal command execution) without a login token — equivalent to trusting the entire LAN. Only enable on trusted home/office networks; after turning off, already-signed-in devices stay valid until session expiry (~30 days), no instant revocation.",
   bodyHint:
     "Saving hot-reloads the forwarder (config goes to the host settings store, no restart needed). After the port changes, LAN devices use the new port and the old one stops immediately.",
   compressOff: "HTTP response compression: off",

--- a/packages/dsh-lan-proxy/src/client/style.css
+++ b/packages/dsh-lan-proxy/src/client/style.css
@@ -59,6 +59,15 @@
 }
 .lp-set-input:focus { outline: none; border-color: var(--dsw-alias-state-info-primary, #3b82f6); }
 .lp-set-hint { font-size: 11px; color: var(--dsw-alias-label-tertiary, #8a919c); line-height: 1.5; }
+/* injectToken 开启态安全警示（issue #380）：常驻提醒「LAN 免 token = 信任整个局域网」。 */
+.lp-set-warn {
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--dsw-alias-state-danger-primary, #dc2626);
+  border: 1px solid var(--dsw-alias-state-danger-border, rgba(220, 38, 38, 0.35));
+  border-radius: 7px;
+  padding: 7px 9px;
+}
 /* HTTP 压缩运行状态行（issue #33 子项 3）：轻量一行，随 state 快照刷新。 */
 .lp-set-status {
   font-size: 11px;

--- a/packages/dsh-lan-proxy/src/config.ts
+++ b/packages/dsh-lan-proxy/src/config.ts
@@ -40,6 +40,14 @@ export interface LanProxyConfig {
   httpCompressEnabled?: boolean;
   /** 压缩档位预设 0..3（默认 1 低）：0 默认 / 1 低 / 2 中 / 3 高，对 gzip 与 Brotli 同时生效。 */
   httpCompressLevel?: number;
+  /**
+   * 自动注入启动令牌（issue #380，默认 true）：LAN 设备首次访问 `GET /` 时
+   * 由转发层自动补当前 dsh web launch token，上游铸造持久会话 cookie——固定
+   * 局域网设备免手工拿 token（token 每次重启变化，只打印在本机终端）。
+   * 开启 = 任何能网络到达本端口的客户端都免 token 获得完整控制权（等效信任
+   * 整个 LAN）；关闭不吊销已发 cookie。详见 README「安全模型」。
+   */
+  injectToken?: boolean;
 }
 
 /** HTTP 压缩运行快照（issue #33 子项 3：GUI 可见的压缩生效状态）。 */
@@ -114,6 +122,12 @@ export const Config: z<LanProxyConfig> = z.object({
   httpCompressEnabled: z.boolean().default(true),
   /** 压缩档位预设 0..3（默认 1 低）：0 默认 / 1 低 / 2 中 / 3 高，对 gzip 与 Brotli 同时生效（见 proxy.resolveCompressionOptions 映射）。 */
   httpCompressLevel: z.natural().max(3).default(1),
+  /**
+   * 自动注入启动令牌（默认开，issue #380）：LAN 设备首次访问 `GET /` 由转发层
+   * 自动补当前 launch token 铸造会话 cookie，固定设备免手工拿 token。安全语义
+   * 见 README「安全模型」——开启等效把 LAN 视为可信网络。
+   */
+  injectToken: z.boolean().default(true),
 });
 
 /**
@@ -142,6 +156,7 @@ const FILE_CONFIG_VALIDATORS: Record<string, (v: unknown) => boolean> = {
   },
   httpCompressEnabled: (v) => typeof v === "boolean",
   httpCompressLevel: (v) => typeof v === "number" && Number.isInteger(v) && v >= 0 && v <= 3,
+  injectToken: (v) => typeof v === "boolean",
 };
 
 /**
@@ -186,6 +201,7 @@ const SETTING_FIELD_HINTS: Record<string, string> = {
   wsDeflatePolicy: "需为 { browser?: boolean, uaDeny?: string[] }（UA 片段数组）",
   httpCompressEnabled: "需为布尔值",
   httpCompressLevel: "需为 0-3 的档位整数（4-9 自动迁移为高档 3）",
+  injectToken: "需为布尔值",
 };
 
 /** validateSettings 的校验结果：null = 全部合法。 */
@@ -236,4 +252,6 @@ export interface ResolvedConfig {
   wsDeflatePolicy: DeflatePolicy;
   httpCompressEnabled: boolean;
   httpCompressLevel: number;
+  /** 自动注入启动令牌（issue #380；默认 true）。 */
+  injectToken: boolean;
 }

--- a/packages/dsh-lan-proxy/src/index.ts
+++ b/packages/dsh-lan-proxy/src/index.ts
@@ -56,6 +56,6 @@ export type { ConfigRouteDeps, PatchResult } from "./config-routes.ts";
 export { apply, pluginDir, DEFAULT_WSS_COMPRESS_PATHS } from "./apply.ts";
 
 // 测试面 re-export（smoke 只依赖主入口，避免发布物保留内部模块）
-export { createLanProxy, hostnameAllowed, formatAuthority, rewriteHeaders, isLoopbackTarget, DEFAULT_OPTIONS, compressWsPath, isCompressible, resolveCompressionOptions, deflateAllowedByPolicy, DEFAULT_DEFLATE_POLICY } from "./proxy.ts";
-export type { ConnStats, DeflatePolicy, LanProxy } from "./proxy.ts";
+export { createLanProxy, hostnameAllowed, formatAuthority, rewriteHeaders, isLoopbackTarget, DEFAULT_OPTIONS, compressWsPath, isCompressible, resolveCompressionOptions, deflateAllowedByPolicy, DEFAULT_DEFLATE_POLICY, hasDshAuthCookie, isTokenMintCandidate, withLaunchToken } from "./proxy.ts";
+export type { ConnStats, DeflatePolicy, LanProxy, TokenProvider } from "./proxy.ts";
 export { ensureSelfSignedTls, certStillValid, toSanEntry, loadTlsFromFiles, SELF_SIGNED_KEY, SELF_SIGNED_CERT } from "./cert.ts";

--- a/packages/dsh-lan-proxy/src/proxy.ts
+++ b/packages/dsh-lan-proxy/src/proxy.ts
@@ -108,7 +108,25 @@ export interface LanProxyOptions {
     /** 压缩档位预设：0 默认 / 1 低 / 2 中 / 3 高（对 gzip 与 Brotli 双生效）。 */
     level?: number;
   };
+  /**
+   * 自动注入启动令牌（issue #380）：提供时，LAN 设备首次访问 `GET /`（无会话
+   * cookie）由转发层自动补当前 launch token——上游铸造持久会话 cookie，固定
+   * 设备免手工拿 token；带失效 cookie 的同类请求在上游 401 后重放一次自愈。
+   * getToken 动态读取（不缓存）：dsh web 重启后 token 变化自动跟随；返回
+   * undefined（connection 服务未就绪/读取失败）时逐请求降级为不注入。
+   */
+  injectToken?: TokenProvider;
   logger?: LanLogger;
+}
+
+/**
+ * 当前 dsh web 进程 launch token 的动态提供者最小面（issue #380）。
+ * apply 侧封装自官方 connection 服务的公开方法 `authenticatedUrl(baseUrl)`
+ * （@deepseek-ai/dsh-client-connection 公开 d.ts API，不依赖私有字段）。
+ */
+export interface TokenProvider {
+  /** 返回当前 launch token；不可用时返回 undefined（逐请求降级为不注入）。 */
+  getToken(): string | undefined;
 }
 
 /** 监听结果：httpPort 必有；httpsPort 仅在 HTTPS 成功启用时给出。 */
@@ -265,6 +283,69 @@ export function rewriteHeaders(headers: IncomingHttpHeaders, targetAuthority: st
   out.host = targetAuthority;
   if (out.origin !== undefined) out.origin = `http://${targetAuthority}`;
   return out;
+}
+
+// ---- injectToken（issue #380）：launch token 自动注入的判定与改写 ----
+// 上游（dsh-client-connection.authorizeIndex）的铸造入口只有 `GET /` 且查询串
+// 恰带一个 token 参数；带 token 的请求一律以 303 结束（匹配→铸 cookie，或
+// 有效 cookie→清参重定向）。因此：
+//   * 对「无会话 cookie」的 GET / 注入 token → 一次跳转即登录；
+//   * 对「已带会话 cookie」的请求**绝不注入**——否则有效 cookie 用户会被
+//     无限 303（浏览器每次都带 cookie、代理每次都注入）。该排除是正确性
+//     必需而非优化，重构时不得移除（smoke 用例锁死意图）。
+//   * 失效 cookie（签名 secret 重置等）会让上述排除变成 401 死锁——对这类
+//     请求在上游 401 后重放一次（带 token），上游 token 分支优先验签、直接
+//     重铸 cookie，浏览器自愈。
+
+/** 上游浏览器会话 cookie 名前缀（dsh-client-connection COOKIE_PREFIX）。 */
+const DSH_AUTH_COOKIE_PREFIX = "dsh-auth-";
+
+/**
+ * 判断请求是否携带 dsh 浏览器会话 cookie（issue #380）。
+ * 按 RFC 6265 口径精确解析：`;` 分段、取 `=` 前名字并 trim、名字前缀匹配——
+ * 禁止整头子串匹配（其他 cookie 的值含该子串会造成误判）。
+ * 导出供纯函数单测。
+ */
+export function hasDshAuthCookie(cookieHeader: string | string[] | undefined): boolean {
+  const segments = Array.isArray(cookieHeader) ? cookieHeader : cookieHeader !== undefined ? [cookieHeader] : [];
+  for (const head of segments) {
+    for (const segment of head.split(";")) {
+      const eq = segment.indexOf("=");
+      if (eq === -1) continue;
+      if (segment.slice(0, eq).trim().startsWith(DSH_AUTH_COOKIE_PREFIX)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * 注入候选判定：GET 且出站路径恰为 `/` 且查询串尚无 token 参数。
+ * 与上游铸造条件（`GET /`、单一 token）严格对齐；其余请求一律不注入
+ * （带 token 的非根请求上游也回 401，注入无意义）。导出供纯函数单测。
+ */
+export function isTokenMintCandidate(method: string | undefined, url: string | undefined): boolean {
+  if (method !== "GET" || url === undefined) return false;
+  try {
+    const parsed = new URL(url, "http://lan-proxy.local");
+    return parsed.pathname === "/" && parsed.searchParams.getAll("token").length === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 把 token 并入请求 URL 的 query（`token` 参数；已存在时覆盖）。解析失败
+ * 返回 undefined（调用方降级为不注入）。导出供纯函数单测。
+ */
+export function withLaunchToken(url: string | undefined, token: string): string | undefined {
+  if (url === undefined) return undefined;
+  try {
+    const parsed = new URL(url, "http://lan-proxy.local");
+    parsed.searchParams.set("token", token);
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -571,7 +652,10 @@ export function createLanProxy(options: LanProxyOptions, logger: LanLogger = con
   // 正常完成/响应截断，交由 proxyRes aborted 处理）。实测复现：若用
   // res.writableEnded 判定，正常请求会在转发完成前被误杀（socket hang up）。
   const proxyResReceived = new WeakSet<ServerResponse>();
-  proxy.on("proxyRes", (proxyRes, _req, res) => {
+  /** injectToken 重放上下文（issue #380）：失效 cookie 候选请求经
+   *  selfHandleResponse 转发，上游 401 时带 token 重放一次自愈。 */
+  const replayContexts = new WeakMap<ServerResponse, { originalUrl: string; token: string }>();
+  proxy.on("proxyRes", (proxyRes, req, res) => {
     proxyResReceived.add(res);
     const abortDownstream = () => {
       connStats.httpClientAborted += 1;
@@ -579,6 +663,33 @@ export function createLanProxy(options: LanProxyOptions, logger: LanLogger = con
     };
     proxyRes.on("aborted", abortDownstream);
     proxyRes.on("error", abortDownstream);
+    const replay = replayContexts.get(res);
+    if (replay === undefined) return;
+    replayContexts.delete(res);
+    if (proxyRes.statusCode === 401) {
+      // 失效 cookie（签名 secret 重置等）：上游验签失败回 401。排干 401 响应体
+      // （keep-alive 槽位可复用），以注入 token 的等价请求重放一次——上游 token
+      // 分支优先于 cookie 校验，直接重铸 cookie，303 + Set-Cookie 透传回浏览器。
+      // 重放请求 URL 已带 token 参数，不再满足候选条件，天然封顶一次。
+      proxyRes.resume();
+      const nextUrl = withLaunchToken(replay.originalUrl, replay.token);
+      if (nextUrl !== undefined) {
+        req.url = nextUrl;
+        proxy.web(req, res, forwardOptions(req));
+        return;
+      }
+      // token 并入失败（怪异 URL，理论不可达）：继续走下方手动透传 401。
+    }
+    // 非 401（有效 cookie 的正常 200 等）或重放改写失败：手动透传上游响应
+    // （selfHandleResponse 下 http-proxy 不自动写头）。hop-by-hop 头交由 Node
+    // 自行管理，显式删除；body 原样字节 pipe（压缩由入口 compression 中间件
+    // 在 res 层协商，不受影响）。
+    const headers = { ...proxyRes.headers };
+    delete headers.connection;
+    delete headers["keep-alive"];
+    delete headers["transfer-encoding"];
+    res.writeHead(proxyRes.statusCode ?? 502, headers);
+    proxyRes.pipe(res);
   });
   proxy.on("proxyReq", (proxyReq, req, res) => {
     // 监听底层 TCP socket 的 close（而非 req 的 close——后者在 Node 中对
@@ -632,6 +743,28 @@ export function createLanProxy(options: LanProxyOptions, logger: LanLogger = con
       });
       res.end();
       return;
+    }
+    // injectToken（issue #380）：铸造候选（`GET /`、无 token 参数、无会话
+    // cookie）→ 注入当前 token 后正常透传，上游一次跳转即铸会话；失效候选
+    // （已带会话 cookie——可能已失效）→ selfHandleResponse 转发，上游 401 时
+    // 带 token 重放一次自愈（proxyRes 监听器内处理）。provider 未就绪或读取
+    // 失败一律降级为普通透传（行为与未开启一致）。注入必须放在 hostnameAllowed
+    // 围栏之后（DNS 重绑定防护前置，见文件头注 2）。
+    const tokenOptions = options.injectToken;
+    if (tokenOptions !== undefined && isTokenMintCandidate(req.method, req.url)) {
+      const token = tokenOptions.getToken();
+      if (token !== undefined) {
+        if (!hasDshAuthCookie(req.headers.cookie)) {
+          // 铸造候选：URL 注入 token（改写失败则原样透传，fail-safe）。
+          const injected = withLaunchToken(req.url, token);
+          if (injected !== undefined) req.url = injected;
+        } else {
+          // 失效候选：selfHandle 转发，401 → 重放自愈；非 401 → 手动透传。
+          replayContexts.set(res, { originalUrl: req.url ?? "/", token });
+          proxy.web(req, res, { ...forwardOptions(req), selfHandleResponse: true });
+          return;
+        }
+      }
     }
     // 围栏（hostnameAllowed / rewriteHeaders）前置完成后，http-proxy 接管转发。
     proxy.web(req, res, forwardOptions(req));

--- a/packages/dsh-lan-proxy/test/smoke.ts
+++ b/packages/dsh-lan-proxy/test/smoke.ts
@@ -1458,15 +1458,22 @@ const main = async () => {
       const expectedIds = [
         "lp-set-enabled", "lp-set-port", "lp-set-https-enabled", "lp-set-https-port",
         "lp-set-cert", "lp-set-key", "lp-set-banner", "lp-set-ws-compress",
-        "lp-set-ws-paths", "lp-set-http-compress", "lp-set-level",
+        "lp-set-ws-paths", "lp-set-http-compress", "lp-set-level", "lp-set-inject-token",
       ];
       const forIds = [...client.matchAll(/htmlFor:\s*"([^"]+)"/g)].map((m: any) => m[1]);
-      assert.deepEqual([...forIds].sort(), [...expectedIds].sort(), "11 行全部 htmlFor 关联");
+      assert.deepEqual([...forIds].sort(), [...expectedIds].sort(), "12 行全部 htmlFor 关联");
       for (const fid of forIds) {
         assert.ok(new RegExp(`id:\\s*"${fid}"`).test(client), `控件侧存在同名 id「${fid}」`);
       }
       const inputModeCount = [...client.matchAll(/inputMode:\s*"numeric"/g)].length;
       assert.equal(inputModeCount, 2, "port/httpsPort 两个 number 输入均带 inputMode=numeric");
+    });
+    // issue #380：injectToken 开关渲染 + 开启态常驻安全警示（评审要求：横幅一次性警示不足）。
+    check("client 渲染 injectToken 开关与开启态警示", () => {
+      assert.ok(client.includes('t("injectToken")'), "开关 label（i18n key）");
+      assert.ok(client.includes('t("injectTokenOnHint")'), "开启态警示文案（i18n key）");
+      assert.ok(client.includes("lp-set-warn"), "警示样式类");
+      assert.ok(client.includes("injectToken: true"), "DEFAULTS 缺省开启（前向兼容：存量用户升级即生效）");
     });
   }
 

--- a/packages/dsh-lan-proxy/test/unit-proxy.src.test.ts
+++ b/packages/dsh-lan-proxy/test/unit-proxy.src.test.ts
@@ -7,6 +7,7 @@
  * - createLanProxy 转发错误处理（不可达上游 → 502，proxy error 分支）
  * - createLanProxy HTTPS 降级（HTTPS 端口被占 → HTTP-only）
  * - createLanProxy 围栏与参数校验（非回环 targetHost / 非法 targetPort）
+ * - injectToken（issue #380）：token 注入判定纯函数 + 端到端注入与 401 重放自愈
  * - 纯函数边界用例（hostnameAllowed / isLoopbackTarget / formatAuthority /
  *   rewriteHeaders / compressWsPath / isCompressible / resolveCompressionOptions）
  */
@@ -22,6 +23,7 @@ import {
   hostnameAllowed, formatAuthority, rewriteHeaders, createLanProxy, isLoopbackTarget,
   DEFAULT_OPTIONS, compressWsPath, isCompressible, resolveCompressionOptions,
   ensureSelfSignedTls, deflateAllowedByPolicy, DEFAULT_DEFLATE_POLICY,
+  hasDshAuthCookie, isTokenMintCandidate, withLaunchToken,
 } from "../src/index.ts";
 import {
   toSanEntry, certStillValid, loadTlsFromFiles, SELF_SIGNED_KEY, SELF_SIGNED_CERT,
@@ -107,6 +109,150 @@ assert.equal(compressWsPath(["/a", "/b"], "/c"), false, "未命中");
 assert.equal(compressWsPath([], "/a"), false, "空列表");
 assert.equal(compressWsPath(undefined, "/a"), false, "undefined 列表");
 assert.equal(compressWsPath(["/a"], ""), false, "空 url");
+
+// ===== injectToken 纯函数（issue #380） =====
+// hasDshAuthCookie：按 RFC 6265 名字精确分段（禁整头子串匹配）
+assert.equal(hasDshAuthCookie(undefined), false, "无 Cookie 头 → false");
+assert.equal(hasDshAuthCookie(""), false, "空 Cookie 头 → false");
+assert.equal(hasDshAuthCookie("dsh-auth-abc=1"), true, "单 cookie 前缀命中");
+assert.equal(hasDshAuthCookie("a=1; dsh-auth-abc=1; b=2"), true, "多 cookie 中段命中");
+assert.equal(hasDshAuthCookie("a=1;dsh-auth-abc=1"), true, "无空格分段命中");
+assert.equal(hasDshAuthCookie(" x = 1 ; dsh-auth-x=y "), true, "名字两侧空格 trim 后命中");
+assert.equal(hasDshAuthCookie("theme=dsh-auth-x"), false, "值含前缀但名字不含 → 不命中（防 includes 误判）");
+assert.equal(hasDshAuthCookie("Xdsh-auth-a=1"), false, "名字仅后缀含前缀 → 不命中");
+assert.equal(hasDshAuthCookie("dsh-auth-=novalue"), true, "空值 cookie 名前缀仍命中");
+assert.equal(hasDshAuthCookie("nodalue"), false, "无 = 段跳过");
+assert.equal(hasDshAuthCookie(["a=1", "dsh-auth-b=2"]), true, "string[] 多值头命中");
+
+// isTokenMintCandidate：GET 且路径恰为 / 且无 token 参数
+assert.equal(isTokenMintCandidate("GET", "/"), true, "GET / → 候选");
+assert.equal(isTokenMintCandidate("GET", "/?foo=bar"), true, "GET / 带其他 query → 候选");
+assert.equal(isTokenMintCandidate("GET", "/?token=own"), false, "已带 token → 非候选");
+assert.equal(isTokenMintCandidate("GET", "/foo"), false, "非根路径 → 非候选");
+assert.equal(isTokenMintCandidate("POST", "/"), false, "POST → 非候选");
+assert.equal(isTokenMintCandidate("HEAD", "/"), false, "HEAD → 非候选（上游只认 GET 铸造）");
+assert.equal(isTokenMintCandidate(undefined, "/"), false, "method 缺失 → 非候选");
+assert.equal(isTokenMintCandidate("GET", undefined), false, "url 缺失 → 非候选");
+
+// withLaunchToken：token 并入 query（保留原 query；解析失败 undefined）
+assert.equal(withLaunchToken("/", "T1"), "/?token=T1", "根路径注入");
+assert.equal(withLaunchToken("/?a=1", "T1"), "/?a=1&token=T1", "保留原 query");
+assert.equal(withLaunchToken("/?token=old", "T1"), "/?token=T1", "已带 token 时覆盖");
+assert.equal(withLaunchToken(undefined, "T1"), undefined, "url 缺失 → undefined");
+
+// ===== injectToken 端到端（issue #380）：注入 + 401 重放自愈 =====
+// mock 上游语义（对齐 dsh-client-connection.authorizeIndex 行为契约）：
+//   带 token=T0K3N 的 GET / → 303 + Set-Cookie（铸造）；无 token →
+//   有效 cookie（dsh-auth-good）→ 200；否则 401。seen 记录上游实际收到的
+//   url / sec-fetch-site / cookie，作为注入与透传断言的单一事实源。
+{
+  const seen = [];
+  const upPort = 21000 + Math.floor(Math.random() * 100);
+  const upServer = createServer((req, res) => {
+    const url = req.url ?? "/";
+    seen.push({ url, secFetchSite: req.headers["sec-fetch-site"], cookie: req.headers.cookie ?? "" });
+    const token = new URL(url, "http://upstream.invalid").searchParams.get("token");
+    if (token === "T0K3N") {
+      res.writeHead(303, { location: "/", "set-cookie": "dsh-auth-minted=1; Path=/; Max-Age=3600" });
+      res.end();
+      return;
+    }
+    if (req.headers.cookie?.includes("dsh-auth-good")) {
+      res.writeHead(200, { "content-type": "text/html" });
+      res.end("<html>ok</html>");
+      return;
+    }
+    res.writeHead(401, { "content-type": "text/plain" });
+    res.end("unauthorized");
+  });
+  await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+
+  // 可变闭包 provider：覆盖「provider 后到」时序（转发器先起、token 后就绪）。
+  let token: string | undefined = "T0K3N";
+  const proxy = createLanProxy({
+    host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
+    injectToken: { getToken: () => token },
+  });
+  const { httpPort } = await proxy.listen();
+  const get = (path, headers = {}, method = "GET") =>
+    new Promise((resolve, reject) => {
+      const req = httpRequest(
+        { hostname: "127.0.0.1", port: httpPort, path, method, headers: { host: "127.0.0.1", ...headers } },
+        (res2) => {
+          let body = "";
+          res2.on("data", (c) => (body += c));
+          res2.on("end", () => resolve({ status: res2.statusCode, headers: res2.headers, body }));
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+  const last = () => seen[seen.length - 1];
+
+  // 1. 铸造候选（无 cookie GET /）→ 注入 token，上游收 ?token=T0K3N，客户端得 303
+  {
+    const r = await get("/");
+    assert.equal(last().url, "/?token=T0K3N", `铸造候选应注入当前 token（实际 ${last().url}）`);
+    assert.equal(r.status, 303, "铸造候选最终得到上游 303（Set-Cookie 透传）");
+    assert.ok(String(r.headers["set-cookie"] ?? "").includes("dsh-auth-minted"), "303 响应携带铸造 Set-Cookie");
+  }
+  // 2. 有效 cookie → 绝不注入（否则无限 303），200 原样透传（selfHandle 手动管道）
+  {
+    const r = await get("/", { cookie: "dsh-auth-good=1" });
+    assert.equal(last().url, "/", "有效 cookie 请求不得注入（打破 303 循环的正确性必需）");
+    assert.equal(r.status, 200, "有效 cookie → 上游 200 透传");
+    assert.equal(r.body, "<html>ok</html>", "selfHandle 管道 body 完整");
+    assert.equal(r.headers["content-type"], "text/html", "selfHandle 管道响应头保留");
+  }
+  // 3. 失效 cookie → 上游 401 → 重放一次（带 token）→ 客户端得 303 自愈
+  {
+    const r = await get("/", { cookie: "dsh-auth-stale=1" });
+    assert.equal(seen[seen.length - 2].url, "/", "失效 cookie 首跳不注入（候选排除）");
+    assert.equal(last().url, "/?token=T0K3N", "401 后应带 token 重放一次");
+    assert.equal(r.status, 303, "重放后客户端得到 303（重铸 cookie 自愈）");
+    assert.ok(String(r.headers["set-cookie"] ?? "").includes("dsh-auth-minted"), "重放 303 携带新铸造 Set-Cookie");
+  }
+  // 4. 已带 token → 不重复注入（保留用户 token，候选条件排除）
+  {
+    const r = await get("/?token=MINE", { cookie: "dsh-auth-good=1" });
+    assert.equal(last().url, "/?token=MINE", "已带 token 的请求不被覆盖");
+    assert.equal(r.status, 200, "已带 token + 有效 cookie → 正常 200");
+  }
+  // 5. POST / → 不注入
+  {
+    const r = await get("/", {}, "POST");
+    assert.equal(last().url, "/", "POST 不注入");
+    assert.equal(r.status, 401, "POST 无 cookie → 上游 401 原样透传");
+  }
+  // 6. 非根路径 → 不注入
+  {
+    const r = await get("/foo");
+    assert.equal(last().url, "/foo", "非根路径不注入");
+    assert.equal(r.status, 401, "非根路径无 cookie → 401 原样透传");
+  }
+  // 7. provider 未就绪（返回 undefined）→ 降级不注入（行为与未开启一致）
+  {
+    token = undefined;
+    const r = await get("/");
+    assert.equal(last().url, "/", "provider 未就绪 → 不注入");
+    assert.equal(r.status, 401, "降级路径 401 原样透传");
+    token = "T0K3N";
+  }
+  // 8. sec-fetch-site 头透传不被注入逻辑破坏
+  {
+    await get("/", { "sec-fetch-site": "same-origin" });
+    assert.equal(last().secFetchSite, "same-origin", "sec-fetch-site 原样透传");
+  }
+  // 9. 值含 dsh-auth- 前缀的其它 cookie → 名字精确解析不误判，仍注入
+  {
+    const r = await get("/", { cookie: "theme=dsh-auth-x" });
+    assert.equal(last().url, "/?token=T0K3N", "值含前缀的无关 cookie 不阻断注入");
+    assert.equal(r.status, 303, "注入链路正常完成");
+  }
+
+  await proxy.close();
+  upServer.close();
+}
 
 // isCompressible
 assert.equal(isCompressible("application/problem+json"), true, "problem+json");


### PR DESCRIPTION
Closes #380

## 实施摘要

按 issue #380 方案实施，对抗评审五处必改点全部落地：

- **injectToken 配置**（默认 `true`，维护者决策：家用固定内网升级即生效）：schema / `FILE_CONFIG_VALIDATORS` / `SETTING_FIELD_HINTS` / `ResolvedConfig` 四处同步键集，走既有 settings 单一通道与热更新。
- **动态 tokenProvider**：内层 `ctx.inject(["connection"])` 二级补挂（照 settings 先例，禁入顶层 inject），仅依赖官方 `authenticatedUrl()` 公开 d.ts API；getter 每次现读不缓存——dsh web 重启后 token 变化自动跟随；provider 后到（转发器先起）经共享 getter 动态生效；读取失败 try/catch 降级为不注入，按状态变化各 warn 一次。
- **注入条件**（全部满足）：`GET` + 路径恰为 `/` + 无 `token` 参数 + 无 `dsh-auth-` 会话 cookie。已带 cookie 请求绝不注入——这是打破无限 303 循环的**正确性必需**（带 token 请求上游必以 303 结束），proxy.ts 注释与 smoke 意图锁死。Cookie 前缀按 RFC 6265 名字精确分段匹配，禁整头 `includes`。
- **401 重放自愈**：失效 cookie 候选（可能已失效）经 `selfHandleResponse` 转发，上游 401 后带 token 重放一次——上游 token 分支优先验签、直接重铸 cookie，303 + Set-Cookie 透传，设备无感恢复；重放 URL 已带 token 不再满足候选条件，天然封顶一次；非 401 走手动透传管道（删 hop-by-hop 头，body 原样 pipe，入口 compression 协商不受影响）。
- **警示**：开启态启动横幅警示行 + 设置卡片常驻红色警示（zh/en 双语，暗/浅色主题变量）。
- **README 安全模型**：信任取舍（等效信任整个 LAN）、默认开启偏离业界惯例的记录（Home Assistant `trusted_networks`、qBittorrent bypass 均为显式开启）、关闭不吊销已发 cookie、失效 cookie 自愈路径、cross-site 残余面分析（CORS opaque + SameSite=Strict + sec-fetch-site 围栏链条闭合）、自建口令页列为演进方向。

## 测试

- `unit-proxy.src.test.ts`：纯函数 20 断言（Cookie 精确解析 / 候选判定 / URL 改写）+ 端到端 9 组用例（mock 上游按 `authorizeIndex` 行为契约：注入 303、有效 cookie 200 零打扰、失效 cookie 401→重放→303 自愈、已带 token 不覆盖、POST/非根路径不注入、provider 未就绪降级、`sec-fetch-site` 透传、值含前缀的无关 cookie 不误判）。
- `smoke.ts`：label/id 关联契约扩到 12 行；新增「injectToken 开关与开启态警示渲染」契约断言。
- 全仓门禁：`pnpm build && pnpm test && pnpm contract && pnpm pack:check` 全绿。

## 不做清单（v1，同 issue）

非根路径深链 303 换取、WS 注入、来源 IP 白名单（v2）、自建口令页（演进方向）。
