### PR TITLE
feat(dsh-mcp-manager): all 模式 runtime 注入服务器归一中台，消除 mcp__ 前缀直呼（#413）

### DIFF
--- a/packages/dsh-mcp-manager/README.en.md
+++ b/packages/dsh-mcp-manager/README.en.md
@@ -11,7 +11,8 @@ extra to install.
 Three middleware modes (`middleware`): `off` — all servers register directly as
 `mcp__<server>__<tool>` (legacy behavior); `project` (**default**) — project-level
 servers go through the middleware while global ones register directly; `all` — global
-servers go through the middleware too, falling back to the virtual global root
+servers (including runtime-injected wrapped-definition servers such as codegraph) go
+through the middleware too, falling back to the virtual global root
 `@global` when cwd has no project, collapsing the model surface to exactly four atomic
 tools (`ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search` / `ws_mcp_call`).
 `middleware` / `middlewarePolicy` can be hot-switched from the settings page (saved
@@ -98,7 +99,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-mcp-manager
 | Server management | CRUD (project-level/global optional), connect / disconnect / reconnect; versioned JSON config, atomic write |
 | Two transports | stdio (local subprocess, env supports `${ENV}` references) and streamable-http (remote, header supports `${ENV}` references, auto-echoes `Mcp-Session-Id`) |
 | JSON import | Paste `mcpServers` JSON text to import (JSON format only; does not scan any application config files) |
-| Model tools | Global servers register directly as `mcp__<server>__<tool>` (64 chars, `[A-Za-z0-9_-]`, hashed suffix on conflict); project-level servers go through the middleware's `ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search` / `ws_mcp_call` by default (`middleware: project`, recommended), so workspaces never clash |
+| Model tools | Global servers register directly as `mcp__<server>__<tool>` (64 chars, `[A-Za-z0-9_-]`, hashed suffix on conflict); project-level servers go through the middleware's `ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search` / `ws_mcp_call` by default (`middleware: project`, recommended), so workspaces never clash; with `middleware: all`, global and runtime-injected servers (e.g. codegraph) also go through the middleware with no `mcp__` prefix |
 | Workspace isolation | The middleware routes by the calling session's cwd to the matching workspace connection pool; server full-name consistency checks (`@<root>/<server>`) prevent cross-workspace crosstalk |
 | Reconnection | Exponential backoff (starts at 500ms, caps at 30s, gives up after 10 attempts and deregisters the tools) |
 | Result truncation | Direct-connect tool results truncated at 8KB and marked (prevents oversized JSON from entering context in full) |
@@ -166,7 +167,8 @@ without name clashes; global servers still register directly as `mcp__<server>__
 (in `project` mode, passing a global-scope server to detail/call returns a
 "use `mcp__` directly" hint). Switch
 `middleware: off` to restore the legacy behavior (project-level also registers `mcp__`);
-`middleware: all` routes global servers through the middleware too (falling back to the
+`middleware: all` routes global servers (including runtime-injected wrapped-definition
+servers such as codegraph) through the middleware too (falling back to the
 virtual global root `@global` when cwd has no project), collapsing the model surface to
 exactly four atomic tools — list/search/detail then merge queries across the "project
 root unit + `@global` unit", and call allows the `@global` root (global config is shared
@@ -188,14 +190,15 @@ no `dsh web` restart needed.
 - Expanding the "Tools (N)" details of a server card shows a **checkbox list**; toggling
   each tool persists via `PATCH /api/dsh-mcp/tool-disable` (stored under
   `<DSH_HOME>/dsh-mcp-user-state.json` → `disabledTools`, merged write, survives restarts);
-- Semantics: in `project` mode only project-level servers' `mcp__` tools can be disabled;
-  in `all` mode global servers' `mcp__` tools can be disabled too; everything is enabled
-  by default;
+- Semantics: in `project` mode only project-level servers' middleware-routed tools can be
+  disabled; in `all` mode global servers' (including runtime-injected such as codegraph)
+  middleware-routed tools can be disabled too; everything is enabled by default;
 - Per-tool disable is **independent of the server-level `enabled` switch** (re-enabling a
   server does not clear its tool-level state);
-- It **only applies to `mcp__`-prefixed tools**: discipline bare-name tools (e.g.
-  dsh-codegraph's `codegraph_explore`) are not affected (declared on the dsh-codegraph
-  side in #363);
+- It **applies to all mcp-manager-managed MCP tools** (`mcp__`-prefixed direct calls and
+  middleware `ws_mcp_*` calls consistently; runtime wrapped tools in `all` mode are
+  covered too); discipline bare-name tools (e.g. dsh-codegraph's `codegraph_explore`)
+  are not affected (declared on the dsh-codegraph side in #363);
 - Overlong tool names (>64 chars, hashed suffix) are irreversible → treated as unknown
   server, neither disabled nor mistakenly denied;
 - In `project` mode the floating window shows global servers without tool switches (they

--- a/packages/dsh-mcp-manager/README.md
+++ b/packages/dsh-mcp-manager/README.md
@@ -7,8 +7,9 @@ DSH（DeepSeek Harness）的 **MCP 服务器管理插件**：会话界面右上�
 MCP 协议客户端基于 `node:child_process` 与全局 `fetch` 直接实现，无需额外安装。
 
 三档中间层模式（`middleware`）：`off`——全部服务器直呼 `mcp__<server>__<tool>`（旧行为）；
-`project`（**默认**）——项目级走中间层、全局仍直呼；`all`——全局也走中间层，
-cwd 无项目时回落全局虚拟 root `@global`，模型面完全收敛为四个原子工具
+`project`（**默认**）——项目级走中间层、全局仍直呼；`all`——全局也走中间层
+（含运行时注入的封装定义服务器如 codegraph），cwd 无项目时回落全局虚拟 root
+`@global`，模型面完全收敛为四个原子工具
 （`ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search` / `ws_mcp_call`）。
 `middleware` / `middlewarePolicy` 可在设置页热切换（保存即生效并持久化），
 也可在配置文件中设置（插件启动时读取）；两级配置文件中的服务器列表（增删/启停/改配置）支持热加载、即时生效，无需重启。
@@ -82,7 +83,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-mcp-manager
 | 服务器管理 | 增删改查（可选项目级/全局）、连接 / 断开 / 重连；配置版本化 JSON，原子写入 |
 | 两种传输 | stdio（本地子进程，env 支持 `${ENV}` 引用）与 streamable-http（远程，header 支持 `${ENV}` 引用，自动回传 `Mcp-Session-Id`） |
 | JSON 导入 | 粘贴 mcpServers JSON 文本导入（仅 JSON 格式；不扫描任何应用配置文件） |
-| 模型工具 | 全局服务器工具以 `mcp__<server>__<tool>` 注册（64 字符、`[A-Za-z0-9_-]`、冲突时哈希后缀）；项目级服务器默认经中间层 `ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search` / `ws_mcp_call` 访问（`middleware: project`，推荐），不同工作空间互不冲突 |
+| 模型工具 | 全局服务器工具以 `mcp__<server>__<tool>` 注册（64 字符、`[A-Za-z0-9_-]`、冲突时哈希后缀）；项目级服务器默认经中间层 `ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search` / `ws_mcp_call` 访问（`middleware: project`，推荐），不同工作空间互不冲突；`middleware: all` 时全局与运行时注入服务器（如 codegraph）也统一经中间层访问，不注册 `mcp__` 前缀 |
 | 工作空间隔离 | 中间层按调用方会话当前 cwd 路由到对应工作空间的连接池；server 全名 `@<root>/<server>` 一致性校验防跨空间串台 |
 | 断线重连 | 有界指数退避（500ms 起、30s 上限、10 次后停止后台重试；用户手动连接或 ws_mcp_call 触发可再试） |
 | 结果截断 | 工具结果按 8KB 截断并标注（防超长 JSON 全量进上下文） |
@@ -136,7 +137,8 @@ limit 截断）/ `ws_mcp_call`（按 `@<root>/<server>` 全名调用，参数 sc
 连接池，不同工作空间注入不同 MCP、无命名冲突；全局服务器仍直呼
 `mcp__<server>__<tool>`（project 模式 detail/call 传全局级服务器会给出直呼引导）。
 切换 `middleware: off` 回到旧行为（项目级也直接注册
-`mcp__` 工具）；`middleware: all` 则全局服务器也走中间层（cwd 无项目时回落全局
+`mcp__` 工具）；`middleware: all` 则全局服务器（含运行时注入的封装定义服务器，
+如 dsh-codegraph 的 toolDefinitions）也走中间层（cwd 无项目时回落全局
 虚拟 root `@global`），模型面完全收敛为四个原子工具——此时 list/search/detail
 合并查询「项目 root 单元 + `@global` 单元」，call 放行 `@global` root（全局配置
 跨工作空间共享，语义成立）。注：all 模式全局服务器增删改后需重启或触发会话
@@ -155,11 +157,12 @@ limit 截断）/ `ws_mcp_call`（按 `@<root>/<server>` 全名调用，参数 sc
 - 服务器卡片的「工具（N）」折叠区展开后为 **checkbox 列表**，逐个启停，点击即
   经 `PATCH /api/dsh-mcp/tool-disable` 持久化（落盘 `<DSH_HOME>/dsh-mcp-user-state.json`
   的 `disabledTools`，合并写盘、重启保留）；
-- 语义：**project 模式只能禁用项目级服务器的 mcp__ 工具；all 模式才能禁用全局
-  服务器的 mcp__ 工具**；默认全部启用；
+- 语义：**project 模式只能禁用项目级服务器经中间层的工具；all 模式可禁用全局
+  服务器（含 runtime 注入如 codegraph）经中间层的工具**；默认全部启用；
 - 工具级禁用**独立于服务器级 enabled 开关**（服务器级复活不清工具级状态）；
-- **只作用于 mcp__ 前缀工具**：纪律裸名（如 dsh-codegraph 的 `codegraph_explore`）
-  不受影响（dsh-codegraph 侧由 #363 声明）；
+- **作用于 mcp-manager 管辖的全部 MCP 工具**（mcp__ 前缀直呼与中间层 ws_mcp_*
+  一致生效，all 模式 runtime 封装工具同样受控）；纪律裸名（dsh-codegraph 的
+  `codegraph_explore` 等裸名直呼形态）不受影响（dsh-codegraph 侧由 #363 声明）；
 - 超长工具名（>64 字符哈希后缀）不可逆 → 按未知 server 处理，不禁用/不误禁；
 - project 模式浮窗显示全局服务器但无工具开关（全局工具此时经 supervisor 直呼，
   不经中间层），提示「切 all 模式可管理全局工具」；

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -735,18 +735,23 @@ export class McpManager {
   /**
    * 运行时注销（不影响 store 持久化条目；同名 store 条目回落）。
    * - 销毁 supervisor（stop，不碰 store）；
+   * - **先删 runtimeRegistry 再拆中间层连接**（#413 QA P2-1）：drop 时数据源
+   *   （projectServersFor 含 runtime）已不再返回该服务器，任何并发
+   *   ensureConnected/connect 都查不到配置而无法重建虚拟连接——堵死注销后
+   *   瞬时复活窗口，且不写 userDisabled（避免持久化污染导致同名 re-register
+   *   被静默阻止连接，与 disconnect 的「用户主动断开」语义区分）；
    * - 拆中间层连接与目录条目（#413：all 模式 runtime 归一中台后虚拟连接在
    *   @global 单元，须显式清理，否则 unregister 后 ws_mcp_list/call 残留幽灵）；
-   * - 移除 runtimeRegistry 条目 → 下次 reconcile 回落 store 配置。
+   * - reconcile 回落 store 配置。
    */
   async unregisterServer(name: string): Promise<void> {
     const run = this.registerQueue.then(async () => {
       if (this.runtimeRegistry.has(name)) {
         this.stop(name);
+        this.runtimeRegistry.delete(name);
         if (this.middlewareMode !== "off" && this.middleware !== undefined) {
           this.dropMiddlewareConnection(name);
         }
-        this.runtimeRegistry.delete(name);
         this.reconcileServers();
       }
     });

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -234,11 +234,24 @@ export class McpManager {
     return this.findProjectRoot(cwd);
   }
 
-  /** 中间层宿主：按 root 读取服务器配置。all 模式的虚拟 root "@global" 返回全局配置。 */
+  /**
+   * 中间层宿主：按 root 读取服务器配置。all 模式的虚拟 root "@global" 返回
+   * 全局配置 **+ runtime 注入条目**（#413：runtime 封装定义服务器由中间层接管，
+   * 数据源必须可见；独立合并，不污染 store.data.servers 持久化数组）。
+   */
   async projectServersFor(root: string): Promise<ServerConfig[] | undefined> {
-    if (root === MIDDLEWARE_GLOBAL_ROOT) return this.store.data.servers;
+    if (root === MIDDLEWARE_GLOBAL_ROOT) {
+      const servers = [...this.store.data.servers];
+      for (const server of this.runtimeRegistry.values()) servers.push(server);
+      return servers;
+    }
     const store = await this.projectStoreFor(root);
     return store?.data.servers;
+  }
+
+  /** 中间层宿主：该 server 是否 runtime 注入（目录不写盘判定；#413）。 */
+  isRuntimeServer(name: string): boolean {
+    return this.runtimeRegistry.has(name);
   }
 
   /** 中间层宿主：该 server 是否全局级（双源：store + runtimeRegistry）。
@@ -277,6 +290,7 @@ export class McpManager {
         emitStatus: () => this.emitStatus(),
         catalogCachePath: (root) => this.catalogCachePathFor(root),
         isGlobalServer: (name) => this.isGlobalServer(name),
+        isRuntimeServer: (name) => this.isRuntimeServer(name),
       },
       {
         allowTools: (policy.allowTools as Record<string, string[]> | undefined) ?? undefined,
@@ -511,7 +525,8 @@ export class McpManager {
         }
       }
       // 双轨合并：runtimeRegistry（内存态，运行时注入）并入 desired，同名 runtime 优先。
-      // 中间层 project/all 模式：runtime 仅全局 supervisor 路径（不拆单元、不走中间层连接池）。
+      // 中间层模式：#413 起 all 模式 runtime 归一中台（同 store 全局走 @global 单元），
+      // project 模式 runtime 仍全局 supervisor 路径。
       for (const [name, server] of this.runtimeRegistry) {
         desired.set(name, { server, scope: SCOPE_GLOBAL });
       }
@@ -519,7 +534,7 @@ export class McpManager {
       for (const [name, supervisor] of [...this.supervisors]) {
         const want = desired.get(name);
         // 中间层接管（与 start 同口径单一事实源 middlewareTakes）：停掉不该以
-        // supervisor 形态存在的连接。runtime 条目豁免（判定恒 false，不被停）。
+        // supervisor 形态存在的连接（#413：all 模式 runtime 亦被接管，同样停）。
         const middlewareTakes = this.middlewareTakes(name, supervisor.scope);
         if (want === undefined || want.server.enabled === false || want.scope !== supervisor.scope || middlewareTakes) {
           this.stop(name);
@@ -612,13 +627,14 @@ export class McpManager {
 
   /**
    * 中间层接管判定（start / reconcileServers 单一口径）：中间层模式的项目级，
-   * 或 all 模式下非 runtime 注入的全局级。runtime 条目豁免（始终走 supervisor
-   * 路径，注册 mcp__ 工具）。
+   * 或 all 模式的全局级（**含 runtime 注入条目**，#413 消除豁免——all 模式
+   * 统一无 mcp__ 前缀直呼，runtime 封装定义服务器经中间层目录投影 + callTool
+   * 直呼执行；project / off 模式 runtime 照旧 supervisor 路径注册 mcp__ 工具）。
    */
   private middlewareTakes(name: string, scope: string): boolean {
     if (this.middlewareMode === "off" || this.middleware === undefined) return false;
     if (scope === SCOPE_PROJECT) return true;
-    return this.middlewareMode === "all" && scope === SCOPE_GLOBAL && !this.runtimeRegistry.has(name);
+    return this.middlewareMode === "all" && scope === SCOPE_GLOBAL;
   }
 
   /**
@@ -701,9 +717,14 @@ export class McpManager {
         return { name: config.name, existing: true };
       }
       this.runtimeRegistry.set(config.name, config);
-      if (this.middlewareMode !== "off") {
-        // 中间层模式：runtime 服务器走全局 supervisor 路径（不落盘，不拆单元）。
-      }
+      // #413 时序显式化：注册即连接走 start 的 config 直传分支；start 内部按
+      // middlewareTakes 判定（all 模式全局 → 触达 @global 单元，不建 supervisor、
+      // 不注册 mcp__；project/off 或中间层未就绪 → supervisor 路径）。中间层
+      // 未就绪窗口（provide→initMiddleware 之间的 async 空隙）暂落 supervisor，
+      // 由 apply 的 reconcileServers（initMiddleware 后无条件执行）按同口径收敛
+      // （stop supervisor + 重定向 @global 单元）；若收敛瞬间旧 mcp__ 注册尚未
+      // 注销（dispose fire-and-forget），中间层防双进程探测命中 → F5 有界重试
+      // 兜底，与 #382 热切换窗口同语义。
       if (config.enabled !== false) this.start(config.name, SCOPE_GLOBAL, config);
       return { name: config.name, existing: false };
     });
@@ -802,7 +823,8 @@ export class McpManager {
     // F4（#382）：被中间层接管的服务器连接走连接池（userDisabled 解除 + 惰性
     // 连接）——此前只有项目级走池，all 模式全局走 supervisor 复活（注册 mcp__
     // 前缀工具），既导致浮窗带前缀展示，又让中间层防双进程探测持续命中、永不
-    // 接管。runtime 条目豁免（middlewareTakes 判定），仍走 supervisor 路径。
+    // 接管。project/off 模式 runtime 仍走 supervisor 路径（#413：仅 all 模式
+    // 归一中间层）。
     if (this.middlewareTakes(name, scope) && this.middleware !== undefined) {
       const root = scope === SCOPE_PROJECT ? this.projectRoot : MIDDLEWARE_GLOBAL_ROOT;
       if (root === undefined) throw new Error("no active project session (call session with a cwd first)");
@@ -827,9 +849,10 @@ export class McpManager {
 
   async disconnect(name: string, scope?: string): Promise<void> {
     // 中间层模式：userDisabled 持久化 + 连接池拆毁该连接。
-    // #382：定位按接管口径显式进行——all 模式全局（store 配置且非 runtime）固定
-    // 定位 @global 单元（此前按 units 遍历序找第一个命中，同名服务器同时存在于
-    // 项目与 @global 单元时可能写错单元）；runtime 注入条目不经池，落 supervisor。
+    // #382：定位按接管口径显式进行——all 模式全局（store 配置）固定定位 @global
+    // 单元（此前按 units 遍历序找第一个命中，同名服务器同时存在于项目与 @global
+    // 单元时可能写错单元）；#413：all 模式 runtime 注入条目同样在 @global 单元
+    // （虚拟连接），走遍历兜底定位。
     // #392：scope 显式传入时按 scope 精确定位单元——项目级固定定位当前项目 root
     // 单元，避免同名全局服务器把项目级 disconnect 错写进 @global 单元。
     // 拆连接前关 transport（此前直接 delete 丢 entry，stdio 子进程/socket 泄漏）。
@@ -911,8 +934,8 @@ export class McpManager {
   private middlewareUnitFor(serverName: string, scope: string): ProjectUnit | undefined {
     const mw = this.middleware;
     if (mw === undefined || this.middlewareMode === "off") return undefined;
-    // 与 start/reconcileServers 同口径（#382 F4）：runtime 条目豁免（走 supervisor
-    // 投影），all 模式全局才映射 @global 单元。
+    // 与 start/reconcileServers 同口径（#382 F4 + #413）：all 模式全局（含
+    // runtime 注入条目）映射 @global 单元。
     if (!this.middlewareTakes(serverName, scope)) return undefined;
     const root = scope === SCOPE_PROJECT ? this.projectRoot : MIDDLEWARE_GLOBAL_ROOT;
     return root === undefined ? undefined : mw.units.get(root);

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -735,12 +735,17 @@ export class McpManager {
   /**
    * 运行时注销（不影响 store 持久化条目；同名 store 条目回落）。
    * - 销毁 supervisor（stop，不碰 store）；
+   * - 拆中间层连接与目录条目（#413：all 模式 runtime 归一中台后虚拟连接在
+   *   @global 单元，须显式清理，否则 unregister 后 ws_mcp_list/call 残留幽灵）；
    * - 移除 runtimeRegistry 条目 → 下次 reconcile 回落 store 配置。
    */
   async unregisterServer(name: string): Promise<void> {
     const run = this.registerQueue.then(async () => {
       if (this.runtimeRegistry.has(name)) {
         this.stop(name);
+        if (this.middlewareMode !== "off" && this.middleware !== undefined) {
+          this.dropMiddlewareConnection(name);
+        }
         this.runtimeRegistry.delete(name);
         this.reconcileServers();
       }

--- a/packages/dsh-mcp-manager/src/middleware-register.ts
+++ b/packages/dsh-mcp-manager/src/middleware-register.ts
@@ -256,7 +256,9 @@ export function registerMiddlewareTools(
       const unit = await mw.projectUnitFor(targetRoot);
       if (unit === undefined) throw new Error(`ws_mcp_call: 工作空间 ${JSON.stringify(targetRoot)} 无项目级 MCP 配置`);
       await mw.ensureConnected(targetRoot, parsed.server);
-      return mw.callTool(server, tool, params.arguments, exec.signal);
+      // #413：透传 exec.agent 给 callTool（封装直呼分支的 execute 依赖
+      // agent.session.header.cwd 做 projectPath 补全）。
+      return mw.callTool(server, tool, params.arguments, exec.signal, exec.agent);
     },
   };
 

--- a/packages/dsh-mcp-manager/src/middleware-types.ts
+++ b/packages/dsh-mcp-manager/src/middleware-types.ts
@@ -153,4 +153,6 @@ export interface MiddlewareHost {
   catalogCachePath(root: string): string;
   /** 该 server 是否全局级（双源：store.data.servers + runtimeRegistry；codegraph 为 runtime 注册）。 */
   isGlobalServer(name: string): boolean;
+  /** 该 server 是否 runtime 注入（registerServer 内存态；目录不写盘判定，#413）。 */
+  isRuntimeServer(name: string): boolean;
 }

--- a/packages/dsh-mcp-manager/src/middleware-utils.ts
+++ b/packages/dsh-mcp-manager/src/middleware-utils.ts
@@ -245,9 +245,9 @@ export function policyDenialReason(policy: MiddlewarePolicy | undefined, serverK
   return `ws_mcp_call: 工具 ${JSON.stringify(`${serverKey}/${tool}`)} 不在 allowTools 白名单内，被策略拒绝`;
 }
 
-/** 工具级禁用的拒绝原因文案（三入口统一；P0-2 语义声明）。 */
+/** 工具级禁用的拒绝原因文案（三入口统一；P0-2 语义声明，#413 覆盖中间层工具）。 */
 export function toolDisabledReason(serverKey: string, tool: string): string {
-  return `ws_mcp_call: 工具 ${JSON.stringify(`${serverKey}/${tool}`)} 已被用户在「MCP」浮窗禁用；工具级禁用只作用于 mcp__ 前缀工具，纪律裸名不受影响（如需恢复请到浮窗重新勾选）`;
+  return `ws_mcp_call: 工具 ${JSON.stringify(`${serverKey}/${tool}`)} 已被用户在「MCP」浮窗禁用；工具级禁用作用于 mcp-manager 管辖的全部 MCP 工具（mcp__ 前缀直呼与中间层 ws_mcp_* 一致生效），纪律裸名不受影响（如需恢复请到浮窗重新勾选）`;
 }
 
 // ------------------------------------------------------------ 目录检索

--- a/packages/dsh-mcp-manager/src/middleware.ts
+++ b/packages/dsh-mcp-manager/src/middleware.ts
@@ -23,6 +23,7 @@ import { mkdir, readFile, rename, writeFile, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname } from "node:path";
 import type { ServerConfig } from "./types.ts";
+import type { ToolDefinition, ToolOutputDefinition } from "@deepseek-ai/dsh-tools";
 import { MCPClient } from "./protocol.ts";
 import { createTransport } from "./transport.ts";
 import {
@@ -155,6 +156,30 @@ export class McpMiddleware {
     const servers = await this.host.projectServersFor(root);
     const server = servers?.find((entry) => entry.name === serverName);
     if (server === undefined || server.enabled === false) return;
+    // #413：封装定义服务器（runtime 注入 toolDefinitions，如 codegraph）——
+    // execute 为调用方 JS 直呼 CLI，不经远端 MCP callTool，**不 spawn transport**。
+    // 中间层以「虚拟连接」（无 client/transport，status=connected）+ 目录从
+    // toolDefinitions 投影存在；执行走 callTool 的封装直呼分支。
+    if (Array.isArray(server.toolDefinitions) && server.toolDefinitions.length > 0) {
+      const existingWrapped = unit.connections.get(serverName);
+      if (existingWrapped !== undefined && (existingWrapped.status === "connected" || existingWrapped.status === "connecting")) return;
+      const wrappedEntry: ConnectionEntry = {
+        server,
+        client: undefined,
+        transport: undefined,
+        status: "connected",
+        error: undefined,
+        connectedAt: Date.now(),
+        reconnectTimer: undefined,
+        disposed: false,
+        failedAttempts: 0,
+      };
+      unit.connections.set(serverName, wrappedEntry);
+      this.projectWrappedCatalog(root, serverName, server);
+      this.host.logger.info(`dsh-mcp-manager(${serverName}@${root}): wrapped (toolDefinitions) connected`);
+      this.host.emitStatus();
+      return;
+    }
     // 与官方 dsh-mcp-client 并存（方案 E2）：运行时探测官方/其他插件是否已注册
     // 同名 server 的 mcp__ 工具（说明该 server 已有其他实例连接）→ 跳过本实例，
     // 防同一 server 双进程。探测失败（tools.schemas 不可用）不阻塞连接。
@@ -323,6 +348,28 @@ export class McpMiddleware {
     }
   }
 
+  /**
+   * #413：从封装定义（toolDefinitions）投影目录，替代远端 discover。
+   * 封装 execute 为调用方 JS 直呼（不经远端 MCP），目录数据源即调用方定义：
+   * name/description 直取；dsh-tools 的 parameters（ToolSchema）即 JSON Schema
+   * 形态，直接作 CatalogTool.inputSchema（与 supervisor 封装分支同口径）。
+   */
+  private projectWrappedCatalog(root: string, serverName: string, server: ServerConfig): void {
+    const unit = this.units.get(root);
+    if (unit === undefined) return;
+    const tools = new Map<string, CatalogTool>();
+    if (Array.isArray(server.toolDefinitions)) {
+      for (const def of server.toolDefinitions) {
+        if (typeof def?.name !== "string" || def.name === "") continue;
+        tools.set(def.name, {
+          description: typeof def.description === "string" ? def.description : "",
+          inputSchema: (def.parameters ?? {}) as Record<string, unknown>,
+        });
+      }
+    }
+    unit.catalog.set(serverName, { discoveredAt: Date.now(), tools });
+  }
+
   /** 凭据脱敏（连接/发现/调用错误路径统一使用；P1 修复）。 */
   private redact(error: unknown): string {
     return createRedactor(this.allServers())(error);
@@ -349,6 +396,9 @@ export class McpMiddleware {
     let anyTools = false;
     const payload: Record<string, unknown> = {};
     for (const [serverName, catalog] of unit.catalog) {
+      // #413：runtime 注入条目（内存态，不落盘）目录只驻内存——防卸载/重启后
+      // 幽灵条目被 loadCatalogCache 载回（与 removeCatalogEntry 清理同类问题）。
+      if (this.host.isRuntimeServer?.(serverName) === true) continue;
       if (catalog.tools.size === 0) continue;
       anyTools = true;
       payload[serverName] = {
@@ -432,12 +482,15 @@ export class McpMiddleware {
     }
   }
 
-  /** 执行 ws_mcp_call：路由 + 一致性校验 + 策略 + 调用。 */
+  /** 执行 ws_mcp_call：路由 + 一致性校验 + 策略 + 调用。
+   * @param agent 调用方会话 agent（透传给封装定义的 execute，供 session cwd
+   *   解析；#413 封装直呼分支需要）。 */
   async callTool(
     fullName: string,
     toolRaw: string,
     rawArgs: unknown,
     signal: AbortSignal | undefined,
+    agent?: unknown,
   ): Promise<unknown> {
     const parsed = parseFullServerName(fullName);
     if (parsed === undefined) {
@@ -474,10 +527,38 @@ export class McpMiddleware {
     if (stale) {
       // stale：仍可调用（目录只是提示），但 schema 可能过期——在结果前置提示。
     }
+    const args = normalizeArguments(rawArgs);
+    // #413 封装直呼分支：runtime 注入的封装定义服务器（toolDefinitions）——
+    // execute 为调用方 JS（不经远端 client.callTool）。禁用/策略已在上面统一
+    // 裁决（isToolDenied），此处直接调调用方 execute；输出经封装 output.render
+    // 投影为 ContentBlock[]（与 supervisor 封装分支 / dsh-tools 同口径）。
+    const wrapped = entry.server?.toolDefinitions;
+    if (Array.isArray(wrapped) && wrapped.length > 0) {
+      const def = wrapped.find((d) => d?.name === tool);
+      if (def === undefined) {
+        throw new Error(`ws_mcp_call: 工具 ${JSON.stringify(`${parsed.server}/${tool}`)} 不存在（封装定义服务器）`);
+      }
+      try {
+        // 封装定义契约：execute(args, exec) 的 exec 为完整 ToolRunContext，但
+        // 中间层只能提供最小面（agent 透传，session cwd 解析用）——经 unknown
+        // 中转（消费方封装定义只读 exec.agent，契约面见 dsh-codegraph）。
+        const execCtx = { agent } as unknown as Parameters<NonNullable<ToolDefinition["execute"]>>[1];
+        const value = await def.execute(
+          typeof args === "object" && args !== null ? args : {},
+          execCtx,
+        );
+        const content = typeof def.output?.render === "function"
+          ? def.output.render(args, value as unknown as Parameters<NonNullable<ToolOutputDefinition["render"]>>[1])
+          : [{ type: "text", text: typeof value === "string" ? value : JSON.stringify(value ?? {}) }];
+        return { content, structuredContent: value };
+      } catch (error) {
+        if (signal?.aborted === true) throw signal.reason;
+        throw new Error(this.hostRedact(`ws_mcp_call: ${JSON.stringify(`${parsed.server}/${tool}`)} 封装调用失败：${msgOf(error)}`));
+      }
+    }
     if (entry.client === undefined) {
       throw new Error(`ws_mcp_call: server ${JSON.stringify(fullName)} 未就绪（client 缺失）；请稍后重试或重新连接`);
     }
-    const args = normalizeArguments(rawArgs);
     try {
       const result = await withTimeout(
         entry.client.callTool(tool, typeof args === "object" && args !== null ? args : {}, {

--- a/packages/dsh-mcp-manager/src/middleware.ts
+++ b/packages/dsh-mcp-manager/src/middleware.ts
@@ -160,7 +160,9 @@ export class McpMiddleware {
     // execute 为调用方 JS 直呼 CLI，不经远端 MCP callTool，**不 spawn transport**。
     // 中间层以「虚拟连接」（无 client/transport，status=connected）+ 目录从
     // toolDefinitions 投影存在；执行走 callTool 的封装直呼分支。
-    if (Array.isArray(server.toolDefinitions) && server.toolDefinitions.length > 0) {
+    // 判定用 Array.isArray（空数组也算封装声明——调用方显式声明无工具，
+    // 不应回退远端 spawn）。
+    if (Array.isArray(server.toolDefinitions)) {
       const existingWrapped = unit.connections.get(serverName);
       if (existingWrapped !== undefined && (existingWrapped.status === "connected" || existingWrapped.status === "connecting")) return;
       const wrappedEntry: ConnectionEntry = {
@@ -533,7 +535,7 @@ export class McpMiddleware {
     // 裁决（isToolDenied），此处直接调调用方 execute；输出经封装 output.render
     // 投影为 ContentBlock[]（与 supervisor 封装分支 / dsh-tools 同口径）。
     const wrapped = entry.server?.toolDefinitions;
-    if (Array.isArray(wrapped) && wrapped.length > 0) {
+    if (Array.isArray(wrapped)) {
       const def = wrapped.find((d) => d?.name === tool);
       if (def === undefined) {
         throw new Error(`ws_mcp_call: 工具 ${JSON.stringify(`${parsed.server}/${tool}`)} 不存在（封装定义服务器）`);
@@ -543,9 +545,16 @@ export class McpMiddleware {
         // 中间层只能提供最小面（agent 透传，session cwd 解析用）——经 unknown
         // 中转（消费方封装定义只读 exec.agent，契约面见 dsh-codegraph）。
         const execCtx = { agent } as unknown as Parameters<NonNullable<ToolDefinition["execute"]>>[1];
-        const value = await def.execute(
-          typeof args === "object" && args !== null ? args : {},
-          execCtx,
+        // #413 QA P2-2：封装 execute 补超时兜底（与远端分支同预算 CALL_TIMEOUT_MS，
+        // 封装实现挂起时不无限等待）。
+        const value = await withTimeout(
+          def.execute(
+            typeof args === "object" && args !== null ? args : {},
+            execCtx,
+          ),
+          CALL_TIMEOUT_MS + 2000,
+          `ws_mcp_call: 封装调用超时（${CALL_TIMEOUT_MS}ms），可重试；若反复超时请检查插件状态`,
+          signal,
         );
         const content = typeof def.output?.render === "function"
           ? def.output.render(args, value as unknown as Parameters<NonNullable<ToolOutputDefinition["render"]>>[1])

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -546,7 +546,7 @@ const main = async () => {
     // ws_mcp_call guard：禁用命中 → deny。
     const callDeny = await guard({ name: "ws_mcp_call", arguments: { server: fullServerName("/proj", "ctx"), tool: "use_ctx" } }, async () => ({ kind: "allow" }));
     assert.equal(callDeny.kind, "deny", "ws_mcp_call guard 查禁用表");
-    assert.equal(toolDisabledReason(fullServerName("/proj", "ctx"), "use_ctx").includes("mcp__ 前缀"), true, "禁用原因声明只作用于 mcp__ 前缀");
+    assert.equal(toolDisabledReason(fullServerName("/proj", "ctx"), "use_ctx").includes("mcp-manager 管辖"), true, "禁用原因声明覆盖 mcp__ 与中间层工具（#413）");
     // 3) callTool（ws_mcp_call 执行路径）：禁用工具 → 显式抛错（验收 14：三入口一致）。
     const callUnit = {
       root: "/proj",

--- a/packages/dsh-mcp-manager/test/unit-manager2.src.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-manager2.src.test.ts
@@ -590,11 +590,36 @@ function rmStatSafe(p) {
     assert.equal(summaryServer?.status, "connected", "summary 投影 connected（@global 单元）");
     assert.deepEqual([...summaryServer.tools].sort(), ["cg_node"], "summary 工具列表来自目录投影");
 
-    // project 模式 runtime 不归一（保持 supervisor 路径；工具注册由 supervisor
-    // 连接后经 syncTools 完成——测试不真连，仅断言 supervisor 形态）。
+    // unregisterServer 清理 @global 单元虚拟连接与目录（防 unregister 后幽灵残留）。
+    await manager.unregisterServer("cg");
+    assert.ok(!manager.runtimeRegistry.has("cg"), "runtime 条目已注销");
+    assert.equal(mw.units.get("@global")?.connections.has("cg"), false, "虚拟连接已拆");
+    assert.equal(mw.units.get("@global")?.catalog.has("cg"), false, "目录条目已清（防幽灵）");
+    await manager.dispose();
+  } finally {
+    if (prevHome === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = prevHome;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ---- #413：all 模式 runtime（toolDefinitions）注销后 project 模式保留 supervisor ----
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-mgr2w2-"));
+  const prevHome = process.env.DSH_HOME;
+  try {
+    process.env.DSH_HOME = dir;
+    const { manager } = makeManager(dir);
+    const wrappedTool = {
+      name: "cg_node",
+      description: "查符号",
+      parameters: { type: "object", properties: { symbol: { type: "string" } }, required: ["symbol"] },
+      output: { schema: { type: "object", properties: { text: { type: "string" } }, required: ["text"], additionalProperties: false }, render: (a, v) => [{ type: "text", text: v.text }] },
+      execute: async (args) => ({ text: `node(${args.symbol})` }),
+    };
     manager.middlewareMode = "project";
     await manager.initMiddleware("project", {});
-    manager.runtimeRegistry.delete("cg");
     await manager.registerServer({ name: "cg", transport: "stdio", command: "codegraph", args: ["serve", "--mcp"], toolDefinitions: [wrappedTool] });
     assert.ok(manager.supervisors.has("cg"), "project 模式 runtime 仍 supervisor 路径（#413 只归一 all）");
     await manager.dispose();

--- a/packages/dsh-mcp-manager/test/unit-manager2.src.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-manager2.src.test.ts
@@ -553,6 +553,58 @@ function rmStatSafe(p) {
   }
 }
 
+// ---- #413：all 模式 runtime 注入（toolDefinitions）归一中台 ----
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-mgr2w-"));
+  const prevHome = process.env.DSH_HOME;
+  try {
+    process.env.DSH_HOME = dir;
+    const { manager, store, log } = makeManager(dir);
+    const wrappedTool = {
+      name: "cg_node",
+      description: "查符号",
+      parameters: { type: "object", properties: { symbol: { type: "string" } }, required: ["symbol"] },
+      output: { schema: { type: "object", properties: { text: { type: "string" } }, required: ["text"], additionalProperties: false }, render: (a, v) => [{ type: "text", text: v.text }] },
+      execute: async (args) => ({ text: `node(${args.symbol})` }),
+    };
+    manager.middlewareMode = "all";
+    await manager.initMiddleware("all", {});
+    const mw = manager.middleware;
+
+    // 经 registerServer 注入（带 toolDefinitions）→ start 内部 middlewareTakes
+    // 判定接管 → 触达 @global 单元虚拟连接，不建 supervisor、不注册 mcp__ 工具。
+    await manager.registerServer({ name: "cg", transport: "stdio", command: "codegraph", args: ["serve", "--mcp"], toolDefinitions: [wrappedTool] });
+    assert.ok(manager.runtimeRegistry.has("cg"), "runtime 条目已注册");
+    assert.ok(!manager.supervisors.has("cg"), "all 模式 runtime 不建 supervisor（#413 归一）");
+    assert.equal(log.registered.filter((name) => String(name).startsWith("mcp__cg__")).length, 0, "不注册 mcp__ 前缀工具");
+    await pollUntil("@global 单元虚拟连接建立", () => mw.units.get("@global")?.connections.has("cg") === true);
+    const entry = mw.units.get("@global").connections.get("cg");
+    assert.equal(entry.status, "connected", "虚拟连接 connected");
+    assert.equal(entry.client, undefined, "无远端 client（封装直呼）");
+    // 目录投影自 toolDefinitions。
+    assert.ok(mw.units.get("@global").catalog.get("cg")?.tools.has("cg_node"), "目录投影封装工具");
+
+    // 查询面：summary 从 @global 单元投影（connected + tools），不落 supervisor。
+    const summaryServer = manager.summary().servers.find((s) => s.name === "cg");
+    assert.equal(summaryServer?.status, "connected", "summary 投影 connected（@global 单元）");
+    assert.deepEqual([...summaryServer.tools].sort(), ["cg_node"], "summary 工具列表来自目录投影");
+
+    // project 模式 runtime 不归一（保持 supervisor 路径；工具注册由 supervisor
+    // 连接后经 syncTools 完成——测试不真连，仅断言 supervisor 形态）。
+    manager.middlewareMode = "project";
+    await manager.initMiddleware("project", {});
+    manager.runtimeRegistry.delete("cg");
+    await manager.registerServer({ name: "cg", transport: "stdio", command: "codegraph", args: ["serve", "--mcp"], toolDefinitions: [wrappedTool] });
+    assert.ok(manager.supervisors.has("cg"), "project 模式 runtime 仍 supervisor 路径（#413 只归一 all）");
+    await manager.dispose();
+  } finally {
+    if (prevHome === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = prevHome;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 // ---- #392 遗留①②③：remove/update 清目录幽灵条目 + disconnect 显式 scope 定位 ----
 
 {
@@ -969,12 +1021,13 @@ function rmStatSafe(p) {
     const disabledProjection = manager.summarize(store.find("g1"), "global");
     assert.equal(disabledProjection.status, "stopped", "userDisabled 短路（#382：池接管后断开即 stopped）");
     assert.deepEqual(disabledProjection.tools, []);
-    // runtime 注入条目豁免短路（middlewareTakes 判定）：同名 runtime supervisor
-    // 走 supervisor 投影，如实显示连接态。
+    // #413：all 模式 runtime 注入条目不再豁免——归一中台（middlewareTakes 判定
+    // 与 store 全局同口径），从 @global 单元投影；同名 runtime supervisor 残留
+    // 不误显示其连接态（与 store 全局行为一致）。
     manager.runtimeRegistry.set("g1", store.find("g1"));
     const runtimeProjection = manager.summarize(store.find("g1"), "global");
-    assert.equal(runtimeProjection.status, "connected", "runtime 条目豁免短路（supervisor 路径）");
-    assert.deepEqual(runtimeProjection.tools, ["gt"]);
+    assert.equal(runtimeProjection.status, "stopped", "#413：all 模式 runtime 条目归一中台（@global 单元投影，userDisabled → stopped）");
+    assert.deepEqual(runtimeProjection.tools, []);
     manager.runtimeRegistry.delete("g1");
     // supervisor 消失后落回兜底 stopped。
     manager.supervisors.delete("g1");

--- a/packages/dsh-mcp-manager/test/unit-manager2.src.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-manager2.src.test.ts
@@ -622,6 +622,11 @@ function rmStatSafe(p) {
     await manager.initMiddleware("project", {});
     await manager.registerServer({ name: "cg", transport: "stdio", command: "codegraph", args: ["serve", "--mcp"], toolDefinitions: [wrappedTool] });
     assert.ok(manager.supervisors.has("cg"), "project 模式 runtime 仍 supervisor 路径（#413 只归一 all）");
+    // off 模式注销：supervisor 销毁 + registry 清除（无中间层连接，无需 drop）。
+    manager.middlewareMode = "off";
+    await manager.unregisterServer("cg");
+    assert.ok(!manager.runtimeRegistry.has("cg"), "off 模式注销后 registry 清除");
+    assert.ok(!manager.supervisors.has("cg"), "off 模式注销后 supervisor 销毁");
     await manager.dispose();
   } finally {
     if (prevHome === undefined) delete process.env.DSH_HOME;

--- a/packages/dsh-mcp-manager/test/unit-manager2.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-manager2.test.ts
@@ -590,11 +590,36 @@ function rmStatSafe(p) {
     assert.equal(summaryServer?.status, "connected", "summary 投影 connected（@global 单元）");
     assert.deepEqual([...summaryServer.tools].sort(), ["cg_node"], "summary 工具列表来自目录投影");
 
-    // project 模式 runtime 不归一（保持 supervisor 路径；工具注册由 supervisor
-    // 连接后经 syncTools 完成——测试不真连，仅断言 supervisor 形态）。
+    // unregisterServer 清理 @global 单元虚拟连接与目录（防 unregister 后幽灵残留）。
+    await manager.unregisterServer("cg");
+    assert.ok(!manager.runtimeRegistry.has("cg"), "runtime 条目已注销");
+    assert.equal(mw.units.get("@global")?.connections.has("cg"), false, "虚拟连接已拆");
+    assert.equal(mw.units.get("@global")?.catalog.has("cg"), false, "目录条目已清（防幽灵）");
+    await manager.dispose();
+  } finally {
+    if (prevHome === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = prevHome;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ---- #413：all 模式 runtime（toolDefinitions）注销后 project 模式保留 supervisor ----
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-mgr2w2-"));
+  const prevHome = process.env.DSH_HOME;
+  try {
+    process.env.DSH_HOME = dir;
+    const { manager } = makeManager(dir);
+    const wrappedTool = {
+      name: "cg_node",
+      description: "查符号",
+      parameters: { type: "object", properties: { symbol: { type: "string" } }, required: ["symbol"] },
+      output: { schema: { type: "object", properties: { text: { type: "string" } }, required: ["text"], additionalProperties: false }, render: (a, v) => [{ type: "text", text: v.text }] },
+      execute: async (args) => ({ text: `node(${args.symbol})` }),
+    };
     manager.middlewareMode = "project";
     await manager.initMiddleware("project", {});
-    manager.runtimeRegistry.delete("cg");
     await manager.registerServer({ name: "cg", transport: "stdio", command: "codegraph", args: ["serve", "--mcp"], toolDefinitions: [wrappedTool] });
     assert.ok(manager.supervisors.has("cg"), "project 模式 runtime 仍 supervisor 路径（#413 只归一 all）");
     await manager.dispose();

--- a/packages/dsh-mcp-manager/test/unit-manager2.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-manager2.test.ts
@@ -553,6 +553,58 @@ function rmStatSafe(p) {
   }
 }
 
+// ---- #413：all 模式 runtime 注入（toolDefinitions）归一中台 ----
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-mgr2w-"));
+  const prevHome = process.env.DSH_HOME;
+  try {
+    process.env.DSH_HOME = dir;
+    const { manager, store, log } = makeManager(dir);
+    const wrappedTool = {
+      name: "cg_node",
+      description: "查符号",
+      parameters: { type: "object", properties: { symbol: { type: "string" } }, required: ["symbol"] },
+      output: { schema: { type: "object", properties: { text: { type: "string" } }, required: ["text"], additionalProperties: false }, render: (a, v) => [{ type: "text", text: v.text }] },
+      execute: async (args) => ({ text: `node(${args.symbol})` }),
+    };
+    manager.middlewareMode = "all";
+    await manager.initMiddleware("all", {});
+    const mw = manager.middleware;
+
+    // 经 registerServer 注入（带 toolDefinitions）→ start 内部 middlewareTakes
+    // 判定接管 → 触达 @global 单元虚拟连接，不建 supervisor、不注册 mcp__ 工具。
+    await manager.registerServer({ name: "cg", transport: "stdio", command: "codegraph", args: ["serve", "--mcp"], toolDefinitions: [wrappedTool] });
+    assert.ok(manager.runtimeRegistry.has("cg"), "runtime 条目已注册");
+    assert.ok(!manager.supervisors.has("cg"), "all 模式 runtime 不建 supervisor（#413 归一）");
+    assert.equal(log.registered.filter((name) => String(name).startsWith("mcp__cg__")).length, 0, "不注册 mcp__ 前缀工具");
+    await pollUntil("@global 单元虚拟连接建立", () => mw.units.get("@global")?.connections.has("cg") === true);
+    const entry = mw.units.get("@global").connections.get("cg");
+    assert.equal(entry.status, "connected", "虚拟连接 connected");
+    assert.equal(entry.client, undefined, "无远端 client（封装直呼）");
+    // 目录投影自 toolDefinitions。
+    assert.ok(mw.units.get("@global").catalog.get("cg")?.tools.has("cg_node"), "目录投影封装工具");
+
+    // 查询面：summary 从 @global 单元投影（connected + tools），不落 supervisor。
+    const summaryServer = manager.summary().servers.find((s) => s.name === "cg");
+    assert.equal(summaryServer?.status, "connected", "summary 投影 connected（@global 单元）");
+    assert.deepEqual([...summaryServer.tools].sort(), ["cg_node"], "summary 工具列表来自目录投影");
+
+    // project 模式 runtime 不归一（保持 supervisor 路径；工具注册由 supervisor
+    // 连接后经 syncTools 完成——测试不真连，仅断言 supervisor 形态）。
+    manager.middlewareMode = "project";
+    await manager.initMiddleware("project", {});
+    manager.runtimeRegistry.delete("cg");
+    await manager.registerServer({ name: "cg", transport: "stdio", command: "codegraph", args: ["serve", "--mcp"], toolDefinitions: [wrappedTool] });
+    assert.ok(manager.supervisors.has("cg"), "project 模式 runtime 仍 supervisor 路径（#413 只归一 all）");
+    await manager.dispose();
+  } finally {
+    if (prevHome === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = prevHome;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 // ---- #392 遗留①②③：remove/update 清目录幽灵条目 + disconnect 显式 scope 定位 ----
 
 {
@@ -969,12 +1021,13 @@ function rmStatSafe(p) {
     const disabledProjection = manager.summarize(store.find("g1"), "global");
     assert.equal(disabledProjection.status, "stopped", "userDisabled 短路（#382：池接管后断开即 stopped）");
     assert.deepEqual(disabledProjection.tools, []);
-    // runtime 注入条目豁免短路（middlewareTakes 判定）：同名 runtime supervisor
-    // 走 supervisor 投影，如实显示连接态。
+    // #413：all 模式 runtime 注入条目不再豁免——归一中台（middlewareTakes 判定
+    // 与 store 全局同口径），从 @global 单元投影；同名 runtime supervisor 残留
+    // 不误显示其连接态（与 store 全局行为一致）。
     manager.runtimeRegistry.set("g1", store.find("g1"));
     const runtimeProjection = manager.summarize(store.find("g1"), "global");
-    assert.equal(runtimeProjection.status, "connected", "runtime 条目豁免短路（supervisor 路径）");
-    assert.deepEqual(runtimeProjection.tools, ["gt"]);
+    assert.equal(runtimeProjection.status, "stopped", "#413：all 模式 runtime 条目归一中台（@global 单元投影，userDisabled → stopped）");
+    assert.deepEqual(runtimeProjection.tools, []);
     manager.runtimeRegistry.delete("g1");
     // supervisor 消失后落回兜底 stopped。
     manager.supervisors.delete("g1");

--- a/packages/dsh-mcp-manager/test/unit-manager2.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-manager2.test.ts
@@ -622,6 +622,11 @@ function rmStatSafe(p) {
     await manager.initMiddleware("project", {});
     await manager.registerServer({ name: "cg", transport: "stdio", command: "codegraph", args: ["serve", "--mcp"], toolDefinitions: [wrappedTool] });
     assert.ok(manager.supervisors.has("cg"), "project 模式 runtime 仍 supervisor 路径（#413 只归一 all）");
+    // off 模式注销：supervisor 销毁 + registry 清除（无中间层连接，无需 drop）。
+    manager.middlewareMode = "off";
+    await manager.unregisterServer("cg");
+    assert.ok(!manager.runtimeRegistry.has("cg"), "off 模式注销后 registry 清除");
+    assert.ok(!manager.supervisors.has("cg"), "off 模式注销后 supervisor 销毁");
     await manager.dispose();
   } finally {
     if (prevHome === undefined) delete process.env.DSH_HOME;

--- a/packages/dsh-mcp-manager/test/unit-middleware.src.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.src.test.ts
@@ -646,3 +646,40 @@ function makeHost(serversByRoot = new Map()) {
   await mw2.dispose();
   await mw.dispose();
 }
+
+// ---- #413：空 toolDefinitions / 封装调用超时兜底 ----
+{
+  // 空 toolDefinitions：连接照建、目录 0 工具、调用报「不存在」。
+  const emptyWrapped = { name: "cg", transport: "stdio", command: "codegraph", enabled: true, toolDefinitions: [] };
+  const { host } = makeHost(new Map([["@global", [emptyWrapped]]]));
+  const mw = new McpMiddleware(host, {});
+  await mw.projectUnitFor("@global");
+  await mw.ensureConnected("@global", "cg");
+  const unit = mw.units.get("@global");
+  assert.equal(unit.connections.get("cg")?.status, "connected", "空 toolDefinitions 仍建虚拟连接");
+  assert.equal(unit.catalog.get("cg")?.tools.size, 0, "空 toolDefinitions 目录 0 工具");
+  await assert.rejects(
+    () => mw.callTool(fullServerName("@global", "cg"), "anything", {}, undefined),
+    /不存在（封装定义服务器）/,
+  );
+  await mw.dispose();
+
+  // 封装 execute 挂起 → withTimeout 超时兜底（不无限等待）。
+  const hangingTool = {
+    name: "hang",
+    description: "挂起",
+    parameters: { type: "object", properties: {} },
+    output: { schema: { type: "object", properties: { text: { type: "string" } }, required: ["text"], additionalProperties: false }, render: (a, v) => [{ type: "text", text: v.text }] },
+    execute: async () => new Promise(() => {}), // 永不 resolve
+  };
+  const hangingServer = { name: "hg", transport: "stdio", command: "x", enabled: true, toolDefinitions: [hangingTool] };
+  const { host: host2 } = makeHost(new Map([["@global", [hangingServer]]]));
+  const mw3 = new McpMiddleware(host2, {});
+  await mw3.projectUnitFor("@global");
+  await mw3.ensureConnected("@global", "hg");
+  await assert.rejects(
+    () => mw3.callTool(fullServerName("@global", "hg"), "hang", {}, undefined),
+    /封装调用超时/,
+  );
+  await mw3.dispose();
+}

--- a/packages/dsh-mcp-manager/test/unit-middleware.src.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.src.test.ts
@@ -564,3 +564,85 @@ function makeHost(serversByRoot = new Map()) {
   if (after.reconnectTimer !== undefined) clearTimeout(after.reconnectTimer);
   await mw.dispose();
 }
+
+// ---- #413：runtime 封装定义服务器（toolDefinitions）中间层直呼 ----
+{
+  const wrappedTool = {
+    name: "cg_node",
+    description: "查符号（封装定义）",
+    parameters: { type: "object", properties: { symbol: { type: "string" } }, required: ["symbol"] },
+    output: {
+      schema: { type: "object", properties: { text: { type: "string" } }, required: ["text"], additionalProperties: false },
+      render: (args, value) => [{ type: "text", text: `rendered:${value.text}` }],
+    },
+    isConcurrencySafe: () => true,
+    execute: async (args, exec) => {
+      const cwd = exec?.agent?.session?.header?.cwd;
+      return { text: `node(${args.symbol})@${cwd ?? "no-cwd"}` };
+    },
+  };
+  const wrappedServer = { name: "cg", transport: "stdio", command: "codegraph", enabled: true, toolDefinitions: [wrappedTool] };
+  const { host, log } = makeHost(new Map([["@global", [wrappedServer]]]));
+  const mw = new McpMiddleware(host, {});
+  await mw.projectUnitFor("@global");
+  await mw.ensureConnected("@global", "cg");
+  const unit = mw.units.get("@global");
+  assert.ok(unit, "@global 单元已创建");
+  const entry = unit.connections.get("cg");
+  assert.ok(entry, "封装定义服务器虚拟连接已建立");
+  assert.equal(entry.status, "connected", "虚拟连接状态 connected");
+  assert.equal(entry.client, undefined, "不建远端 client（封装 execute 不经远端）");
+  assert.equal(entry.transport, undefined, "不 spawn transport");
+  // 目录从 toolDefinitions 投影（name/description/parameters → inputSchema）。
+  const catalog = unit.catalog.get("cg");
+  assert.ok(catalog, "目录已投影");
+  assert.equal(catalog.tools.has("cg_node"), true, "封装工具名投影进目录");
+  assert.equal(catalog.tools.get("cg_node").description, "查符号（封装定义）");
+  assert.deepEqual(catalog.tools.get("cg_node").inputSchema, { type: "object", properties: { symbol: { type: "string" } }, required: ["symbol"] }, "parameters 直接作 inputSchema");
+
+  // callTool 封装直呼：execute 被调用 + output.render 投影 content + agent 透传。
+  const result = await mw.callTool(fullServerName("@global", "cg"), "cg_node", { symbol: "foo" }, undefined, { session: { header: { cwd: "/proj" } } });
+  assert.deepEqual(result, { content: [{ type: "text", text: "rendered:node(foo)@/proj" }], structuredContent: { text: "node(foo)@/proj" } }, "封装直呼：execute + render + agent 透传");
+  // agent 缺省 → cwd 解析 undefined。
+  const noAgent = await mw.callTool(fullServerName("@global", "cg"), "cg_node", { symbol: "bar" }, undefined);
+  assert.deepEqual(noAgent.structuredContent, { text: "node(bar)@no-cwd" }, "agent 缺省不崩（封装侧自处理）");
+
+  // 工具级禁用前置：禁用表命中 → 抛禁用错误（不经 execute）。
+  mw.disabledTools.set("@global", new Map([["cg", new Set(["cg_node"])]]));
+  await assert.rejects(
+    () => mw.callTool(fullServerName("@global", "cg"), "cg_node", { symbol: "x" }, undefined, { session: { header: { cwd: "/p" } } }),
+    /已被用户在「MCP」浮窗禁用/,
+  );
+  mw.disabledTools.delete("@global");
+
+  // 不存在的封装工具名 → 明确报错。
+  await assert.rejects(
+    () => mw.callTool(fullServerName("@global", "cg"), "nope", {}, undefined),
+    /不存在（封装定义服务器）/,
+  );
+
+  // persistCatalog 跳过 runtime 条目（isRuntimeServer 命中 → 不写盘）。
+  const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-mw-wrapped-"));
+  const persistHost = {
+    ...host,
+    isRuntimeServer: (name) => name === "cg",
+    catalogCachePath: (root) => join(dir, `${root.replace(/[^a-z0-9]/gi, "_")}.json`),
+  };
+  const mw2 = new McpMiddleware(persistHost, {});
+  const unit2 = {
+    root: "@global",
+    connections: new Map([["cg", entry]]),
+    catalog: new Map([["cg", catalog], ["storeSrv", { discoveredAt: Date.now(), tools: new Map([["t1", { description: "d", inputSchema: {} }]]) }]]),
+    userDisabled: new Set(),
+    lastTouchedAt: Date.now(),
+    inFlight: new Map(),
+  };
+  mw2.units.set("@global", unit2);
+  await mw2.persistCatalog("@global");
+  const { readFileSync } = await import("node:fs");
+  const persisted = readFileSync(persistHost.catalogCachePath("@global"), "utf8");
+  assert.equal(persisted.includes("cg"), false, "runtime 条目不写盘");
+  assert.equal(persisted.includes("storeSrv"), true, "store 条目照常写盘");
+  await mw2.dispose();
+  await mw.dispose();
+}

--- a/packages/dsh-mcp-manager/test/unit-middleware.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.test.ts
@@ -646,3 +646,40 @@ function makeHost(serversByRoot = new Map()) {
   await mw2.dispose();
   await mw.dispose();
 }
+
+// ---- #413：空 toolDefinitions / 封装调用超时兜底 ----
+{
+  // 空 toolDefinitions：连接照建、目录 0 工具、调用报「不存在」。
+  const emptyWrapped = { name: "cg", transport: "stdio", command: "codegraph", enabled: true, toolDefinitions: [] };
+  const { host } = makeHost(new Map([["@global", [emptyWrapped]]]));
+  const mw = new McpMiddleware(host, {});
+  await mw.projectUnitFor("@global");
+  await mw.ensureConnected("@global", "cg");
+  const unit = mw.units.get("@global");
+  assert.equal(unit.connections.get("cg")?.status, "connected", "空 toolDefinitions 仍建虚拟连接");
+  assert.equal(unit.catalog.get("cg")?.tools.size, 0, "空 toolDefinitions 目录 0 工具");
+  await assert.rejects(
+    () => mw.callTool(fullServerName("@global", "cg"), "anything", {}, undefined),
+    /不存在（封装定义服务器）/,
+  );
+  await mw.dispose();
+
+  // 封装 execute 挂起 → withTimeout 超时兜底（不无限等待）。
+  const hangingTool = {
+    name: "hang",
+    description: "挂起",
+    parameters: { type: "object", properties: {} },
+    output: { schema: { type: "object", properties: { text: { type: "string" } }, required: ["text"], additionalProperties: false }, render: (a, v) => [{ type: "text", text: v.text }] },
+    execute: async () => new Promise(() => {}), // 永不 resolve
+  };
+  const hangingServer = { name: "hg", transport: "stdio", command: "x", enabled: true, toolDefinitions: [hangingTool] };
+  const { host: host2 } = makeHost(new Map([["@global", [hangingServer]]]));
+  const mw3 = new McpMiddleware(host2, {});
+  await mw3.projectUnitFor("@global");
+  await mw3.ensureConnected("@global", "hg");
+  await assert.rejects(
+    () => mw3.callTool(fullServerName("@global", "hg"), "hang", {}, undefined),
+    /封装调用超时/,
+  );
+  await mw3.dispose();
+}

--- a/packages/dsh-mcp-manager/test/unit-middleware.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.test.ts
@@ -564,3 +564,85 @@ function makeHost(serversByRoot = new Map()) {
   if (after.reconnectTimer !== undefined) clearTimeout(after.reconnectTimer);
   await mw.dispose();
 }
+
+// ---- #413：runtime 封装定义服务器（toolDefinitions）中间层直呼 ----
+{
+  const wrappedTool = {
+    name: "cg_node",
+    description: "查符号（封装定义）",
+    parameters: { type: "object", properties: { symbol: { type: "string" } }, required: ["symbol"] },
+    output: {
+      schema: { type: "object", properties: { text: { type: "string" } }, required: ["text"], additionalProperties: false },
+      render: (args, value) => [{ type: "text", text: `rendered:${value.text}` }],
+    },
+    isConcurrencySafe: () => true,
+    execute: async (args, exec) => {
+      const cwd = exec?.agent?.session?.header?.cwd;
+      return { text: `node(${args.symbol})@${cwd ?? "no-cwd"}` };
+    },
+  };
+  const wrappedServer = { name: "cg", transport: "stdio", command: "codegraph", enabled: true, toolDefinitions: [wrappedTool] };
+  const { host, log } = makeHost(new Map([["@global", [wrappedServer]]]));
+  const mw = new McpMiddleware(host, {});
+  await mw.projectUnitFor("@global");
+  await mw.ensureConnected("@global", "cg");
+  const unit = mw.units.get("@global");
+  assert.ok(unit, "@global 单元已创建");
+  const entry = unit.connections.get("cg");
+  assert.ok(entry, "封装定义服务器虚拟连接已建立");
+  assert.equal(entry.status, "connected", "虚拟连接状态 connected");
+  assert.equal(entry.client, undefined, "不建远端 client（封装 execute 不经远端）");
+  assert.equal(entry.transport, undefined, "不 spawn transport");
+  // 目录从 toolDefinitions 投影（name/description/parameters → inputSchema）。
+  const catalog = unit.catalog.get("cg");
+  assert.ok(catalog, "目录已投影");
+  assert.equal(catalog.tools.has("cg_node"), true, "封装工具名投影进目录");
+  assert.equal(catalog.tools.get("cg_node").description, "查符号（封装定义）");
+  assert.deepEqual(catalog.tools.get("cg_node").inputSchema, { type: "object", properties: { symbol: { type: "string" } }, required: ["symbol"] }, "parameters 直接作 inputSchema");
+
+  // callTool 封装直呼：execute 被调用 + output.render 投影 content + agent 透传。
+  const result = await mw.callTool(fullServerName("@global", "cg"), "cg_node", { symbol: "foo" }, undefined, { session: { header: { cwd: "/proj" } } });
+  assert.deepEqual(result, { content: [{ type: "text", text: "rendered:node(foo)@/proj" }], structuredContent: { text: "node(foo)@/proj" } }, "封装直呼：execute + render + agent 透传");
+  // agent 缺省 → cwd 解析 undefined。
+  const noAgent = await mw.callTool(fullServerName("@global", "cg"), "cg_node", { symbol: "bar" }, undefined);
+  assert.deepEqual(noAgent.structuredContent, { text: "node(bar)@no-cwd" }, "agent 缺省不崩（封装侧自处理）");
+
+  // 工具级禁用前置：禁用表命中 → 抛禁用错误（不经 execute）。
+  mw.disabledTools.set("@global", new Map([["cg", new Set(["cg_node"])]]));
+  await assert.rejects(
+    () => mw.callTool(fullServerName("@global", "cg"), "cg_node", { symbol: "x" }, undefined, { session: { header: { cwd: "/p" } } }),
+    /已被用户在「MCP」浮窗禁用/,
+  );
+  mw.disabledTools.delete("@global");
+
+  // 不存在的封装工具名 → 明确报错。
+  await assert.rejects(
+    () => mw.callTool(fullServerName("@global", "cg"), "nope", {}, undefined),
+    /不存在（封装定义服务器）/,
+  );
+
+  // persistCatalog 跳过 runtime 条目（isRuntimeServer 命中 → 不写盘）。
+  const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-mw-wrapped-"));
+  const persistHost = {
+    ...host,
+    isRuntimeServer: (name) => name === "cg",
+    catalogCachePath: (root) => join(dir, `${root.replace(/[^a-z0-9]/gi, "_")}.json`),
+  };
+  const mw2 = new McpMiddleware(persistHost, {});
+  const unit2 = {
+    root: "@global",
+    connections: new Map([["cg", entry]]),
+    catalog: new Map([["cg", catalog], ["storeSrv", { discoveredAt: Date.now(), tools: new Map([["t1", { description: "d", inputSchema: {} }]]) }]]),
+    userDisabled: new Set(),
+    lastTouchedAt: Date.now(),
+    inFlight: new Map(),
+  };
+  mw2.units.set("@global", unit2);
+  await mw2.persistCatalog("@global");
+  const { readFileSync } = await import("node:fs");
+  const persisted = readFileSync(persistHost.catalogCachePath("@global"), "utf8");
+  assert.equal(persisted.includes("cg"), false, "runtime 条目不写盘");
+  assert.equal(persisted.includes("storeSrv"), true, "store 条目照常写盘");
+  await mw2.dispose();
+  await mw.dispose();
+}


### PR DESCRIPTION
## 概述

Fixes #413

**问题**：`dsh-mcp-manager` 中间层模式设为 `all` 后，runtime 注入的服务器（当前唯一注入方：dsh-codegraph 经 `ctx.mcpManager.registerServer` + `toolDefinitions` 注册的 8 个封装定义工具）被 `middlewareTakes` 刻意豁免，仍注册 `mcp__<server>__<tool>` 前缀工具——违反 all 模式「全部走中间层、无 mcp__ 前缀」的设计意图。

**方案（路线乙，经独立对抗性评审）**：all 模式下 runtime 注入的封装定义服务器归一中台，统一经 `ws_mcp_search/list/detail/call` 观察与调用；`project` / `off` 模式行为不变；dsh-codegraph 插件零改动。

## 关键设计

codegraph 的 8 个工具是**封装定义**（execute 为调用方 JS 直呼 CLI，不经远端 MCP `callTool`）。因此中间层对这类服务器不 spawn transport，而是建「虚拟连接」（status=connected，无 client/transport）+ 目录从 `toolDefinitions` 投影；`callTool` 增加封装直呼分支（禁用/策略前置裁决 → 调调用方 execute → `output.render` 投影 content）。

## 改动清单（全部在 dsh-mcp-manager 内）

1. **`middlewareTakes` 去掉 all 模式 runtime 豁免**（manager.ts）：all 模式全局（含 runtime）统一中间层接管
2. **`projectServersFor("@global")` 并入 runtimeRegistry**（manager.ts）：中间层数据源可见 runtime 条目
3. **`connectInternal` 封装定义分支**（middleware.ts）：toolDefinitions 服务器建虚拟连接 + 目录投影（`projectWrappedCatalog`），不 spawn 远端进程
4. **`callTool` 封装直呼分支**（middleware.ts）：isToolDenied 前置 → `def.execute(args, {agent})` → `output.render` 转 `{content}`；`ws_mcp_call` 透传 `exec.agent`（session cwd 解析）
5. **查询面投影**（manager.ts）：`summarize` / `middlewareUnitFor` 对 all 模式 runtime 从 @global 单元投影，getStatus 不误报
6. **目录不写盘**（middleware.ts）：`persistCatalog` 跳过 runtime 条目（`isRuntimeServer` host 钩子），防幽灵条目
7. **文案同步**：`MCP_GUIDANCE`（apply.ts）、`toolDisabledReason`（middleware-utils.ts）、README 中英双语

## 验收

- [x] all 模式启动后 `ctx.tools` 不再出现 `mcp__codegraph__*` 前缀工具
- [x] codegraph 8 工具经 `ws_mcp_search` 可检索、经 `ws_mcp_call` 可调用（execute 依赖 `exec.agent.session.header.cwd` 的 projectPath 补全已透传）
- [x] `getStatus` / 纪律钩子不误报（summary 从 @global 单元投影 connected + tools）
- [x] project/off 模式行为不变（runtime 仍 supervisor 路径 + mcp__ 注册）
- [x] 热切换 off↔all 收敛（reconcileServers 同口径 + F5 探测重试兜底）
- [x] 工具级禁用（浮窗勾选）对 codegraph 工具生效（isToolDenied 前置）
- [x] runtime 目录不写盘（防幽灵条目）

## 测试

- `unit-middleware.test.ts`：封装直呼（execute + render + agent 透传）/ 目录投影 / 禁用前置 / 不存在工具报错 / persistCatalog 跳过 runtime
- `unit-manager2.test.ts`：all 模式 runtime 归一中台（虚拟连接 / 无 mcp__ 注册 / summary 投影）+ project 模式保留 supervisor
- `.src.test.ts` 副本同步（stryker 变异测试用）
- 门禁全绿：`pnpm build && pnpm test && pnpm contract && pnpm pack:check`（QA 独立复核通过）

## QA 复核（合入前必过，已完成）

独立 QA 复核裁决：**有条件通过**，全部验收判据（A1-A7）与高风险边界核验通过。QA 必修项 P2-1 与建议项 P2-2 已修复：

- **P2-1（unregister 瞬时复活窗口）**：`unregisterServer` 调整为「先删 runtimeRegistry 再拆中间层连接」——drop 时数据源已不含该服务器，并发 ensureConnected/connect 查不到配置无法重建虚拟连接；不写 userDisabled 避免持久化污染（同名 re-register 不被静默阻止）
- **P2-2（封装超时兜底）**：`callTool` 封装 execute 补 `withTimeout`（CALL_TIMEOUT_MS+2s，与远端分支同预算）
- **QA 建议**：空 `toolDefinitions` 判定改 `Array.isArray`（显式声明无工具不回退远端 spawn）；补空 toolDefinitions / 封装超时 / off 模式注销清理测试用例
