### PR TITLE
ci(release): 发布管线 action pin commit SHA + workflow-assert 覆盖 release/health（#435）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,16 +25,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
         # 版本以根 package.json 的 packageManager 字段为单一事实源（勿同时指定 version）
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
           cache: pnpm
@@ -83,12 +83,12 @@ jobs:
 
       - name: Create GitHub Release (curated notes)
         if: ${{ steps.notes.outputs.path != '' }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           body_path: ${{ steps.notes.outputs.path }}
 
       - name: Create GitHub Release (fallback auto-notes)
         if: ${{ steps.notes.outputs.path == '' }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -5,11 +5,12 @@
 /**
  * workflow-assert — CI workflow 结构静态断言（#85 v3 F2 防回归条款）。
  *
- * 断言 ci.yml / observe.yml 的关键结构不变量：
+ * 断言 ci.yml / observe*.yml / release.yml / health-report.yml 的关键结构不变量：
  *   - repo-gate 聚合闸：if always()、fail-closed 断言步骤、required check 名不变
  *   - fail-closed 双闸：filter 失败 fallback 全量切片
  *   - build-test 矩阵恒全集构建（repo-gate 全局门禁依赖全量 lib 产物，评审 F1）
- *   - action 一律 pin commit SHA（供应链纪律，与 health-report.yml 既有惯例一致）
+ *   - action 一律 pin commit SHA（供应链纪律，release.yml 为最高风险面——持有
+ *     NPM_TOKEN + contents: write，必须纳入断言盲区外全覆盖；health-report.yml 同防回归）
  *   - observe.yml：全量班调度（北京次日 04:00）、self-cov --check 执行点在位；
  *     全量清单 ↔ stryker.conf.d 文件集 ↔ gauntlet mutation.packages 三方一致
  *   - observe-incremental.yml：增量班调度（北京 12/16/20/24）、无日期闸、
@@ -34,6 +35,8 @@ const ROOT = join(import.meta.dirname, '../..')
 const CI = readFileSync(join(ROOT, '.github/workflows/ci.yml'), 'utf8')
 const OBSERVE = readFileSync(join(ROOT, '.github/workflows/observe.yml'), 'utf8')
 const OBSERVE_INC = readFileSync(join(ROOT, '.github/workflows/observe-incremental.yml'), 'utf8')
+const RELEASE = readFileSync(join(ROOT, '.github/workflows/release.yml'), 'utf8')
+const HEALTH = readFileSync(join(ROOT, '.github/workflows/health-report.yml'), 'utf8')
 const GAUNTLET = JSON.parse(readFileSync(join(ROOT, 'scripts/data/gauntlet.config.json'), 'utf8'))
 const MANIFEST = JSON.parse(readFileSync(join(ROOT, 'scripts/data/plugins-manifest.json'), 'utf8'))
 
@@ -135,8 +138,11 @@ test('ci.yml: changes case 映射覆盖全部包（防新增包静默漏检，�
   assert.deepEqual(loopList, [...SLICE_PACKAGES].sort(), 'for 循环清单与切片包集不一致')
 })
 
-test('ci.yml/observe*.yml: 第三方与官方 action 一律 pin commit SHA', () => {
-  for (const [name, text] of [['ci.yml', CI], ['observe.yml', OBSERVE], ['observe-incremental.yml', OBSERVE_INC]]) {
+test('ci.yml/observe*/release/health-report.yml: 第三方与官方 action 一律 pin commit SHA', () => {
+  for (const [name, text] of [
+    ['ci.yml', CI], ['observe.yml', OBSERVE], ['observe-incremental.yml', OBSERVE_INC],
+    ['release.yml', RELEASE], ['health-report.yml', HEALTH],
+  ]) {
     // 逐行解析 uses: 值（避免贪婪 \S+ 吞掉 @ref，评审 F9）
     const lines = text.split('\n').filter((l) => l.trim().startsWith('uses:'))
     assert.ok(lines.length > 0, `${name} 存在 uses 步骤`)


### PR DESCRIPTION
Fixes #435

## 断言表（对照验收标准逐条）

| # | 验收断言 | 结论 | 证据 |
|---|---|---|---|
| 1 | release.yml 5 处 uses 全部 40 位 SHA pin | ✅ | `grep -cE "uses: [a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+@[0-9a-f]{40}" .github/workflows/release.yml` = 5；`grep -n uses:` 见 L28 checkout / L33 pnpm / L37 setup-node / L86+L92 softprops |
| 2 | workflow-assert pin-SHA 测试遍历 5 个 workflow | ✅ | 遍历清单 `[["ci.yml", CI], ["observe.yml", OBSERVE], ["observe-incremental.yml", OBSERVE_INC], ["release.yml", RELEASE], ["health-report.yml", HEALTH]]`；新增 `RELEASE` / `HEALTH` 常量于文件顶部常量区 |
| 3 | `pnpm test:scripts` 全绿 | ✅ | 56/56 pass，fail 0 / cancelled 0 / skipped 0（基线保持） |
| 4 | release.yml 逻辑零改动 | ✅ | diff 仅 5 处 uses 行；版本校验 / 发布顺序 / release notes 双路径 / 权限 contents: write / 并发组均原样保留 |
| 5 | 其他文件零改动 | ✅ | `git diff --stat` 仅 release.yml + workflow-assert.test.ts 两文件；提交前 git status 无 `packages/*/undefined`、`*.jsonl` 污染 |

## 门禁结果

| 命令 | 结果 |
|---|---|
| `pnpm install --frozen-lockfile` | exit 0 |
| `pnpm build` | exit 0 |
| `pnpm test` | exit 0 |
| `pnpm contract` | exit 0 |
| `pnpm pack:check` | exit 0 |
| `pnpm typecheck` | exit 0 |
| `pnpm test:scripts` | 56/56 pass |

## softprops pin SHA 取值来源

- 仓库历史 `git log --all -S softprops`：两处引入（d6b4fd2 / 1b88720）均为 `@v2` 浮动引用，无历史 pin SHA 可沿用；
- `gh api repos/softprops/action-gh-release/git/ref/tags/v2` → `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65`（与 v2.6.2 tag 同 commit），保持 `@v2` 版本语义不变；
- 注：`repos/softprops/action-gh-release/tags/v2` 端点 404（该 tag 不在 tags 列表 API 的可见排序中），改走 `git/ref/tags/v2` 权威解析成功。