### PR TITLE
fix(dsh-notifier): tab pane 数组子项补 key（#402 重开——PR #407 合并后遗留）

### DIFF
--- a/packages/dsh-notifier/src/client/index.ts
+++ b/packages/dsh-notifier/src/client/index.ts
@@ -1163,8 +1163,8 @@ const NS = "notifier";
       React.createElement("button", { type: "button", className: "dn-set-btn", onClick: function () { sendTest(); } }, t("sendTest")),
     );
 
-    // 历史列表（D1/D2）
-    var historyEl = React.createElement("div", { className: "dn-set-section" },
+    // 历史列表（D1/D2）；key 供 eventsPane 数组子项对齐（#402 复核项）
+    var historyEl = React.createElement("div", { className: "dn-set-section", key: "history" },
       React.createElement("div", { className: "dn-set-title" }, t("historyTitle")),
       React.createElement("button", {
         type: "button", className: "dn-set-btn dn-set-btnSmall",
@@ -1217,7 +1217,7 @@ const NS = "notifier";
 
     // 「通知频道」tab 内的就近保存（#402 第 6 条）：复用 save()（全量草稿语义，与
     // foot 保存一致且幂等）；saved 为全局反馈状态，两处同源渲染。
-    var tabSave = React.createElement("div", { className: "dn-ch-saveRow" },
+    var tabSave = React.createElement("div", { className: "dn-ch-saveRow", key: "tab-save" },
       saved ? React.createElement("span", { className: saved.err ? "dn-set-error" : "dn-set-saved" }, saved.msg) : null,
       React.createElement("button", { type: "button", className: "dn-set-save", onClick: save }, t("save")),
     );


### PR DESCRIPTION
Reopens #402（按 ISSUE-WORKFLOW §2.9 重开原 issue：本修复属 #402 改动自身带出的同域不符项，不另开 follow-up issue）

## 背景

PR #407 squash merge 时（7f4bd11），合并前复核闸定位到的「pane 数组子项缺 key」修复提交未随合并入库：

- `eventsPane` 数组内 `historyEl`（`dn-set-section`）、`channelsPane` 数组内 `tabSave`（`dn-ch-saveRow`）作为数组子项缺 `key`，React 列表对齐告警；
- 其余子项（adv-params details、section()/row() 内部生成元素、eventChildren/channelsChildren 各元素）均有 key，不受影响。

## 改动

- `historyEl` 补 `key: "history"`、`tabSave` 补 `key: "tab-save"`（静态 key，结构固定无重排）；
- 共 3 行，无行为变化。

## 验证

- `pnpm --filter @wingsky-1/dsh-notifier build && test` 全绿（service contract / smoke OK）；
- 基于最新 main（643d45a）cherry-pick，无冲突。