### PR TITLE
fix(provider-usage): 胶囊跟随会话内切模型——投影读取 next 优先（#383）

### DIFF
--- a/packages/dsh-provider-usage/README.md
+++ b/packages/dsh-provider-usage/README.md
@@ -78,8 +78,9 @@ npx @deepseek-ai/dsh plugin --profile web add @wingsky-1/dsh-provider-usage
 内置适配器 `opencode-go-builtin`（OpenCode Go 官方 `/v1/usage` 三窗口用量）与
 `deepseek-official-builtin`（DeepSeek 官方余额 + 峰谷倒计时徽标，见下节）开箱即用。
 
-> provider 跟随语义：切换会话即时刷新；会话内切模型/provider 无宿主推送信号，
-> 由每次取数前的复检兜底自愈——最长一个轮询周期内跟随（#71）。
+> provider 跟随语义（0.1.2 投影面，#383）：切换会话即时刷新；会话内切模型经宿主
+> modelSelection 投影帧（control frame type:projection）实时推送、客户端**切完即重拉**；
+> 信号缺失最坏场景由每次取数前的复检兜底自愈（#71）——最长一个轮询周期内收敛。
 
 > **图解文档**：完整的流程图 / 时序图（启动装配、`/stats` 取数全链路、`/history` 面板、自定义适配器注入三条路径与热更新、客户端交互、密钥解析链）见 [docs/architecture.md](docs/architecture.md)。
 

--- a/packages/dsh-provider-usage/src/client/core.ts
+++ b/packages/dsh-provider-usage/src/client/core.ts
@@ -88,7 +88,8 @@ export interface HistoryResponseV2 {
 
 /**
  * 会话行的 modelSelection 投影值（dsh 0.1.2-alpha.2 SessionProjectionMap）：
- * lastUsed = 上次实际使用；next = 待确认意图（pending），二者均可能缺失。
+ * lastUsed = 上次实际使用的选择；next = 当前选择/待确认意图（宿主 view：
+ * next = pending ?? lastUsed，**next 是检测主判据**），二者均可能缺失。
  */
 export interface ModelSelectionLike {
   provider?: string;
@@ -195,12 +196,15 @@ export function sessionAncestryChain(
 
 /**
  * 从会话行读取 per-session modelSelection 投影的 provider（0.1.2 投影面，#383 修正）：
- * 读 list 快照行拍平的 projectionValues.modelSelection（lastUsed 优先 = 上次实际使用，
- * next 次之 = 待确认意图）；均缺失返回 undefined。纯同步快照读取，不触发任何 RPC。
+ * 读 list 快照行拍平的 projectionValues.modelSelection，**next 优先**（= 当前选择/待确认
+ * 意图，宿主 view 语义 next = pending ?? lastUsed）——会话内切模型只更新 pending 的
+ * next，lastUsed 要等真正发起请求才随动，读 lastUsed 优先会造成「切模型不跟随」；
+ * lastUsed 仅作兜底（next 缺失时取上次实际使用）；均缺失返回 undefined。
+ * 纯同步快照读取，不触发任何 RPC。
  */
 function providerFromProjection(row: SessionListRowLike | undefined): string | undefined {
   const ms = row?.projectionValues?.modelSelection;
-  const sel = ms?.lastUsed ?? ms?.next;
+  const sel = ms?.next ?? ms?.lastUsed;
   return typeof sel?.provider === "string" && sel.provider.length > 0 ? sel.provider : undefined;
 }
 

--- a/packages/dsh-provider-usage/test/client-revalidate.worker.mjs
+++ b/packages/dsh-provider-usage/test/client-revalidate.worker.mjs
@@ -231,8 +231,15 @@ function makeFakeServices(initialProvider) {
   const state = {
     listCurrent: "s1",
     byId: { s1: {} },
-    // 0.1.2-alpha.2：行携带 per-session modelSelection 投影（lastUsed 为主槽位）
-    projectionBySession: { s1: { provider: initialProvider, model: "model-x" } },
+    // 0.1.2-alpha.2：行携带 per-session modelSelection 投影——双槽位形状
+    // { lastUsed, next }（宿主 wire view：next = pending ?? lastUsed）。
+    // #383 追加：会话内切模型只更新 next（pending），lastUsed 等真发请求才随动
+    projectionBySession: {
+      s1: {
+        lastUsed: { provider: initialProvider, model: "model-x" },
+        next: { provider: initialProvider, model: "model-x" },
+      },
+    },
   };
   const listSubs = [];
   const sessions = {
@@ -247,7 +254,7 @@ function makeFakeServices(initialProvider) {
               id,
               proj === undefined
                 ? base
-                : { ...base, projectionValues: { modelSelection: { lastUsed: proj } } },
+                : { ...base, projectionValues: { modelSelection: proj } },
             ];
           }),
         ),
@@ -336,17 +343,22 @@ client.apply(ctx);
 }
 
 // 场景 2（A1 核心）：会话内切模型 a→b——sessionId/list.current 均不变，宿主信号【不 fire】，
-// 手动触发一次轮询回调 → refreshStats 取数前复检 → 使用新 provider
+// 手动触发一次轮询回调 → refreshStats 取数前复检 → 使用新 provider。
+// #383 追加根因：切模型只更新 next（pending），lastUsed 保持旧值（等真发请求才随动）——
+// 修复后胶囊应跟随 next 的新 provider，而非滞留 lastUsed
 {
   const before = statsCalls.length;
-  svc.state.projectionBySession.s1 = { provider: "mock-b", model: "model-x" }; // 会话内切换：行投影 lastUsed 已变
+  svc.state.projectionBySession.s1 = {
+    lastUsed: { provider: "mock-a", model: "model-x" }, // 上次实际使用仍为 a（未发新请求）
+    next: { provider: "mock-b", model: "model-x" }, // 当前选择已切到 b（pending）
+  };
   const pollTimer = intervals.find((t) => t.ms === 60000);
   assert.ok(pollTimer, "60s 轮询定时器已注册");
   pollTimer.fn();
 
   await until(
     () => lastProviderOf(statsCalls) === "mock-b" && pillLabel()?.innerHTML.includes("MOCK-B"),
-    "轮询周期内 refreshStats 自愈到 mock-b",
+    "轮询周期内 refreshStats 自愈到 mock-b（next 优先，不滞留 lastUsed）",
   );
   const afterSwitch = statsCalls.slice(before);
   assert.ok(
@@ -358,14 +370,17 @@ client.apply(ctx);
     const box = deepFind([docBody], ".dou-charts");
     return box !== null && String(box.innerHTML).includes('data-p="mock-b"');
   }, "面板内容跟随 mock-b");
-  console.log("[client-revalidate.worker] 场景2 A1 轮询自愈 a→b（含面板） ✓");
+  console.log("[client-revalidate.worker] 场景2 A1 轮询自愈 a→b（next 优先，含面板） ✓");
 }
 
 // 场景 3（维护者补充需求）：切换会话 s2，provider 相同（mock-b）→ 仍立即刷一次 stats
 {
   svc.state.byId.s2 = {};
   svc.state.listCurrent = "s2";
-  svc.state.projectionBySession.s2 = { provider: "mock-b", model: "model-x" };
+  svc.state.projectionBySession.s2 = {
+    lastUsed: { provider: "mock-b", model: "model-x" },
+    next: { provider: "mock-b", model: "model-x" },
+  };
   const before = statsCalls.length;
   svc.fireSessionChanged(); // 宿主信号：切换会话时 fire
   await until(() => statsCalls.length > before, "同 provider 切换会话仍立即刷新 stats");
@@ -377,7 +392,10 @@ client.apply(ctx);
 {
   svc.state.byId.s3 = {};
   svc.state.listCurrent = "s3";
-  svc.state.projectionBySession.s3 = { provider: "mock-a", model: "model-x" };
+  svc.state.projectionBySession.s3 = {
+    lastUsed: { provider: "mock-a", model: "model-x" },
+    next: { provider: "mock-a", model: "model-x" },
+  };
   const before = statsCalls.length;
   svc.fireSessionChanged();
   await until(

--- a/packages/dsh-provider-usage/test/client-revalidate.worker.mjs
+++ b/packages/dsh-provider-usage/test/client-revalidate.worker.mjs
@@ -342,8 +342,9 @@ client.apply(ctx);
   assert.ok(deepFind([docBody], ".dou-panel"), "面板已展开");
 }
 
-// 场景 2（A1 核心）：会话内切模型 a→b——sessionId/list.current 均不变，宿主信号【不 fire】，
-// 手动触发一次轮询回调 → refreshStats 取数前复检 → 使用新 provider。
+// 场景 2a（#383 修复核心·即时路径）：会话内切模型 a→b——sessionId/list.current 均不变，
+// 但宿主 modelSelection 投影帧（control frame type:projection）会 fire sessions.list
+// subscribe → detect 立即复检 → 切完即重拉，不等 60s 轮询。
 // #383 追加根因：切模型只更新 next（pending），lastUsed 保持旧值（等真发请求才随动）——
 // 修复后胶囊应跟随 next 的新 provider，而非滞留 lastUsed
 {
@@ -352,15 +353,13 @@ client.apply(ctx);
     lastUsed: { provider: "mock-a", model: "model-x" }, // 上次实际使用仍为 a（未发新请求）
     next: { provider: "mock-b", model: "model-x" }, // 当前选择已切到 b（pending）
   };
-  const pollTimer = intervals.find((t) => t.ms === 60000);
-  assert.ok(pollTimer, "60s 轮询定时器已注册");
-  pollTimer.fn();
-
+  svc.fireSessionChanged(); // 模拟宿主投影帧 → sessions.list subscribe fire
   await until(
     () => lastProviderOf(statsCalls) === "mock-b" && pillLabel()?.innerHTML.includes("MOCK-B"),
-    "轮询周期内 refreshStats 自愈到 mock-b（next 优先，不滞留 lastUsed）",
+    "切模型后投影帧 fire → 立即跟随 mock-b（next 优先，不滞留 lastUsed）",
   );
   const afterSwitch = statsCalls.slice(before);
+  assert.ok(statsCalls.length > before, "fire 后确有新请求（即时性：非轮询驱动）");
   assert.ok(
     afterSwitch.every((u) => new URL(u, "http://x").searchParams.get("provider") === "mock-b"),
     `切换后 refreshStats 使用新 provider（实际 ${JSON.stringify(afterSwitch)}）`,
@@ -370,7 +369,27 @@ client.apply(ctx);
     const box = deepFind([docBody], ".dou-charts");
     return box !== null && String(box.innerHTML).includes('data-p="mock-b"');
   }, "面板内容跟随 mock-b");
-  console.log("[client-revalidate.worker] 场景2 A1 轮询自愈 a→b（next 优先，含面板） ✓");
+  console.log("[client-revalidate.worker] 场景2a 切模型即时跟随（投影帧 fire，next 优先，含面板） ✓");
+}
+
+// 场景 2b（#71 A1 兜底路径）：会话内再切 b→a，投影帧【不 fire】（信号缺失最坏场景）——
+// 手动触发一次轮询回调 → refreshStats 取数前复检 → 使用新 provider（最长一个轮询周期收敛）
+{
+  const before = statsCalls.length;
+  svc.state.projectionBySession.s1 = {
+    lastUsed: { provider: "mock-b", model: "model-x" }, // 上次实际使用已随请求变 b
+    next: { provider: "mock-a", model: "model-x" }, // 当前选择切回 a（pending）
+  };
+  const pollTimer = intervals.find((t) => t.ms === 60000);
+  assert.ok(pollTimer, "60s 轮询定时器已注册");
+  pollTimer.fn();
+
+  await until(
+    () => lastProviderOf(statsCalls) === "mock-a" && pillLabel()?.innerHTML.includes("MOCK-A"),
+    "轮询周期内 refreshStats 自愈到 mock-a（next 优先，不滞留 lastUsed）",
+  );
+  assert.ok(statsCalls.length > before, "轮询确有新请求");
+  console.log("[client-revalidate.worker] 场景2b 轮询兜底自愈 b→a（#71 A1） ✓");
 }
 
 // 场景 3（维护者补充需求）：切换会话 s2，provider 相同（mock-b）→ 仍立即刷一次 stats

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -649,6 +649,18 @@ export function formatPanel() { return "<p>x</p>"; }
     assert.ok(injectLine.includes('"remote.session"'), "inject 数组必须声明 remote.session（modelCatalog 兜底，#383）");
     assert.ok(injectLine.includes('"slots"'), "inject 数组必须声明 slots（否则 ctx.slots 访问抛 without inject，#383）");
   }
+  // #383 追加根因：modelSelection 投影读取必须 next 优先（看宿主 view 语义
+  // next = pending ?? lastUsed——会话内切模型只更新 next，lastUsed 等真发请求才随动；
+  // 读 lastUsed 优先会造成「切模型胶囊不跟随」，回归防线放契约层）
+  {
+    const coreSource = readFileSync(join(pkgDir, "src/client/core.ts"), "utf8");
+    const readLine = coreSource.split("\n").find((l) => l.includes("?.next ?? ms?.lastUsed") || l.includes("ms?.lastUsed ?? ms?.next"));
+    assert.ok(readLine !== undefined, "core.ts providerFromProjection 存在投影读取行");
+    assert.ok(
+      /ms\?\.next \?\? ms\?\.lastUsed/.test(readLine ?? ""),
+      `投影读取必须 next 优先（当前行：${(readLine ?? "").trim()}）`,
+    );
+  }
   // issue #116：避让已去除——客户端不再探测 MCP 浮窗做动态偏移，改为固定定位（位置只由配置决定）
   assert.ok(!clientSource.includes("mcpClearance"), "客户端源码已去除 MCP 避让（mcpClearance）");
   assert.ok(!clientSource.includes("data-dsh-mcp-float"), "客户端源码已去除 MCP 浮窗探测避让");

--- a/packages/dsh-provider-usage/test/unit-detect.test.ts
+++ b/packages/dsh-provider-usage/test/unit-detect.test.ts
@@ -6,6 +6,8 @@
  * provider —— 子代理会话自身投影缺失时沿 parentId 上溯父会话投影取 provider、
  * 上溯深度封顶与环防御、全链投影缺失回落 ctx.remote.session.modelCatalog().default
  * 兜底、wire 形状（projections.values）不得被误读（#383 反向断言）、
+ * **next 优先于 lastUsed**（#383 追加：会话内切模型只更新 next，读 lastUsed 优先
+ * 会滞留旧 provider）、
  * 全链失败保持上次检测 + 「提供商未识别」标注决策、无任何会话维持原回落行为
  * （回归防护）、ordinary 会话直连解析回归。
  *
@@ -57,6 +59,8 @@ function makeSessions(byId, current) {
 /**
  * 行投影小工具：构造 SessionSummary 防御式行（#383：拍平 projectionValues 形状）。
  * provider 缺省 → 行无 modelSelection 投影（模拟子代理/未解析会话）。
+ * 槽位语义（宿主 wire view：next = pending ?? lastUsed）：默认只写 lastUsed；
+ * slot:"next" 只写 next（模拟仅待确认意图）；两者并存场景在用例内联构造。
  */
 function row(provider, opts = {}) {
   const { parentId, parentSessionId, origin, slot } = opts;
@@ -121,7 +125,8 @@ function makeRemote(providerByDefault) {
 }
 
 {
-  // lastUsed 优先于 next：两者并存时取 lastUsed（#383：拍平 projectionValues 形状）
+  // next 优先于 lastUsed：两者并存时取 next（#383 追加根因——会话内切模型只更新
+  // pending 的 next，lastUsed 等真正发请求才随动，读 lastUsed 优先造成「切模型不跟随」）
   const sessions = makeSessions(
     {
       own: {
@@ -136,7 +141,7 @@ function makeRemote(providerByDefault) {
     "own",
   );
   const got = await resolveProviderFromSession(sessions, makeRemote());
-  assert.equal(got, "last-p", "lastUsed 优先于 next");
+  assert.equal(got, "next-p", "next 优先于 lastUsed（会话内切模型紧跟当前选择）");
 }
 
 {


### PR DESCRIPTION
## 问题

#383 前两轮修复（#385 投影形状、#393 ctx 注入）已让「切换会话」胶囊跟随生效；但**同一会话内切换模型，胶囊适配器展示不更新**——此功能丢失。

## 根因（dsh 0.1.2-alpha.2 发布物源码实证）

宿主端 `modelSelection` 投影 fold（`dsh-api-session-controller/lib/types/model-selection-projection.js`）语义：

- `model/selection` 事件（用户切模型的意图）→ 只更新 `pending`，**`lastUsed` 不动**；
- `request/header` 事件（真正发起请求）→ 才把 `lastUsed` 更新为该请求的 provider/model；
- wire view：`{ lastUsed, next: pending ?? lastUsed }` —— **`next` 才是「当前/下一次应使用」的模型选择**。

而本插件 `providerFromProjection`（`packages/dsh-provider-usage/src/client/core.ts`）读 `ms?.lastUsed ?? ms?.next` **lastUsed 优先**：会话内切模型后（未发请求）`pending` 已变、`lastUsed` 仍旧 → 永远解析到旧 provider → 胶囊不跟随；「切换会话」读的是新会话行自身的投影（其 lastUsed 即该会话所用 provider）→ 跟随正常，与现象吻合。

测试同步固化了错误方向：`unit-detect.test.ts` 断言「两者并存取 lastUsed」；`client-revalidate.worker.mjs` 以「行投影 lastUsed 已变」模拟会话内切模型——现实是 lastUsed 不变、next 变，故未覆盖真实场景。

## 修复

- `core.ts`：`providerFromProjection` 改 `ms?.next ?? ms?.lastUsed`（next 为检测主判据 = 当前选择/待确认意图，lastUsed 兜底）；
- `unit-detect.test.ts`：两者并存断言翻转为 next 优先；
- `client-revalidate.worker.mjs`：fake 行投影改双槽位 `{lastUsed, next}`；场景 2 改为 **lastUsed 不变、next 变**（真实切模型形态）→ 轮询自愈跟随 next；
- `smoke.ts`：客户端契约区补「投影读取必须 next 优先」回归防线。

## 验证

- 全门禁绿：`pnpm build && pnpm test && pnpm contract && pnpm pack:check`；
- unit-detect：两槽并存 → next 胜；wire 形状不被误读；全链缺失兜底不回退；
- worker：会话内切模型（lastUsed 停滞）轮询自愈到 next 新 provider，胶囊与面板均跟随。

Fixes #383
