### PR TITLE
fix(ci): docs-only PR 不再触发全量门禁——AGENTS.md 移出 global 过滤面（#432）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,15 +70,16 @@ jobs:
               - 'scripts/**'
               - 'agents/**'
               - '.github/**'
-              # docs/** 刻意不在 global 面（#220）：gate/build/release 脚本均不消费
-              # docs/ 内容，文档 PR 无需变异切片与 smoke/typecheck（release-notes
-              # 校验仅存在于 tag 触发的 release.yml）。若未来新增消费 docs 的门禁
-              # 脚本，须同步加回此处——workflow-assert 契约已锁定该约定
+              # docs/** 与 AGENTS.md 刻意不在 global 面（#220）：gate/build/release
+              # 脚本均不消费其内容，纯文档 PR 无需变异切片与 smoke/typecheck
+              # （release-notes 校验仅存在于 tag 触发的 release.yml）。AGENTS.md 与
+              # docs/** 同等对待（根级纯文档，无门禁脚本消费其内容）。若未来新增
+              # 消费 docs/AGENTS.md/README 等的门禁脚本，须同步加回此处——
+              # workflow-assert 契约已锁定该约定
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - 'tsconfig.base.json'
-              - 'AGENTS.md'
             dsh-notifier:
               - 'packages/dsh-notifier/**'
               # #322：stryker 段配置变更须命中本包面（段配置是 mutation 单一事实源，

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -154,13 +154,16 @@ test('observe.yml: 夜间调度 + 双硬门禁执行点 + issues 写权限', () 
   assert.ok(OBSERVE.includes('observe-check.mjs'), '阈值校验+回落检测脚本执行点（F1/F6）')
 })
 
-test('#220: docs 不在 ci.yml global 过滤面——文档 PR 不触发变异切片', () => {
-  // gate/build/release 脚本均不消费 docs/ 内容；release-notes 校验仅在 release.yml。
-  // 若未来新增消费 docs 的门禁脚本，须把 'docs/**' 加回 global 组并同步本断言
+test('#220: docs 与 AGENTS.md 不在 ci.yml global 过滤面——文档 PR 不触发变异切片', () => {
+  // gate/build/release 脚本均不消费 docs/ 与 AGENTS.md 内容；release-notes 校验
+  // 仅在 release.yml。若未来新增消费 docs/AGENTS.md/README 等的门禁脚本，
+  // 须把对应路径加回 global 组并同步本断言
   const filterBlock = CI.slice(CI.indexOf('filters: |'), CI.indexOf("dsh-notifier:"))
   assert.ok(!/^.*-\s'docs\/\*\*'/m.test(filterBlock),
     "docs/** 不得出现在 global 过滤组——纯文档 PR 不应触发全量切片")
-  assert.ok(CI.includes('# docs/** 刻意不在 global 面'),
+  assert.ok(!/^.*-\s'AGENTS\.md'/m.test(filterBlock),
+    "AGENTS.md 不得出现在 global 过滤组——改根级纯文档不应触发全量切片")
+  assert.ok(CI.includes('# docs/** 与 AGENTS.md 刻意不在 global 面'),
     '过滤面旁必须保留理由注释（防后人「好心」加回）')
 })
 


### PR DESCRIPTION
Fixes #432

## 根因

ci.yml changes job 的 global 过滤面含 `AGENTS.md`（L81）→ 改 AGENTS.md 的 docs-only PR → GLOBAL_HIT=true → 全量切片（33 jobs vs 代码 PR 16-18）。README*.md / CONTRIBUTING.md 本就不在 global 面，唯独 AGENTS.md 在。已实证 gate/build/release 脚本均不消费 AGENTS.md 内容（全仓 grep `scripts/gate`、`scripts/build`、`scripts/release`、`release.yml`，仅 baseline 快照内源码注释与 threshold-monotonic 日志文案两处巧合字样，无任何脚本读取其内容）。

## 改动（2 文件）

1. `.github/workflows/ci.yml`：global 过滤组删除 `- 'AGENTS.md'`；更新注释块——AGENTS.md 与 docs/** 同等对待（根级纯文档，无门禁脚本消费其内容）；若未来新增消费 AGENTS.md/README 等的门禁脚本，须加回 global 面并同步契约断言。
2. `scripts/test/workflow-assert.test.ts`：#220 测试扩展——新增断言 `AGENTS.md` 不在 global 过滤组（`-\s'AGENTS\.md'` 不应出现），测试名/注释同步为「docs 与 AGENTS.md 不在 ci.yml global 过滤面——文档 PR 不触发变异切片」。

## 验收断言表

| # | 验收标准 | 结论 | 证据 |
|---|---|---|---|
| 1 | ci.yml global 面不再含 AGENTS.md | ✅ | `grep -n 'AGENTS' ci.yml` 仅命中注释行 73/75/77，无 `- 'AGENTS.md'` 过滤行；global 组以 `- 'tsconfig.base.json'` 结尾 |
| 2 | workflow-assert 新增 AGENTS.md 不在 global 的断言 | ✅ | `assert.ok(!/^.*-\s'AGENTS\.md'/m.test(filterBlock), "AGENTS.md 不得出现在 global 过滤组——改根级纯文档不应触发全量切片")`；`pnpm test:scripts` 56/56 全绿 |
| 3 | 模拟 #429 类 PR → hitPackages 只含对应包面、AGENTS.md 不再触发 GLOBAL_HIT | ✅ | 本地推演（见下节） |
| 4 | 未改动其他文件 | ✅ | `git diff --stat` 仅 2 文件：ci.yml + workflow-assert.test.ts |

## GLOBAL_HIT 推演（#429 类 PR：改 AGENTS.md + 包内 test）

以 #429 真实改动为样例输入（`AGENTS.md` + `packages/dsh-verify-isolated/test/smoke.ts`），忠实模拟 dorny/paths-filter 匹配（minimatch 子集 glob 转正则）与 changes job「Compute hit packages」逻辑：

| 场景 | global 组命中 | GLOBAL_HIT | 切片结果 |
|---|---|---|---|
| 修复前（AGENTS.md 在 global 面） | true | true | 全量切片（8 包 matrix） |
| 修复后（AGENTS.md 移出 global 面） | false | false | 增量切片 hitPackages=["dsh-verify-isolated"]（仅对应包） |

机制链路：GLOBAL_HIT 由 `steps.filter.outputs.global` 驱动；修复后根级 `AGENTS.md` 不匹配 global 组任一 glob（`shared/**`、`scripts/**`、`agents/**`、`.github/**`、`package.json`、`pnpm-lock.yaml`、`pnpm-workspace.yaml`、`tsconfig.base.json`）→ global=false → 走增量分支；包面条目 `packages/dsh-verify-isolated/**` 命中 test/smoke.ts → hitPackages 只含该包面。fail-closed 双闸（base 不可用 / filter 失败 → 全量）语义不受影响。

## 门禁（worktree 根全量）

- `pnpm install --frozen-lockfile` ✅
- `pnpm build` ✅ / `pnpm test` ✅ / `pnpm contract` ✅ / `pnpm pack:check` ✅ / `pnpm typecheck` ✅（全五连）
- `pnpm test:scripts` ✅ 56/56（含扩展后 #220，重点断言项）