### PR TITLE
fix(dsh-notifier): 设置面板布局收敛——频道tab去重复保存/权限状态入浏览器卡/动作并入历史区 (#418)

### DIFF
--- a/packages/dsh-notifier/src/client/index.ts
+++ b/packages/dsh-notifier/src/client/index.ts
@@ -52,7 +52,7 @@ const NS = "notifier";
     kinds: "/api/dsh-notifier/kinds",
   };
   var STYLE_ID = "dsh-notifier-style";
-  var CSS_VERSION = "402-1";
+  var CSS_VERSION = "418-1";
   // 浏览器通知图标（内联 SVG data URL，零外部资源；铃铛造型）。
   var NOTIFY_ICON =
     "data:image/svg+xml;utf8," +
@@ -532,6 +532,11 @@ const NS = "notifier";
     var activeTabDraft = useState("events" as "events" | "channels");
     var activeTab = activeTabDraft[0];
     var setActiveTab = activeTabDraft[1];
+    // #418：浏览器通知权限状态行在频道卡内——Notification.permission 非 React state，
+    // 请求权限完成后 bump 一次触发重渲染刷新状态行文案/隐藏按钮。
+    var permTickDraft = useState(0);
+    var permTick = permTickDraft[0];
+    var setPermTick = permTickDraft[1];
     // 加载基线（A4）：保存时只提交与基线不同的键（增量 diff），未改动的键不提交。
     // 用 useRef 持久化：组件每次渲染局部变量会重置为 null，导致 save() 闭包里读不到
     // 基线而永远判定「无变化」。
@@ -853,6 +858,35 @@ const NS = "notifier";
     }
 
     /**
+     * 浏览器通知权限状态行（#418：从全局降级区移入「浏览器通知」频道卡）。
+     * 三态文案 + 未授权时的「请求通知权限」按钮（手势内请求，完成后刷新状态）；
+     * 非安全上下文/无 Notification API 时返回 null（对应降级文案仍在全局 notes）。
+     */
+    function browserPermLine() {
+      if (!("Notification" in window) || !isSecureContext()) return null;
+      var text = "";
+      var pending = false;
+      if (Notification.permission === "granted") text = t("permGranted");
+      else if (Notification.permission === "denied") text = t("permDenied");
+      else {
+        text = t("permDefault");
+        pending = true;
+      }
+      return React.createElement("div", { className: "dn-ch-perm" },
+        React.createElement("span", { className: "dn-ch-permText" }, text),
+        pending ? React.createElement("button", {
+          type: "button", className: "dn-set-btn dn-set-btnSmall",
+          onClick: function () {
+            requestPermission(function () {
+              setSaved(t("permRequested"));
+              setPermTick(permTick + 1); // 触发重渲染刷新权限状态行
+            });
+          },
+        }, t("requestPerm")) : null,
+      );
+    }
+
+    /**
      * 内置频道卡（browser/system）：开关 + 行为参数 + 状态行 + per-channel 测试。
      * #402 第 1 条：整卡 details 可折叠——非受控 + key remount 形态（key 含 enabled，
      * open 仅 mount 生效），未启用默认收起、启用默认展开；手动开合完全交 DOM，
@@ -889,6 +923,8 @@ const NS = "notifier";
         ),
         extras,
         statusLine(channelId),
+        // #418：浏览器通知权限状态行归入浏览器频道卡（权限授权入口同卡就近可达）
+        channelId === "browser" ? browserPermLine() : null,
         React.createElement("div", { className: "dn-ch-actions" }, testBtn(channelId)),
       );
     }
@@ -1129,7 +1165,8 @@ const NS = "notifier";
       ),
     ));
 
-    // 三端降级文案（A5/A8）
+    // 三端降级文案（A5/A8；#418：浏览器通知权限状态行已移入「浏览器通知」频道卡，
+    // 这里只保留服务不可用 / 非安全上下文 / 平台不支持三条全局降级说明）
     var degradation: any[] = [];
     if (metaValue && metaValue.writable === false) {
       degradation.push(React.createElement("div", { className: "dn-set-note", key: "settings-unavailable" },
@@ -1139,37 +1176,31 @@ const NS = "notifier";
       if (!isSecureContext()) {
         degradation.push(React.createElement("div", { className: "dn-set-note", key: "insecure" },
           t("httpDegraded")));
-      } else {
-        var permText = "";
-        if (Notification.permission === "granted") permText = t("permGranted");
-        else if (Notification.permission === "denied") permText = t("permDenied");
-        else permText = t("permDefault");
-        degradation.push(React.createElement("div", { className: "dn-set-note", key: "perm" }, permText));
       }
     } else {
       degradation.push(React.createElement("div", { className: "dn-set-note", key: "noapi" },
         t("iosUnsupported")));
     }
 
-    // 动作区（A6/A7）
+    // 动作区（A6/A7；#418：并入「通知记录」分区头部，与刷新按钮并排——不再单列
+    // 「动作」分区；请求权限按钮随权限状态行一起归入「浏览器通知」频道卡）
     var actions = React.createElement("div", { className: "dn-set-actions" },
       React.createElement("button", { type: "button", className: "dn-set-btn" + (clearArmedValue ? " dn-set-btnDanger" : ""), onClick: confirmClear },
         clearArmedValue ? t("clearConfirm") : t("clearLabel")),
-      ("Notification" in window && Notification.permission === "default")
-        ? React.createElement("button", { type: "button", className: "dn-set-btn", onClick: function () {
-            requestPermission(function () { setSaved(t("permRequested")); });
-          } }, t("requestPerm"))
-        : null,
       React.createElement("button", { type: "button", className: "dn-set-btn", onClick: function () { sendTest(); } }, t("sendTest")),
     );
 
-    // 历史列表（D1/D2）；key 供 eventsPane 数组子项对齐（#402 复核项）
+    // 历史列表（D1/D2）+ 动作（#418：清理/发送测试并入本分区头部与刷新并排，key 供
+    // eventsPane 数组子项对齐（#402 复核项））
     var historyEl = React.createElement("div", { className: "dn-set-section", key: "history" },
       React.createElement("div", { className: "dn-set-title" }, t("historyTitle")),
-      React.createElement("button", {
-        type: "button", className: "dn-set-btn dn-set-btnSmall",
-        onClick: function () { loadHistory({ value: true }); },
-      }, t("refresh")),
+      React.createElement("div", { className: "dn-set-historyTools" },
+        actions,
+        React.createElement("button", {
+          type: "button", className: "dn-set-btn dn-set-btnSmall",
+          onClick: function () { loadHistory({ value: true }); },
+        }, t("refresh")),
+      ),
       !history || history.length === 0
         ? React.createElement("div", { className: "dn-set-note" }, t("historyEmpty"))
         : React.createElement("ul", { className: "dn-set-history" },
@@ -1215,13 +1246,6 @@ const NS = "notifier";
       }, t("secChannels")),
     );
 
-    // 「通知频道」tab 内的就近保存（#402 第 6 条）：复用 save()（全量草稿语义，与
-    // foot 保存一致且幂等）；saved 为全局反馈状态，两处同源渲染。
-    var tabSave = React.createElement("div", { className: "dn-ch-saveRow", key: "tab-save" },
-      saved ? React.createElement("span", { className: saved.err ? "dn-set-error" : "dn-set-saved" }, saved.msg) : null,
-      React.createElement("button", { type: "button", className: "dn-set-save", onClick: save }, t("save")),
-    );
-
     // 事件 tab 内容（tab 本身已表意，事件开关不再包 section 标题；子分区保留各自标题）
     var eventsPane = [
       eventChildren,
@@ -1231,12 +1255,11 @@ const NS = "notifier";
       ),
       section(t("secDnd"), quietChildren),
       historyEl,
-      section(t("secActions"), actions),
     ];
-    // 频道 tab 内容：频道卡组（内置 + Bark）+ 添加按钮 + 就近保存
+    // 频道 tab 内容：频道卡组（内置 + Bark）+ 添加按钮（#418：无就近保存——
+    // 与 foot 保存同一份全量草稿，双保存按钮视觉重复；域级拆分属 #405 跟踪）
     var channelsPane = [
       channelsChildren,
-      tabSave,
     ];
 
     // #402 第 4 条：去掉设置卡 title/副标题（对应两个文案键已从字典删除，

--- a/packages/dsh-notifier/src/client/locales.ts
+++ b/packages/dsh-notifier/src/client/locales.ts
@@ -68,7 +68,7 @@ export const zh = {
   clearConfirm: "确认清理记录？",
   clearLabel: "清理记录",
   requestPerm: "请求通知权限",
-  permRequested: "权限请求完成，请刷新查看状态",
+  permRequested: "权限请求完成",
   sendTest: "发送测试通知",
   refresh: "刷新",
   // 历史区
@@ -81,7 +81,6 @@ export const zh = {
   secChannels: "通知频道",
   secDedup: "合并/去重",
   secDnd: "免打扰时段",
-  secActions: "动作",
   tabLabel: "通知中心",
   save: "保存",
   // ===== M2 频道卡（issue #366）=====
@@ -187,7 +186,7 @@ export const en: Record<NotifierLocaleKey, string> = {
   clearConfirm: "Clear history?",
   clearLabel: "Clear history",
   requestPerm: "Request permission",
-  permRequested: "Permission requested — refresh to see the status",
+  permRequested: "Permission request completed",
   sendTest: "Send test notification",
   refresh: "Refresh",
   historyTitle: "History (last 10)",
@@ -197,7 +196,6 @@ export const en: Record<NotifierLocaleKey, string> = {
   secChannels: "Channels",
   secDedup: "Merge / dedup",
   secDnd: "Do-not-disturb",
-  secActions: "Actions",
   tabLabel: "Notification center",
   save: "Save",
   chEnabled: "Enabled",

--- a/packages/dsh-notifier/src/client/style.css
+++ b/packages/dsh-notifier/src/client/style.css
@@ -143,6 +143,15 @@
 }
 
 .dn-set-card .dn-set-history { list-style: none; margin: 4px 0 0; padding: 0; }
+/* #418：历史分区头部工具行——动作按钮（清理/发送测试）与刷新并排 */
+.dn-set-card .dn-set-historyTools {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 2px;
+}
+.dn-set-card .dn-set-historyTools .dn-set-actions { margin-top: 0; }
 .dn-set-card .dn-set-historyItem {
   padding: 5px 0;
   border-bottom: 1px solid var(--dsw-alias-border-l1, #e2e5ea);
@@ -269,13 +278,18 @@
   line-height: 1.6;
   word-break: break-all;
 }
-/* #402 第 6 条：「通知频道」tab 内就近保存行（复用 foot 保存同款按钮） */
-.dn-set-card .dn-ch-saveRow {
+/* #418：浏览器通知权限状态行（移入「浏览器通知」频道卡；授权按钮同卡就近可达） */
+.dn-set-card .dn-ch-perm {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
   gap: 8px;
-  margin-top: 8px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+  font-size: 11px;
+}
+.dn-set-card .dn-ch-permText {
+  color: var(--dsw-alias-label-tertiary, #8a919c);
+  line-height: 1.5;
 }
 .dn-set-card .dn-ch-actions {
   display: flex;

--- a/packages/dsh-notifier/test/client-contract.test.ts
+++ b/packages/dsh-notifier/test/client-contract.test.ts
@@ -74,16 +74,38 @@ const pkgDir = fileURLToPath(new URL("..", import.meta.url));
   // 第 1 条：频道卡 details 折叠形态（key 含 enabled —— 非受控 + key remount）
   assert.ok(src.includes('React.createElement("details"'), "#402：频道卡为 details 可折叠");
   assert.ok(src.includes('failBadge('), "#402：投递失败徽标上提卡头（收起可见）");
-  // 第 2 条：卡内双 tab + kind 徽标 + 就近保存（关键 class 进产物）
+  // 第 2 条：卡内双 tab + kind 徽标（关键 class 进产物）
   assert.ok(src.includes("dn-set-tabs") && src.includes("dn-set-tabActive"), "#402：卡内双 tab 结构");
   assert.ok(src.includes("dn-set-tabBadge"), "#402：待确认 kind 的 tab 徽标");
-  assert.ok(src.includes("dn-ch-saveRow"), "#402：「通知频道」tab 就近保存");
-  assert.ok(client.includes("dn-set-tabs") && client.includes("dn-ch-saveRow"), "#402：tab/保存 class 进产物");
+  assert.ok(client.includes("dn-set-tabs"), "#402：tab class 进产物");
   // 第 4 条：设置卡 title/副标题移除（源码与字典两侧）
   assert.ok(!src.includes("settingsName") && !src.includes("settingsDescription"), "#402：设置卡 title/副标题渲染已删");
   assert.ok(!locales.includes("settingsName:") && !locales.includes("settingsDescription:"), "#402：locales 字典 settingsName/settingsDescription 已删");
   // 第 2 条配套：术语统一（「通知频道」/「选择频道」，消除与旧「投递频道」混用）
   assert.ok(locales.includes('secChannels: "通知频道"') && locales.includes('routePick: "选择频道"'), "#402：tab 术语统一为「通知频道」");
+}
+
+// ---- issue #418：设置面板布局收敛（去重复保存 / 权限入浏览器卡 / 动作并入历史区）----
+{
+  const src = readFileSync(new URL("../src/client/index.ts", import.meta.url), "utf8");
+  const locales = readFileSync(new URL("../src/client/locales.ts", import.meta.url), "utf8");
+  const client = readFileSync(new URL("../lib/client.js", import.meta.url), "utf8");
+
+  // 1. 频道 tab 去就近保存：单一保存入口（foot），且源码/产物/样式三处无 dn-ch-saveRow
+  assert.ok(!src.includes("dn-ch-saveRow"), "#418：频道 tab 就近保存行已移除");
+  assert.ok(!client.includes("dn-ch-saveRow"), "#418：产物无就近保存 class");
+  assert.ok(!src.includes("tabSave"), "#418：tabSave 变量已移除");
+  // 2. 浏览器通知权限状态行移入浏览器频道卡（browserPermLine 只挂在 browser 卡）
+  assert.ok(src.includes("browserPermLine"), "#418：浏览器权限状态行归入频道卡");
+  assert.ok(src.includes('channelId === "browser" ? browserPermLine()'), "#418：权限行只渲染于浏览器卡");
+  assert.ok(src.includes("dn-ch-perm"), "#418：权限行 class 进源码");
+  assert.ok(client.includes("dn-ch-perm"), "#418：权限行 class 进产物");
+  // 权限状态行不再出现在全局降级区（perm 三态文案仅存于 browserPermLine 分支）
+  assert.ok(!src.includes('key: "perm"'), "#418：全局降级区不再渲染权限状态");
+  // 3. 动作并入历史区（清理/发送测试在 historyTools 内与刷新并排）；「动作」分区标题移除
+  assert.ok(src.includes("dn-set-historyTools"), "#418：历史区工具行（动作+刷新）");
+  assert.ok(!src.includes("secActions"), "#418：源码无「动作」分区标题引用");
+  assert.ok(!locales.includes("secActions:"), "#418：locales 字典已删 secActions 键");
 }
 
 // lib/toast.ps1 发布物完整性（issue #238）：必须带 UTF-8 BOM 且与源文件逐字节一致。


### PR DESCRIPTION
## 关联 issue
Closes #418

## 改动内容

设置 → 通知中心面板三处布局问题修复：

1. **「通知频道」tab 去重复保存**：删除 tab 内就近保存行（`dn-ch-saveRow`），恢复为单一保存入口（foot 保存）。两个按钮保存的是同一份全量草稿（save() 幂等），视觉重复误导。域级保存拆分属 #405 跟踪。
2. **浏览器通知权限状态行移入「浏览器通知」频道卡**：`browserPermLine()` 渲染三态（已授权/已拒绝/未授权）+ 未授权时的「请求权限」按钮，挂在浏览器频道卡内（状态行之后）；全局降级区只保留 settingsSvcDown / httpDegraded / iosUnsupported 三条。请求权限完成后 `setPermTick` 触发重渲染刷新状态行。
3. **动作并入「通知记录」分区**：清理记录 / 发送测试通知按钮移入历史分区头部（`dn-set-historyTools`），与刷新按钮并排；删除单独「动作」分区（secActions 键停用）。请求权限按钮随权限行一起归入浏览器卡。

### 涉及文件
- `src/client/index.ts`：browserPermLine / dn-set-historyTools / 删 tabSave / CSS_VERSION bump
- `src/client/locales.ts`：删 secActions 键；permRequested 文案更新（无需再手动刷新）
- `src/client/style.css`：删 .dn-ch-saveRow；新增 .dn-ch-perm / .dn-set-historyTools
- `test/client-contract.test.ts`：#418 断言块（无 dn-ch-saveRow / browserPermLine / 无 secActions 等）

## 验证
- ✅ `pnpm build && pnpm test && pnpm contract && pnpm pack:check` 全绿
- ✅ 控制台无错误