### PR TITLE
refactor(meta): 观察期开关收敛 gauntlet.config.json 单一事实源——crap-check 去 argv 改读 config（#440）

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -20,7 +20,7 @@ pnpm build        # 全仓构建 = pnpm -r build（各包：clean-lib → tsc �
 pnpm contract     # 客户端契约（node scripts/gate/contract-check.ts）
 pnpm test         # 全量 smoke（Node ≥23.6 原生 type stripping 直跑）
 pnpm cov          # 覆盖率采集（c8 包裹 smoke，测量对象 = lib 编译产物）
-pnpm crap         # 单函数 CRAP 检查（先跑 cov；观察期只记录，--strict 为未来硬卡点）
+pnpm crap         # 单函数 CRAP 检查（先跑 cov；阈值唯一事实源 scripts/data/gauntlet.config.json 的 crap.threshold / crap.strict，观察期仅记录，翻期可置 true 判红）
 node scripts/gate/self-cov.mjs
                   # self-written 覆盖率口径报告（先跑 cov；读 coverage/coverage-final.json，
                   # 去 esbuild 内联 vendor 段与 __ 运行时垫片后仅计自写函数/行/分支，

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,7 +17,7 @@
 - `gate/verify-npm-layout.ts` — npm 发布布局校验。
 - `gate/verify-docs.ts` — 文档/description 校验（缺 .md、占位符残留）。
 - `gate/aggregate.ts` — 聚合 `cordis.patch.yml` 生成 + 一致性校验（`--check` 供 CI）。
-- `gate/crap-check.mjs` — 单函数 CRAP 复杂度检查（观察期只记录，`--strict` 为未来硬卡点）。
+- `gate/crap-check.mjs` — 单函数 CRAP 复杂度检查（阈值唯一事实源 scripts/data/gauntlet.config.json 的 crap.threshold / crap.strict，观察期仅记录，翻期可置 true 判红）
 
 ## lib/（纯共享库，只被 import，不被 `node` 直接调用）
 

--- a/scripts/gate/crap-check.mjs
+++ b/scripts/gate/crap-check.mjs
@@ -215,5 +215,5 @@ if (strict) {
   }
   console.log('crap-check: [strict] 无超阈热点，OK');
 } else {
-  console.log('crap-check: OK（观察期模式：明细已落盘 coverage/crap-report.json）');
+  console.log(`crap-check: OK（strict=false 观察期，strict 来源 gauntlet.config.json: crap.strict，明细已落盘 coverage/crap-report.json）`);
 }

--- a/scripts/gate/crap-check.mjs
+++ b/scripts/gate/crap-check.mjs
@@ -16,6 +16,11 @@
  *
  * 噪音过滤：esbuild 内联的 node_modules 依赖段与 `__` 前缀垫片函数不计入统计
  *   （发布物自包含导致依赖代码进 bundle，但它们不是本仓自写代码）。
+ *
+ * 阈值与判红开关唯一事实源 = scripts/data/gauntlet.config.json 的
+ *   crap.threshold / crap.strict（`--threshold` 仅作临时覆盖，strict 无 argv 覆盖）。
+ *   crap.strict=false：超阈热点 exit 0，仅落盘 coverage/crap-report.json（观察期）；
+ *   crap.strict=true：超阈热点 exit 1。翻期只改 config，不改本脚本。
  */
 import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -24,7 +29,7 @@ import * as acorn from 'acorn';
 const repoRoot = process.cwd();
 const configPath = join(repoRoot, 'scripts', 'data', 'gauntlet.config.json');
 const config = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf8')) : {};
-/** 阈值唯一事实源 = scripts/data/gauntlet.config.json；--threshold 仅作临时覆盖。 */
+/** 阈值与 strict 唯一事实源 = scripts/data/gauntlet.config.json；--threshold 仅作临时覆盖。 */
 const DEFAULT_THRESHOLD = config.crap?.threshold ?? 12;
 const argv = process.argv.slice(2);
 const idx = argv.indexOf('--threshold');
@@ -33,7 +38,7 @@ if (!Number.isFinite(threshold) || threshold <= 0) {
   console.error('crap-check: invalid --threshold');
   process.exit(2);
 }
-const strict = argv.includes('--strict');
+const strict = Boolean(config.crap?.strict);
 
 const coveragePath = join(repoRoot, 'coverage', 'coverage-final.json');
 if (!existsSync(coveragePath)) {

--- a/scripts/gate/observe-check.mjs
+++ b/scripts/gate/observe-check.mjs
@@ -14,8 +14,8 @@
  *   - --body-file <path>   输出 markdown 报告
  *   - --marker-file <path> 输出回落追评正文；无回落时输出空文件
  *
- * 退出码：0 = 正常（含"未达标但 strict=false"的观察期情形）；
- *         1 = strict 开启且存在 threshold 违约；
+ * 退出码：0 = 正常（含未达标但对应 config strict=false 的观察期情形）；
+ *         1 = 对应 gauntlet.config.json 中 strict=true 且存在 threshold 违约；
  *         2 = 环境/数据缺失错误
  */
 import { readFileSync, existsSync, writeFileSync, readdirSync } from 'node:fs';

--- a/scripts/gate/self-cov.mjs
+++ b/scripts/gate/self-cov.mjs
@@ -17,8 +17,9 @@
  *   node scripts/gate/self-cov.mjs --json    # 仅 stdout JSON 摘要（依然落盘，除非 --dry-run）
  *   node scripts/gate/self-cov.mjs --dry-run # 预览，不落盘
  *
- * 观察期模式：本脚本只记录不判红；gauntlet.config.json 的
- * coverage.selfWrittenFunctions 字段记录基线，不做硬卡点。
+ * strict 由 gauntlet.config.json 的 coverage.selfWrittenFunctions.strict 决定；
+ * --check 生效时，低于 coverage.selfWrittenFunctions.threshold 且 strict=true 判红，
+ * strict=false 则保持观察期，仅告警不判红。
  */
 import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join, resolve, isAbsolute } from 'node:path';

--- a/scripts/release/health-report-body.mjs
+++ b/scripts/release/health-report-body.mjs
@@ -12,6 +12,9 @@ function readJson(path) {
 
 const summary = readJson('coverage/coverage-summary.json');
 const crap = readJson('coverage/crap-report.json');
+const gauntlet = readJson('scripts/data/gauntlet.config.json');
+const crapStrict = Boolean(crap?.strict ?? gauntlet?.crap?.strict);
+const crapMode = crapStrict ? 'strict 判红' : '观察期（仅记录）';
 
 const lines = [];
 lines.push('## 机器信号段（自动生成，勿改）');
@@ -29,7 +32,7 @@ if (summary?.total) {
 if (crap) {
   const pct = crap.totalFns ? Math.round((crap.coveredFns / crap.totalFns) * 100) : 0;
   lines.push(
-    `- CRAP（阈值 ${crap.threshold}，观察期模式）：函数 ${crap.totalFns} 个，已覆盖 ` +
+    `- CRAP（阈值 ${crap.threshold}，${crapMode}，strict 来源 scripts/data/gauntlet.config.json: crap.strict）：函数 ${crap.totalFns} 个，已覆盖 ` +
     `${pct}%；超阈热点 ${crap.hotspots.length} 个`,
   );
   const top = crap.hotspots.slice(0, 5);
@@ -49,7 +52,7 @@ lines.push('');
 
 lines.push('## 人工判断段（留给维护者填写）');
 lines.push('- 这些信号是否构成「Agent 在原地打转」的结论？');
-lines.push('- 阈值收紧/放宽建议：<由人决定>（两周观察期后校准 crap-check 阈值与 --strict 开关）');
+lines.push('- 阈值收紧/放宽建议：<由人决定>（依据 scripts/data/gauntlet.config.json 的 crap.threshold / crap.strict 调整）');
 lines.push('- 是否需要重划包边界：<由人决定>');
 
 console.log(lines.join('\n'));

--- a/scripts/test/crap-check.test.ts
+++ b/scripts/test/crap-check.test.ts
@@ -41,6 +41,6 @@ test('crap.strict 是唯一判红开关，忽略 --strict argv', () => {
   const hard = run(true)
   assert.equal(observe.status, 0, `strict=false 应观察期放行：${observe.stderr}`)
   assert.equal(hard.status, 1, `strict=true 应判红：${hard.stderr}`)
-  assert.match(observe.stdout, /观察期模式/)
+  assert.match(observe.stdout, /strict=false 观察期/)
   assert.match(hard.stderr, /判定为红/)
 })

--- a/scripts/test/crap-check.test.ts
+++ b/scripts/test/crap-check.test.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// @ts-nocheck
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const ROOT = join(import.meta.dirname, '../..')
+const SCRIPT = join(ROOT, 'scripts/gate/crap-check.mjs')
+
+function fixture(strict) {
+  const dir = mkdtempSync(join(tmpdir(), 'crap-check-test-'))
+  mkdirSync(join(dir, 'scripts/data'), { recursive: true })
+  mkdirSync(join(dir, 'coverage'), { recursive: true })
+  mkdirSync(join(dir, 'packages/fake/lib'), { recursive: true })
+  writeFileSync(join(dir, 'scripts/data/gauntlet.config.json'), JSON.stringify({ crap: { threshold: 1, strict } }))
+  writeFileSync(join(dir, 'packages/fake/lib/index.js'), 'function uncovered() { if (false) return 1; return 0 }\nuncovered()\n')
+  writeFileSync(join(dir, 'coverage/coverage-final.json'), JSON.stringify({
+    [join(dir, 'packages/fake/lib/index.js')]: {
+      fnMap: { '0': { loc: { start: { line: 1, column: 0 } } } },
+      f: { '0': 0 },
+    },
+  }))
+  return dir
+}
+
+function run(strict) {
+  const dir = fixture(strict)
+  try {
+    return spawnSync(process.execPath, [SCRIPT, '--strict'], { cwd: dir, encoding: 'utf8' })
+  } finally {
+    // spawnSync 已完成，临时 fixture 可安全清理。
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+test('crap.strict 是唯一判红开关，忽略 --strict argv', () => {
+  const observe = run(false)
+  const hard = run(true)
+  assert.equal(observe.status, 0, `strict=false 应观察期放行：${observe.stderr}`)
+  assert.equal(hard.status, 1, `strict=true 应判红：${hard.stderr}`)
+  assert.match(observe.stdout, /观察期模式/)
+  assert.match(hard.stderr, /判定为红/)
+})


### PR DESCRIPTION
Fixes #440

## 6 条验收标准断言表
| 标准 | 结论 | 证据 |
|------|------|------|
| 1. config 单一事实源 | PASS | node -e 读 config 输出 false true true；crap-check 无 argv.includes('--strict') |
| 2. crap 判红行为 | PASS | 新增 scripts/test/crap-check.test.ts fixture 断言 strict=false exit 0、strict=true exit 1 |
| 3. 四脚本无散落开关 | PASS | grep -rn -- '--strict' scripts/gate scripts/release 排除 --strict-en 无命中 |
| 4. 观察期文案与 config 对齐 | PASS | 四脚本「观察期」均为 config 引用；health-report-body 读 config.crap.strict |
| 5. README/docs 声明同步 | PASS | DEVELOPMENT.md/scripts/README.md crap 行命中 gauntlet.config.json，不含「--strict 为未来硬卡点」 |
| 6. #42 翻期依赖注记 | PASS | 见下文 #42 翻期声明 |

## #42 翻期依赖注记
#42 二期校准未定档、维持跟踪；本收敛不改变判红口径（crap.strict=false 观察期照旧）；#42 确认后翻期仅需将 crap.strict 置 true 并同步条目 5 文档表述，不改任何脚本。