### PR TITLE
refactor(meta): settings 命名空间接线收敛——shared 增 onScope，notifier/lan-proxy 去复刻（#436）

### DIFF
--- a/packages/dsh-lan-proxy/src/settings.ts
+++ b/packages/dsh-lan-proxy/src/settings.ts
@@ -1,42 +1,25 @@
 /**
- * dsh-lan-proxy — 官方 settings 命名空间接线（#276 方案 A 阶段 3 拆出）。
+ * dsh-lan-proxy — 官方 settings 命名空间接线（薄包装，收敛自 shared）。
  *
  * 职责：插件在官方 settings 服务中的命名空间（SETTINGS_NS）、minimal 类型面
  * （OwnerScopeLike / SettingsServiceLike / LanProxySettingsHooks）与挂载函数
- * installLanProxySettings。非导出辅助 isUnloading / warnLog 亦归此模块
- * （apply.ts 经 module 导出复用 warnLog，不重复实现）。
+ * installLanProxySettings。issue #436 起不再包内复刻接线——实现统一转发
+ * shared/installSettingsNamespace（单一事实源），hooks 依次透传 onScope /
+ * setSource / onChange；onScope 供存量配置迁移写入。
+ *
+ * 为什么不用官方 @deepseek-ai/dsh-settings 包：插件运行时沿自身 lib/ 向上
+ * 解析不到该包（MODULE_NOT_FOUND），动态 import 会静默失败——与
+ * shared/settings-namespace.js 相同的服务面注入方案。
  */
 import type { Context } from "@deepseek-ai/cordis";
-import { errorMessage } from "../../../shared/host-utils.js";
+import { installSettingsNamespace } from "../../../shared/settings-namespace.js";
 import { Config } from "./config.ts";
 import type { LanProxyConfig } from "./config.ts";
 
+export { warnLog } from "../../../shared/settings-namespace.js";
+
 /** 本插件在官方 settings 服务中的命名空间。 */
 export const SETTINGS_NS = "dsh-lan-proxy";
-
-/**
- * 是否正处于插件自身 fiber 卸载中（区别于「仅丢失 settings 服务」）。
- * 与 shared/settings-namespace.js 同款判据：fiber.state ∈ { unloading, unloaded,
- * disposed }。（包内复刻：coder 规程禁止改 shared/，而 owner scope 写能力需要
- * 拿到 register 返回值，shared 版 hooks 不外露 scope。）
- */
-function isUnloading(ctx: unknown): boolean {
-  const fiber =
-    ctx && typeof ctx === "object" && "fiber" in ctx
-      ? (ctx as { fiber?: { state?: unknown } }).fiber
-      : undefined;
-  const state = fiber && typeof fiber === "object" ? fiber.state : undefined;
-  return state === "unloading" || state === "unloaded" || state === "disposed";
-}
-
-/** 日志兜底：logger 可能确实没有（极端降级），全部可选调用。 */
-export function warnLog(ctx: unknown, message: string): void {
-  const logger =
-    ctx && typeof ctx === "object" && "logger" in ctx
-      ? (ctx as { logger?: { warn?: (...a: unknown[]) => void } }).logger
-      : undefined;
-  if (typeof logger?.warn === "function") logger.warn(message);
-}
 
 /**
  * owner scope 最小类型面（官方 SettingsScope<T> 的子集；仅 import type 无法
@@ -70,50 +53,19 @@ export interface LanProxySettingsHooks {
 }
 
 /**
- * 注册插件自有 settings 命名空间并把 owner scope 交给调用方
- * （服务面注入，零包依赖；语义等值复刻官方 installSettingsSection 与
- * shared/installSettingsNamespace——差异仅在把 register 返回的 owner scope
- * 经 onScope 外露，供存量配置迁移写入）。
- *
- * 为什么不用官方 @deepseek-ai/dsh-settings 包：插件运行时沿自身 lib/ 向上
- * 解析不到该包（MODULE_NOT_FOUND），动态 import 会静默失败——与
- * shared/settings-namespace.js 相同的服务面注入方案。
+ * 注册插件自有 settings 命名空间并把 owner scope 交给调用方。
+ * 薄包装（#436）：转发 shared/installSettingsNamespace——setSource / onChange /
+ * onScope 依次透传，降级与卸载回落语义统一由 shared 承担。对外签名与 #436 前
+ * 保持一致：ctx / entry（组合层配置，作为命名空间的 base 层）/ hooks。
  *
  * @param ctx - 插件宿主端 apply 收到的 cordis 上下文。
  * @param entry - 组合层配置，作为命名空间的 base 层。
  * @param hooks - source 收藏、变更通知与 scope 移交。
  */
 export function installLanProxySettings(ctx: Context, entry: LanProxyConfig, hooks: LanProxySettingsHooks): void {
-  type InjectFn = (services: string[], fn: (c: any) => void) => void;
-  if (typeof (ctx as unknown as { inject?: InjectFn })?.inject !== "function") {
-    warnLog(ctx, `${SETTINGS_NS}: ctx.inject 不可用 — 设置命名空间未注册，设置卡降级`);
-    return;
-  }
-  (ctx.inject as unknown as InjectFn)(["settings"], (sctx) => {
-    const settings = sctx && (sctx.settings as SettingsServiceLike | undefined);
-    if (!settings || typeof settings.register !== "function") {
-      warnLog(ctx, `${SETTINGS_NS}: settings 服务缺少 register 能力 — 设置命名空间未注册，设置卡降级`);
-      return;
-    }
-    let scope: OwnerScopeLike;
-    try {
-      scope = settings.register(SETTINGS_NS, Config, { base: entry });
-    } catch (err) {
-      warnLog(ctx, `${SETTINGS_NS}: settings.register 失败 — ${errorMessage(err)}`);
-      return;
-    }
-    hooks.onScope(scope, settings);
-    hooks.setSource(() => scope.get());
-    sctx.effect(() => () => {
-      if (isUnloading(ctx)) return;
-      hooks.setSource(() => entry);
-      hooks.onChange();
-    });
-    hooks.onChange();
-    // 热更新统一走官方 scope.watch（提交后异步串行回调）。
-    scope.watch(() => {
-      if (isUnloading(ctx)) return;
-      hooks.onChange();
-    });
+  installSettingsNamespace(ctx, SETTINGS_NS, Config, entry, {
+    setSource: hooks.setSource,
+    onChange: hooks.onChange,
+    onScope: hooks.onScope,
   });
 }

--- a/packages/dsh-mcp-manager/test/unit-shared.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-shared.test.ts
@@ -117,7 +117,9 @@ import { installSettingsNamespace } from "../../../shared/settings-namespace.js"
   assert.equal(onChangeCount, 3, "disposer 触发 onChange");
 }
 
-// ---- onScope（#436）：register 成功后、setSource 之前回调；服务缺失不触发 ----
+// ---- onScope（#436）：register 成功后、setSource 之前回调 ----
+// 说明：settings 服务缺失用例（上方 L37-50）hooks 不含 onScope，未对「缺失不
+// 触发」做独立断言——属不传 onScope 的兼容回归（既有 7 处隐式覆盖该分支）。
 
 {
   let scopeSeen = null;

--- a/packages/dsh-mcp-manager/test/unit-shared.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-shared.test.ts
@@ -117,6 +117,40 @@ import { installSettingsNamespace } from "../../../shared/settings-namespace.js"
   assert.equal(onChangeCount, 3, "disposer 触发 onChange");
 }
 
+// ---- onScope（#436）：register 成功后、setSource 之前回调；服务缺失不触发 ----
+
+{
+  let scopeSeen = null;
+  let serviceSeen = null;
+  const order = [];
+  const scope = {
+    get: () => ({ from: "scope" }),
+    watch: () => () => {},
+  };
+  const settings = { register: () => scope };
+  const ctx = {
+    logger: { warn: () => {} },
+    inject: (keys, cb) => {
+      if (Array.isArray(keys) && keys.includes("settings")) {
+        cb({ settings, effect: (fn) => { fn(); return () => {}; } });
+      }
+      return () => {};
+    },
+  };
+  installSettingsNamespace(ctx, "test-ns", {}, { from: "entry" }, {
+    setSource: () => { order.push("setSource"); },
+    onChange: () => {},
+    onScope: (s, svc) => {
+      scopeSeen = s;
+      serviceSeen = svc;
+      order.push("onScope");
+    },
+  });
+  assert.equal(scopeSeen, scope, "onScope 收到 register 返回的 owner scope");
+  assert.equal(serviceSeen, settings, "onScope 收到 settings 服务");
+  assert.deepEqual(order, ["onScope", "setSource"], "onScope 先于 setSource 回调");
+}
+
 // ---- isUnloading 短路：fiber 处于卸载态时 disposer / watch 不动作 ----
 
 for (const state of ["unloading", "unloaded", "disposed"]) {

--- a/packages/dsh-notifier/src/index.ts
+++ b/packages/dsh-notifier/src/index.ts
@@ -145,7 +145,8 @@ export function apply(ctx: Context, config: NotifierApplyConfig = {}): void {
   /**
    * 当前配置（运行时镜像，与 settings 命名空间解析值保持同步）。
    * settings attach 后由 setSource 指向 scope.get()，变更经 onChange 刷新；
-   * 服务缺失时回落组合层 entry（normalizeConfig 兜底默认值）。
+   * 服务缺失时回落组合层 entry——setSource/onChange 均经 normalizeConfig 收口，
+   * 回落形态与初始一致（同键同值、默认值兜底，与 attach 态同源）。
    */
   let current: NotifyConfig = normalizeConfig(entry);
   /** settings 读取来源 thunk（attach 后为 scope.get()）。 */
@@ -719,10 +720,14 @@ export function apply(ctx: Context, config: NotifierApplyConfig = {}): void {
   installNotifierSettings(ctx, entry, {
     setSource: (s) => {
       source = s;
-      current = s();
+      // 收口归一化（#436 复核 P1-1）：setSource 与 onChange 两处都过 normalizeConfig
+      // ——服务消失回落时 s() 为裸 entry，需默认值兜底才能与初始 current
+      // （normalizeConfig(entry)）形态一致；normalizeConfig 幂等，对 scope.get()
+      // 的官方解析结果重复归一化无害。
+      current = normalizeConfig(s());
     },
     onChange: () => {
-      current = source();
+      current = normalizeConfig(source());
     },
     onScope: (scope, service) => {
       attachedScope = scope;

--- a/packages/dsh-notifier/src/settings.ts
+++ b/packages/dsh-notifier/src/settings.ts
@@ -1,49 +1,29 @@
 /**
- * dsh-notifier — 官方 settings 命名空间接线（issue #76，包内复刻）。
+ * dsh-notifier — 官方 settings 命名空间接线（薄包装，收敛自 shared）。
  *
  * 职责：插件在官方 settings 服务中的命名空间（SETTINGS_NS）、minimal 类型面
  * （OwnerScopeLike / SettingsServiceLike / NotifierSettingsHooks）与挂载函数
- * installNotifierSettings。形态等值复刻同仓 dsh-lan-proxy 的
- * installLanProxySettings（PR #267）：服务面注入零包依赖、register 返回的
- * owner scope 经 onScope 外露供写（存量迁移）、热更新统一走 scope.watch。
+ * installNotifierSettings。issue #436 起不再包内复刻接线——实现统一转发
+ * shared/installSettingsNamespace（单一事实源），hooks 依次透传 onScope /
+ * setSource / onChange；onScope 供存量迁移与乐观并发（经 service.update）。
  *
  * 为什么不用官方 @deepseek-ai/dsh-settings 包：插件运行时沿自身 lib/ 向上
  * 解析不到该包（MODULE_NOT_FOUND），动态 import 会静默失败——与
  * shared/settings-namespace.js 相同的服务面注入方案。
- * 为什么不用 schemastery 构造 schema：notifier 无该依赖且 coder 禁改
- * package.json；官方 register 对 schema 的最小调用面是「callable（resolve
- * 时直接调用）+ toJSON（describe 序列化）+ 无 secret 的平铺形态（redact
- * walk 走 default 原样返回）」，包内以零依赖函数形态等值覆盖。
+ * 为什么不用 schemastery 构造 schema：notifier 无该依赖；官方 register 对
+ * schema 的最小调用面是「callable（resolve 时直接调用）+ toJSON（describe
+ * 序列化）+ 无 secret 的平铺形态（redact walk 走 default 原样返回）」，这里以
+ * 零依赖函数形态 createNotifierSchema 等值覆盖（与 #436 前一致）。
  */
 import type { Context } from "@deepseek-ai/cordis";
-import { errorMessage } from "../../../shared/host-utils.js";
+import { installSettingsNamespace } from "../../../shared/settings-namespace.js";
 import { normalizeConfig } from "./config.ts";
 import type { NotifyConfig } from "./config.ts";
 
+export { warnLog } from "../../../shared/settings-namespace.js";
+
 /** 本插件在官方 settings 服务中的命名空间。 */
 export const SETTINGS_NS = "dsh-notifier";
-
-/**
- * 是否正处于插件自身 fiber 卸载中（区别于「仅丢失 settings 服务」）。
- * 官方判据：fiber.state ∈ { unloading, unloaded, disposed }。
- */
-function isUnloading(ctx: unknown): boolean {
-  const fiber =
-    ctx && typeof ctx === "object" && "fiber" in ctx
-      ? (ctx as { fiber?: { state?: unknown } }).fiber
-      : undefined;
-  const state = fiber && typeof fiber === "object" ? fiber.state : undefined;
-  return state === "unloading" || state === "unloaded" || state === "disposed";
-}
-
-/** 日志兜底：logger 可能确实没有（极端降级），全部可选调用。 */
-export function warnLog(ctx: unknown, message: string): void {
-  const logger =
-    ctx && typeof ctx === "object" && "logger" in ctx
-      ? (ctx as { logger?: { warn?: (...a: unknown[]) => void } }).logger
-      : undefined;
-  if (typeof logger?.warn === "function") logger.warn(message);
-}
 
 /**
  * owner scope 最小类型面（官方 SettingsScope<T> 的子集）。注意官方 scope 的
@@ -96,45 +76,19 @@ function createNotifierSchema(): unknown {
 
 /**
  * 注册插件自有 settings 命名空间并把 owner scope 交给调用方。
- * 语义等值复刻官方 installSettingsSection / shared installSettingsNamespace，
- * 差异仅在把 register 返回的 owner scope 经 onScope 外露，供存量配置迁移写入
- * 与乐观并发（经 service.update(ns, patch, expectedRevision)）。
+ * 薄包装（#436）：转发 shared/installSettingsNamespace——setSource / onChange /
+ * onScope 依次透传，降级与卸载回落语义统一由 shared 承担。对外签名与 #436 前
+ * 保持一致：ctx / entry（组合层配置的通知字段，经 sanitizeSettings 白名单过滤
+ * 后传入，作为命名空间的 base 层；无有效键则为空 base）/ hooks。
  *
  * @param ctx - 插件宿主端 apply 收到的 cordis 上下文。
- * @param entry - 组合层配置的通知字段（经 sanitizeSettings 白名单过滤后传入，
- *   作为命名空间的 base 层；无有效键则为空 base）。
+ * @param entry - 组合层配置的通知字段（作为命名空间的 base 层）。
  * @param hooks - source 收藏、变更通知与 scope 移交。
  */
 export function installNotifierSettings(ctx: Context, entry: Record<string, unknown>, hooks: NotifierSettingsHooks): void {
-  type InjectFn = (services: string[], fn: (c: any) => void) => void;
-  if (typeof (ctx as unknown as { inject?: InjectFn })?.inject !== "function") {
-    warnLog(ctx, `${SETTINGS_NS}: ctx.inject 不可用 — 设置命名空间未注册，设置卡降级`);
-    return;
-  }
-  (ctx.inject as unknown as InjectFn)(["settings"], (sctx) => {
-    const settings = sctx && (sctx.settings as SettingsServiceLike | undefined);
-    if (!settings || typeof settings.register !== "function") {
-      warnLog(ctx, `${SETTINGS_NS}: settings 服务缺少 register 能力 — 设置命名空间未注册，设置卡降级`);
-      return;
-    }
-    let scope: OwnerScopeLike;
-    try {
-      scope = settings.register(SETTINGS_NS, createNotifierSchema(), { base: entry });
-    } catch (err) {
-      warnLog(ctx, `${SETTINGS_NS}: settings.register 失败 — ${errorMessage(err)}`);
-      return;
-    }
-    hooks.onScope(scope, settings);
-    hooks.setSource(() => scope.get());
-    sctx.effect(() => () => {
-      if (isUnloading(ctx)) return;
-      hooks.onChange();
-    });
-    hooks.onChange();
-    // 热更新统一走官方 scope.watch（提交后异步串行回调）。
-    scope.watch(() => {
-      if (isUnloading(ctx)) return;
-      hooks.onChange();
-    });
+  installSettingsNamespace(ctx, SETTINGS_NS, createNotifierSchema(), entry, {
+    setSource: hooks.setSource,
+    onChange: hooks.onChange,
+    onScope: hooks.onScope,
   });
 }

--- a/packages/dsh-notifier/test/routes.test.ts
+++ b/packages/dsh-notifier/test/routes.test.ts
@@ -743,6 +743,55 @@ try {
     assert.ok(records.length <= 200, "滚动上限 200：读取最多 200 条");
     assert.equal(records[records.length - 1].message, "m209", "保留的是最新记录");
   }
+  // P2-4（#436 复核 P1-1 同根因）：settings 服务消失 → 回落 current 与初始形态
+  // 一致（same-shape）。entry 只给 maxConnections（缺 notifySound/askRemindMin 等
+  // 默认键）：回落若不经 normalizeConfig 会退回裸 entry（notifySound=true →
+  // undefined、askRemindMin 缺失）——与初始 normalizeConfig(entry) 形态不对称。
+  // 观测面 = GET /config 的 effective（redactConfigView(resolve()) = current 全量
+  // 视图，含 askRemindMin）。捕获 shared 的回落 disposer 手动触发（模拟服务消失
+  // 但插件存活，isUnloading=false 不短路）。
+  {
+    const { apply } = await import("../lib/index.js");
+    const { makeFakeCtx, makeFakeSettings } = await import("./helpers.ts");
+    const entry = { maxConnections: 64 };
+    let fallbackDisposer = null;
+    const fakeSettings = makeFakeSettings({ base: entry });
+    const { ctx, routes } = makeFakeCtx({
+      inject(serviceNames, fn) {
+        if (Array.isArray(serviceNames) && serviceNames.includes("settings")) {
+          fn({
+            settings: fakeSettings.service,
+            effect(f2) {
+              const d = f2();
+              const disp = typeof d === "function" ? d : () => {};
+              fallbackDisposer = disp;
+              return disp;
+            },
+          });
+        }
+      },
+    });
+    apply(ctx, {
+      enabled: true,
+      maxConnections: 64,
+      configFile: join(work, "p24-cfg.json"),
+      historyFile: join(work, "p24-hist.jsonl"),
+    });
+    const cfgRoute = routes.find((r) => r.path === ROUTES.config);
+    const getEffective = async () => {
+      const { rec, res } = makeRes();
+      await cfgRoute.handler(fakeReq({}), res);
+      return JSON.parse(rec.text).effective;
+    };
+    const before = await getEffective();
+    assert.equal(before.maxConnections, 64, "attach 态 current 反映 entry 值");
+    assert.equal(before.notifySound, true, "attach 态 notifySound 默认值兜底");
+    assert.equal(before.askRemindMin, 5, "attach 态 askRemindMin 默认值兜底");
+    assert.ok(fallbackDisposer, "shared 回落 disposer 已捕获（服务消失回落路径可达）");
+    fallbackDisposer(); // 模拟 settings 服务消失（插件存活）→ 回落
+    const after = await getEffective();
+    assert.deepEqual(after, before, "回落 current 与初始形态 same-shape（同键同值、默认值兜底一致）");
+  }
 } finally {
   mainNotifier.dispose(); // 停心跳（P2-5：30s unref 定时器不在测试进程存活期残留）
   rmSync(work, { recursive: true, force: true });

--- a/shared/settings-namespace.d.ts
+++ b/shared/settings-namespace.d.ts
@@ -15,7 +15,18 @@ export interface SettingsNamespaceHooks {
   onChange(): void;
   /** 可选自定义校验，透传给 settings.register。 */
   validate?: unknown;
+  /**
+   * 可选；register 返回 owner scope 后立即回调（先于 setSource）。
+   * 供存量配置迁移 / 写路径装配使用；settings 服务缺失时不触发。
+   */
+  onScope?(scope: unknown, service: unknown): void;
 }
+
+/**
+ * 日志兜底：logger 可能确实没有（极端降级），全部可选调用。
+ * 单一事实源（#436）：notifier / lan-proxy 曾各复刻一份，现统一引用本导出。
+ */
+export declare function warnLog(ctx: unknown, message: string): void;
 
 /**
  * 注册插件自有 settings 命名空间（服务面注入，无包依赖）。

--- a/shared/settings-namespace.js
+++ b/shared/settings-namespace.js
@@ -57,9 +57,10 @@ export function warnLog(ctx, message) {
 /**
  * 安装「可选 settings 消费者的标准接线」：settings 服务存在时，把 `ns` 以组合层
  * `entry` 作为 `base` 注册进 settings 服务，并让 `hooks.setSource` 指向解析后的
- * owner scope（hooks.onScope 可选：register 成功后先交 scope）；服务消失/插件
- * 卸载时回落到 entry。注册随 scoped fiber 生效——settings 服务从未挂载则本函数
- * 什么都不做（卡片降级，功能不受影响）。
+ * owner scope（hooks.onScope 可选：register 成功后先交 scope）；仅服务消失
+ * （scoped fiber 注销而插件仍存活）时回落到 entry；插件自身卸载时不回落
+ * （disposer 短路，随 fiber 注销）。注册随 scoped fiber 生效——settings 服务
+ * 从未挂载则本函数什么都不做（卡片降级，功能不受影响）。
  *
  * 等值语义参考官方 `installSettingsSection`
  * （@deepseek-ai/dsh-settings@0.1.0-rc.7，MIT）。这里不 import 该包，纯粹以

--- a/shared/settings-namespace.js
+++ b/shared/settings-namespace.js
@@ -19,6 +19,10 @@
 //   3. `setSource` 指向 `scope.get()`；卸载/服务消失时回落到组合层 entry；
 //   4. `onChange` 在来源切换与 `scope.watch` 变化时触发。
 //
+// #436 收敛：`onScope`（可选）在 register 返回 owner scope 后立即回调（先于
+// setSource），供 notifier / lan-proxy 做存量配置迁移与写路径装配；warnLog 为
+// 单一事实源（notifier / lan-proxy 曾各复刻一份，现统一引用本导出）。
+//
 // 约定：js + d.ts 双写（tsc rootDir 硬约束）；只 import Node 内置；零运行时依赖。
 
 /**
@@ -38,9 +42,11 @@ function isUnloading(ctx) {
 
 /**
  * 日志兜底：logger 可能确实没有（极端降级），全部可选调用。
+ * 单一事实源（#436）：notifier / lan-proxy 曾各复刻一份 warnLog，现统一引用本导出。
  * @param {unknown} ctx - cordis 插件上下文。
+ * @param {string} message - 告警消息。
  */
-function warn(ctx, message) {
+export function warnLog(ctx, message) {
   const logger =
     ctx && typeof ctx === "object" && "logger" in ctx
       ? /** @type {{ warn?: (...a: unknown[]) => void }} */ (/** @type {any} */ (ctx).logger)
@@ -51,8 +57,9 @@ function warn(ctx, message) {
 /**
  * 安装「可选 settings 消费者的标准接线」：settings 服务存在时，把 `ns` 以组合层
  * `entry` 作为 `base` 注册进 settings 服务，并让 `hooks.setSource` 指向解析后的
- * owner scope；服务消失/插件卸载时回落到 entry。注册随 scoped fiber 生效——
- * settings 服务从未挂载则本函数什么都不做（卡片降级，功能不受影响）。
+ * owner scope（hooks.onScope 可选：register 成功后先交 scope）；服务消失/插件
+ * 卸载时回落到 entry。注册随 scoped fiber 生效——settings 服务从未挂载则本函数
+ * 什么都不做（卡片降级，功能不受影响）。
  *
  * 等值语义参考官方 `installSettingsSection`
  * （@deepseek-ai/dsh-settings@0.1.0-rc.7，MIT）。这里不 import 该包，纯粹以
@@ -62,24 +69,26 @@ function warn(ctx, message) {
  * @param {string} ns - 插件自有命名空间（小写 kebab，通常 `<plugin 名>`，须唯一）。
  * @param {unknown} schema - schemastery schema，解析该命名空间的值（通常为插件 Config）。
  * @param {unknown} entry - 组合层配置，作为命名空间的 `base` 层。
- * @param {{ setSource(source: () => unknown): void; onChange(): void; validate?: unknown }} hooks
+ * @param {{ setSource(source: () => unknown): void; onChange(): void; validate?: unknown; onScope?: (scope: unknown, settings: unknown) => void }} hooks
  *   - setSource：把插件对该命名空间的读取来源指向返回的 scope（`scope.get()`）。
  *     rc.7 下 settings 服务存在时，卡片数据应经此 scope 读写。
  *   - onChange：来源切换或命名空间值变化时触发，插件据此刷新自身状态/落盘。
  *   - validate：可选的自定义校验（透传给 settings.register）。
+ *   - onScope：可选；register 返回 owner scope 后立即回调（先于 setSource），
+ *     notifier / lan-proxy 在此做存量配置迁移与写路径装配（#436）。
  * @returns {void}
  */
 export function installSettingsNamespace(ctx, ns, schema, entry, hooks) {
   // 防御：ctx.inject 不可用（极简宿主/测试桩）与 settings 服务缺失同属降级场景，
   // 静默跳过（卡片降级，不影响插件主体）。
   if (typeof ctx?.inject !== "function") {
-    warn(ctx, `${ns}: ctx.inject 不可用 — 设置命名空间未注册，卡片降级`);
+    warnLog(ctx, `${ns}: ctx.inject 不可用 — 设置命名空间未注册，卡片降级`);
     return;
   }
   ctx.inject(["settings"], (sctx) => {
     const settings = sctx && sctx.settings;
     if (!settings || typeof settings.register !== "function") {
-      warn(ctx, `${ns}: settings 服务缺少 register 能力 — 设置命名空间未注册，卡片降级`);
+      warnLog(ctx, `${ns}: settings 服务缺少 register 能力 — 设置命名空间未注册，卡片降级`);
       return;
     }
     let scope;
@@ -90,8 +99,11 @@ export function installSettingsNamespace(ctx, ns, schema, entry, hooks) {
       });
     } catch (err) {
       // 重复注册等硬错误：报日志但不中断插件主体（宿主导入时并行注册同名 ns 会走到这）。
-      warn(ctx, `${ns}: settings.register 失败 — ${String(err && err.message ? err.message : err)}`);
+      warnLog(ctx, `${ns}: settings.register 失败 — ${String(err && err.message ? err.message : err)}`);
       return;
+    }
+    if (hooks && typeof hooks.onScope === "function") {
+      hooks.onScope(scope, settings);
     }
     hooks.setSource(() => scope.get());
     sctx.effect(() => () => {


### PR DESCRIPTION
## 概述

修复 #436：`shared/settings-namespace.js` 的 `installSettingsNamespace` 是宿主端 settings 命名空间接线的单一事实源，而 `dsh-notifier` / `dsh-lan-proxy` 各自在包内「语义等值复刻」了一份（唯一实质差异 = 经 `hooks.onScope(scope, settings)` 外露 owner scope，供存量迁移/乐观并发），`warnLog` 亦各定义一份。

本次改动：shared hooks 增加**可选** `onScope`；两包改为 import shared 的薄包装（对外函数名 `installNotifierSettings` / `installLanProxySettings` 与签名保持不变）；`warnLog` 收敛为 shared 单一导出。**shared/ 契约层改动已获维护者 approved**（issue 已打 `approved` + `zone/auto`）。

## 全量断言表

| # | issue 验收标准 | 结论 | 证据 |
|---|---|---|---|
| 1 | `installSettingsNamespace` 参数化后 notifier/lan-proxy 复用 shared | ✅ 落实 | `shared/settings-namespace.js` hooks 增 `onScope?`（register 成功后、`setSource` 之前回调，不传则跳过）；`packages/dsh-notifier/src/settings.ts`、`packages/dsh-lan-proxy/src/settings.ts` 删除包内复刻（-142 行净删），改为转发 `installSettingsNamespace`，钩子依次透传 `onScope`/`setSource`/`onChange` |
| 2 | 对外函数名与签名不变 | ✅ 落实 | `installNotifierSettings(ctx: Context, entry: Record<string, unknown>, hooks: NotifierSettingsHooks)` / `installLanProxySettings(ctx: Context, entry: LanProxyConfig, hooks: LanProxySettingsHooks)` 签名原样保留；`SETTINGS_NS`、`OwnerScopeLike`、`SettingsServiceLike`、`XxxSettingsHooks` 类型导出与 re-export 面不变（`warnLog` 经 re-export 保持模块导出面） |
| 3 | `warnLog` 两份复刻合并到 shared | ✅ 落实 | shared 原私有 `warn()` 升级为导出 `warnLog()`（.js + .d.ts 同步）；notifier/lan-proxy 本地实现删除，lan-proxy `apply.ts` 的 `import { warnLog } from "./settings.ts"` 经 re-export 继续可用 |
| 4 | owner scope 外露（onScope）行为保留 | ✅ 落实 | notifier 存量迁移（`migrateLegacyConfig`）与 lan-proxy `config.json` rename-first 迁移均在 `onScope` 内执行——shared 在 `settings.register` 成功后调用 `hooks.onScope(scope, settings)`，时机与包内原实现一致（先 onScope 后 setSource） |
| 5 | 5 个既有调用方兼容（不传 onScope） | ✅ 兼容 | 逐一核实 `installSettingsNamespace(` 全部调用点：① `dsh-provider-usage/src/apply.ts:830` ② `dsh-mcp-manager/src/apply.ts:118` ③ `dsh-mcp-manager/test/unit-shared.test.ts` 既有 7 处 —— 均不传 `onScope`，新增可选分支 `typeof hooks.onScope === "function"` 跳过，行为零变化；`dsh-mcp-manager/src/client/index.ts` 仅注释引用命名空间（key = 宿主端注册的 ns），非 hooks 调用方，无改动 |
| 6 | 卸载回落语义统一为 shared 实现 | ✅ 统一（notifier 有行为微调） | 改动前：notifier 卸载回落仅 `onChange()`（不回落 source），lan-proxy 为 `setSource(entry)+onChange()`；改动后两者统一走 shared：`setSource(() => entry) + onChange()`。**微调说明**：notifier 在「settings 服务（scoped fiber）消失但插件仍存活」时，读取来源将从失效 scope 回落到组合层 entry 再触发 onChange——对插件为更安全语义（source 不再指向失效 scope），且常态（服务不消失）不受影响；lan-proxy 无行为变化 |
| 7 | shared 契约层 js + d.ts 同步 | ✅ 落实 | `SettingsNamespaceHooks` 增 `onScope?(scope: unknown, service: unknown): void`；新增 `warnLog` 声明；JSDoc 同步更新 |
| 8 | test 断言按「签名保持、实现内聚」调整 | ✅ 落实 | 仅新增 `dsh-mcp-manager/test/unit-shared.test.ts` onScope 分支断言（scope/service 透传 + `["onScope","setSource"]` 顺序）；lan-proxy `unit-apply.test.ts` 的 `installLanProxySettings` 全分支/`warnLog` 降级断言经 apply 间接覆盖 new shared 实现后保持全绿，未改断言；notifier 测试经 apply 间接覆盖，未断言卸载回落差异，无需调整 |
| 9 | 门禁 | ✅ 全绿 | 五连 + scripts 均在独立 worktree 实测：`pnpm build` ✅ / `pnpm test` ✅ / `pnpm contract` ✅ / `pnpm pack:check` ✅ / `pnpm typecheck` ✅ / `pnpm test:scripts` ✅（56 pass / 0 fail） |

## 行为对比摘要

| 行为 | 改动前 | 改动后 |
|---|---|---|
| notifier 卸载回落（服务消失） | 仅 `onChange()`（source 仍指失效 scope） | `setSource(() => entry)` + `onChange()`（回落到组合层 entry）——微调，见上表 #6 |
| lan-proxy 卸载回落 | `setSource(() => entry)` + `onChange()` | 同左（不变） |
| 降级告警（inject 缺失 / 服务缺 register / register 抛错） | 各包本地 `warnLog` 实现 | 统一 shared `warnLog`（文案、行为一致） |
| 命名空间注册 / `scope.watch` 热更新 / `onChange` 触发 | 两包各自复刻 | 统一 shared 实现 |

## 验证说明

- 所有门禁在**独立 worktree**（`dsh-hub-task-436`，分支 `task/436`，基于 `origin/main` `0c0787b`）执行；`pnpm install` 未产生 lockfile 实质变更（`pnpm-lock.yaml` 未改动，未提交）。
- 改动文件：`shared/settings-namespace.js`、`shared/settings-namespace.d.ts`、`packages/dsh-notifier/src/settings.ts`、`packages/dsh-lan-proxy/src/settings.ts`、`packages/dsh-mcp-manager/test/unit-shared.test.ts`（共 +105 / -142）。

Fixes #436