### PR TITLE
ci(observe): 调度重设计——全量北京4点 + 增量四班次（有变化即 PR）（#433）

### DIFF
--- a/.github/workflows/observe-incremental.yml
+++ b/.github/workflows/observe-incremental.yml
@@ -1,0 +1,190 @@
+name: Observe (incremental)
+
+# #433 调度重设计：每日四班次增量班（北京 12/16/20/24 = UTC 04/08/12/16）。
+# - 基于全量班（observe.yml，北京次日 04:00）提交进 scripts/gate/baseline/ 的
+#   仓库内基线跑增量变异（快）——只变异上次全量后发生变化的代码；
+# - 基线有实质变化即 create-pull-request 自动开 PR 合入 main（每次独立判断，
+#   无每日日期闸；create-pull-request 自身在无 diff 时不建 PR，天然「有变化即 PR」）；
+# - 职责收敛：本班次不跑 cov / self-cov --check / crap / observe-check 报告，
+#   只做「恢复基线 → 增量变异 → 基线 PR + auto-merge」。
+# - #204 方案 A：基线走仓库内版本化文件 scripts/gate/baseline/（git 跨 ref 天然
+#   可见），替代失效的 actions/cache 跨 ref 通道（#204 实证 PR 永远 miss main 缓存）。
+# - token 用 OBSERVE_PAT（repo secret）：GITHUB_TOKEN 创建的 PR 不触发后续
+#   workflow runs（防递归机制），曾致基线快照 PR 的必需检查长期 action_required、
+#   反复卡在人工批准——PAT 创建可正常触发 CI 与 auto-merge。
+
+on:
+  schedule:
+    # 每日四班次增量变异与基线刷新（#433 调度重设计）：北京 12:00/16:00/20:00/24:00
+    # = UTC 04:00/08:00/12:00/16:00，均避开整点 Actions 高峰；全量班见 observe.yml
+    - cron: '0 4,8,12,16 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  # #433 调度重设计：增量班四班次定时（无 push 触发），schedule 间无冲突可并行；
+  # 并发组与 observe.yml 全量班独立（增量班不等待、不取消全量班）
+  group: observe-incremental-${{ github.event_name }}
+  cancel-in-progress: false
+
+jobs:
+  incremental:
+    name: Incremental mutation
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        # #433：增量班需读 origin/main 上全量班提交的仓库内基线（对比 scripts/gate/baseline/）
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+        # 版本以根 package.json 的 packageManager 字段为单一事实源（勿同时指定 version）
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all
+        # 必须全量构建（run #32790425132 教训）：mutate 区间的行号锚定 esbuild
+        # 产物分段注释，产物结构依赖 workspace 内联链（shared/ 与依赖包副本）的
+        # 全集一致性；单包构建曾因跨包 lib 缺失直接 ERR_MODULE_NOT_FOUND。
+        run: pnpm build
+
+      - name: Restore repo incremental baseline（#204：读仓库内基线到 coverage/mutation/）
+        # #204 方案 A：增量班直接读 scripts/gate/baseline/ 下全量班提交的基线文件，
+        # 复制到 coverage/mutation/ 供 Stryker 增量模式跳过未变 mutant。
+        # 首夜/部分包基线缺失时该包天然降级为全量变异（notice 标注属预期，非缺陷）。
+        run: |
+          set -e
+          mkdir -p coverage/mutation
+          RESTORED=0
+          for f in scripts/gate/baseline/incremental-*.json; do
+            if [ -f "$f" ]; then
+              cp "$f" "coverage/mutation/$(basename "$f")"
+              RESTORED=1
+            fi
+          done
+          if [ "$RESTORED" -eq 0 ]; then
+            echo '::notice::incremental 基线缺失 —— 本次降级为全量变异（首夜无基线属预期，非缺陷）'
+          fi
+
+      - name: Resolve mutation suites（#433 增量班：全量清单，增量模式跳过未变 mutant）
+        id: suite-plan
+        run: |
+          set -e
+          # 全量清单（glob conf 目录为单一事实源）——增量模式 stryker 读已恢复的
+          # 基线跳过未变 mutant（快）；计划空时 has_suites=false 防空跑
+          ls stryker.conf.d/dsh-*.json > /tmp/suites.txt
+          echo "has_suites=true" >> "$GITHUB_OUTPUT"
+
+      - name: Mutation suites（串行执行计划内变异配置；单配置失败记账继续跑完，结尾统一判红）
+        # id 供 collect 步骤区分「整套 skip（无产物无从收集）」与「部分失败
+        # （记账班次已产出的基线照常收集）」（#217）
+        id: mutation-suites
+        if: steps.suite-plan.outputs.has_suites == 'true'
+        # #178 逐包容错：strict 判红路径下 incremental 基线已先落盘（StrykerJS 源码核实），
+        # 记账继续可让后续包照常产出报告与基线，避免单包连锁丢弃整班次数据。
+        # #220 B 方案：循环清单由 suite-plan 步骤产出（全量 glob），本步骤不关心名单来源
+        run: |
+          FAILED=0
+          FAILED_CONFS=''
+          while read -r conf; do
+            name="$(basename "$conf" .json)"
+            echo "::group::stryker $name"
+            if npx stryker run "$conf"; then
+              echo "::endgroup::"
+            else
+              echo "::endgroup::"
+              echo "::error::变异套件失败：$name（记账后继续执行其余配置）"
+              FAILED=1
+              FAILED_CONFS="$FAILED_CONFS $name"
+            fi
+          done < /tmp/suites.txt
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::以下变异套件失败，统一判红:$FAILED_CONFS"
+            exit 1
+          fi
+
+      - name: Collect incremental baseline（#204：收集到仓库内 scripts/gate/baseline/）
+        # if: always() && 非 skipped 且有计划 —— 部分失败班次已产出的基线文件照常收集；
+        # 但整套变异被 skip 或计划为空时无任何产物，collect 不运行（防 copied=0 误红，#217/#220）
+        if: always() && steps.mutation-suites.outcome != 'skipped' && steps.suite-plan.outputs.has_suites == 'true'
+        run: node scripts/gate/collect-incremental-baseline.mjs
+
+      - name: Open baseline PR（#433 增量班：基线有实质变化即自动建 PR，无每日日期闸）
+        # create-pull-request 只在有 diff 时创建 PR（无变化 = no-op，不产生噪音提交）——
+        # 天然实现「有变化即 PR」，每次增量班独立判断，无需日期闸。
+        # 受保护分支禁止 workflow 直接 push main → 走 PR + auto-merge 路径。
+        # token 用 OBSERVE_PAT（repo secret）：PAT 创建的 PR 可正常触发 CI 与 auto-merge
+        # （GITHUB_TOKEN 不触发后续 workflow runs，曾致基线 PR 反复卡人工批准）。
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          token: ${{ secrets.OBSERVE_PAT }}
+          branch: ci/incremental-baseline
+          base: main
+          title: 'chore(ci): update incremental mutation baseline（增量快照）'
+          body: |
+            增量变异产出的 Stryker incremental 基线快照（#433 调度重设计；增量班基于
+            全量班基线跑增量变异后收集）。
+
+            变更内容：`scripts/gate/baseline/` 下的 incremental 基线文件与
+            manifest.json（仅当基线内容有实质变化时本 PR 才会被创建）。
+
+            无代码逻辑变更；合并后 PR 的 mutation-gate 将直接读取本目录基线
+            走增量变异（跳过未变 mutant），替代失效的 actions/cache 跨 ref 通道。
+          commit-message: 'chore(ci): update incremental mutation baseline（增量快照）'
+          labels: 'ci'
+          delete-branch: true
+          signoff: false
+
+      - name: Auto-merge baseline PR（若被创建）
+        # create-pull-request 只建 PR 不合并；此处用 gh 开启 auto-merge。
+        # 竞态处理：create-pull-request 刚创建 PR 后，GitHub API 可能有传播延迟，
+        # 单次 gh pr list 可能查不到 → 用循环重试（最多 60s）规避。
+        # 注意：auto-merge 需要分支保护规则允许该 bot PR 自动合并（CI 全绿 + 无
+        # review 要求，或配置 auto-merge 通过条件）。若保护规则要求 review，本步骤
+        # 会失败并在日志提示，不影响增量变异其余流程。
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.OBSERVE_PAT }}
+        run: |
+          PR=""
+          for i in $(seq 1 12); do
+            PR=$(gh pr list --repo "$GITHUB_REPOSITORY" --head ci/incremental-baseline --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)
+            if [ -n "$PR" ]; then
+              echo "PR #$PR 已可见（第 ${i} 次轮询）"
+              break
+            fi
+            echo "等待 PR 可见性传播（第 ${i} 次，5s）…"
+            sleep 5
+          done
+          if [ -n "$PR" ]; then
+            echo "开启 auto-merge：PR #$PR"
+            gh pr merge "$PR" --repo "$GITHUB_REPOSITORY" --auto --squash || \
+              echo "::warning::auto-merge 开启失败（可能受分支保护 review 规则限制）——需人工合入 PR #$PR"
+          else
+            echo "无基线变更 PR（基线内容未变化或创建失败），跳过 auto-merge"
+          fi
+
+      - name: Upload artifacts（mutation 报告留档）
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: observe-incremental-reports
+          path: |
+            coverage/mutation/
+          retention-days: 14
+          if-no-files-found: error   # 报告缺失本身即异常（fail-closed，评审 F4 旁证）

--- a/.github/workflows/observe.yml
+++ b/.github/workflows/observe.yml
@@ -2,9 +2,12 @@ name: Observe (nightly)
 
 # #85 v3 F1/F6 定案：观察期采集与变异门禁的夜间调度。
 # - cov / self-cov --check（阈值硬校验）/ crap 明细
-# - 六包全量变异（串行）+ mutate 面守卫（F5）
+# - 全量变异（串行）
 # - 报告落 issue（幂等：同日不重开）；回落 >1pp 自动追评（隔夜必有工单）
 # 变异硬门禁在本 workflow 生效：任一包 covered < threshold 且 strict 开启 → 运行失败。
+# #276 方案 A + #433 调度重设计：本 workflow 为每日全量班（北京次日 04:00 = UTC 20:00，
+# cron '0 20 * * *'）——全量变异 + 基线快照 PR（日期闸每日最多一次）；每日四班次
+# 增量变异见 observe-incremental.yml（北京 12/16/20/24，有变化即 PR，无日期闸）。
 # #178 v2 增量链路（#204 修订：缓存 → 仓库内版本化基线）：
 # - 本 workflow 刻意不做 actions/cache restore —— 无增量基线即天然全量，无需 --force；
 #   请勿"好心"补 restore 步骤（会破坏全量基线语义）。
@@ -16,9 +19,9 @@ name: Observe (nightly)
 
 on:
   schedule:
-    # 每日四班次全量变异与基线刷新（#276 方案 A 调度重设计）：北京 09:00/12:00/16:00/20:00
-    # = UTC 01:00/04:00/08:00/12:00，均避开整点 Actions 高峰
-    - cron: '0 1,4,8,12 * * *'
+    # 每日全量变异与基线刷新（#276 方案 A + #433 调度重设计）：北京次日 04:00
+    # = UTC 20:00，避开整点 Actions 高峰；增量班见 observe-incremental.yml
+    - cron: '0 20 * * *'
   workflow_dispatch:
 
 permissions:
@@ -27,7 +30,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  # #276 方案 A：四班次定时全量（无 push 触发），schedule 间无冲突可并行
+  # #276 方案 A + #433 调度重设计：全量班每日定时一次（无 push 触发），
+  # 与 observe-incremental.yml 增量班并发组独立，schedule 间无冲突可并行
   group: observe-${{ github.event_name }}
   cancel-in-progress: false
 
@@ -70,13 +74,13 @@ jobs:
         run: pnpm crap
         continue-on-error: true   # 观察期：基线校准归 #42 二期
 
-      - name: Resolve mutation suites（#276 方案 A：四班次全量）
+      - name: Resolve mutation suites（#276 方案 A + #433 全量班：每日一次全量）
         id: suite-plan
         run: |
           set -e
-          # 全量清单（glob conf 目录为单一事实源）——四班次定时全量变异，
-          # 无 push 裁剪分支（#220 按需基线的 push 触发已随 #276 方案 A 调度
-          # 重设计移除，见本文件 on: 节）
+          # 全量清单（glob conf 目录为单一事实源）——全量班即全量变异，无 push
+          # 裁剪分支（#220 按需基线的 push 触发已随 #276 方案 A 调度重设计移除，
+          # #433 起本 workflow 收敛为每日全量班，见本文件 on: 节）
           ls stryker.conf.d/dsh-*.json > /tmp/suites.txt
           echo "mode=full" >> "$GITHUB_OUTPUT"
           echo "has_suites=true" >> "$GITHUB_OUTPUT"
@@ -119,8 +123,8 @@ jobs:
         if: always() && steps.mutation-suites.outcome != 'skipped' && steps.suite-plan.outputs.has_suites == 'true'
         run: node scripts/gate/collect-incremental-baseline.mjs
 
-      - name: Baseline PR date gate（快照每日最多一次，防 git 膨胀 #276 方案 A）
-        # 四班次全量变异照常执行、基线文件照常 collect；但「基线快照 PR 合入 main」
+      - name: Baseline PR date gate（全量班快照 PR 每自然日最多一次，防 git 膨胀 #276 方案 A）
+        # 全量班每日一次变异照常执行、基线文件照常 collect；但「基线快照 PR 合入 main」
         # 限制为每自然日最多一次：检查 main 上基线的实质变更记录（manifest.json）
         # 最近一次提交是否今天（UTC）。今日已有快照 → 标记 skip_pr，
         # Open baseline PR 步骤跳过。变异执行不受本闸限制。
@@ -141,7 +145,7 @@ jobs:
             echo "skip_pr=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Open baseline PR（基线有变化时自动建 PR 合入 main；受每日日期闸约束）
+      - name: Open baseline PR（基线有变化时自动建 PR 合入 main；受全量班每日日期闸约束）
         # create-pull-request 只在有 diff 时创建 PR（无变化 = no-op，不产生噪音提交）。
         # 受保护分支禁止 workflow 直接 push main → 走 PR + auto-merge 路径。
         # PR 由 bot 身份创建，auto-merge 需在 PR 创建后由后续步骤开启（该 action 本身

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -47,12 +47,18 @@ testFiles、阈值口径与 `gauntlet.config.json` 三方一致，由 workflow-a
 **全量分工总述**：PR 门管变更切片；夜间 observe 门管主干全量；发版前
 release.yml tag 管线跑全量门禁——全量只在这三处语义中的后两处真实执行。
 
-- **夜间全量落基线**（observe.yml）：刻意不 restore 任何缓存——无 incremental
-  基线即天然全量；运行末尾把六份 `coverage/mutation/incremental-*.json` 收集到
+- **observe 调度（#433）**：每日全量班（observe.yml，北京次日 04:00 = UTC
+  20:00，cron `0 20 * * *`）刷新基线——刻意不 restore 任何缓存——无 incremental
+  基线即天然全量；运行末尾把全部 `coverage/mutation/incremental-*.json` 收集到
   仓库内版本化目录 `scripts/gate/baseline/`（#204 方案 A：git 跨 ref 天然可见，
-  替代按 ref 隔离、PR 永远 miss 的 actions/cache），有实质变化时经
-  create-pull-request 自动开 PR 合入 main。逐包容错记账：单包失败记账继续
-  跑完其余包，结尾统一非零退出。
+  替代按 ref 隔离、PR 永远 miss 的 actions/cache），有实质变化且当日尚无快照时
+  经 create-pull-request 自动开 PR 合入 main（快照 PR 每自然日最多一次日期闸防
+  git 膨胀）。逐包容错记账：单包失败记账继续跑完其余包，结尾统一非零退出。
+  每日四班次增量班（observe-incremental.yml，北京 12/16/20/24 = UTC 04/08/12/16，
+  cron `0 4,8,12,16 * * *`）：restore 仓库基线 → 增量变异（快，跳过未变
+  mutant）→ 基线有实质变化即 create-pull-request + auto-merge（无日期闸，每次
+  独立判断「有变化即 PR」；create-pull-request 无 diff 时自然 no-op）；增量班
+  不跑 cov/self-cov/crap 等报告，职责收敛为「变异 + 基线 PR」。
 - **PR 增量门禁**（ci.yml，#217 变异/覆盖解耦为三段式）：
   1. `coverage` job（全局单次）：单进程跑 `pnpm cov` + `self-cov.mjs`，产物
      `coverage/self-coverage.json` 经 artifact 下发——cov 从变异矩阵剥离后，

--- a/scripts/gate/baseline/README.md
+++ b/scripts/gate/baseline/README.md
@@ -1,8 +1,10 @@
-# Incremental mutation baseline（#204 · #276 方案 A）
+# Incremental mutation baseline（#204 · #276 方案 A · #433 调度重设计）
 
-本目录存放定时全量变异产出的 Stryker incremental 基线（每段一个 JSON，含 mutant
-指纹与覆盖信息），由 `.github/workflows/observe.yml` 每日四班次（北京 09/12/16/20）
-更新、经 `create-pull-request` 自动合入 main（快照 PR 每日最多一次，日期闸）。
+本目录存放定时变异产出的 Stryker incremental 基线（每段一个 JSON，含 mutant
+指纹与覆盖信息），由 `.github/workflows/observe.yml` 每日全量班（北京次日 04:00
+= UTC 20:00）与 `.github/workflows/observe-incremental.yml` 增量班（北京
+12/16/20/24）更新、经 `create-pull-request` 自动合入 main（全量班快照 PR 每
+自然日最多一次日期闸；增量班无日期闸、基线有实质变化即 PR）。
 
 PR 的 `mutation-gate`（ci.yml）直接从本目录读取对应段基线文件，复制到
 `coverage/mutation/` 供 Stryker 增量模式跳过未变 mutant——替代失效的

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -10,8 +10,10 @@
  *   - fail-closed 双闸：filter 失败 fallback 全量切片
  *   - build-test 矩阵恒全集构建（repo-gate 全局门禁依赖全量 lib 产物，评审 F1）
  *   - action 一律 pin commit SHA（供应链纪律，与 health-report.yml 既有惯例一致）
- *   - observe.yml：四班次调度、self-cov --check 执行点在位；
- *     六包串行清单 ↔ stryker.conf.d 文件集 ↔ gauntlet mutation.packages 三方一致
+ *   - observe.yml：全量班调度（北京次日 04:00）、self-cov --check 执行点在位；
+ *     全量清单 ↔ stryker.conf.d 文件集 ↔ gauntlet mutation.packages 三方一致
+ *   - observe-incremental.yml：增量班调度（北京 12/16/20/24）、无日期闸、
+ *     有变化即 PR、不跑覆盖校验
  *   - changes 的 case 映射覆盖全部包（防新增包静默漏检，评审 F7）
  *   - #187 触发面收敛：mutation-gate 仅限 pull_request；repo-gate 判定走
  *     scripts/gate/repo-gate-assert.mjs 并以判定表全组合单测锁死
@@ -31,6 +33,7 @@ import { spawnSync } from 'node:child_process'
 const ROOT = join(import.meta.dirname, '../..')
 const CI = readFileSync(join(ROOT, '.github/workflows/ci.yml'), 'utf8')
 const OBSERVE = readFileSync(join(ROOT, '.github/workflows/observe.yml'), 'utf8')
+const OBSERVE_INC = readFileSync(join(ROOT, '.github/workflows/observe-incremental.yml'), 'utf8')
 const GAUNTLET = JSON.parse(readFileSync(join(ROOT, 'scripts/data/gauntlet.config.json'), 'utf8'))
 const MANIFEST = JSON.parse(readFileSync(join(ROOT, 'scripts/data/plugins-manifest.json'), 'utf8'))
 
@@ -132,8 +135,8 @@ test('ci.yml: changes case 映射覆盖全部包（防新增包静默漏检，�
   assert.deepEqual(loopList, [...SLICE_PACKAGES].sort(), 'for 循环清单与切片包集不一致')
 })
 
-test('ci.yml/observe.yml: 第三方与官方 action 一律 pin commit SHA', () => {
-  for (const [name, text] of [['ci.yml', CI], ['observe.yml', OBSERVE]]) {
+test('ci.yml/observe*.yml: 第三方与官方 action 一律 pin commit SHA', () => {
+  for (const [name, text] of [['ci.yml', CI], ['observe.yml', OBSERVE], ['observe-incremental.yml', OBSERVE_INC]]) {
     // 逐行解析 uses: 值（避免贪婪 \S+ 吞掉 @ref，评审 F9）
     const lines = text.split('\n').filter((l) => l.trim().startsWith('uses:'))
     assert.ok(lines.length > 0, `${name} 存在 uses 步骤`)
@@ -193,30 +196,46 @@ test('#322: 每个带 stryker 配置的包在 path-filter 均有段配置通配�
   }
 })
 
-test('#276 方案 A: observe 四班次全量——定时触发、无 push 裁剪、快照 PR 日期闸', () => {
-  assert.ok(OBSERVE.includes("'0 1,4,8,12 * * *'"),
-    '每日四班次（UTC 01/04/08/12 = 北京 09/12/16/20）全量变异')
-  assert.ok(OBSERVE.includes('Resolve mutation suites'), 'suite-plan 步骤在位')
+test('#433 调度重设计: observe 全量班（北京次日 04:00）+ 增量班四班次（有变化即 PR）', () => {
+  // ── 全量班（observe.yml）：每日一次，北京次日 04:00 = UTC 20:00 ──
+  assert.ok(OBSERVE.includes("'0 20 * * *'"),
+    '全量班 cron 必须为每日一次 UTC 20:00（北京次日 04:00）')
+  assert.ok(OBSERVE.includes('Resolve mutation suites'), '全量班 suite-plan 步骤在位')
   assert.ok(OBSERVE.includes('ls stryker.conf.d/dsh-*.json > /tmp/suites.txt'),
-    'suite-plan 必须纯全量（glob conf 目录为单一事实源，无 push 裁剪分支）')
+    '全量班 suite-plan 必须纯全量（glob conf 目录为单一事实源，无 push 裁剪分支）')
   assert.ok(!OBSERVE.includes('EVENT_NAME'), 'observe 不得再依赖 push/事件类型（#276 方案 A 已移除 push 触发）')
   assert.ok(OBSERVE.includes('steps.suite-plan.outputs.has_suites == \'true\''),
-    '变异执行与 collect 必须以 has_suites 为前提——空计划不跑 collect 防 copied=0 误红')
-  assert.ok(OBSERVE.includes('skip_pr=true'), '快照 PR 日期闸（每日最多一次）在位')
+    '全量班变异执行与 collect 必须以 has_suites 为前提——空计划不跑 collect 防 copied=0 误红')
+  assert.ok(OBSERVE.includes('skip_pr=true'), '全量班快照 PR 日期闸（每自然日最多一次）在位')
   assert.ok(OBSERVE.includes("steps.pr-gate.outputs.skip_pr == 'false'"),
-    'Open baseline PR 必须以日期闸放行为前提')
+    '全量班 Open baseline PR 必须以日期闸放行为前提')
   assert.ok(OBSERVE.includes('scripts/gate/baseline/manifest.json'),
-    '日期闸须只匹配 manifest.json（基线实质变更记录）——避免 README 等静态文件重置闸')
-  assert.ok(OBSERVE.includes('--format=%ct'), '日期闸须用 committer Unix 时间戳 + date -u 转 UTC（杜绝时区混用跨日误判）')
+    '全量班日期闸须只匹配 manifest.json（基线实质变更记录）——避免 README 等静态文件重置闸')
+  assert.ok(OBSERVE.includes('--format=%ct'), '全量班日期闸须用 committer Unix 时间戳 + date -u 转 UTC（杜绝时区混用跨日误判）')
+
+  // ── 增量班（observe-incremental.yml）：每日四班次，北京 12/16/20/24 = UTC 04/08/12/16 ──
+  assert.ok(OBSERVE_INC.includes("'0 4,8,12,16 * * *'"),
+    '增量班 cron 必须为每日四班次（UTC 04/08/12/16 = 北京 12/16/20/次日 0 点）')
+  assert.ok(OBSERVE_INC.includes('workflow_dispatch'), '增量班支持手动 dispatch')
+  assert.ok(OBSERVE_INC.includes('Resolve mutation suites'), '增量班 suite-plan 步骤在位')
+  assert.ok(OBSERVE_INC.includes('collect-incremental-baseline.mjs'), '增量班收集脚本执行点在位')
+  assert.ok(OBSERVE_INC.includes('create-pull-request@'), '增量班基线经 create-pull-request 自动开 PR')
+  assert.ok(OBSERVE_INC.includes('gh pr merge'), '增量班 auto-merge 步骤在位')
+  assert.ok(!OBSERVE_INC.includes('skip_pr=true'), '增量班不得有日期闸——每次独立判断、有变化即 PR')
+  assert.ok(!OBSERVE_INC.includes('self-cov.mjs --check'), '增量班不跑覆盖校验（职责收敛到全量班）')
 })
 
 test('#220 段式三方一致：observe 计划 ↔ stryker.conf.d 文件集 ↔ gauntlet 包集', () => {
-  // observe.yml 循环清单由 suite-plan 步骤产出（#276 方案 A：四班次纯全量）；
+  // observe 两班（全量班 observe.yml + 增量班 observe-incremental.yml）循环清单
+  // 均由各自 suite-plan 步骤产出（#433：全量班即全量、增量班基于基线跑增量但
+  // 清单同样 glob 全量——新增配置自动纳入，Stryker 增量模式跳过未变 mutant）；
   // 循环本身从计划文件读取
-  assert.ok(OBSERVE.includes('ls stryker.conf.d/dsh-*.json'),
-    'observe suite-plan 的全量清单必须以 glob stryker.conf.d/dsh-*.json 为单一事实源（新增配置自动纳入）')
-  assert.ok(OBSERVE.includes('while read -r conf; do'),
-    '变异循环必须从 suite-plan 清单文件逐行消费')
+  for (const [name, wf] of [['observe.yml', OBSERVE], ['observe-incremental.yml', OBSERVE_INC]]) {
+    assert.ok(wf.includes('ls stryker.conf.d/dsh-*.json'),
+      `${name} suite-plan 的全量清单必须以 glob stryker.conf.d/dsh-*.json 为单一事实源（新增配置自动纳入）`)
+    assert.ok(wf.includes('while read -r conf; do'),
+      `${name} 变异循环必须从 suite-plan 清单文件逐行消费`)
+  }
 
   // stryker.conf.d 实际文件集 → 基础包名集合（段配置 <pkg>-<后缀>.json 与包级
   // <pkg>.json 统一归并到 <pkg>——功能段名/数字段名兼容，basePkgOfConf 共享函数）
@@ -308,28 +327,39 @@ test('gauntlet: mutation.packages 全部带 threshold 字段且 ≥60（阶段�
 // 基线改「仓库内版本化文件」——夜间 collect 到 scripts/gate/baseline/ + create-pull-request 合入 main，
 // PR 侧直接读文件（git 跨 ref 天然可见、可本地实证）。
 
-test('#178+#204: observe.yml 夜间保持全量——只收集仓库基线不读缓存', () => {
-  assert.ok(
-    !OBSERVE.includes('actions/cache/restore'),
-    'observe.yml 严禁出现 restore 缓存步骤——无基线即天然全量（v2 架构定案，勿"好心"补 restore）',
-  )
-  assert.ok(
-    !OBSERVE.includes('actions/cache/save@'),
-    'observe.yml 已改用仓库内基线（#204），不得出现 cache/save 步骤',
-  )
-  const collectIdx = OBSERVE.indexOf('Collect incremental baseline')
-  assert.ok(collectIdx > 0, 'collect 步骤在位（夜间基线 → 仓库内固定路径）')
-  const collectBlock = OBSERVE.slice(collectIdx, OBSERVE.indexOf('- name:', collectIdx + 10))
-  assert.ok(collectBlock.includes('if: always()'), 'collect 步骤必须 if: always()（部分失败夜已产出的基线照常收集）')
-  assert.ok(collectBlock.includes('collect-incremental-baseline.mjs'), 'collect 脚本执行点在位')
-  assert.ok(OBSERVE.includes('create-pull-request@'), '基线经 create-pull-request 自动开 PR 合入 main（受保护分支禁直接 push）')
-  assert.ok(OBSERVE.includes('peter-evans/create-pull-request'), '使用业界标准 peter-evans/create-pull-request')
-  assert.ok(OBSERVE.includes('contents: write'), 'observe.yml permissions 需 contents: write（自动 PR 创建需要）')
-  assert.ok(OBSERVE.includes('pull-requests: write'), 'observe.yml permissions 需 pull-requests: write')
+test('#178+#204: observe 两班均只读仓库基线不读缓存——全量班不 restore、增量班 restore 仓库文件', () => {
+  for (const [name, wf] of [['observe.yml', OBSERVE], ['observe-incremental.yml', OBSERVE_INC]]) {
+    assert.ok(
+      !wf.includes('actions/cache/restore'),
+      `${name} 严禁出现 restore 缓存步骤——基线走仓库内文件（#204 架构定案，勿"好心"补 actions/cache restore）`,
+    )
+    assert.ok(
+      !wf.includes('actions/cache/save@'),
+      `${name} 已改用仓库内基线（#204），不得出现 cache/save 步骤`,
+    )
+    const collectIdx = wf.indexOf('Collect incremental baseline')
+    assert.ok(collectIdx > 0, `${name} collect 步骤在位（夜间/增量基线 → 仓库内固定路径）`)
+    const collectBlock = wf.slice(collectIdx, wf.indexOf('- name:', collectIdx + 10))
+    assert.ok(collectBlock.includes('if: always()'),
+      `${name} collect 步骤必须 if: always()（部分失败班次已产出的基线照常收集）`)
+    assert.ok(collectBlock.includes('collect-incremental-baseline.mjs'), `${name} collect 脚本执行点在位`)
+    assert.ok(wf.includes('create-pull-request@'), `${name} 基线经 create-pull-request 自动开 PR 合入 main（受保护分支禁直接 push）`)
+    assert.ok(wf.includes('peter-evans/create-pull-request'), `${name} 使用业界标准 peter-evans/create-pull-request`)
+    assert.ok(wf.includes('contents: write'), `${name} permissions 需 contents: write（自动 PR 创建需要）`)
+    assert.ok(wf.includes('pull-requests: write'), `${name} permissions 需 pull-requests: write`)
+  }
+  // 增量班刻意 restore 仓库内基线（读 scripts/gate/baseline/ 到 coverage/mutation/，
+  // 同 ci.yml mutation-gate 思路）；全量班刻意不恢复任何基线——无增量基线即天然全量
+  assert.ok(OBSERVE_INC.includes('Restore repo incremental baseline'),
+    '增量班 restore 仓库基线步骤在位（#433：基于全量班基线跑增量变异）')
+  assert.ok(OBSERVE_INC.includes('scripts/gate/baseline/incremental-'),
+    '增量班 restore 必须读 scripts/gate/baseline/（仓库内版本化基线，#204 方案 A）')
+  assert.ok(OBSERVE_INC.includes('::notice::'),
+    '增量班基线缺失时须打 notice 标注全量降级（首夜属预期，防误判缺陷）')
 })
 
-test('#276 方案 A: src 级 mutate 退役产物行号机制——ci/observe 均不得再出现 sync/guard', () => {
-  for (const [name, wf] of [['ci.yml', CI], ['observe.yml', OBSERVE]]) {
+test('#276 方案 A: src 级 mutate 退役产物行号机制——ci/observe 两班均不得再出现 sync/guard', () => {
+  for (const [name, wf] of [['ci.yml', CI], ['observe.yml', OBSERVE], ['observe-incremental.yml', OBSERVE_INC]]) {
     assert.ok(!wf.includes('sync-mutate-segments.mjs'),
       `${name} 不得再调用 sync-mutate-segments.mjs（src 级 mutate 无产物行号，已退役）`)
     assert.ok(!wf.includes('mutate-scope-guard.mjs'),
@@ -769,13 +799,16 @@ test('#217: repo-gate 五维聚合 needs + 判定脚本 env 全维注入', () =>
   // 判定表实现侧同维锁定（env ↔ evaluateGate 输入一一对应）
 })
 
-test('#217: observe.yml Mutation suites id + collect 区分整套 skip 与部分失败', () => {
-  const sIdx = OBSERVE.indexOf('- name: Mutation suites')
-  assert.ok(sIdx > 0, 'Mutation suites 步骤在位')
-  const sBlock = OBSERVE.slice(sIdx, OBSERVE.indexOf('- name:', sIdx + 10))
-  assert.ok(sBlock.includes('id: mutation-suites'), 'Mutation suites 必须声明 id 供下游引用 outcome')
-  const cIdx = OBSERVE.indexOf('- name: Collect incremental baseline')
-  const cBlock = OBSERVE.slice(cIdx, OBSERVE.indexOf('- name:', cIdx + 10))
-  assert.ok(cBlock.includes("if: always() && steps.mutation-suites.outcome != 'skipped'"),
-    'collect 条件必须区分整套 skip（无产物不收集）与部分失败（记账夜照常收集）')
+test('#217: observe 两班 Mutation suites id + collect 区分整套 skip 与部分失败', () => {
+  for (const [name, wf] of [['observe.yml', OBSERVE], ['observe-incremental.yml', OBSERVE_INC]]) {
+    const sIdx = wf.indexOf('- name: Mutation suites')
+    assert.ok(sIdx > 0, `${name} Mutation suites 步骤在位`)
+    const sBlock = wf.slice(sIdx, wf.indexOf('- name:', sIdx + 10))
+    assert.ok(sBlock.includes('id: mutation-suites'), `${name} Mutation suites 必须声明 id 供下游引用 outcome`)
+    const cIdx = wf.indexOf('- name: Collect incremental baseline')
+    assert.ok(cIdx > 0, `${name} Collect incremental baseline 步骤在位`)
+    const cBlock = wf.slice(cIdx, wf.indexOf('- name:', cIdx + 10))
+    assert.ok(cBlock.includes("if: always() && steps.mutation-suites.outcome != 'skipped'"),
+      `${name} collect 条件必须区分整套 skip（无产物不收集）与部分失败（记账班次照常收集）`)
+  }
 })


### PR DESCRIPTION
Fixes #433

## 改动文件

- `.github/workflows/observe.yml`（改）：cron `0 1,4,8,12 * * *` → `0 20 * * *`，头注释/suite-plan/日期闸注释同步「全量班」语义
- `.github/workflows/observe-incremental.yml`（新）：增量四班次 workflow
- `scripts/test/workflow-assert.test.ts`（改 + 新增）：#433 断言重写、新 workflow 纳入 pin-SHA/防缓存/collect 等遍历清单
- `docs/DEVELOPMENT.md`（改）：L46-54 段调度描述同步
- `scripts/gate/baseline/README.md`（改）：调度来源描述同步（全量班 + 增量班双来源）

## 验收断言表（对照 issue #433 验收清单 1-7）

| # | 验收条目 | 结论 | 证据（文件:行号） |
|---|----------|------|-------------------|
| 1 | observe.yml：cron `0 20 * * *`（北京次日04:00），保留 cov/self-cov --check/crap/全量变异/基线收集/基线 PR（含日期闸） | ✅ | `observe.yml:24` cron `'0 20 * * *'`；`observe.yml:64-75` cov/crap 保留；`observe.yml:71` `self-cov.mjs --check`；`observe.yml:77-86` suite-plan 全量 glob `ls stryker.conf.d/dsh-*.json`；`observe.yml:124` collect；`observe.yml:126-146` 日期闸 `skip_pr=true` + manifest.json + `--format=%ct`；`observe.yml:157-171` create-pull-request + OBSERVE_PAT |
| 2 | observe-incremental.yml：cron `0 4,8,12,16 * * *`（北京12/16/20/24），restore 基线 → 增量变异 → 有实质变化即 create-pull-request + auto-merge，无日期闸 | ✅ | `observe-incremental.yml:20` cron `'0 4,8,12,16 * * *'`；`:66-82` Restore repo incremental baseline（读 `scripts/gate/baseline/incremental-*.json`，缺失打 `::notice::` 降级全量）；`:84-120` suite-plan 全量 glob + Mutation suites 串行循环；`:125` collect；`:133-147` create-pull-request（title「增量快照」，无 skip_pr 日期闸——无 diff 时 action 自身 no-op，天然「有变化即 PR」）；`:162-176` auto-merge（gh pr merge --auto --squash，OBSERVE_PAT，≤60s 轮询） |
| 3 | 增量班从 origin/main fetch 并 diff 仅跑命中包；diff 不可得 fail-closed 全量 | ✅（实现路径按任务书选型：全量 glob + Stryker 增量模式，与 diff 裁剪等效且更稳） | 任务书明确步骤 7「全量 glob `ls stryker.conf.d/dsh-*.json`（增量模式 stryker 会跳过未变 mutant，快）」——`observe-incremental.yml:84-87`；Checkout `fetch-depth: 0`（`observe-incremental.yml:51-56`）保证仓库基线与历史完整；增量模式按已恢复基线跳过未变 mutant，实际变异面=自上次全量后变化代码（与「仅跑命中包」目的等效）；schedule 事件无 before 的 diff 不可得场景被 glob 方案天然规避（无 push 时仍全量兜底）。若 qa 要求字面 diff 裁剪，可后续在 suite-plan 步骤补 origin/main 对比 |
| 4 | workflow-assert 按新调度重写；新 workflow 满足 pin-SHA 与 fail-closed 约束 | ✅ | `workflow-assert.test.ts:36` 新增 `OBSERVE_INC` 常量；`:138` pin-SHA 遍历 `[ci.yml, observe.yml, observe-incremental.yml]`（新 workflow 全部 uses 均 40 位 SHA）；`:199-224` #433 测试重写（OBSERVE cron/日期闸/EVENT_NAME 保留 + OBSERVE_INC cron/无 skip_pr/无 self-cov）；`:228-251` #220 三方一致扩展两文件；`:330-359` #178+#204 actions/cache 禁令与 collect/PR/权限断言覆盖两文件；`:361-385` 退役脚本禁令覆盖两文件；`:802-813` #217 mutation id + collect 条件覆盖两文件 |
| 5 | docs/DEVELOPMENT.md L46-54 调度描述同步；observe 头注释同步 | ✅ | `docs/DEVELOPMENT.md:50-62`「observe 调度（#433）」段（全量班 cron `0 20` + 增量班四班次 cron `0 4,8,12,16`，日期闸/无日期闸语义）；`observe.yml:3-10` 头注释（去掉「六包串行」「F5」过时字样，标 #276 方案 A + #433 调度重设计）；`scripts/gate/baseline/README.md:1-10` 双来源同步 |
| 6 | 五连门禁全绿 + test:scripts 全绿 | ✅ | 本地实测：build ✅ / test（smoke）✅ / contract ✅ / pack:check ✅ / typecheck ✅ / `pnpm test:scripts` 56/56 pass（与基线 56 持平，无新增用例数漂移）。详见门禁摘要 |
| 7 | 提交规范：`ci(observe): 调度重设计——全量北京4点 + 增量四班次（有变化即 PR）（#433）`，禁 emoji | ✅ | commit `c87a4ab`，标题全等，无 emoji，单 commit |

## 测试服从实现说明

- 验收 3 的「从 origin/main fetch 并 diff 仅跑命中包」与主控任务书「全量 glob + 增量模式」存在实现路径差异：按任务书步骤 7 明确选型执行（任务书优先于 issue 评论描述），断言表如实标注，供 qa 复核。
- workflow-assert 中原 #220 断言「observe suite-plan 全量清单 glob」对 OBSERVE 保留并同步扩展至 OBSERVE_INC（两班同一单一事实源）；#178+#204 原「observe.yml 不 restore 缓存」断言扩展为「两班均无 actions/cache」，增量班 restore 的是仓库内文件而非缓存。
- 增量班职责收敛：不跑 cov/self-cov/crap/observe-check（`observe-incremental.yml` 全文件无 `self-cov.mjs` / `observe-check.mjs`；#433 测试 `!OBSERVE_INC.includes('self-cov.mjs --check')` 断言 `workflow-assert.test.ts:221`）。

## 门禁摘要（本地 worktree 实测）

| 门禁 | 结果 |
|------|------|
| pnpm install --frozen-lockfile | ✅ Done in 1.6s |
| pnpm build | ✅ 全包构建完成（exit 0） |
| pnpm test | ✅ smoke 全过（exit 0） |
| pnpm contract | ✅ 客户端契约全部通过 |
| pnpm pack:check | ✅ 全部 tarball 完整 |
| pnpm typecheck | ✅ 全部 Done |
| pnpm test:scripts | ✅ 56/56 pass（workflow-assert 全部新断言绿） |

## 提交前自查

- `git status` 无 `packages/*/undefined`、`*.jsonl` 污染 ✅
