### PR TITLE
fix(provider-usage): sessions.list 快照噪声帧不再触发 /stats 高频调用——detect 改 current diff 语义 + modelCatalog 官方同款缓存 (#419)

### DIFF
--- a/packages/dsh-provider-usage/src/client/core.ts
+++ b/packages/dsh-provider-usage/src/client/core.ts
@@ -208,17 +208,80 @@ function providerFromProjection(row: SessionListRowLike | undefined): string | u
   return typeof sel?.provider === "string" && sel.provider.length > 0 ? sel.provider : undefined;
 }
 
+/** modelCatalog 兜底缓存 TTL（#419）：与宿主 stats 缓存同量级（30s）。
+ *  全链投影缺失时兜底 RPC 从「跟随快照帧频率」收敛为「每 TTL 一次」。 */
+export const CATALOG_CACHE_TTL_MS = 30_000;
+
+/**
+ * 全局目录 default.provider 读取器（#419 抽象）：返回 undefined = 不可用/失败。
+ * 默认实现读 remote.session.modelCatalog（RemoteResult 解包）；调用方可注入带缓存的
+ * 实现（makeCatalogCache），对齐官方 dsh-client-ui-model-selection 的 catalog 消费
+ * 语义（ready 命中 + inflight 共享 + 显式失效，从不裸调）。
+ */
+export type CatalogLoader = (remote: RemoteLike | undefined) => Promise<string | undefined>;
+
+/** 默认 catalog loader：裸调 remote.session.modelCatalog（无缓存，纯函数语义）。 */
+export async function defaultCatalogLoader(remote: RemoteLike | undefined): Promise<string | undefined> {
+  const modelCatalog = remote?.session?.modelCatalog;
+  if (typeof modelCatalog !== "function") return undefined;
+  try {
+    const res = await modelCatalog();
+    if (res?.ok === true && typeof res.value?.default?.provider === "string") {
+      return res.value.default.provider;
+    }
+  } catch {
+    // 目录读取失败按不可用处理（不抛给调用方）
+  }
+  return undefined;
+}
+
+/**
+ * 官方 catalog 同款缓存工厂（#419）：ready 命中 + inflight 并发共享 +
+ * 失败不缓存（下次重试）+ 显式 reset 失效。默认 TTL 见 CATALOG_CACHE_TTL_MS。
+ * 与官方 dsh-client-ui-model-selection 的 Catalog.load() 三防护等价
+ * （store ready 命中 / inflight 共享 / 仅 miss 时打 RPC）。
+ */
+export function makeCatalogCache(
+  ttlMs: number = CATALOG_CACHE_TTL_MS,
+): { load: CatalogLoader; reset: () => void } {
+  let cached: { provider: string; at: number } | null = null;
+  let inflight: Promise<string | undefined> | null = null;
+  return {
+    load(remote) {
+      if (cached !== null && Date.now() - cached.at <= ttlMs) {
+        return Promise.resolve(cached.provider);
+      }
+      if (inflight !== null) return inflight;
+      inflight = defaultCatalogLoader(remote)
+        .then((provider) => {
+          if (provider !== undefined) cached = { provider, at: Date.now() };
+          return provider;
+        })
+        .finally(() => {
+          inflight = null;
+        });
+      return inflight;
+    },
+    reset() {
+      cached = null;
+      inflight = null;
+    },
+  };
+}
+
 /**
  * 解析当前展示会话的 provider（issue #69 方案 A+B 检测半区，0.1.2 适配）：
  * 主判据 = 沿 parentId 上溯链（封顶 3、防环），逐会话读 per-session modelSelection 投影
  * （lastUsed/next 的 provider），首个非空者胜——与旧 models() 按会话查询语义等价；
- * 全链投影缺失 → 兜底读 ctx.remote.session.modelCatalog() 的 default.provider（全局目录，
- * 一次调用，RemoteResult 解包）。全链失败返回 undefined，兜底语义由
- * decideProviderAfterDetect 决定（保持上次检测 / 回落默认）。
+ * 全链投影缺失 → 兜底读全局目录 default.provider（默认裸调 modelCatalog；
+ * #419：客户端可注入缓存版 loader，避免跟随快照帧频率裸打 RPC）。
+ * 全链失败返回 undefined，兜底语义由 decideProviderAfterDetect 决定
+ * （保持上次检测 / 回落默认）。
  */
 export async function resolveProviderFromSession(
   sessions: SessionsServiceLike | undefined,
   remote: RemoteLike | undefined,
+  catalogLoader: CatalogLoader = defaultCatalogLoader,
 ): Promise<string | undefined> {
   const sessionId = currentSessionId(sessions);
   if (sessionId === undefined) return undefined;
@@ -227,17 +290,11 @@ export async function resolveProviderFromSession(
     const provider = providerFromProjection(byId?.[sid]);
     if (provider !== undefined) return provider;
   }
-  // 兜底：全局 modelCatalog 的 default（RemoteResult 解包，仅投影全缺时一次）
-  const modelCatalog = remote?.session?.modelCatalog;
-  if (typeof modelCatalog === "function") {
-    try {
-      const res = await modelCatalog();
-      if (res?.ok === true && typeof res.value?.default?.provider === "string") {
-        return res.value.default.provider;
-      }
-    } catch {
-      // 目录读取失败按全链失败处理（不抛给调用方）
-    }
+  // 兜底：全局目录 default.provider（loader 注入；仅投影全缺时一次）
+  try {
+    return await catalogLoader(remote);
+  } catch {
+    // 目录读取失败按全链失败处理（不抛给调用方）
   }
   return undefined;
 }

--- a/packages/dsh-provider-usage/src/client/index.ts
+++ b/packages/dsh-provider-usage/src/client/index.ts
@@ -14,6 +14,7 @@ import {
   resolveProviderFromSession,
   decideProviderAfterDetect,
   currentSessionId,
+  makeCatalogCache,
   fetchStats,
   fetchHistory,
   fetchUiConfig,
@@ -119,6 +120,12 @@ let currentProvider: string = FALLBACK_PROVIDER;
 let detectedProvider: string | undefined;
 /** true = 有会话但 provider 未能确认（胶囊 title 标注「提供商未识别」）。 */
 let providerUnknown = false;
+/** #419：上次 detect 时的快照 current id——区分「切换会话」与「投影/运行态噪声帧」，
+ *  仅前者触发立即补刷 stats（维护者需求 #71），后者只刷胶囊 title。 */
+let lastDetectCurrent: string | undefined;
+/** #419：全局目录 default.provider 兜底缓存（官方 catalog 同款：ready 命中 +
+ *  inflight 共享 + TTL 失效），避免全链投影缺失时跟随快照帧频率裸打 modelCatalog RPC。 */
+const catalogCache = makeCatalogCache();
 /** 最近一次 /stats 响应。 */
 let lastStats: StatsResponseV2 | null = null;
 /** 最近一次 /history 响应。 */
@@ -256,7 +263,7 @@ async function revalidateProvider(): Promise<boolean> {
   if (sessions === undefined) return false;
   // 先同步取会话在场快照（区分「无任何会话」与「有会话但不可解析」，await 前读取防竞态）
   const hadSession = currentSessionId(sessions) !== undefined;
-  const resolved = await resolveProviderFromSession(sessions, remote);
+  const resolved = await resolveProviderFromSession(sessions, remote, catalogCache.load);
   const decision = decideProviderAfterDetect({
     resolved,
     hadSession,
@@ -674,18 +681,31 @@ export function apply(ctx: any): void {
     // （issue #69：子代理会话 models() 必拒（agent-busy），检测沿 parentId 上溯父会话；
     //   全链失败保持上次检测结果并标注未识别，仅「从未成功」才回落默认——不再无条件回落）
     // 检测半区已抽为 revalidateProvider（A1，issue #71）：与 refreshStats 取数前复检共用。
+    //
+    // #419 diff 语义（对齐官方 dsh-client-ui-session 的 publishCurrent）：sessions.list
+    // 快照在会话运行期间高频更新（running bit / projection 逐条写入 / 子代理地址等），
+    // 订阅回调只响应「current 会话切换」类结构性变化——立即补刷 stats（维护者需求
+    // #71）；其余噪声帧仅重渲染胶囊 title（unknown 标注等），数据刷新交给 60s 轮询，
+    // 消除 agent 活跃期间的 /stats 高频调用。
     let unsubSessions: (() => void) | undefined;
     const detect = (): void => {
       void (async () => {
+        // #419：先取快照 current（结构性判定基准），await 前读取防竞态
+        const cur = currentSessionId(sessions);
         const changed = await revalidateProvider();
         if (changed) {
+          lastDetectCurrent = cur; // 已立即重拉（onProviderChanged），同步判定基准
           onProviderChanged(); // provider 变了 → 立即重拉（切换会话即时跟随）
           return;
         }
         renderPill(); // provider 未变但未知标注可能变化 → 刷胶囊 title
-        // 维护者补充需求（issue #71）：切换会话即使 provider 相同也立即刷一次 stats，
-        // 不等 60s 轮询 / visibilitychange（浮窗在场才刷；roster 变化触发的 detect 同样受益）
-        if (floatPill !== undefined) void refreshStats();
+        // #419：仅在 current 会话切换（含空 ↔ 有值）时立即补刷；投影/运行态噪声
+        // 帧（current 不变）不打断轮询节奏——宿主 30s 缓存命中时请求本身仍照发，
+        // 逐帧补刷会放大为高频 HTTP（本 issue 根因）。
+        if (cur !== lastDetectCurrent) {
+          lastDetectCurrent = cur;
+          if (floatPill !== undefined) void refreshStats();
+        }
       })();
     };
     // 0.1.2-alpha.2：客户端 sessions 订阅统一走 list 快照（currentProvideInfo 已移除）。
@@ -706,6 +726,8 @@ export function apply(ctx: any): void {
       renderGeneration += 1;
       detectedProvider = undefined;
       providerUnknown = false;
+      lastDetectCurrent = undefined;
+      catalogCache.reset(); // 失效目录缓存：热卸载/重挂载后兜底目录重拉（#419）
       sessions = undefined;
       remote = undefined;
     }, "dsh-provider-usage: float");

--- a/packages/dsh-provider-usage/test/client-revalidate.worker.mjs
+++ b/packages/dsh-provider-usage/test/client-revalidate.worker.mjs
@@ -407,6 +407,24 @@ client.apply(ctx);
   console.log("[client-revalidate.worker] 场景3 切换会话（同 provider）立即刷 stats ✓");
 }
 
+// 场景 3b（#419 核心）：会话运行期间快照噪声帧（projection 写入 / running bit 等——
+// current 不变）→ detect 复检但不补刷 stats，请求数不增长
+{
+  const before = statsCalls.length;
+  // 模拟投影逐条写入（如 sessionListMetadata/title 更新）：current 不变
+  svc.state.projectionBySession.s2 = {
+    lastUsed: { provider: "mock-b", model: "model-x" },
+    next: { provider: "mock-b", model: "model-x" },
+  };
+  svc.fireSessionChanged();
+  svc.fireSessionChanged(); // 多帧噪声
+  svc.fireSessionChanged();
+  // 给 detect 异步体一个结算窗口 + 让 refreshStats 若误触发有暴露窗口
+  await new Promise((r) => setTimeout(r, 100));
+  assert.equal(statsCalls.length, before, "快照噪声帧（current 不变）不触发 /stats（#419 diff 语义）");
+  console.log("[client-revalidate.worker] 场景3b 快照噪声帧不刷 stats ✓");
+}
+
 // 场景 4：切换会话 s3 跨 provider（b→a）→ fire 后立即拉新 provider，不等轮询
 {
   svc.state.byId.s3 = {};
@@ -423,6 +441,22 @@ client.apply(ctx);
   );
   assert.ok(statsCalls.length > before, "fire 后确有新请求（即时性：非轮询驱动）");
   console.log("[client-revalidate.worker] 场景4 切换会话跨 provider 即时跟随 ✓");
+}
+
+// 场景 4b（#419 回归）：current 切走（undefined）再切回——即使 provider 相同也立即补刷
+{
+  svc.state.listCurrent = undefined;
+  svc.fireSessionChanged();
+  await until(() => statsCalls.length > 0 && pillLabel()?.innerHTML !== "", "无会话回落渲染", 3000);
+  const before = statsCalls.length;
+  svc.state.listCurrent = "s3";
+  svc.state.projectionBySession.s3 = {
+    lastUsed: { provider: "mock-a", model: "model-x" },
+    next: { provider: "mock-a", model: "model-x" },
+  };
+  svc.fireSessionChanged();
+  await until(() => statsCalls.length > before, "current 变化（同 provider）立即补刷", 3000);
+  console.log("[client-revalidate.worker] 场景4b current 变化立即补刷（#419 diff 判定） ✓");
 }
 
 // 场景 5：卸载清理不抛错

--- a/packages/dsh-provider-usage/test/unit-detect.test.ts
+++ b/packages/dsh-provider-usage/test/unit-detect.test.ts
@@ -47,6 +47,9 @@ const {
   decideProviderAfterDetect,
   FALLBACK_PROVIDER,
   UNKNOWN_PROVIDER_HINT,
+  makeCatalogCache,
+  defaultCatalogLoader,
+  CATALOG_CACHE_TTL_MS,
 } = core;
 
 // ---------------------------------------------------------------- 构造工具
@@ -280,4 +283,101 @@ function makeRemote(providerByDefault) {
   assert.equal(got, "prov-k", "首个解析成功者胜");
 }
 
-console.log("[unit-detect] 全部断言通过 ✓ (#69 检测链；#383 projectionValues 形状修正)");
+// ---------------------------------------------------------------- 7) modelCatalog 兜底缓存（#419：官方 catalog 同款）
+
+{
+  // 重复 detect（全链投影缺失）→ 缓存命中，RPC 只打一次
+  let calls = 0;
+  const remote = {
+    session: {
+      modelCatalog: async () => { calls += 1; return { ok: true, value: { default: { provider: "cached-p" } } }; },
+    },
+  };
+  const cache = makeCatalogCache();
+  const sessions = makeSessions({ s: row(undefined) }, "s");
+  const a = await resolveProviderFromSession(sessions, remote, cache.load);
+  const b = await resolveProviderFromSession(sessions, remote, cache.load);
+  const c = await resolveProviderFromSession(sessions, remote, cache.load);
+  assert.equal(a, "cached-p", "首次兜底解析成功");
+  assert.equal(b, "cached-p", "重复检测缓存命中");
+  assert.equal(c, "cached-p", "第三次仍命中");
+  assert.equal(calls, 1, "三次检测只打一次 modelCatalog RPC（缓存收敛）");
+}
+
+{
+  // 并发共享 inflight：同一时刻多个检测只打一次 RPC
+  let calls = 0;
+  const remote = {
+    session: {
+      modelCatalog: async () => { calls += 1; return { ok: true, value: { default: { provider: "inflight-p" } } }; },
+    },
+  };
+  const cache = makeCatalogCache();
+  const sessions = makeSessions({ s: row(undefined) }, "s");
+  const results = await Promise.all([
+    resolveProviderFromSession(sessions, remote, cache.load),
+    resolveProviderFromSession(sessions, remote, cache.load),
+    resolveProviderFromSession(sessions, remote, cache.load),
+  ]);
+  assert.deepEqual(results, ["inflight-p", "inflight-p", "inflight-p"], "并发检测全部解析成功");
+  assert.equal(calls, 1, "并发检测共享同一 inflight（官方 Catalog.load 语义）");
+}
+
+{
+  // 失败不缓存：下次重试；reset 后重拉
+  let calls = 0;
+  const remote = {
+    session: {
+      modelCatalog: async () => {
+        calls += 1;
+        if (calls === 1) return { ok: false, error: { code: "boom" } };
+        return { ok: true, value: { default: { provider: "ok-p" } } };
+      },
+    },
+  };
+  const cache = makeCatalogCache();
+  const sessions = makeSessions({ s: row(undefined) }, "s");
+  assert.equal(await resolveProviderFromSession(sessions, remote, cache.load), undefined, "失败 → undefined");
+  assert.equal(await resolveProviderFromSession(sessions, remote, cache.load), "ok-p", "失败不缓存 → 下次重试成功");
+  assert.equal(calls, 2, "失败帧不写入缓存");
+  // reset 后（provider 检测结果变化挂点）强制重拉
+  const before = calls;
+  await resolveProviderFromSession(sessions, remote, cache.load);
+  cache.reset();
+  await resolveProviderFromSession(sessions, remote, cache.load);
+  assert.equal(calls, before + 1, "reset 后再次裸调");
+}
+
+{
+  // TTL 过期 → 重拉；TTL 常量对齐宿主 stats 缓存量级（30s）
+  let calls = 0;
+  const remote = {
+    session: {
+      modelCatalog: async () => { calls += 1; return { ok: true, value: { default: { provider: "ttl-p" } } }; },
+    },
+  };
+  const cache = makeCatalogCache(50); // 短 TTL 便于测试
+  const sessions = makeSessions({ s: row(undefined) }, "s");
+  await resolveProviderFromSession(sessions, remote, cache.load);
+  await new Promise((r) => setTimeout(r, 60));
+  await resolveProviderFromSession(sessions, remote, cache.load);
+  assert.equal(calls, 2, "TTL 过期后重拉");
+  assert.equal(CATALOG_CACHE_TTL_MS, 30000, "默认 TTL 30s（与宿主 stats 缓存同量级）");
+}
+
+{
+  // 默认 loader（无缓存）语义不变：裸调 remote
+  let calls = 0;
+  const remote = {
+    session: {
+      modelCatalog: async () => { calls += 1; return { ok: true, value: { default: { provider: "bare-p" } } }; },
+    },
+  };
+  assert.equal(await defaultCatalogLoader(remote), "bare-p", "默认 loader 解析 default.provider");
+  assert.equal(await defaultCatalogLoader(remote), "bare-p", "重复调用仍裸调");
+  assert.equal(calls, 2, "默认 loader 每次裸调（无缓存语义）");
+  assert.equal(await defaultCatalogLoader(undefined), undefined, "无 remote → undefined");
+  assert.equal(await defaultCatalogLoader({ session: {} }), undefined, "无 modelCatalog → undefined");
+}
+
+console.log("[unit-detect] 全部断言通过 ✓ (#69 检测链；#383 projectionValues 形状修正；#419 modelCatalog 缓存)");

--- a/packages/dsh-provider-usage/test/unit-refresh-revalidate.test.ts
+++ b/packages/dsh-provider-usage/test/unit-refresh-revalidate.test.ts
@@ -26,11 +26,16 @@ const pkgDir = join(here, "..");
     /async function refreshStats[\s\S]*?await revalidateProvider\(\)/.test(src),
     "refreshStats 取数前先复检 provider（A1 主接线）",
   );
-  // detect 变化分支 → onProviderChanged 立即重拉；未变分支 → renderPill 后仍立即补刷一次
+  // detect 变化分支 → onProviderChanged 立即重拉；未变分支 → renderPill 后仅 current
+  // 会话切换时补刷（#419 diff 语义：投影/运行态噪声帧不刷，收敛高频 /stats 调用）
   assert.ok(/const changed = await revalidateProvider\(\);[\s\S]*?onProviderChanged\(\)/.test(src),
     "detect 复检变化 → 立即重拉（切换会话即时跟随）");
-  assert.ok(/renderPill\(\);[\s\S]*?floatPill !== undefined\) void refreshStats\(\)/.test(src),
-    "detect 未变分支立即补刷 stats（维护者补充需求：切换会话即刷）");
+  assert.ok(/renderPill\(\);[\s\S]*?currentSessionId\(sessions\)[\s\S]*?lastDetectCurrent/.test(src),
+    "detect 未变分支按 current diff 判定是否补刷（#419 去高频）");
+  // #419：modelCatalog 兜底走缓存 loader（官方 catalog 同款），不再裸调跟随帧频率
+  assert.ok(src.includes("makeCatalogCache()"), "客户端持有 catalog 缓存实例");
+  assert.ok(src.includes("catalogCache.load"), "resolveProviderFromSession 注入缓存 loader");
+  assert.ok(src.includes("catalogCache.reset()"), "卸载时失效目录缓存");
 }
 
 // ---------------------------------------------------------------- 子进程行为级剧本


### PR DESCRIPTION
## 背景

浏览器 DevTools 观察 /api/dsh-provider-usage/stats 持续高频调用，agent 活跃期间几乎不间断。

## 根因

客户端 client/index.ts 的 detect() 订阅 sessions.list 快照：任何快照变更（running bit 翻转、sessionListMetadata/title 等 projection 逐条写入、子代理地址变更等）都触发一次无条件 refreshStats()（#71 遗留的「provider 未变也刷」分支）。dsh 会话运行期间快照高频更新（官方 dsh-api-session-controller 客户端 Notifier 每微任务/帧 flush 通知订阅者），于是 agent 每轮活动都带一次 /stats HTTP 请求——即使宿主端 30s 缓存命中返回 status:cached，请求本身照发。

另：client/core.ts 的 resolveProviderFromSession 兜底每次 detect 都裸调一次 ctx.remote.session.modelCatalog()（全链投影缺失时），无缓存、无 inflight 共享，跟随 detect 频率。

## 修复（对齐官方最佳实践）

1. detect diff 语义（对齐官方 dsh-client-ui-session 的 publishCurrent）：
   - 未变分支：仅 current 会话切换（含空 ↔ 有值）时立即补刷 stats（保留维护者需求 #71）；投影/运行态噪声帧只刷胶囊 title，数据刷新交给 60s 轮询；
   - changed 分支同步 lastDetectCurrent 判定基准（修复「切会话跨 provider 后下一噪声帧误判为切换」的连带 bug）。
2. modelCatalog 官方同款缓存（对齐官方 dsh-client-ui-model-selection 的 Catalog.load()）：makeCatalogCache —— ready 命中 + inflight 并发共享 + 失败不缓存 + TTL 30s + 卸载 reset()；全链投影缺失时兜底 RPC 不再跟随快照帧频率。

## 测试

- worker 新增场景 3b（快照噪声帧不刷 stats）、场景 4b（current 变化补刷回归）；
- unit-detect 新增缓存/并发共享/失败不缓存/reset/TTL 五组断言；
- 外壳契约断言同步 #419 接线。
- 全门禁 pnpm build && pnpm test && pnpm contract && pnpm pack:check 绿。

Closes #419