### PR TITLE
fix(dsh-mcp-manager): 连接生命周期口径统一——runtime 重连回退 + all 模式池接管下沉 + 展示剥前缀 + 防双进程探测重试

### DIFF
--- a/packages/dsh-mcp-manager/src/apply.ts
+++ b/packages/dsh-mcp-manager/src/apply.ts
@@ -69,6 +69,9 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
         return found as unknown as import("../../../shared/mcp-manager-service.js").McpServerSummary;
       },
       getTools: (name: string) => {
+        // 契约（#382 F4）：getTools 返回**注册名**（mcp__<server>__<tool> 前缀，
+        // 与 ctx.tools 注册表一致）；summary().tools 返回**裸名**（展示/禁用表
+        // 键口径）。消费方按需自取，勿混用两套键。
         const sup = manager.supervisors.get(name);
         if (sup === undefined) return [];
         const tools: Array<{ name: string; description?: string }> = [];
@@ -132,17 +135,16 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
   let watchCleanup: () => void = () => {};
 
   if (enabled) {
-    await manager.startAll();
-    await manager.loadCatalogCache();
-
-    // 中间层（ws_mcp_search / ws_mcp_call）：按 Config.middleware 模式注册。
-    // project 模式：项目级服务器不再注册 mcp__ 工具，改经中间层路由调用；
-    // 全局服务器仍 mcp__ 直呼（双轨迁移默认）。
+    // F3（#382）：中间层初始化提前到 startAll 之前——start 内部的接管判定
+    // （middlewareTakes）依赖 middleware 实例与模式；此前 startAll 先建全部
+    // supervisor、中间层初始化完才 reconcile 停掉（all 含全局），「先建后停」
+    // 的竞态窗口内 mcp__ 注册残留，中间层防双进程探测命中且无重试 → 热更新后
+    // 全局服务器掉线。重排后 all 模式启动直接走 @global 单元惰性连接，不建
+    // supervisor；project 模式全局照旧 supervisor。
     // 默认值与 Config schema 一致（project）；宿主未 parse 原始 config 时兜底。
     const middlewareMode = normalizeMiddlewareMode(config?.middleware ?? "project");
-    // 中间层模式热切换（设置页「中间层模式」下拉；initMiddleware 幂等已有，
-    // off↔project/all 需重新注册/卸载中间层工具——dispose 后重建）。
-    // 注册在模式分支之外：启动即 off 时也能从设置页切到 project/all。
+    // 路由输入：exec.agent 当前 cwd = agent.session.header.cwd（实证已闭合）。
+    // all 模式：cwd 无项目（或无项目配置）时 fallback 到全局虚拟 root @global。
     const resolveRoot = async (agent: unknown): Promise<string | undefined> => {
       if (typeof agent !== "object" || agent === null) return undefined;
       const session = (agent as { session?: { header?: { cwd?: unknown } } }).session;
@@ -155,6 +157,20 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
       }
       return undefined;
     };
+    if (middlewareMode !== "off") {
+      const mw = await manager.initMiddleware(middlewareMode, (config?.middlewarePolicy as Record<string, unknown> | undefined) ?? {});
+      disposeMiddleware = registerMiddlewareTools(manager.ctx, mw, resolveRoot, middlewareMode, {
+        disabledTools: manager.disabledTools,
+      });
+    }
+    await manager.startAll();
+    await manager.loadCatalogCache();
+    manager.reconcileServers();
+    manager.logger.info(`dsh-mcp-manager: middleware mode=${middlewareMode}`);
+
+    // 中间层模式热切换（设置页「中间层模式」下拉；initMiddleware 幂等已有，
+    // off↔project/all 需重新注册/卸载中间层工具——dispose 后重建）。
+    // 注册在模式分支之外：启动即 off 时也能从设置页切到 project/all。
     manager.setMiddlewareMode = async (mode: MiddlewareMode): Promise<void> => {
       if (normalizeMiddlewareMode(mode) === manager.middlewareMode) return;
       const next = normalizeMiddlewareMode(mode);
@@ -166,23 +182,12 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
           disabledTools: manager.disabledTools,
         });
       }
-      // off ↔ project/all：重注册/卸载中间层工具后 reconcile，恢复 supervisor
-      // 接管（all 模式含全局）或停掉（off 语义）——防同一 server 双进程。
+      // off ↔ project/all：重注册/卸载中间层工具后 reconcile——all 模式下全局
+      // supervisor 由 reconcile 停掉、新全局条目经 start 内部接管触达 @global
+      // 单元（#382 F3）；off 语义停掉全部中间层接管条目。防同一 server 双进程。
       manager.reconcileServers();
       manager.logger.info(`dsh-mcp-manager: middleware mode=${next} (hot-switched)`);
     };
-    if (middlewareMode !== "off") {
-      const mw = await manager.initMiddleware(middlewareMode, (config?.middlewarePolicy as Record<string, unknown> | undefined) ?? {});
-      // 路由输入：exec.agent 当前 cwd = agent.session.header.cwd（实证已闭合）。
-      // all 模式：cwd 无项目（或无项目配置）时 fallback 到全局虚拟 root @global。
-      disposeMiddleware = registerMiddlewareTools(manager.ctx, mw, resolveRoot, middlewareMode, {
-        disabledTools: manager.disabledTools,
-      });
-      // startAll 在中间层注册前执行（off 语义），此处立即 reconcile：停掉
-      // 项目级（all 含全局）supervisor（改由中间层接管），防同一 server 双进程。
-      manager.reconcileServers();
-      manager.logger.info(`dsh-mcp-manager: middleware mode=${middlewareMode}`);
-    }
 
     // L1 能力目录注入（history-based 去重，仿 dsh-tool-skill catalog）：
     // 决策逻辑在 resolveCatalogInjection（纯函数，可单测）。

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -45,6 +45,21 @@ function dshHomePath() {
 }
 
 /**
+ * 剥 mcp__<server>__ 前缀还原裸名（#382 F4 展示口径统一）。前缀不匹配（不可
+ * 剥）原样返回；剥后为空或仍以 mcp__ 开头（跨 server 注册名）原样返回。超长
+ * 哈希名剥出截断键——与 guard 层（tools/pre-execute 路径二按注册名反解）结果
+ * 相同，禁用表键口径统一生效。
+ */
+function stripMcpPrefix(registeredName: string, serverName: string): string {
+  const prefix = `mcp__${serverName}__`;
+  if (!registeredName.startsWith(prefix)) return registeredName;
+  let name = registeredName;
+  while (name.startsWith(prefix)) name = name.slice(prefix.length);
+  if (name === "" || name.startsWith("mcp__")) return registeredName;
+  return name;
+}
+
+/**
  * 管理器：持有全局存储 + 当前会话项目的项目级存储、每个服务器的监督器
  * 与状态通知。全局服务器常连；项目级服务器（<项目根>/.dsh/mcp.json）只在
  * 当前会话 cwd 属于该项目时连接（跟随会话切换）。
@@ -467,13 +482,9 @@ export class McpManager {
       let changed = false;
       for (const [name, supervisor] of [...this.supervisors]) {
         const want = desired.get(name);
-        // runtime 条目豁免中间层接管（走全局 supervisor 路径，不被中间层停掉/跳过）。
-        const isRuntime = this.runtimeRegistry.has(name);
-        // 中间层 project/all 模式：项目级（all 含全局）服务器由中间层接管
-        // （不注册 mcp__ 工具，避免双连接双进程）。runtime 条目例外。
-        const middlewareTakes = !isRuntime && this.middlewareMode !== "off" && (
-          supervisor.scope === SCOPE_PROJECT || (this.middlewareMode === "all" && supervisor.scope === SCOPE_GLOBAL)
-        );
+        // 中间层接管（与 start 同口径单一事实源 middlewareTakes）：停掉不该以
+        // supervisor 形态存在的连接。runtime 条目豁免（判定恒 false，不被停）。
+        const middlewareTakes = this.middlewareTakes(name, supervisor.scope);
         if (want === undefined || want.server.enabled === false || want.scope !== supervisor.scope || middlewareTakes) {
           this.stop(name);
           changed = true;
@@ -481,17 +492,15 @@ export class McpManager {
       }
       for (const [name, want] of desired) {
         if (want.server.enabled === false) continue;
-        // runtime 条目豁免中间层跳过（走全局 supervisor 路径，reconcile 不杀 runtime）。
-        const isRuntime = this.runtimeRegistry.has(name);
-        // 中间层 project/all 模式：项目级（all 含全局）跳过 supervisor（由中间层惰性连接）。
-        // runtime 条目例外。
-        if (!isRuntime && this.middlewareMode !== "off" && (
-          want.scope === SCOPE_PROJECT || (this.middlewareMode === "all" && want.scope === SCOPE_GLOBAL)
-        )) continue;
+        // project 模式项目级：由中间层单元管理（touchMiddlewareUnit 惰性重建），
+        // 不经 start；all 模式全局照常 start——start 内部下沉接管（触达 @global）。
+        if (this.middlewareMode === "project" && want.scope === SCOPE_PROJECT) continue;
         const existing = this.supervisors.get(name);
         if (existing === undefined || existing.scope !== want.scope) {
           this.start(name, want.scope);
-          changed = true;
+          // all 模式全局接管路径（start 内部触达池）不建 supervisor——池连接
+          // 变化由 connectInternal emitStatus 上报，不计入 supervisor 集合变化。
+          if (!this.middlewareTakes(name, want.scope)) changed = true;
         }
       }
       return changed;
@@ -519,8 +528,30 @@ export class McpManager {
       const store = scope === SCOPE_PROJECT ? this.projectStore : this.store;
       if (store === undefined) return;
       server = store.find(name);
+      // F2（#382）：runtime 注入条目不落 store——global scope 查不到时回退
+      // runtimeRegistry（双轨合并，与 summary/catalogServersFor 同口径），修
+      // codegraph 等动态注册服务器「浮窗重连断开后连不回」。仅限 global：
+      // project 回退会把 runtime 条目挂错 scope，被下次 reconcile 无声停掉。
+      if (server === undefined && scope === SCOPE_GLOBAL) {
+        const runtime = this.runtimeRegistry.get(name);
+        if (runtime !== undefined) {
+          this.logger.warn(`dsh-mcp-manager: server "${name}" not in store; using runtime registry entry`);
+          server = runtime;
+        }
+      }
     }
     if (server === undefined) return;
+    // F3（#382）：中间层接管判定下沉到 start（与 reconcileServers 同口径，见
+    // middlewareTakes）。all 模式全局非 runtime 不建 supervisor——杜绝「先建
+    // supervisor 再被 reconcile 停掉」的竞态窗口（热更新后 mcp__ 注册残留 →
+    // 中间层防双进程探测命中且无重试 → 掉线），改触达 @global 单元惰性连接；
+    // 中间层模式项目级不建 supervisor，拆项目单元惰性重建。startAll / add /
+    // update / reconcile 各入口自动收敛，无需逐处特判。
+    if (this.middlewareTakes(name, scope)) {
+      if (scope === SCOPE_PROJECT) this.touchMiddlewareUnit();
+      else this.touchGlobalUnit(name);
+      return;
+    }
     const existing = this.supervisors.get(name);
     if (existing !== undefined && existing.client !== undefined) {
       // 已连接：若现有 config 与直传 config 不同（runtime 注入覆盖 store），重建。
@@ -541,6 +572,57 @@ export class McpManager {
     const supervisor = new ConnectionSupervisor(this, server, scope);
     this.supervisors.set(name, supervisor);
     void supervisor.connect();
+  }
+
+  /**
+   * 中间层接管判定（start / reconcileServers 单一口径）：中间层模式的项目级，
+   * 或 all 模式下非 runtime 注入的全局级。runtime 条目豁免（始终走 supervisor
+   * 路径，注册 mcp__ 工具）。
+   */
+  private middlewareTakes(name: string, scope: string): boolean {
+    if (this.middlewareMode === "off" || this.middleware === undefined) return false;
+    if (scope === SCOPE_PROJECT) return true;
+    return this.middlewareMode === "all" && scope === SCOPE_GLOBAL && !this.runtimeRegistry.has(name);
+  }
+
+  /**
+   * 触达 @global 单元并确保该全局服务器连接（all 模式 start 接管路径）。
+   * projectUnitFor 首次触达会连带惰性连接全部全局服务器，等价 startAll 语义；
+   * userDisabled 命中不连（与浮窗断开语义一致）。
+   */
+  private touchGlobalUnit(name: string): void {
+    const mw = this.middleware;
+    if (mw === undefined) return;
+    void mw.projectUnitFor(MIDDLEWARE_GLOBAL_ROOT)
+      .then((unit) => {
+        if (unit === undefined || unit.userDisabled.has(name)) return;
+        void mw.ensureConnected(MIDDLEWARE_GLOBAL_ROOT, name);
+      })
+      .catch(() => {});
+  }
+
+  /**
+   * 拆除中间层池中该 server 的连接（update/remove 配置变更后强制重建；
+   * 不写 userDisabled——与 disconnect 的禁用语义区分）。此前 update/remove 仅
+   * 处理项目单元，all 模式全局池连接与目录残留导致「已删服务器仍可调用」。
+   */
+  private dropMiddlewareConnection(name: string): void {
+    const mw = this.middleware;
+    if (mw === undefined) return;
+    let dropped = false;
+    for (const unit of mw.units.values()) {
+      const entry = unit.connections.get(name);
+      if (entry === undefined) continue;
+      dropped = true;
+      entry.disposed = true;
+      if (entry.reconnectTimer !== undefined) clearTimeout(entry.reconnectTimer);
+      const client = entry.client;
+      entry.client = undefined;
+      entry.transport = undefined;
+      if (client !== undefined && client.transport !== undefined) void client.transport.close().catch(() => {});
+      unit.connections.delete(name);
+    }
+    if (dropped) this.emitStatus();
   }
 
   stop(name: string): void {
@@ -620,9 +702,10 @@ export class McpManager {
     store.upsert(merged);
     await store.save();
     this.stop(name);
-    if (this.middlewareMode !== "off" && scope === SCOPE_PROJECT) {
-      // 中间层：拆毁当前 root 单元（下次惰性重建读新配置）。
-      this.touchMiddlewareUnit();
+    if (this.middlewareMode !== "off") {
+      // 中间层：拆池内旧配置连接（项目/全局单元统一处理；#382 此前只拆项目
+      // 单元，all 模式全局旧连接残留导致编辑不生效）。
+      this.dropMiddlewareConnection(name);
     }
     if (merged.enabled !== false) {
       // 编辑后重新连接（即便此前未连接）
@@ -634,9 +717,10 @@ export class McpManager {
   async remove(name: string, scope: string = SCOPE_GLOBAL): Promise<void> {
     const store = scope === SCOPE_PROJECT ? await this.projectStoreOrThrow() : this.store;
     this.stop(name);
-    if (this.middlewareMode !== "off" && scope === SCOPE_PROJECT) {
-      // 中间层：拆毁当前 root 单元（下次惰性重建读新配置）。
-      this.touchMiddlewareUnit();
+    if (this.middlewareMode !== "off") {
+      // 中间层：拆池内连接 + 目录随单元重建收敛（#382 此前只拆项目单元，
+      // all 模式全局删除后池连接残留——ws_mcp_call 仍可调用已删服务器）。
+      this.dropMiddlewareConnection(name);
     }
     store.remove(name);
     await store.save();
@@ -654,11 +738,23 @@ export class McpManager {
     if (server === undefined) {
       const store = scope === SCOPE_PROJECT ? await this.projectStoreOrThrow() : this.store;
       server = store.find(name);
+      // F2（#382）：与 start 同款回退——runtime 注入条目不落 store，global
+      // scope 查不到时回退 runtimeRegistry，修 codegraph 浮窗重连必失败。
+      if (server === undefined && scope === SCOPE_GLOBAL) {
+        const runtime = this.runtimeRegistry.get(name);
+        if (runtime !== undefined) {
+          this.logger.warn(`dsh-mcp-manager: server "${name}" not in store; using runtime registry entry`);
+          server = runtime;
+        }
+      }
     }
     if (server === undefined) throw new Error(`server "${name}" not found in ${scope} scope`);
-    // 中间层模式：项目级连接走中间层连接池（userDisabled 解除 + 惰性连接）。
-    if (this.middlewareMode !== "off" && scope === SCOPE_PROJECT && this.middleware !== undefined) {
-      const root = this.projectRoot;
+    // F4（#382）：被中间层接管的服务器连接走连接池（userDisabled 解除 + 惰性
+    // 连接）——此前只有项目级走池，all 模式全局走 supervisor 复活（注册 mcp__
+    // 前缀工具），既导致浮窗带前缀展示，又让中间层防双进程探测持续命中、永不
+    // 接管。runtime 条目豁免（middlewareTakes 判定），仍走 supervisor 路径。
+    if (this.middlewareTakes(name, scope) && this.middleware !== undefined) {
+      const root = scope === SCOPE_PROJECT ? this.projectRoot : MIDDLEWARE_GLOBAL_ROOT;
       if (root === undefined) throw new Error("no active project session (call session with a cwd first)");
       const unit = await this.middleware.projectUnitFor(root);
       if (unit === undefined) throw new Error(`workspace ${root} has no project MCP config`);
@@ -677,13 +773,32 @@ export class McpManager {
   }
 
   async disconnect(name: string): Promise<void> {
-    // 中间层模式：项目级断开 → userDisabled 持久化 + 连接池拆毁该连接。
+    // 中间层模式：userDisabled 持久化 + 连接池拆毁该连接。
+    // #382：定位按接管口径显式进行——all 模式全局（store 配置且非 runtime）固定
+    // 定位 @global 单元（此前按 units 遍历序找第一个命中，同名服务器同时存在于
+    // 项目与 @global 单元时可能写错单元）；runtime 注入条目不经池，落 supervisor。
+    // 拆连接前关 transport（此前直接 delete 丢 entry，stdio 子进程/socket 泄漏）。
     if (this.middlewareMode !== "off" && this.middleware !== undefined) {
-      const unit = [...this.middleware.units.values()].find((entry) => entry.connections.has(name) || entry.userDisabled.has(name));
-      if (unit !== undefined) {
-        unit.userDisabled.add(name);
+      let targetUnit: ProjectUnit | undefined;
+      if (this.middlewareMode === "all" && this.store.find(name) !== undefined && !this.runtimeRegistry.has(name)) {
+        targetUnit = this.middleware.units.get(MIDDLEWARE_GLOBAL_ROOT);
+      } else {
+        targetUnit = [...this.middleware.units.values()].find((unit) => unit.connections.has(name) || unit.userDisabled.has(name));
+      }
+      if (targetUnit !== undefined) {
+        targetUnit.userDisabled.add(name);
         await this.saveUserState(this.middleware.units);
-        unit.connections.delete(name);
+        const entry = targetUnit.connections.get(name);
+        if (entry !== undefined) {
+          entry.disposed = true;
+          if (entry.reconnectTimer !== undefined) clearTimeout(entry.reconnectTimer);
+          const client = entry.client;
+          entry.client = undefined;
+          entry.transport = undefined;
+          if (client !== undefined && client.transport !== undefined) void client.transport.close().catch(() => {});
+          targetUnit.connections.delete(name);
+        }
+        this.emitStatus();
         return;
       }
     }
@@ -734,8 +849,9 @@ export class McpManager {
   private middlewareUnitFor(serverName: string, scope: string): ProjectUnit | undefined {
     const mw = this.middleware;
     if (mw === undefined || this.middlewareMode === "off") return undefined;
-    const taken = scope === SCOPE_PROJECT || (this.middlewareMode === "all" && scope === SCOPE_GLOBAL);
-    if (!taken) return undefined;
+    // 与 start/reconcileServers 同口径（#382 F4）：runtime 条目豁免（走 supervisor
+    // 投影），all 模式全局才映射 @global 单元。
+    if (!this.middlewareTakes(serverName, scope)) return undefined;
     const root = scope === SCOPE_PROJECT ? this.projectRoot : MIDDLEWARE_GLOBAL_ROOT;
     return root === undefined ? undefined : mw.units.get(root);
   }
@@ -744,8 +860,6 @@ export class McpManager {
     // 中间层模式（#228 回归修复）：被中间层接管的服务器从连接池 + 目录缓存
     // 投影状态与工具列表——此前只读 supervisors，项目级无 supervisor 条目恒
     // 兜底 "stopped"，浮窗/summary 与真实连接态脱节。返回形状不变。
-    // 注意不做 userDisabled 短路：all 模式全局 connect 走 supervisor 复活
-    // （#234 既有限制），短路会把「supervisor 实际已连接」反向投影成 stopped。
     const unit = this.middlewareUnitFor(server.name, scope);
     if (unit !== undefined) {
       const entry = unit.connections.get(server.name);
@@ -765,9 +879,20 @@ export class McpManager {
           disabledTools: disabledList.length > 0 ? disabledList : undefined,
         };
       }
+      // #382 F4：userDisabled 短路——池中已断开（用户浮窗断开）的服务器不再落
+      // supervisor 分支（all 模式全局经池接管后 supervisor 不复存在；同名 runtime
+      // 残留时也不误显示其连接态）。#234 注释前提（全局 connect 走 supervisor 复活）
+      // 随 F4 消失。
+      if (unit.userDisabled.has(server.name)) {
+        return { ...server, scope, status: "stopped", error: undefined, tools: [] };
+      }
     }
     const supervisor = this.supervisors.get(server.name);
-    const supervisorTools = supervisor?.tools ?? [];
+    // #382 F4：展示口径统一裸名——剥 mcp__<server>__ 前缀（与中间层投影分支、
+    // 工具级禁用表键、guard 层反解口径一致；此前浮窗禁用提交带前缀名而 guard
+    // 查裸名，禁用静默无效）。超长哈希名剥出截断键，与 guard 路径二反解结果
+    // 相同，禁用链路一致生效；前缀不匹配（不可剥）原样返回。
+    const supervisorTools = (supervisor?.tools ?? []).map((tool) => stripMcpPrefix(tool, server.name));
     const disabledForServer = this.disabledTools.get(MIDDLEWARE_GLOBAL_ROOT)?.get(server.name) ?? this.disabledTools.get(this.projectRoot ?? "")?.get(server.name);
     const supervisorDisabled = disabledForServer !== undefined ? supervisorTools.filter((tool) => disabledForServer.has(tool)) : [];
     return {

--- a/packages/dsh-mcp-manager/src/middleware-types.ts
+++ b/packages/dsh-mcp-manager/src/middleware-types.ts
@@ -54,6 +54,8 @@ export interface ConnectionEntry {
   disposed: boolean;
   /** 连续失败次数（有界指数退避依据；连接成功后清零）。 */
   failedAttempts: number;
+  /** 防双进程探测命中后的重试已排（#382 F5：只重试一次；连接成功后复位）。 */
+  probeRetried?: boolean;
 }
 
 /** 目录中的单服务器条目。 */

--- a/packages/dsh-mcp-manager/src/middleware.ts
+++ b/packages/dsh-mcp-manager/src/middleware.ts
@@ -46,6 +46,7 @@ import {
   fullServerName,
   isToolDenied,
   toolDisabledReason,
+  MIDDLEWARE_GLOBAL_ROOT,
 } from "./middleware-utils.ts";
 import type {
   MiddlewareHost,
@@ -155,6 +156,25 @@ export class McpMiddleware {
         const prefix = `mcp__${serverName}__`;
         if (Array.isArray(registered) && registered.some((schema) => typeof schema?.name === "string" && (schema.name as string).startsWith(prefix))) {
           this.host.logger.warn(`dsh-mcp-manager(${serverName}@${root}): server 已由其他插件（如官方 dsh-mcp-client）注册 mcp__ 工具，跳过本实例连接（防双进程）`);
+          // F5（#382）：命中多为热更新/模式切换窗口期——旧实例 mcp__ 注册尚未
+          // 注销（dispose 为 fire-and-forget）。确保存在可挂重试定时器的 entry
+          // （首次连接无旧 entry → 落 failed 占位；旧 entry 保留其退避语义），
+          // 安排一次有界延迟重试，避免窗口期「一次定终身」掉线；重试经
+          // ensureConnected（尊重 userDisabled + in-flight 去重），再命中仍跳过
+          // （官方 client 真接管场景不空转）。
+          const retryEntry = unit.connections.get(serverName) ?? {
+            server,
+            client: undefined,
+            transport: undefined,
+            status: "failed",
+            error: undefined,
+            connectedAt: undefined,
+            reconnectTimer: undefined,
+            disposed: false,
+            failedAttempts: 0,
+          };
+          unit.connections.set(serverName, retryEntry);
+          this.scheduleProbeRetry(root, serverName);
           return;
         }
       } catch {
@@ -173,6 +193,7 @@ export class McpMiddleware {
       reconnectTimer: undefined,
       disposed: false,
       failedAttempts: entry?.failedAttempts ?? 0,
+      probeRetried: entry?.probeRetried ?? false,
     };
     unit.connections.set(serverName, newEntry);
     const closeHandler = (error: Error) => {
@@ -193,6 +214,7 @@ export class McpMiddleware {
       newEntry.status = "connected";
       newEntry.connectedAt = Date.now();
       newEntry.failedAttempts = 0;
+      newEntry.probeRetried = false;
       this.host.logger.info(`dsh-mcp-manager(${serverName}@${root}): connected`);
       this.host.emitStatus();
     } catch (error) {
@@ -225,6 +247,30 @@ export class McpMiddleware {
       if (entry.disposed) return;
       void this.connectInternal(root, serverName);
     }, delayMs);
+    entry.reconnectTimer.unref?.();
+  }
+
+  /**
+   * 防双进程探测命中后的一次性有界重试（#382 F5）。定时器复用 entry.reconnectTimer
+   * 槽位（teardownUnit/disconnect 路径统一清理）；重试经 ensureConnected——它
+   * 查 userDisabled + in-flight 去重，不会复活用户已断开的服务器、不与手动重连
+   * 并发冲突。每代 entry 只重试一次（probeRetried 标记；连接成功复位），官方
+   * dsh-mcp-client 真接管时不会反复空转。
+   */
+  private scheduleProbeRetry(root: string, serverName: string): void {
+    const unit = this.units.get(root);
+    if (unit === undefined) return;
+    const entry = unit.connections.get(serverName);
+    if (entry === undefined || entry.disposed) return;
+    if (entry.reconnectTimer !== undefined) return;
+    if (entry.probeRetried === true) return;
+    entry.probeRetried = true;
+    const PROBE_RETRY_DELAY_MS = 3000;
+    entry.reconnectTimer = setTimeout(() => {
+      entry.reconnectTimer = undefined;
+      if (entry.disposed) return;
+      void this.ensureConnected(root, serverName);
+    }, PROBE_RETRY_DELAY_MS);
     entry.reconnectTimer.unref?.();
   }
 
@@ -430,12 +476,15 @@ export class McpMiddleware {
     return servers;
   }
 
-  /** LRU 淘汰：无活动引用（lastTouchedAt 最旧）且超过上限时淘汰最旧单元。 */
+  /** LRU 淘汰：无活动引用（lastTouchedAt 最旧）且超过上限时淘汰最旧单元。
+   * @global 单元豁免（#382 F3）：全局服务器常连语义不随多项目切换被淘汰
+   * （supervisor 时代全局永不淘汰，池接管后需显式豁免保持等价语义）。 */
   evictIfNeeded(maxUnits = 16): void {
     while (this.units.size > maxUnits) {
       let oldestKey: string | undefined;
       let oldestAt = Infinity;
       for (const [root, unit] of this.units) {
+        if (root === MIDDLEWARE_GLOBAL_ROOT) continue;
         if (unit.lastTouchedAt < oldestAt) {
           oldestAt = unit.lastTouchedAt;
           oldestKey = root;

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -2400,9 +2400,10 @@ const main = async () => {
         false,
         "未禁用封装工具放行",
       );
-      // 可见性/能力目录：summary 工具列表为 mcp__ 公开名（与普通工具同口径）。
+      // 可见性/能力目录：summary 工具列表为裸名（#382 F4 展示口径统一：剥
+      // mcp__ 前缀，与中间层投影分支/禁用表键/guard 反解口径一致）。
       const sum = manager.summarize(sup.server, SCOPE_GLOBAL);
-      assert.deepEqual(sum.tools, ["mcp__codegraph__codegraph_explore", "mcp__codegraph__codegraph_status"], "summary 工具列表为公开名");
+      assert.deepEqual(sum.tools, ["codegraph_explore", "codegraph_status"], "summary 工具列表为裸名（#382 剥前缀口径）");
 
       // 不带 toolDefinitions → 现状回归：远端 schema + 通用 callTool 路径不变。
       const plainRegistered = [];

--- a/packages/dsh-mcp-manager/test/unit-manager2.src.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-manager2.src.test.ts
@@ -484,6 +484,72 @@ function rmStatSafe(p) {
   }
 }
 
+// ---- #382 F2/F3/F4/F5：runtime 回退重连 + all 模式池接管 + 防双进程探测重试 ----
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-mgr2g-"));
+  const prevHome = process.env.DSH_HOME;
+  try {
+    process.env.DSH_HOME = dir;
+    const { manager, store, log } = makeManager(dir);
+
+    // F2：runtime 注入条目（不落 store）——reconnect 不再抛 not found，
+    // 断开后按 runtimeRegistry 配置经 supervisor 复活。
+    manager.runtimeRegistry.set("rt", normalizeServer(quietServer("rt")));
+    await manager.reconnect("rt");
+    assert.ok(manager.supervisors.has("rt"), "runtime 条目 reconnect 复活（F2 回退 runtimeRegistry）");
+    // F2 否定：project scope 不回退 runtime（挂错 scope 会被下次 reconcile
+    // 无声停掉）——runtime 条目按 project 查询照旧抛 not found。
+    manager.projectStore = new McpStore(join(dir, "p.json"));
+    await manager.projectStore.load();
+    await assert.rejects(() => manager.connect("rt", "project"), /not found/);
+
+    // F3：all 模式 start 全局非 runtime → 不建 supervisor、不注册 mcp__ 工具，
+    // 改触达 @global 单元惰性连接（连接条目最终出现在池中）。
+    manager.middlewareMode = "all";
+    await manager.initMiddleware("all", {});
+    store.upsert(normalizeServer(quietServer("g2")));
+    manager.start("g2", "global");
+    assert.ok(!manager.supervisors.has("g2"), "all 模式全局 start 不建 supervisor（F3 下沉）");
+    assert.equal(log.registered.filter((name) => String(name).startsWith("mcp__g2__")).length, 0, "不注册 mcp__ 前缀工具");
+    await pollUntil("@global 单元连接条目建立", () => manager.middleware.units.get("@global")?.connections.has("g2") === true);
+
+    // F4：all 模式 connect 全局走池（userDisabled 解除 + ensureConnected），
+    // 不复活 supervisor。
+    manager.middleware.units.get("@global").userDisabled.add("g2");
+    await manager.connect("g2");
+    assert.ok(!manager.supervisors.has("g2"), "connect 不复活 supervisor（F4 走池）");
+    assert.ok(!manager.middleware.units.get("@global").userDisabled.has("g2"), "userDisabled 已解除");
+
+    // F5：防双进程探测命中 → 落 failed 占位 entry + 一次性重试定时器。
+    manager.ctx.tools.schemas = () => [{ name: "mcp__g3__t" }];
+    store.upsert(normalizeServer(quietServer("g3")));
+    manager.start("g3", "global");
+    await pollUntil("探测命中占位 entry", () => {
+      const probeEntry = manager.middleware.units.get("@global")?.connections.get("g3");
+      return probeEntry !== undefined && probeEntry.probeRetried === true;
+    });
+    const probeEntry = manager.middleware.units.get("@global").connections.get("g3");
+    assert.ok(probeEntry.reconnectTimer !== undefined, "重试定时器已排（F5 有界重试）");
+    // 一次性语义：probeRetried 已置位，再次 ensureConnected 命中探测不重排。
+    await manager.middleware.ensureConnected("@global", "g3");
+    assert.ok(probeEntry.reconnectTimer !== undefined, "重试定时器保持（probeRetried 一次性）");
+    // 否定用例：userDisabled 已写时，重试路径（ensureConnected）不连接。
+    manager.middleware.units.get("@global").userDisabled.add("g3");
+    await manager.middleware.ensureConnected("@global", "g3");
+    assert.equal(
+      manager.middleware.units.get("@global").connections.get("g3").status,
+      "failed",
+      "userDisabled 命中不重连（重试经 ensureConnected 的禁用语义保证）",
+    );
+    await manager.dispose();
+  } finally {
+    if (prevHome === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = prevHome;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 // ---- add / update（scope project 抛错路径在 unit-manager 已覆盖，此处补全局） ----
 
 {
@@ -805,16 +871,23 @@ function rmStatSafe(p) {
     assert.equal(gAll.status, "connected", "all 模式全局经 @virtual root 投影");
     assert.deepEqual(gAll.tools, ["gt"]);
 
-    // 反向投影回归（#228 打回 P1）：池中条目被拆且 userDisabled，但 supervisor
-    // 已复活连接（all 模式全局 connect 绕过中间层池的 #234 既有限制）→ 必须
-    // 如实投影 supervisor 状态，不得因 userDisabled 恒报 stopped。
+    // 反向投影迁移（#382 F4）：池中条目被拆且 userDisabled → userDisabled 短路
+    // 投影 stopped。all 模式全局 connect 已改走中间层池（不再 supervisor 复活），
+    // 短路不再误伤真实连接；supervisor 残留（理论不该存在）也不误显示其连接态。
     const globalUnit = mw.units.get("@global");
     globalUnit.connections.delete("g1");
     globalUnit.userDisabled.add("g1");
     manager.supervisors.set("g1", { status: "connected", error: undefined, tools: ["gt"] });
-    const revived = manager.summarize(store.find("g1"), "global");
-    assert.equal(revived.status, "connected", "supervisor 复活后如实投影（userDisabled 不短路）");
-    assert.deepEqual(revived.tools, ["gt"]);
+    const disabledProjection = manager.summarize(store.find("g1"), "global");
+    assert.equal(disabledProjection.status, "stopped", "userDisabled 短路（#382：池接管后断开即 stopped）");
+    assert.deepEqual(disabledProjection.tools, []);
+    // runtime 注入条目豁免短路（middlewareTakes 判定）：同名 runtime supervisor
+    // 走 supervisor 投影，如实显示连接态。
+    manager.runtimeRegistry.set("g1", store.find("g1"));
+    const runtimeProjection = manager.summarize(store.find("g1"), "global");
+    assert.equal(runtimeProjection.status, "connected", "runtime 条目豁免短路（supervisor 路径）");
+    assert.deepEqual(runtimeProjection.tools, ["gt"]);
+    manager.runtimeRegistry.delete("g1");
     // supervisor 消失后落回兜底 stopped。
     manager.supervisors.delete("g1");
     assert.equal(manager.summarize(store.find("g1"), "global").status, "stopped");

--- a/packages/dsh-mcp-manager/test/unit-manager2.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-manager2.test.ts
@@ -484,6 +484,72 @@ function rmStatSafe(p) {
   }
 }
 
+// ---- #382 F2/F3/F4/F5：runtime 回退重连 + all 模式池接管 + 防双进程探测重试 ----
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-mgr2g-"));
+  const prevHome = process.env.DSH_HOME;
+  try {
+    process.env.DSH_HOME = dir;
+    const { manager, store, log } = makeManager(dir);
+
+    // F2：runtime 注入条目（不落 store）——reconnect 不再抛 not found，
+    // 断开后按 runtimeRegistry 配置经 supervisor 复活。
+    manager.runtimeRegistry.set("rt", normalizeServer(quietServer("rt")));
+    await manager.reconnect("rt");
+    assert.ok(manager.supervisors.has("rt"), "runtime 条目 reconnect 复活（F2 回退 runtimeRegistry）");
+    // F2 否定：project scope 不回退 runtime（挂错 scope 会被下次 reconcile
+    // 无声停掉）——runtime 条目按 project 查询照旧抛 not found。
+    manager.projectStore = new McpStore(join(dir, "p.json"));
+    await manager.projectStore.load();
+    await assert.rejects(() => manager.connect("rt", "project"), /not found/);
+
+    // F3：all 模式 start 全局非 runtime → 不建 supervisor、不注册 mcp__ 工具，
+    // 改触达 @global 单元惰性连接（连接条目最终出现在池中）。
+    manager.middlewareMode = "all";
+    await manager.initMiddleware("all", {});
+    store.upsert(normalizeServer(quietServer("g2")));
+    manager.start("g2", "global");
+    assert.ok(!manager.supervisors.has("g2"), "all 模式全局 start 不建 supervisor（F3 下沉）");
+    assert.equal(log.registered.filter((name) => String(name).startsWith("mcp__g2__")).length, 0, "不注册 mcp__ 前缀工具");
+    await pollUntil("@global 单元连接条目建立", () => manager.middleware.units.get("@global")?.connections.has("g2") === true);
+
+    // F4：all 模式 connect 全局走池（userDisabled 解除 + ensureConnected），
+    // 不复活 supervisor。
+    manager.middleware.units.get("@global").userDisabled.add("g2");
+    await manager.connect("g2");
+    assert.ok(!manager.supervisors.has("g2"), "connect 不复活 supervisor（F4 走池）");
+    assert.ok(!manager.middleware.units.get("@global").userDisabled.has("g2"), "userDisabled 已解除");
+
+    // F5：防双进程探测命中 → 落 failed 占位 entry + 一次性重试定时器。
+    manager.ctx.tools.schemas = () => [{ name: "mcp__g3__t" }];
+    store.upsert(normalizeServer(quietServer("g3")));
+    manager.start("g3", "global");
+    await pollUntil("探测命中占位 entry", () => {
+      const probeEntry = manager.middleware.units.get("@global")?.connections.get("g3");
+      return probeEntry !== undefined && probeEntry.probeRetried === true;
+    });
+    const probeEntry = manager.middleware.units.get("@global").connections.get("g3");
+    assert.ok(probeEntry.reconnectTimer !== undefined, "重试定时器已排（F5 有界重试）");
+    // 一次性语义：probeRetried 已置位，再次 ensureConnected 命中探测不重排。
+    await manager.middleware.ensureConnected("@global", "g3");
+    assert.ok(probeEntry.reconnectTimer !== undefined, "重试定时器保持（probeRetried 一次性）");
+    // 否定用例：userDisabled 已写时，重试路径（ensureConnected）不连接。
+    manager.middleware.units.get("@global").userDisabled.add("g3");
+    await manager.middleware.ensureConnected("@global", "g3");
+    assert.equal(
+      manager.middleware.units.get("@global").connections.get("g3").status,
+      "failed",
+      "userDisabled 命中不重连（重试经 ensureConnected 的禁用语义保证）",
+    );
+    await manager.dispose();
+  } finally {
+    if (prevHome === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = prevHome;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 // ---- add / update（scope project 抛错路径在 unit-manager 已覆盖，此处补全局） ----
 
 {
@@ -805,16 +871,23 @@ function rmStatSafe(p) {
     assert.equal(gAll.status, "connected", "all 模式全局经 @virtual root 投影");
     assert.deepEqual(gAll.tools, ["gt"]);
 
-    // 反向投影回归（#228 打回 P1）：池中条目被拆且 userDisabled，但 supervisor
-    // 已复活连接（all 模式全局 connect 绕过中间层池的 #234 既有限制）→ 必须
-    // 如实投影 supervisor 状态，不得因 userDisabled 恒报 stopped。
+    // 反向投影迁移（#382 F4）：池中条目被拆且 userDisabled → userDisabled 短路
+    // 投影 stopped。all 模式全局 connect 已改走中间层池（不再 supervisor 复活），
+    // 短路不再误伤真实连接；supervisor 残留（理论不该存在）也不误显示其连接态。
     const globalUnit = mw.units.get("@global");
     globalUnit.connections.delete("g1");
     globalUnit.userDisabled.add("g1");
     manager.supervisors.set("g1", { status: "connected", error: undefined, tools: ["gt"] });
-    const revived = manager.summarize(store.find("g1"), "global");
-    assert.equal(revived.status, "connected", "supervisor 复活后如实投影（userDisabled 不短路）");
-    assert.deepEqual(revived.tools, ["gt"]);
+    const disabledProjection = manager.summarize(store.find("g1"), "global");
+    assert.equal(disabledProjection.status, "stopped", "userDisabled 短路（#382：池接管后断开即 stopped）");
+    assert.deepEqual(disabledProjection.tools, []);
+    // runtime 注入条目豁免短路（middlewareTakes 判定）：同名 runtime supervisor
+    // 走 supervisor 投影，如实显示连接态。
+    manager.runtimeRegistry.set("g1", store.find("g1"));
+    const runtimeProjection = manager.summarize(store.find("g1"), "global");
+    assert.equal(runtimeProjection.status, "connected", "runtime 条目豁免短路（supervisor 路径）");
+    assert.deepEqual(runtimeProjection.tools, ["gt"]);
+    manager.runtimeRegistry.delete("g1");
     // supervisor 消失后落回兜底 stopped。
     manager.supervisors.delete("g1");
     assert.equal(manager.summarize(store.find("g1"), "global").status, "stopped");


### PR DESCRIPTION
## 背景

dsh-mcp-manager 有两条连接路径：supervisor 路径（注册 `mcp__<server>__<tool>` 前缀工具）与中间层路径（`ws_mcp_*` 工具按 `@<root>/<server>` 路由，all 模式下全局服务器走虚拟 root `@global` 连接池）。另有 runtime 注入通道（`registerServer`，如 dsh-codegraph，条目在 `runtimeRegistry`，不落盘）。四个现象同根：**连接口径与工具名口径在多入口间不一致**。

## 现象与修复（F2–F5）

### 1. runtime 注入服务器（codegraph）浮窗重连必失败
`connect()` 只查 store，`runtimeRegistry` 条目查不到 → 抛 `not found`。
**F2**：`connect()`/`start()` 在 global scope store 查不到时回退 `runtimeRegistry`（仅限 global，防挂错 scope 被 reconcile 无声停掉）。

### 2. 热更新后全局服务器掉线一阵自愈
apply 先 `startAll()`（建全部全局 supervisor）→ 中间层初始化后才 reconcile 停掉。竞态窗口内 `mcp__` 注册残留，防双进程探测命中且无重试 → 连接停在 failed。
**F3**：`middlewareTakes` 判定下沉进 `start()`（all 模式全局非 runtime 不建 supervisor，改触达 `@global` 单元）；apply 启动顺序重排（initMiddleware 提前到 startAll 前）；`evictIfNeeded` 豁免 `@global`；`update`/`remove` 后 `dropMiddlewareConnection` 拆池连接。
**F5**：防双进程探测命中后落占位 entry + 3s 后经 `ensureConnected` 一次性重试（`probeRetried` 标记，尊重 userDisabled）。

### 3. all 模式浮窗工具名带 `mcp__` 前缀 + 工具级禁用对 supervisor 路径静默无效
`summarize()` supervisor 分支输出注册名（带前缀）；浮窗提交带前缀名进禁用表而 guard 查裸名 → 禁用永不生效。
**F4**：`summarize()` supervisor 分支剥 `mcp__<server>__` 前缀输出裸名（`stripMcpPrefix`）；`connect()`/`reconnect()` all 模式全局非 runtime 走中间层池；`disconnect` 定位 `@global` 单元并关 transport；`userDisabled` 短路投影；`getTools` 契约注释（注册名 vs 裸名）。

## 验收（issue #382 标准）

- [x] runtime 注入服务器浮窗「重连」成功，不再抛 not found；
- [x] all 模式启动/热更新不创建全局 supervisor（无先建后停窗口）；
- [x] all 模式浮窗工具名显示裸名；工具级禁用对 supervisor 路径工具生效；
- [x] 防双进程探测命中后有界重试且不复活 userDisabled 条目；
- [x] off/project 模式行为不变；单包 + 全仓门禁全绿。

## 测试

- `unit-manager2` 双副本（.test/.src.test）新增 F2–F5 断言块；
- smoke 公开名断言迁移裸名；
- 单包 `pnpm build && pnpm test` 全绿。

Fixes #382
