### PR TITLE
chore(release): v0.2.0——8 包版本对齐 + release-notes（含升级指南）

### DIFF
--- a/docs/release-notes/v0.2.0.md
+++ b/docs/release-notes/v0.2.0.md
@@ -22,14 +22,15 @@ npm i -g @deepseek-ai/dsh@0.1.2-alpha.3
 dsh --version   # 应显示 0.1.2-alpha.3
 ```
 
-**2. 升级插件**（升级后需**重启一次** `dsh web`，bundle 层只在启动时组合）：
+**2. 升级插件到 0.2.0**（用指定版本形式；升级后需**重启一次** `dsh web`，bundle 层只在启动时组合）：
 
 ```sh
-# 升级当前 profile 下全部插件
-dsh plugin --profile web update
+# 全家桶（聚合包 + 其拉齐的子包）升到 0.2.0
+dsh plugin --profile web update @wingsky-1/dsh-plugins-all@0.2.0
 
-# 或升级全家桶（聚合包 + 其拉齐的子包）
-dsh plugin --profile web update @wingsky-1/dsh-plugins-all
+# 或逐个插件指定版本（示例，按需替换包名）
+dsh plugin --profile web update @wingsky-1/dsh-notifier@0.2.0
+dsh plugin --profile web update @wingsky-1/dsh-mcp-manager@0.2.0
 ```
 
 **3. 废弃插件移除**（`dsh-idle-archive` / `dsh-subagent-model-inherit` 已退役、npm 已标 deprecated；仍安装着的用户请移除）：
@@ -95,14 +96,15 @@ npm i -g @deepseek-ai/dsh@0.1.2-alpha.3
 dsh --version   # should print 0.1.2-alpha.3
 ```
 
-**2. Upgrade plugins** (restart `dsh web` once afterwards — bundles are composed only at startup):
+**2. Upgrade plugins to 0.2.0** (pin the exact version; restart `dsh web` once afterwards — bundles are composed only at startup):
 
 ```sh
-# Upgrade all plugins in the current profile
-dsh plugin --profile web update
+# Bundle (aggregate + the sub-packages it pulls in) to 0.2.0
+dsh plugin --profile web update @wingsky-1/dsh-plugins-all@0.2.0
 
-# Or upgrade the bundle (aggregate + the sub-packages it pulls in)
-dsh plugin --profile web update @wingsky-1/dsh-plugins-all
+# Or pin per-plugin versions (examples — replace with the packages you use)
+dsh plugin --profile web update @wingsky-1/dsh-notifier@0.2.0
+dsh plugin --profile web update @wingsky-1/dsh-mcp-manager@0.2.0
 ```
 
 **3. Remove retired plugins** (`dsh-idle-archive` / `dsh-subagent-model-inherit` are retired and deprecated on npm; remove if still installed):

--- a/docs/release-notes/v0.2.0.md
+++ b/docs/release-notes/v0.2.0.md
@@ -13,6 +13,34 @@
 
 v0.2.0 是 **0.1.x 功能线冻结后的首个版本**，核心主线为「**适配 dsh 0.1.2-alpha.3 + 插件集多语言（i18n）接入**」。本版将官方类型层统一锁到 `0.1.2-alpha.3`，并依托官方 locale 框架为六个插件的界面文案接入双语能力；同时完成通知中心化 M2（设置 UI 重设计 + Bark 频道 + 动态 kind 路由）、多项连接稳定性与生命周期治理。
 
+### 升级指南
+
+**1. 升级 dsh 本体**（目标 `0.1.2-alpha.3`；`latest` dist-tag 可能滞后，需显式 pin）：
+
+```sh
+npm i -g @deepseek-ai/dsh@0.1.2-alpha.3
+dsh --version   # 应显示 0.1.2-alpha.3
+```
+
+**2. 升级插件**（升级后需**重启一次** `dsh web`，bundle 层只在启动时组合）：
+
+```sh
+# 升级当前 profile 下全部插件
+dsh plugin --profile web update
+
+# 或升级全家桶（聚合包 + 其拉齐的子包）
+dsh plugin --profile web update @wingsky-1/dsh-plugins-all
+```
+
+**3. 废弃插件移除**（`dsh-idle-archive` / `dsh-subagent-model-inherit` 已退役、npm 已标 deprecated；仍安装着的用户请移除）：
+
+```sh
+dsh plugin --profile web remove @wingsky-1/dsh-idle-archive
+dsh plugin --profile web remove @wingsky-1/dsh-subagent-model-inherit
+```
+
+> 未全局安装 `dsh` 时，将上述 `dsh plugin ...` 换成 `npx @deepseek-ai/dsh plugin ...` 即可。
+
 ### 新功能
 
 - **[dsh-notifier]** 通知中心化 M2——设置 UI 重设计 + Bark 频道 + kindRoutes（issue #366，#399）
@@ -57,6 +85,34 @@ v0.2.0 是 **0.1.x 功能线冻结后的首个版本**，核心主线为「**适
 ### Overview
 
 v0.2.0 is the **first release after the 0.1.x feature freeze**, centered on **adapting to dsh 0.1.2-alpha.3 + plugin-set i18n**. This release locks the official type layer to `0.1.2-alpha.3`, brings bilingual UI text to six plugins via the official locale framework, and ships notifier Notification Center M2 (settings UI redesign + Bark channel + dynamic kind routing) plus a round of connection-stability and lifecycle governance.
+
+### Upgrade Guide
+
+**1. Upgrade dsh itself** (target `0.1.2-alpha.3`; the `latest` dist-tag may lag — pin explicitly):
+
+```sh
+npm i -g @deepseek-ai/dsh@0.1.2-alpha.3
+dsh --version   # should print 0.1.2-alpha.3
+```
+
+**2. Upgrade plugins** (restart `dsh web` once afterwards — bundles are composed only at startup):
+
+```sh
+# Upgrade all plugins in the current profile
+dsh plugin --profile web update
+
+# Or upgrade the bundle (aggregate + the sub-packages it pulls in)
+dsh plugin --profile web update @wingsky-1/dsh-plugins-all
+```
+
+**3. Remove retired plugins** (`dsh-idle-archive` / `dsh-subagent-model-inherit` are retired and deprecated on npm; remove if still installed):
+
+```sh
+dsh plugin --profile web remove @wingsky-1/dsh-idle-archive
+dsh plugin --profile web remove @wingsky-1/dsh-subagent-model-inherit
+```
+
+> Without a global `dsh` binary, prefix `npx @deepseek-ai/dsh` instead of `dsh`.
 
 ### Features
 

--- a/docs/release-notes/v0.2.0.md
+++ b/docs/release-notes/v0.2.0.md
@@ -17,29 +17,39 @@ v0.2.0 是 **0.1.x 功能线冻结后的首个版本**，核心主线为「**适
 
 - **[dsh-notifier]** 通知中心化 M2——设置 UI 重设计 + Bark 频道 + kindRoutes（issue #366，#399）
 - **[dsh-notifier]** 设置页 UI/UX 打磨——频道折叠（默认折叠未启用）+ 事件·频道双 Tab + Bark 折叠入口提示 + 去 title/副标题 + tab 标签 i18n 跟随 + Tab 级就近保存（#402，#407）
+- **[dsh-notifier]** Bark 实例新增 levels（kind→level 映射矩阵），提问等关键事件可按类型提级（#430）
+- **[dsh-notifier]** 免打扰豁免扩至全部内置事件——QUIET_ALLOW_KINDS 6 项 + 放开 allowKinds 白名单 + 跟随已启用/恢复默认快捷项（#421，#424）
+- **[dsh-mcp-manager]** all 模式 runtime 注入服务器归一中台，消除 mcp__ 前缀直呼（#413，#420）
 - **[dsh-notifier / dsh-provider-usage / dsh-mcp-manager / dsh-lan-proxy / dsh-web-file-preview / dsh-idle-archive]** 六包 i18n 接入——官方 locale 双通道，界面文案随界面语言切换（#348，*注：dsh-idle-archive 已退役，#397*）
 - **[dsh-lan-proxy]** injectToken 自动注入启动令牌，含 401 重放自愈（#380，#387）
 - **[dsh-notifier]** 完成风暴聚合 + 通知中心 service（Channel SPI + 动态 kind 待确认）（#366）
 
 ### 修复
 
+- **[dsh-notifier]** 设置面板布局收敛——频道 tab 去重复保存 / 权限状态入浏览器卡 / 动作并入历史区（#418，#425）
+- **[dsh-notifier]** eventsPane/channelsPane 数组子项补 key（history/tab-save）（#411）
 - **[dsh-mcp-manager]** MCP 工具管理勾选态改红色 × 表示禁用（#401，#403）
 - **[dsh-mcp-manager]** middleware 持久化重启恢复 + #391 评审六项遗留（#400）
 - **[dsh-mcp-manager]** 连接生命周期口径统一——runtime 重连回退 + all 模式池接管下沉 + 展示剥前缀 + 防双进程探测重试（#391）
 - **[dsh-mcp-manager]** ws_mcp_list 输出禁用条目条件赋值，修 lossless JSON 校验失败（#384）
+- **[dsh-mcp-manager]** 移动端切后台切回后项目级 MCP 恢复重建（#412，#416）
 - **[dsh-lan-proxy]** 压缩桥接透传入站头 + 默认白名单改 /api/remote.mux（#379，#386）
 - **[dsh-lan-proxy]** 旧压缩白名单等价迁移到 remote.mux + deny 集剔除响应头（#395，#398）
 - **[dsh-lan-proxy]** 复核修复——IPv6 桥接 URL 方括号拼接 + README.en 同步 + deny 口径补全（#379，#394）
 - **[dsh-provider-usage]** 胶囊不跟随会话 provider——客户端 ctx 服务未注入（inject 缺 sessions/remote + 误用 ctx.get）（#383，#393）
 - **[dsh-provider-usage]** 胶囊跟随会话内切模型——投影读取 next 优先（#383，#404）
 - **[dsh-provider-usage]** 胶囊跟随会话 provider——投影字段改读拍平 projectionValues（#383，#385）
+- **[dsh-provider-usage]** sessions.list 快照噪声帧不再触发 /stats——detect 改 current diff 语义 + modelCatalog 官方同款缓存（#419，#422）
 - **[dsh-web-file-preview]** 预览卡片布局主权回归——id 提权对轰宿主移动端对话框模板劫持（#388，#396）
+- **[dsh-mcp-manager]** 注入上下文文本优化——MCP_GUIDANCE 精简 + codegraph/ws_mcp_* 描述负向锚与去重（#414，#415）
 
 ### 维护与工程化
 
 - **[chore]** 退役 dsh-idle-archive 与 dsh-subagent-model-inherit（官方/社区已覆盖）（#397）
 - **[dsh]** 0.1.2-alpha.2 适配 + 六包 i18n 接入（#323，#348）
 - **[dsh-mcp-manager]** 变异副本同步 #381 回归断言（#390）
+- **[dsh-verify-isolated]** skill 脚本改经注入的资源 base 定位，清除已归档 dsh-dev-utils 引用（#428，#429）
+- **[ci]** 增量变异基线例行快照（#408）
 
 <a id="en"></a><a id="user-content-en"></a>
 ## English
@@ -52,26 +62,36 @@ v0.2.0 is the **first release after the 0.1.x feature freeze**, centered on **ad
 
 - **[dsh-notifier]** Notification Center M2 — settings UI redesign + Bark channel + kindRoutes (issue #366, #399)
 - **[dsh-notifier]** Settings UI/UX polish — channel cards collapsible (disabled collapsed by default) + event/channel dual tabs + Bark advanced-collapse affordance + title/subtitle removal + tab-label i18n + tab-level save (#402, #407)
+- **[dsh-notifier]** Bark instances gain levels (kind→level mapping matrix) — key events like questions can escalate by type (#430)
+- **[dsh-notifier]** Quiet-period exemptions extended to all built-in events — QUIET_ALLOW_KINDS 6 items + allowKinds whitelist opened + follow-enabled/restore-default shortcuts (#421, #424)
+- **[dsh-mcp-manager]** all-mode runtime-injected servers unified into one registry, eliminating direct mcp__-prefixed calls (#413, #420)
 - **[dsh-notifier / dsh-provider-usage / dsh-mcp-manager / dsh-lan-proxy / dsh-web-file-preview / dsh-idle-archive]** Six-plugin i18n via official locale dual-channel (#348; note: dsh-idle-archive is retired, #397)
 - **[dsh-lan-proxy]** injectToken auto-injects startup token with 401 replay self-heal (#380, #387)
 - **[dsh-notifier]** Burst aggregation + Notification Center service (Channel SPI + dynamic kind confirmation) (#366)
 
 ### Bug Fixes
 
+- **[dsh-notifier]** Settings panel layout convergence — channel tab duplicate-save removal / permission status into browser card / actions merged into history area (#418, #425)
+- **[dsh-notifier]** eventsPane/channelsPane array children get keys (history/tab-save) (#411)
 - **[dsh-mcp-manager]** MCP tool management toggle becomes red × to indicate disabled (#401, #403)
 - **[dsh-mcp-manager]** middleware persistence recovery on restart + #391 review leftovers (#400)
 - **[dsh-mcp-manager]** Connection lifecycle unification — runtime reconnect fallback + all-mode pool takeover + display prefix stripping + dual-process probe retry guard (#391)
 - **[dsh-mcp-manager]** ws_mcp_list disabled-entry conditional assignment fixes lossless JSON validation (#384)
+- **[dsh-mcp-manager]** Project-level MCP rebuilds after mobile background/foreground switch (#412, #416)
 - **[dsh-lan-proxy]** Compression bridge passthrough of inbound headers + default whitelist moved to /api/remote.mux (#379, #386)
 - **[dsh-lan-proxy]** Legacy compression whitelist migrated equivalently to remote.mux + deny-set response-header removal (#395, #398)
 - **[dsh-lan-proxy]** Recheck fixes — IPv6 bridge URL bracket concatenation + README.en sync + deny semantics (#379, #394)
 - **[dsh-provider-usage]** Capsule no longer follows session provider — client ctx service not injected (inject missing sessions/remote + misuse of ctx.get) (#383, #393)
 - **[dsh-provider-usage]** Capsule follows in-session model switch — projection reads next first (#383, #404)
 - **[dsh-provider-usage]** Capsule follows session provider — projection fields read flattened projectionValues (#383, #385)
+- **[dsh-provider-usage]** sessions.list snapshot noise frames no longer trigger /stats — detect switched to current-diff semantics + modelCatalog official-style cache (#419, #422)
 - **[dsh-web-file-preview]** Preview card layout sovereignty — id priority-boost vs host mobile dialog template hijack (#388, #396)
+- **[dsh-mcp-manager]** Injected context text polish — MCP_GUIDANCE trimming + codegraph/ws_mcp_* description negative anchors and dedup (#414, #415)
 
 ### Maintenance
 
 - **[chore]** Retire dsh-idle-archive and dsh-subagent-model-inherit (covered by official/community) (#397)
 - **[dsh]** 0.1.2-alpha.2 adaptation + six-plugin i18n (#323, #348)
 - **[dsh-mcp-manager]** Mutation copy sync of #381 regression assertions (#390)
+- **[dsh-verify-isolated]** Skill script resolves resources via injected base, removing archived dsh-dev-utils references (#428, #429)
+- **[ci]** Incremental mutation baseline routine snapshot (#408)

--- a/packages/dsh-codegraph/package.json
+++ b/packages/dsh-codegraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-codegraph",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "codegraph MCP + worktree 开发纪律：探测/引导安装 codegraph CLI，经 mcp-manager 核心服务运行时注册 MCP 服务器，工具层强制「查询前 sync + projectPath」，非 git 仓不启用（#329 阶段2）",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-lan-proxy/package.json
+++ b/packages/dsh-lan-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-lan-proxy",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "局域网访问 dsh web UI：在 0.0.0.0:<port> 监听，把 HTTP/HTTPS 与 WebSocket/wss 转发到回环 web 服务器（默认 127.0.0.1:3080）。重写 Host/Origin 以通过 /api 浏览器信任围栏，仅接受 IP 字面量或 localhost 的 Host 头（DNS 重绑定防护）。HTTPS 默认并存（3443），证书可配置或自动生成自签名。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-mcp-manager/package.json
+++ b/packages/dsh-mcp-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-mcp-manager",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "DSH MCP 管理器：Web 侧边栏「MCP」入口，面板按状态分级展示 MCP 服务器（运行中/连接中/已配置/失败），支持快速接入（stdio / streamable-http 表单）与粘贴 mcpServers JSON 导入。已连接服务器的工具以 mcp__<server>__<tool> 注册给模型直接调用。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-notifier/package.json
+++ b/packages/dsh-notifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-notifier",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "审批/完成/错误事件通知：浏览器 Notification + 系统原生 toast（Windows PowerShell WinRT / macOS osascript / Linux notify-send，均无需额外安装）；提示音可配、每条通知独立显示不互相替换、非安全上下文自动降级横幅",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-plugins-all/package.json
+++ b/packages/dsh-plugins-all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-plugins-all",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "DSH 插件全家桶聚合包：一键安装全部功能插件（notifier / provider-usage / mcp-manager / lan-proxy / verify-isolated / web-file-preview）。装它 = 子包 dependencies 拉齐 + 聚合 cordis patch 激活。dsh-gzip 已退役（压缩合并进 lan-proxy），不再随全家桶分发。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-provider-usage/package.json
+++ b/packages/dsh-provider-usage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-provider-usage",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "用量统计悬浮框（v2 契约）：胶囊 + 详情面板，宿主端渲染 HTML 注入；用户 mjs 适配器三函数接入任意数据源（fetchData/formatCapsule/formatPanel），宿主注入共享图表工具（utils），密钥配置链注入、按天分片 JSONL 历史、热更新可选；内置 OpenCode Go / DeepSeek 官方 / 智谱 Coding Plan (CN) 适配器",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-verify-isolated/package.json
+++ b/packages/dsh-verify-isolated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-verify-isolated",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "DSH 插件开发的隔离环境浏览器验证 skill：临时 DSH_HOME + 独立 verify_<随机> profile 双重隔离，一键拉起隔离 dsh web（自动构建/挂载/启动/清理），不污染正在使用的 web profile",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-web-file-preview/package.json
+++ b/packages/dsh-web-file-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-web-file-preview",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "点击对话中的文件链接在 web 端预览：宿主端按 MIME 服务会话工作区内文件（图片直出/文本 UTF-8 直出 + git diff），客户端拦截文件链接弹出预览 Modal（Markdown/代码高亮/Diff/图片灯箱）",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 变更

v0.2.0 发版（基于最新主干 b6f10a9）：

- **8 包版本对齐 0.2.0**（codegraph / lan-proxy / mcp-manager / notifier / plugins-all / provider-usage / verify-isolated / web-file-preview）
- **docs/release-notes/v0.2.0.md**：中英双节 + 双锚补位 + 锚定声明（dsh 0.1.2-alpha.3），覆盖 v0.1.14..HEAD 全部 28 提交；含升级指南（dsh 升级 / 插件指定版本升级 / 废弃插件移除命令）

## 验证

- catalog/peer 锚定 alpha.3 已在 #410 全门禁通过
- 本分支仅版本号 + 文档改动，release.yml 推 tag 时全量门禁兜底

## 发版流程

PR 合入后推 v0.2.0 tag 触发 release.yml（verify-version 校验全包==0.2.0 → 全门禁 → 依赖序 publish → 建 Release）