### PR TITLE
fix(dsh-mcp-manager): 移动端切后台切回后项目级 MCP 恢复重建（#412）

### DIFF
--- a/packages/dsh-mcp-manager/src/client/constants.ts
+++ b/packages/dsh-mcp-manager/src/client/constants.ts
@@ -16,6 +16,7 @@ export const API = {
   reconnect: "/api/dsh-mcp/servers/reconnect",
   importJson: "/api/dsh-mcp/import/json",
   session: "/api/dsh-mcp/session",
+  resume: "/api/dsh-mcp/resume",
   config: "/api/dsh-mcp/config",
   events: "/api/dsh-mcp/events",
   health: "/api/dsh-mcp/health",

--- a/packages/dsh-mcp-manager/src/client/index.ts
+++ b/packages/dsh-mcp-manager/src/client/index.ts
@@ -251,11 +251,17 @@ export function apply(ctx: any): void {
     // SSE 广播不会重放需补拉一次；后台期间连接可能已被静默掐断成半开，
     // onerror/close 均不触发，重建代价低（服务端首帧即全量 summary），换推送
     // 链路确定性复活。5s 节流挡快速切换的重复建连。
+    //
+    // #412：仅重建 SSE 不够——宿主中间层连接池里的项目级 MCP 连接同样可能被
+    // 切后台掐成半开（transport onClose 不触发，entry 卡在 connected），此时
+    // GET /servers 纯读只是重复显示僵死状态。故切回前台额外 POST resume 让宿主
+    // 对当前工作空间连接做受控重建（对齐 SSE forceReconnect 语义），再重新拉取
+    // 真实状态。resume 与 forceReconnect 共用 5s 节流挡快速切换。
     const onVisible = () => {
-      if (!document.hidden) {
-        forceReconnect();
-        void refresh(state, actions).catch(() => {});
-      }
+      if (document.hidden) return;
+      forceReconnect();
+      void api(state.API.resume, { method: "POST" }).catch(() => {});
+      void refresh(state, actions).catch(() => {});
     };
     document.addEventListener("visibilitychange", onVisible);
 

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -440,6 +440,33 @@ export class McpManager {
   }
 
   /**
+   * 切回前台恢复：对当前工作空间连接的受控重建（对齐 SSE forceReconnect，#412）。
+   * 移动端切后台会静默掐断 TCP（半开，双方收不到 FIN/RST → transport onClose 不触发），
+   * 连接池 entry 可能卡在 connected 而实际已死；此入口忽略当前状态 force 重建
+   * 当前工作空间单元（当前项目 root；all 模式无项目时回退 @global）内所有非
+   * userDisabled 连接。force 重建健康连接一次代价低（本地 stdio / http 重连毫秒级），
+   * 与 SSE 每次切回前台 forceReconnect 的语义对称。调用方：POST /api/dsh-mcp/resume
+   *（客户端 visibilitychange 回前台触发）。
+   */
+  async resumeReconnect(): Promise<void> {
+    const mw = this.middleware;
+    if (mw === undefined || this.middlewareMode === "off") return;
+    const root = this.projectRoot ?? (this.middlewareMode === "all" ? MIDDLEWARE_GLOBAL_ROOT : undefined);
+    if (root === undefined) return;
+    const unit = mw.units.get(root);
+    if (unit === undefined) return;
+    const targets = [...unit.connections.keys()].filter((name) => !unit.userDisabled.has(name));
+    await Promise.all(
+      targets.map((name) =>
+        mw.ensureConnected(root, name, { force: true }).catch(() => {
+          // ensureConnected 内部已捕获连接失败并落 failed + 退避重连；这里只兜底
+          // 防未处理 reject，单个服务器恢复失败不阻断其余。
+        }),
+      ),
+    );
+  }
+
+  /**
    * 重读磁盘配置（全局 + 当前项目）并同步连接集合。
    * 供「浮窗刷新」等读取路径调用：外部修改 mcp.json 后无需重启宿主。
    * 仅在配置或连接集合实际变化时广播，避免空转 SSE → 客户端 refresh 循环。
@@ -783,7 +810,10 @@ export class McpManager {
       if (unit === undefined) throw new Error(`workspace ${root} has no project MCP config`);
       unit.userDisabled.delete(name);
       await this.saveUserState(this.middleware.units);
-      await this.middleware.ensureConnected(root, name);
+      // force 受控重建（#412）：用户显式「连接」即使 entry 半开卡在 connected
+      // 也强制重建——此前 ensureConnected 对 connected 短路，半开死连接点「连接」
+      // 无效（切回前台/刷新均无恢复入口）。
+      await this.middleware.ensureConnected(root, name, { force: true });
       return;
     }
     const existing = this.supervisors.get(name);

--- a/packages/dsh-mcp-manager/src/middleware.ts
+++ b/packages/dsh-mcp-manager/src/middleware.ts
@@ -109,8 +109,12 @@ export class McpMiddleware {
     return unit;
   }
 
-  /** 连接一个服务器（in-flight 去重；失败后台重连）。 */
-  async ensureConnected(root: string, serverName: string): Promise<void> {
+  /** 连接一个服务器（in-flight 去重；失败后台重连）。
+   * @param opts.force 用户显式连接（浮窗「连接」/切回前台恢复）时 true：忽略
+   *  entry 当前状态（含半开卡在 connected 的死连接），总是受控重建；惰性/重试
+   *  路径缺省 false，保持「已 connected 则短路」防重复建连。
+   */
+  async ensureConnected(root: string, serverName: string, opts: { force?: boolean } = {}): Promise<void> {
     const unit = this.units.get(root);
     if (unit === undefined) return;
     if (unit.userDisabled.has(serverName)) return;
@@ -119,7 +123,7 @@ export class McpMiddleware {
     if (server === undefined || server.enabled === false) return;
     const existing = unit.inFlight.get(serverName);
     if (existing !== undefined) return existing as Promise<void>;
-    const promise = this.connectInternal(root, serverName);
+    const promise = this.connectInternal(root, serverName, opts);
     unit.inFlight.set(serverName, promise);
     try {
       await promise;
@@ -128,13 +132,17 @@ export class McpMiddleware {
     }
   }
 
-  private async connectInternal(root: string, serverName: string): Promise<void> {
+  private async connectInternal(root: string, serverName: string, opts: { force?: boolean } = {}): Promise<void> {
     const unit = this.units.get(root);
     if (unit === undefined) return;
+    const force = opts.force === true;
     const entry = unit.connections.get(serverName);
-    if (entry !== undefined && (entry.status === "connected" || entry.status === "connecting")) return;
-    // 重连路径：旧 entry（failed）的 transport 先 close，防 streamable-http
-    // 半开 socket 累积泄漏（P1 修复）。
+    // 非 force：已 connected/connecting 短路，防重复建连。
+    // force（用户显式「连接」/切回前台恢复）：忽略当前状态，总是受控重建——
+    // 修半开死连接卡在 connected 后 connect/refresh 均短路失效（#412）。
+    if (!force && entry !== undefined && (entry.status === "connected" || entry.status === "connecting")) return;
+    // 重连路径：旧 entry（failed，或 force 重建的死连接）的 transport 先 close，
+    // 防 streamable-http 半开 socket 累积泄漏（P1 修复）。
     if (entry !== undefined) {
       const oldClient = entry.client;
       const oldTransport = entry.transport;
@@ -162,6 +170,9 @@ export class McpMiddleware {
           // 安排一次有界延迟重试，避免窗口期「一次定终身」掉线；重试经
           // ensureConnected（尊重 userDisabled + in-flight 去重），再命中仍跳过
           // （官方 client 真接管场景不空转）。
+          // #412 force 重建：复用旧 entry 可能是 connected 死连接，必须置
+          // failed——否则 probeRetry 3s 后 ensureConnected（无 force）对
+          // connected 短路，重试永不执行（死循环）。
           const retryEntry = unit.connections.get(serverName) ?? {
             server,
             client: undefined,
@@ -173,6 +184,9 @@ export class McpMiddleware {
             disposed: false,
             failedAttempts: 0,
           };
+          retryEntry.status = "failed";
+          retryEntry.client = undefined;
+          retryEntry.transport = undefined;
           unit.connections.set(serverName, retryEntry);
           this.scheduleProbeRetry(root, serverName);
           return;

--- a/packages/dsh-mcp-manager/src/routes.ts
+++ b/packages/dsh-mcp-manager/src/routes.ts
@@ -38,6 +38,8 @@ export interface RoutesManager {
   setToolDisabled?(root: string, server: string, tool: string, disabled: boolean): Promise<void>;
   /** 中间层模式热切换（apply 注入；缺省不可用）。 */
   setMiddlewareMode?(mode: string): Promise<void>;
+  /** 切回前台受控重建当前工作空间连接（apply 注入；缺省不可用）。 */
+  resumeReconnect?(): Promise<void>;
   projectStoreOrThrow(): Promise<McpStore>;
   store: McpStore;
   /** 当前会话项目根（tool-disable 路由一致性校验用）。 */
@@ -65,6 +67,7 @@ export const ROUTES = {
   servers: "/api/dsh-mcp/servers",
   config: "/api/dsh-mcp/config",
   session: "/api/dsh-mcp/session",
+  resume: "/api/dsh-mcp/resume",
   connect: "/api/dsh-mcp/servers/connect",
   disconnect: "/api/dsh-mcp/servers/disconnect",
   reconnect: "/api/dsh-mcp/servers/reconnect",
@@ -243,6 +246,20 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
         }
         try {
           await manager.setSession((body as Record<string, unknown>).cwd as string);
+          writeJson(res, 200, { ok: true, summary: manager.summary() });
+        } catch (error) {
+          handleError(res, error);
+        }
+      },
+    },
+    {
+      kind: "exact",
+      path: ROUTES.resume,
+      handler: async (req, res) => {
+        if (!guard(req, res, "POST")) return;
+        try {
+          if (typeof manager.resumeReconnect !== "function") throw new Error("resumeReconnect unavailable");
+          await manager.resumeReconnect();
           writeJson(res, 200, { ok: true, summary: manager.summary() });
         } catch (error) {
           handleError(res, error);

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -654,13 +654,20 @@ const main = async () => {
     assert.match(clientSrc, /if\s*\(watchdog\s*!==\s*(?:void 0|undefined)\)\s*clearTimeout\(watchdog\)/, "卸载清 watchdog");
     assert.match(clientSrc, /closeEvents\(\);\s*document\.removeEventListener\("visibilitychange"/, "卸载关 SSE 并摘监听");
   });
-  check("回前台强制重建 SSE（visibilitychange → forceReconnect + 补拉）", () => {
+  check("回前台强制重建 SSE + 受控重建连接（visibilitychange → forceReconnect + resume + 补拉）", () => {
     const clientSrc = readFileSync(new URL("../lib/client.js", import.meta.url), "utf8");
     assert.match(clientSrc, /addEventListener\("visibilitychange",\s*onVisible\)/, "visibilitychange 监听已挂");
     assert.match(
       clientSrc,
-      /onVisible\s*=\s*\(\)\s*=>\s*\{\s*if\s*\(!document\.hidden\)\s*\{\s*forceReconnect\(\)/,
+      /onVisible\s*=\s*\(\)\s*=>\s*\{\s*if\s*\(document\.hidden\)\s*return;\s*forceReconnect\(\)/,
       "回前台路径先强制重建 SSE",
+    );
+    // #412：切回前台额外 POST resume 驱动宿主受控重建当前工作空间连接（半开
+    // 死连接卡 connected 时纯读 refresh 无法恢复）。
+    assert.match(
+      clientSrc,
+      /api\(state\.API\.resume,\s*\{\s*method:\s*"POST"\s*\}\)/,
+      "回前台路径调用 resume 驱动宿主重建当前工作空间连接",
     );
   });
 
@@ -1408,7 +1415,7 @@ const main = async () => {
   {
     const { store, cleanup } = tempStore();
     try {
-      const managerState = { sessionCwd: undefined, lastScope: undefined };
+      const managerState = { sessionCwd: undefined, lastScope: undefined, resumed: 0 };
       // 浮窗 UI 配置（可变，验证 config 读/写回传）。
       let uiCfg = { position: "top-right", offsetX: 8, offsetY: 8, blankY: 40 };
       const manager = {
@@ -1447,12 +1454,16 @@ const main = async () => {
         connect: async () => {},
         disconnect: async () => {},
         reconnect: async () => {},
+        // #412 resume：切回前台受控重建当前工作空间连接（记录调用次数供路由断言）。
+        resumeReconnect: async () => {
+          managerState.resumed += 1;
+        },
       };
       const routes = makeRoutes(manager, process.cwd());
       const find = (path) => routes.find((route) => route.path === path);
 
-      check("注册 8 条 exact 路由（含 tool-disable）", () => {
-        assert.equal(routes.length, 8);
+      check("注册 9 条 exact 路由（含 tool-disable / resume）", () => {
+        assert.equal(routes.length, 9);
         for (const route of routes) assert.equal(route.kind, "exact");
       });
 
@@ -1620,6 +1631,19 @@ const main = async () => {
         await find(ROUTES.toolDisable).handler(fakeReq("GET", ROUTES.toolDisable), res405);
         assert.equal(res405.state.status, 405);
       });
+      await checkAsync("resume：POST 合法 → 200 + 调用 resumeReconnect；围栏 403 / GET 405", async () => {
+        const before = managerState.resumed;
+        const res = fakeRes();
+        await find(ROUTES.resume).handler(fakeReq("POST", ROUTES.resume), res);
+        assert.equal(res.state.status, 200);
+        assert.equal(managerState.resumed, before + 1, "resumeReconnect 被调用（#412 切回前台恢复入口）");
+        const res403 = fakeRes();
+        await find(ROUTES.resume).handler(fakeFenceBroken("POST", ROUTES.resume), res403);
+        assert.equal(res403.state.status, 403);
+        const res405 = fakeRes();
+        await find(ROUTES.resume).handler(fakeReq("GET", ROUTES.resume), res405);
+        assert.equal(res405.state.status, 405);
+      });
       await checkAsync("tool-disable：缺 server/tool → 400；root 不属于工作空间 / setToolDisabled 未挂 → 400", async () => {
         const res1 = fakeRes();
         await find(ROUTES.toolDisable).handler(
@@ -1728,7 +1752,7 @@ const main = async () => {
     const ctx = fakeCtx();
     try {
       await apply(ctx, { enabled: true, storePath: join(dir, "dsh-mcp.json") });
-      assert.equal(ctx.routes.length, 10); // 8 条业务路由 + 1 条 SSE events + 1 条 health
+      assert.equal(ctx.routes.length, 11); // 9 条业务路由 + 1 条 SSE events + 1 条 health
       assert.ok(ctx.routes.some((route) => route.path === ROUTES.events), "SSE events 路由已注册");
       assert.equal(ctx.sections.length, 1);
       assert.equal(ctx.sections[0].name, "plugin:dsh-mcp-manager");

--- a/packages/dsh-mcp-manager/test/unit-middleware.src.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.src.test.ts
@@ -514,3 +514,53 @@ function makeHost(serversByRoot = new Map()) {
     /已被用户禁用/,
   );
 }
+
+// ---- #412 force 受控重建：半开 connected entry 不短路 ----
+{
+  const servers = [{ name: "ctx", transport: "stdio", command: "npx", enabled: true }];
+  const { host } = makeHost(new Map([[ROOT, servers]]));
+  // 防双进程探测命中（避免真实 spawn；重建落 failed 占位 + 排重试）
+  host.ctx.tools.schemas = () => [{ name: "mcp__ctx__t" }];
+  const mw = new McpMiddleware(host, {});
+  // 直接构造单元（不走 projectUnitFor 惰性连接，测试全程不 spawn）
+  const unit = {
+    root: ROOT,
+    connections: new Map(),
+    catalog: new Map(),
+    userDisabled: new Set(),
+    lastTouchedAt: Date.now(),
+    inFlight: new Map(),
+  };
+  mw.units.set(ROOT, unit);
+  // 预置「半开死连接」：status 卡 connected、transport 已静默断链（模拟移动端
+  // 切后台掐断 TCP 后 onClose 不触发）。
+  const deadTransport = { close: () => { deadTransport.closed = true; return Promise.resolve(); }, closed: false };
+  const deadEntry = {
+    server: servers[0],
+    client: {},
+    transport: deadTransport,
+    status: "connected",
+    error: undefined,
+    connectedAt: Date.now(),
+    reconnectTimer: undefined,
+    disposed: false,
+    failedAttempts: 0,
+  };
+  unit.connections.set("ctx", deadEntry);
+
+  // 非 force：connected 短路——entry 引用与 transport 原样保留（惰性路径防重复建连）。
+  await mw.ensureConnected(ROOT, "ctx");
+  assert.equal(unit.connections.get("ctx"), deadEntry, "非 force 短路保留原 entry");
+  assert.equal(deadTransport.closed, false, "非 force 不 close 旧 transport");
+
+  // force：忽略 connected 状态受控重建——旧 transport 被 close、entry 置 failed
+  // + 重试排程（探测命中防双进程路径复用 entry，不再短路）。
+  await mw.ensureConnected(ROOT, "ctx", { force: true });
+  assert.equal(deadTransport.closed, true, "force 关闭旧 transport（半开 socket 不泄漏）");
+  const after = unit.connections.get("ctx");
+  assert.equal(after.status, "failed", "force 重建置 failed（防 probeRetry 对 connected 短路死循环）");
+  assert.equal(after.transport, undefined, "旧 transport 已清空（重建代际）");
+  assert.equal(after.probeRetried, true, "重试已排（probeRetried 一次性标记）");
+  if (after.reconnectTimer !== undefined) clearTimeout(after.reconnectTimer);
+  await mw.dispose();
+}

--- a/packages/dsh-mcp-manager/test/unit-middleware.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.test.ts
@@ -514,3 +514,53 @@ function makeHost(serversByRoot = new Map()) {
     /已被用户禁用/,
   );
 }
+
+// ---- #412 force 受控重建：半开 connected entry 不短路 ----
+{
+  const servers = [{ name: "ctx", transport: "stdio", command: "npx", enabled: true }];
+  const { host } = makeHost(new Map([[ROOT, servers]]));
+  // 防双进程探测命中（避免真实 spawn；重建落 failed 占位 + 排重试）
+  host.ctx.tools.schemas = () => [{ name: "mcp__ctx__t" }];
+  const mw = new McpMiddleware(host, {});
+  // 直接构造单元（不走 projectUnitFor 惰性连接，测试全程不 spawn）
+  const unit = {
+    root: ROOT,
+    connections: new Map(),
+    catalog: new Map(),
+    userDisabled: new Set(),
+    lastTouchedAt: Date.now(),
+    inFlight: new Map(),
+  };
+  mw.units.set(ROOT, unit);
+  // 预置「半开死连接」：status 卡 connected、transport 已静默断链（模拟移动端
+  // 切后台掐断 TCP 后 onClose 不触发）。
+  const deadTransport = { close: () => { deadTransport.closed = true; return Promise.resolve(); }, closed: false };
+  const deadEntry = {
+    server: servers[0],
+    client: {},
+    transport: deadTransport,
+    status: "connected",
+    error: undefined,
+    connectedAt: Date.now(),
+    reconnectTimer: undefined,
+    disposed: false,
+    failedAttempts: 0,
+  };
+  unit.connections.set("ctx", deadEntry);
+
+  // 非 force：connected 短路——entry 引用与 transport 原样保留（惰性路径防重复建连）。
+  await mw.ensureConnected(ROOT, "ctx");
+  assert.equal(unit.connections.get("ctx"), deadEntry, "非 force 短路保留原 entry");
+  assert.equal(deadTransport.closed, false, "非 force 不 close 旧 transport");
+
+  // force：忽略 connected 状态受控重建——旧 transport 被 close、entry 置 failed
+  // + 重试排程（探测命中防双进程路径复用 entry，不再短路）。
+  await mw.ensureConnected(ROOT, "ctx", { force: true });
+  assert.equal(deadTransport.closed, true, "force 关闭旧 transport（半开 socket 不泄漏）");
+  const after = unit.connections.get("ctx");
+  assert.equal(after.status, "failed", "force 重建置 failed（防 probeRetry 对 connected 短路死循环）");
+  assert.equal(after.transport, undefined, "旧 transport 已清空（重建代际）");
+  assert.equal(after.probeRetried, true, "重试已排（probeRetried 一次性标记）");
+  if (after.reconnectTimer !== undefined) clearTimeout(after.reconnectTimer);
+  await mw.dispose();
+}


### PR DESCRIPTION
## 动机

Fixes #412 —— 移动端把标签页切到后台再切回时，**项目级** MCP 显示「未连接」，浮窗「刷新 / 连接」均无效；切到其他工作目录再切回才恢复。

**根因**（三层叠加）：

1. **连接池无半开检测**：`index.ts` 对 SSE 通道已有 60s watchdog + visibilitychange 受控重建（#268），但中间层**连接池**（`McpMiddleware.connectInternal`）没有等价机制。移动端切后台会静默掐断 TCP（半开，双方收不到 FIN/RST），SDK transport 的 `onClose` 不触发，`entry.status` 卡在 `connected`。
2. **半开连接卡死在 connected 导致「刷新 / 连接」短路**：`connectInternal` 开头 `if (entry.status === "connected" || "connecting") return;` —— 用户点「连接」时 `ensureConnected → connectInternal` 直接 return，不重建；`refresh` 纯读 GET /servers 也不驱动重连。
3. **切回前台只重建 SSE**：客户端 `onVisible` 只 `forceReconnect()`（SSE）+ `refresh()`（纯读），不驱动宿主重建项目连接。

## 改动

- **middleware.ts**：`ensureConnected` / `connectInternal` 增加 `force` 语义——用户显式连接或切回前台恢复时忽略 entry 当前状态（含半开卡 connected 的死连接）强制受控重建（旧 transport 先 close 防 socket 泄漏）；惰性/重试路径缺省短路不变。探测命中路径复用旧 entry 时置 `failed`，防 `probeRetry` 对 connected 短路死循环。
- **manager.ts**：`connect()` 中间层路径改走 `force`；新增 `resumeReconnect()`——对当前工作空间单元（项目 root；all 模式无项目回退 @global）内全部非 userDisabled 连接做受控重建，对齐 SSE `forceReconnect` 语义。
- **routes.ts**：新增 `POST /api/dsh-mcp/resume`（loopback 围栏 403 / 方法错 405）。
- **client/index.ts**：`visibilitychange` 切回前台时，除重建 SSE + 补拉外，额外 POST resume 驱动宿主重建当前工作空间连接，再拉取真实状态（与 SSE 共用 5s 节流）。
- **测试**：
  - `unit-middleware.test.ts` / `.src.test.ts`：force 重建断言（非 force 短路保留 / force 关旧 transport + 置 failed + 重试排程）。
  - `smoke.ts`：resume 路由围栏（403/405）+ 调用断言；onVisible 产物断言更新（resume 调用）；路由数 8→9 / 10→11。

## 验证

- `pnpm build && pnpm test`（包级）✓
- `pnpm -r build && pnpm -r test && pnpm contract && pnpm pack:check`（仓库级全门禁）✓
- 单元测试：`node test/unit-middleware.test.ts` ✓

## 遗留

阶段三（连接池 60s 半开 watchdog，方案 B）作为后续增强另行跟踪，不在本次范围（见 issue #412 评论）。

Fixes #412