### PR TITLE
refactor: 注入上下文文本优化——MCP_GUIDANCE 精简 + codegraph/ws_mcp_* 描述负向锚与去重（#414）

### DIFF
--- a/packages/dsh-codegraph/src/tool-definition.ts
+++ b/packages/dsh-codegraph/src/tool-definition.ts
@@ -41,6 +41,12 @@ const TEXT_OUTPUT: ToolDefinition["output"] = {
   },
 };
 
+/** 公共样板文案单一事实源（防描述漂移；#414）：各工具参数/描述统一引用，
+ * 不再手抄。projectPath 语义：显式传入优先，缺省补全为当前会话 worktree。 */
+const SHARED = {
+  projectPath: "目标 worktree 路径（缺省补全为当前会话 worktree）",
+};
+
 /** 从 execute 上下文取会话 cwd（缺省 undefined）。 */
 function sessionCwd(exec: { agent?: { session?: { header?: { cwd?: string } } } }): string | undefined {
   return exec?.agent?.session?.header?.cwd;
@@ -52,15 +58,15 @@ export function buildExploreToolDefinition(): ToolDefinition {
   return {
     name: "codegraph_explore",
     description:
-      "查询 codegraph 代码图谱（本地索引，返回相关符号源码 + 调用路径）。" +
-      "自动先 sync 目标 worktree 索引再查（新鲜度硬保证）；projectPath 缺省补全为当前" +
-      "会话 worktree；无索引/无法确定 projectPath 时拒绝并提示。结构类代码问题优先用它。" +
-      "只需单符号源码/调用关系用 codegraph_node；找文件结构用 codegraph_files。",
+      "查询 codegraph 代码图谱（本地索引）：返回命中符号的定义源码与调用路径。" +
+      "会自动先 sync 目标 worktree 索引；projectPath 缺省补全为当前会话 worktree；" +
+      "无索引/无法定位时拒绝并返回引导。结构/依赖类问题（谁调用 X、改 X 影响谁、找符号定义）优先用它。" +
+      "NOT 用于逐字文本搜索——那是 grep 的事；本工具查调用图/符号定义。查单个符号源码/调用关系用 codegraph_node；列文件结构用 codegraph_files。",
     parameters: {
       type: "object",
       properties: {
         query: { type: "string", description: "代码问题/符号名（如：X 被谁调用）" },
-        projectPath: { type: "string", description: "目标 worktree 路径（缺省补全为当前会话 worktree）" },
+        projectPath: { type: "string", description: SHARED.projectPath },
       },
       required: ["query"],
     },
@@ -166,12 +172,12 @@ export function buildImpactToolDefinition(): ToolDefinition {
     "codegraph_impact",
     "分析「修改/删除某符号会影响哪些代码」（调用方及其下游）。改代码前用它看影响面。" +
       "symbol 必填；同名符号先用 codegraph_search 找归属、传限定名；depth 默认 2（1-5），" +
-      "越大结果越全但越慢。只想看单符号源码与直接调用/被调关系用 codegraph_node；" +
+      "越大结果越全但越慢。NOT 用于全文搜词——查文本位置用 grep。只想看单符号源码与直接调用/被调关系用 codegraph_node；" +
       "找「谁调用 X」用 codegraph_callers。",
     {
       symbol: { type: "string", description: "目标符号名（同名时传完整限定名）" },
       depth: { type: "number", description: "遍历深度（默认 2，范围 1-5；越大结果越全但越慢）", minimum: 1, maximum: 5 },
-      projectPath: { type: "string", description: "目标 worktree 路径（缺省补全为当前会话 worktree）" },
+      projectPath: { type: "string", description: SHARED.projectPath },
     },
     ["symbol"],
     (args) => {
@@ -195,14 +201,15 @@ export function buildNodeToolDefinition(): ToolDefinition {
     "查单个符号的源码与调用/被调 trail（符号模式），或按行号读文件并附符号表与依赖方" +
       "（文件模式）。**symbol 与 file 二选一**：查符号用 symbol；读文件用 file" +
       "（可带 offset/limit 分页；只要符号表用 symbolsOnly）。都传以 symbol 优先；" +
-      "都不传报错给用法。查影响面用 codegraph_impact；查谁调用用 codegraph_callers。",
+      "都不传报错给用法。NOT 用于全文搜词——查文本位置用 grep；本工具按符号/文件读源码。" +
+      "查影响面用 codegraph_impact；查谁调用用 codegraph_callers。",
     {
       symbol: { type: "string", description: "符号名（符号模式；与 file 二选一，都传以 symbol 优先）" },
       file: { type: "string", description: "文件路径（文件模式；与 symbol 二选一，如 'src/auth.ts'）" },
       offset: { type: "number", description: "文件模式：1-based 起始行（分页）", minimum: 1 },
       limit: { type: "number", description: "文件模式：最大行数（分页）", minimum: 1 },
       symbolsOnly: { type: "boolean", description: "文件模式：只要符号表 + 依赖方，不读源码" },
-      projectPath: { type: "string", description: "目标 worktree 路径（缺省补全为当前会话 worktree）" },
+      projectPath: { type: "string", description: SHARED.projectPath },
     },
     [],
     (args) => {
@@ -226,16 +233,16 @@ function buildCallersCalleesTool(name: "codegraph_callers" | "codegraph_callees"
   const sub = name === "codegraph_callers" ? "callers" : "callees";
   const description = name === "codegraph_callers"
     ? "列出所有调用「符号 X」的函数/方法。查「X 被谁用、改它影响谁」；limit 默认 20、上限 100。" +
-      "想看符号本身源码用 codegraph_node；看 X 调用了谁用 codegraph_callees。"
+      "NOT 用于全文搜词——查文本位置用 grep；本工具按符号查调用者。想看符号本身源码用 codegraph_node；看 X 调用了谁用 codegraph_callees。"
     : "列出「符号 X」调用的所有函数/方法。查「X 依赖谁」；limit 默认 20、上限 100。" +
-      "想看符号本身源码用 codegraph_node；看谁调用 X 用 codegraph_callers。";
+      "NOT 用于全文搜词——查文本位置用 grep；本工具按符号查被调者。想看符号本身源码用 codegraph_node；看谁调用 X 用 codegraph_callers。";
   return buildCliTool(
     name,
     description,
     {
       symbol: { type: "string", description: "目标符号名（同名时传完整限定名）" },
       limit: { type: "number", description: "最大结果数（默认 20，范围 1-100）", minimum: 1, maximum: 100 },
-      projectPath: { type: "string", description: "目标 worktree 路径（缺省补全为当前会话 worktree）" },
+      projectPath: { type: "string", description: SHARED.projectPath },
     },
     ["symbol"],
     (args) => {
@@ -267,7 +274,8 @@ export function buildSearchToolDefinition(): ToolDefinition {
   return buildCliTool(
     "codegraph_search",
     "按关键词搜索代码库符号（函数/类/变量等），返回位置与摘要。不知道精确符号名时用它找；" +
-      "找到后用 codegraph_node 查详情、callers/callees 查关系。kind 限定符号种类" +
+      "找到后用 codegraph_node 查详情、callers/callees 查关系。NOT 用于查调用关系——那是 callers/callees；" +
+      "本工具按名找符号。kind 限定符号种类" +
       "（function/method/class/interface/type/variable/route/component）；limit 默认 10。",
     {
       query: { type: "string", description: "搜索关键词（符号名/片段）" },
@@ -277,7 +285,7 @@ export function buildSearchToolDefinition(): ToolDefinition {
         enum: ["function", "method", "class", "interface", "type", "variable", "route", "component"],
       },
       limit: { type: "number", description: "最大结果数（默认 10）", minimum: 1 },
-      projectPath: { type: "string", description: "目标 worktree 路径（缺省补全为当前会话 worktree）" },
+      projectPath: { type: "string", description: SHARED.projectPath },
     },
     ["query"],
     (args) => {
@@ -299,6 +307,7 @@ export function buildFilesToolDefinition(): ToolDefinition {
     "codegraph_files",
     "从索引列出项目文件结构（tree/flat/grouped）。找文件路径或了解项目结构时用；" +
       "filter 只列该目录下文件；pattern 按 glob 过滤；maxDepth 限制 tree 深度。" +
+      "NOT 用于查调用关系——那是 callers/callees；本工具只列文件结构。" +
       "注意：只覆盖已索引文件（index/sync 时存在的文件）。",
     {
       filter: { type: "string", description: "只列该目录下的文件（如 'src'）" },
@@ -309,7 +318,7 @@ export function buildFilesToolDefinition(): ToolDefinition {
         enum: ["tree", "flat", "grouped"],
       },
       maxDepth: { type: "number", description: "tree 格式的最大目录深度", minimum: 1 },
-      projectPath: { type: "string", description: "目标 worktree 路径（缺省补全为当前会话 worktree）" },
+      projectPath: { type: "string", description: SHARED.projectPath },
     },
     [],
     (args) => {
@@ -332,9 +341,8 @@ export function buildFilesToolDefinition(): ToolDefinition {
 export function buildStatusToolDefinition(): ToolDefinition {
   return buildCliTool(
     "codegraph_status",
-    "查看当前 codegraph 索引的状态与统计（索引是否完整、文件/符号数、待同步变更数、" +
-      "是否需要重索引）。不确定索引是否新鲜/完整时先用它；查询类工具会自动 sync，" +
-      "无需手动 sync。path 为位置参数（缺省补全为当前会话 worktree）。",
+    "查看当前 codegraph 索引的状态与统计（是否完整、文件/符号数、待同步变更数、是否需要重索引）。" +
+      "本工具只查状态不执行查询；索引新鲜度由查询类工具自动维护。path 为位置参数。",
     {
       path: { type: "string", description: "目标 worktree 路径（缺省补全为当前会话 worktree；位置参数）" },
     },

--- a/packages/dsh-mcp-manager/src/apply.ts
+++ b/packages/dsh-mcp-manager/src/apply.ts
@@ -20,9 +20,10 @@ import type { MiddlewareMode } from "./middleware-types.ts";
 import { makeRoutes, makeEventsRoute, makeHealthRoute, sseData, uiConfigChangedFrame } from "./routes.ts";
 
 /** 向 Agent 宣告插件（announceToAgent 开启时注入）。能力清单由动态目录
- * （<available_mcp_servers>，见 L1）承担，此处只说明管理界面与使用约束。 */
+ * （<available_mcp_servers>，见 L1）承担，此处只保留插件存在、安全边界与术语约定，
+ * 不再复述 UI 配置路径与调用流程（那部分由能力目录与中间层工具描述承担）。 */
 export const MCP_GUIDANCE =
-  "本机已安装 dsh-mcp-manager 插件（DSH MCP 管理器）：会话界面右上角浮窗管理 MCP 服务器（全局配置 ~/.dsh/dsh-mcp.json；项目级配置 <项目根>/.dsh/mcp.json，跟随会话切换展示并连接对应项目的服务器；支持 stdio / streamable-http，可粘贴 mcpServers JSON 导入，不预设任何服务器）。已配置服务器的能力清单见会话内的 <available_mcp_servers>（仅描述能力，不代表连接状态）。项目级 MCP 工具经 ws_mcp_list/ws_mcp_search 检索（先 ws_mcp_list 完整盘点服务器与工具，再按需 ws_mcp_detail 查完整 inputSchema），经 ws_mcp_call 调用（先用 ws_mcp_search 检索，再 ws_mcp_call 调用；已知 server/tool 时可直呼免搜索）；全局服务器连接后其工具以 mcp__<server>__<tool> 注册可用。工具可被用户在「MCP」浮窗禁用（禁用原因会说明，且工具级禁用只作用于 mcp__ 前缀工具）。限制：MCP 工具在真实服务器上执行，先确认再操作；stdio 服务器的子进程继承宿主权限；工具结果可能含敏感信息。用户提到「MCP / mcp 服务 / 上下文服务器」时即指本插件，请据此协作。";
+  "本机已安装 dsh-mcp-manager（DSH MCP 管理器）：统一管理 MCP 服务器连接，不预设任何服务器。MCP 工具在真实服务器上执行，stdio 子进程继承宿主权限，结果可能含敏感信息——涉及写/敏感操作先向用户说明并征得同意。用户提到「MCP / mcp 服务 / 上下文服务器」即指本插件；已配置服务器与调用规则见会话内的能力目录。";
 
 /**
  * 挂载 MCP 管理器：加载存储、启动已启用服务器、注册路由与提示词。

--- a/packages/dsh-mcp-manager/src/middleware-register.ts
+++ b/packages/dsh-mcp-manager/src/middleware-register.ts
@@ -191,7 +191,7 @@ export function registerMiddlewareTools(
   const call: ToolDefinition = {
     name: "ws_mcp_call",
     description:
-      "调用当前工作空间的一个 MCP 工具（在真实服务器上执行，先确认再操作）。server/tool 来自 ws_mcp_search 或 ws_mcp_list；参数 schema 用 ws_mcp_detail 查询（已知时可直呼，免搜索）。",
+      "调用当前工作空间的一个 MCP 工具（在真实服务器上执行）。参数 schema 先用 ws_mcp_detail 核对（已知 server/tool 时可直呼免搜索）；涉及写/敏感操作前先向用户说明并征得同意。",
     parameters: {
       type: "object",
       properties: {
@@ -263,7 +263,7 @@ export function registerMiddlewareTools(
   const list: ToolDefinition = {
     name: "ws_mcp_list",
     description:
-      "列出当前工作空间全部 MCP 服务器与每台服务器的完整工具清单（不受检索 limit 截断）。返回服务器全名、工具名与描述，供盘点与后续 ws_mcp_detail / ws_mcp_call 使用。不返回 inputSchema——查单个工具完整 schema 请用 ws_mcp_detail。all 模式下含全局服务器。",
+      "列出当前工作空间全部 MCP 服务器与每台服务器的完整工具清单（不受检索 limit 截断），供盘点。返回服务器全名、工具名与描述。不返回 inputSchema——查单个工具完整 schema 用 ws_mcp_detail。all 模式下含全局服务器。",
     parameters: {
       type: "object",
       properties: {


### PR DESCRIPTION
## 背景

agent 会话上下文注入文本存在：MCP_GUIDANCE 墙式文本（330 字无换行，混入人类 UI 操作与实现细节）、codegraph 工具描述样板句手抄 N 遍（漂移）、营销腔（"新鲜度硬保证"）、status 参数名与描述矛盾、缺负向边界。经 6 轮独立对抗评审收敛为「安全范围」改动。

## 改动（全部为注入文本/description 文案，不碰参数契约/output/execute）

### dsh-mcp-manager
- **MCP_GUIDANCE 精简**：330 字墙式 → 3 行 ~150 字。删配置路径/JSON 导入/mcp__ 注册/调用流程（人类 UI 与实现细节），保留插件存在、安全三段、术语约定。
- **ws_mcp_call/list 描述职责单一化**：去冗余导航复述，保留 smoke:219-225 绑定的互引与负向短语。

### dsh-codegraph
- **SHARED 单一事实源**：`SHARED.projectPath` 常量，8 个工具参数描述统一引用（消手抄漂移）。
- **负向锚 + 场景信号**：每个工具 description 加 NOT 边界（"逐字文本搜索用 grep"等）+ 场景信号，决策信号下沉到 description（模型每回合优先读 schema）。
- **status 修复**：删「自动 sync 无需手动」矛盾句与「查询前先确认」诱导句；参数 path 描述与参数名对齐。
- **explore 措辞**：删「新鲜度硬保证」营销腔，具体化为「返回命中符号定义源码与调用路径」。

## 门禁（worktree 内全绿）

```
pnpm build        ✅
pnpm test         ✅（mcp-manager + codegraph smoke/单测全过）
pnpm contract     ✅
pnpm pack:check   ✅
```

## 范围边界

- 未动：纪律文本（DISCIPLINE_TEXT，避开 smoke:924-925 硬断言）、catalog 目录机制、参数契约/execute。
- 暂缓项（后续单开）：纪律重写、目录范类化/引导唯一化（红 smoke:2016-2022）、ws_mcp_* 占位符同源渲染（不可实现）。

## 关联

- Closes/Refs: #414
- 与 #413（all 模式消除 mcp__ 直呼）独立：#413 改接管逻辑，本 PR 只改注入文本。
