### PR TITLE
refactor(scripts): pack-check 对 shared 声明副本改枚举随包断言（#461 L2）

### DIFF
--- a/scripts/build/bundle-host.ts
+++ b/scripts/build/bundle-host.ts
@@ -21,6 +21,7 @@ import { dirname, join, relative, resolve, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { build } from 'esbuild'
 import { buildClient, buildMermaidChunk, copyClientResources } from './build-client.ts'
+import { walkFiles } from '../lib/walk-files.ts'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 // 插件目录相对当前工作目录解析（pnpm --filter 场景 cwd=包目录传 .；仓库根场景传 packages/dsh-*）
@@ -37,20 +38,6 @@ const packagesDir = join(ROOT, 'packages')
 if (!pkgDir.startsWith(packagesDir + sep) || pkgDir === packagesDir) {
   console.error(`[bundle-host] 插件目录须在 packages/ 下（实际: ${process.argv[2]}）`)
   process.exit(1)
-}
-
-/** 递归收集目录下满足谓词的文件（返回相对路径列表，不含目录）。 */
-function walkFiles(dir, predicate) {
-  const out = []
-  const visit = (cur) => {
-    for (const f of readdirSync(cur, { withFileTypes: true })) {
-      const abs = join(cur, f.name)
-      if (f.isDirectory()) visit(abs)
-      else if (predicate(f.name)) out.push(relative(dir, abs).split(sep).join('/'))
-    }
-  }
-  visit(dir)
-  return out
 }
 
 // 1. esbuild 内联 shared（tsc 产物 → 自包含单文件，临时文件再替换，避免占用原文件）

--- a/scripts/gate/pack-check.ts
+++ b/scripts/gate/pack-check.ts
@@ -17,6 +17,7 @@ import { fileURLToPath } from 'node:url'
 import { executeClient } from '../lib/client-contract-lib.ts'
 import { extractInlinedPackages, readMermaidChunkRefs } from '../build/collect-licenses.ts'
 import { AGGREGATE_NAME, checkAggregateConsistency, filterOutRetiredDirs, listPluginDirs, loadManifest, warnUnknownEntries } from '../lib/plugins-manifest-lib.ts'
+import { assertSharedDtsPresent, listSharedDts } from '../lib/shared-dts-lib.ts'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
@@ -44,6 +45,9 @@ const { kept: plugins, skipped: retiredDirs } = filterOutRetiredDirs(listPluginD
 if (retiredDirs.length > 0) {
   console.warn(`[pack-check] 跳过已退役包残留目录: ${retiredDirs.join(', ')}（manifest.retired 已登记，请清理）`)
 }
+// shared 声明副本期望清单（issue #461 L2）：仓库 shared/ 全部 .d.ts（递归含子目录）
+// 随包逐一断言——新增 shared 子目录/文件（如 client/i18n.d.ts）自动纳入，防漏打包静默
+const SHARED_DTS_EXPECTED = listSharedDts(ROOT)
 
 let failed = 0
 for (const p of plugins) {
@@ -63,9 +67,11 @@ for (const p of plugins) {
     for (const f of ['README.md', 'LICENSE', 'cordis.patch.yml']) {
       if (!existsSync(join(pkgRoot, f))) problems.push(`缺 ${f}`)
     }
-    // shared 声明副本（bundle-host d.ts X1 递归复制，含子目录 host/）须随包发布
-    if (!existsSync(join(pkgRoot, 'shared', 'host', 'plugin-skeleton.d.ts'))) {
-      problems.push('缺 shared/host/plugin-skeleton.d.ts（shared 递归副本）')
+    // shared 声明副本（bundle-host d.ts X1 递归复制，含子目录 host/ client/）须随包发布：
+    // 枚举比对仓库 shared/ 全部 .d.ts（issue #461 L2），缺哪个报哪个，防新增漏打包静默
+    const missingSharedDts = assertSharedDtsPresent(join(pkgRoot, 'shared'), SHARED_DTS_EXPECTED)
+    if (missingSharedDts.length > 0) {
+      problems.push(`缺 shared 声明副本: ${missingSharedDts.join(', ')}（shared 递归副本未随包）`)
     }
     const idx = readFileSync(join(pkgRoot, 'lib', 'index.js'), 'utf8')
     // 只匹配 import 语句中的仓库外相对引用（esbuild 模块注释含路径文本，不算断链）

--- a/scripts/lib/shared-dts-lib.ts
+++ b/scripts/lib/shared-dts-lib.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * shared-dts-lib — shared 声明副本随包断言的共享库（issue #461 L2）。
+ *
+ * 机制：bundle-host d.ts X1（2b 段）把仓库 shared/ 下全部 *.d.ts（递归，含
+ * 子目录 host/ client/）复制进包内 shared/ 随包发布。此前 pack-check 只硬编码
+ * 断言 plugin-skeleton.d.ts 一个文件，新增 shared d.ts（如 client/i18n.d.ts）
+ * 漏打包时静默放行——「机制保证」没有「断言保证」兜底。
+ *
+ * 本库把断言升级为「仓库 shared/ 枚举清单 与 tarball 内 shared/ 副本逐一比对」：
+ *   - listSharedDts(root)：枚举仓库 shared/ 下全部 .d.ts 相对路径（与
+ *     bundle-host 2b 复制谓词同源，walk-files 单一事实源）；
+ *   - assertSharedDtsPresent(pkgSharedDir, expected)：tarball 缺哪个文件报哪个。
+ * 未来 shared 新增子目录/文件自动纳入断言，无需再改 pack-check。
+ */
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { walkFiles } from './walk-files.ts'
+
+/**
+ * 枚举仓库 shared/ 下全部声明文件（.d.ts，递归含子目录），返回相对路径列表。
+ * 谓词与 bundle-host d.ts X1 2b 复制段完全一致（walk-files 共享实现）。
+ * @param {string} root 仓库根（含 shared/ 目录）
+ * @returns {string[]} 相对路径，如 ['client/i18n.d.ts', 'host/plugin-skeleton.d.ts', ...]
+ */
+export function listSharedDts(root) {
+  return walkFiles(join(root, 'shared'), (f) => f.endsWith('.d.ts'))
+}
+
+/**
+ * 断言 tarball 内 shared/ 副本覆盖期望清单。
+ * @param {string} pkgSharedDir tarball 解包后的 shared/ 目录
+ * @param {string[]} expected listSharedDts 结果（相对路径清单）
+ * @returns {string[]} 缺失文件相对路径列表（空 = 完整）
+ */
+export function assertSharedDtsPresent(pkgSharedDir, expected) {
+  return expected.filter((rel) => !existsSync(join(pkgSharedDir, rel)))
+}

--- a/scripts/lib/walk-files.ts
+++ b/scripts/lib/walk-files.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * walk-files — 递归收集目录下满足谓词的文件（返回相对路径列表，不含目录）。
+ *
+ * 单一事实源：从 bundle-host.ts 私有实现提取，构建复制（d.ts X1 2b 段）与
+ * pack-check 随包断言（shared-dts-lib）共用同一实现，杜绝两处枚举逻辑漂移
+ * （机制保证 → 断言保证的前提是「同一个谓词、同一套遍历」）。
+ */
+import { readdirSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+
+/** 递归收集 dir 下满足 predicate(文件名) 的文件，返回相对路径（/ 分隔，不含目录）。 */
+export function walkFiles(dir, predicate) {
+  const out = []
+  const visit = (cur) => {
+    for (const f of readdirSync(cur, { withFileTypes: true })) {
+      const abs = join(cur, f.name)
+      if (f.isDirectory()) visit(abs)
+      else if (predicate(f.name)) out.push(relative(dir, abs).split(sep).join('/'))
+    }
+  }
+  visit(dir)
+  return out
+}

--- a/scripts/test/shared-dts.test.ts
+++ b/scripts/test/shared-dts.test.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * shared-dts-lib 自测（node:test，issue #461 L2）。
+ *
+ * L2 目标：pack-check 对 shared 声明副本断言从「硬编码 plugin-skeleton.d.ts 单文件」
+ * 升级为「仓库 shared/ 全部 .d.ts（递归含子目录）逐一随包」——新增 shared 子目录/文件
+ * （如 client/i18n.d.ts）漏打包时必须 fail-loud，机制保证 → 断言保证。
+ *
+ * 覆盖：
+ *   - listSharedDts 枚举正确（含 host/ client/ 子目录，返回相对路径）
+ *   - assertSharedDtsPresent 缺文件报错 / 完整通过
+ *   - 与 bundle-host d.ts X1 复制谓词同源：bundle-host 必须复用共享 walkFiles
+ *     （防「复制机制」与「断言清单」两处枚举实现漂移）
+ *   - 真实仓库方向：当前 shared/ 的 d.ts 清单非空且含新增 client/i18n.d.ts
+ * 运行：node --test scripts/test/shared-dts.test.ts（或 pnpm test:scripts）
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { assertSharedDtsPresent, listSharedDts } from '../lib/shared-dts-lib.ts'
+import { walkFiles } from '../lib/walk-files.ts'
+
+function tempDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'sdt-test-'))
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
+}
+
+function fixtureShared(root) {
+  // 构造与真实 shared/ 同构的目录：顶层 loopback.d.ts + host/ + client/ 子目录
+  const shared = join(root, 'shared')
+  mkdirSync(join(shared, 'host'), { recursive: true })
+  mkdirSync(join(shared, 'client'), { recursive: true })
+  writeFileSync(join(shared, 'loopback.d.ts'), '')
+  writeFileSync(join(shared, 'host', 'plugin-skeleton.d.ts'), '')
+  writeFileSync(join(shared, 'client', 'i18n.d.ts'), '')
+  // 非 .d.ts 文件不得被枚举（.js 是运行时内联源，不随包）
+  writeFileSync(join(shared, 'host', 'plugin-skeleton.js'), '')
+  writeFileSync(join(shared, 'client', 'i18n.js'), '')
+  return shared
+}
+
+test('#1 listSharedDts 递归枚举全部 .d.ts（含子目录、排除 .js）', () => {
+  const { dir, cleanup } = tempDir()
+  try {
+    fixtureShared(dir)
+    const list = listSharedDts(dir)
+    assert.deepEqual(list, ['client/i18n.d.ts', 'host/plugin-skeleton.d.ts', 'loopback.d.ts'])
+  } finally {
+    cleanup()
+  }
+})
+
+test('#2 assertSharedDtsPresent 缺文件报错（含子目录路径）', () => {
+  const { dir, cleanup } = tempDir()
+  try {
+    const shared = fixtureShared(dir)
+    // 模拟 pack-check 语义：期望清单来自仓库 shared/（删除前快照），
+    // tarball 副本缺 client/i18n.d.ts（新增 shared d.ts 漏随包）→ 必须报出
+    const expected = listSharedDts(dir)
+    rmSync(join(shared, 'client', 'i18n.d.ts'))
+    const missing = assertSharedDtsPresent(shared, expected)
+    assert.deepEqual(missing, ['client/i18n.d.ts'])
+  } finally {
+    cleanup()
+  }
+})
+
+test('#3 assertSharedDtsPresent 完整副本通过（空缺件清单）', () => {
+  const { dir, cleanup } = tempDir()
+  try {
+    fixtureShared(dir)
+    const missing = assertSharedDtsPresent(join(dir, 'shared'), listSharedDts(dir))
+    assert.deepEqual(missing, [])
+  } finally {
+    cleanup()
+  }
+})
+
+test('#4 与真实仓库 shared/ 一致：清单非空、含新增 client/i18n.d.ts、路径真实存在', () => {
+  const root = join(import.meta.dirname, '..', '..')
+  const list = listSharedDts(root)
+  assert.ok(list.length >= 3, '仓库 shared/ 至少含顶层 + host/ + client/ 的 d.ts')
+  // 必须命中 L2 新增断言目标：client/ 子目录文件（i18n.d.ts）
+  assert.ok(list.includes('client/i18n.d.ts'), '新增 shared/client/i18n.d.ts 必须进入枚举清单')
+  // 全部为 .d.ts 且在仓库 shared/ 真实存在
+  for (const rel of list) {
+    assert.match(rel, /\.d\.ts$/)
+    assert.ok(existsSync(join(root, 'shared', rel)), `清单项 ${rel} 应在仓库 shared/ 真实存在`)
+  }
+})
+
+test('#5 同源防漂移：bundle-host 复用共享 walkFiles，无私有枚举实现', () => {
+  const root = join(import.meta.dirname, '..', '..')
+  const bundleHost = readFileSync(join(root, 'scripts', 'build', 'bundle-host.ts'), 'utf8')
+  // 机制保证：bundle-host d.ts X1（2b）必须 import 共享 walkFiles，而不是自写遍历
+  assert.match(bundleHost, /import \{ walkFiles \} from '\.\.\/lib\/walk-files\.ts'/, 'bundle-host 必须复用共享 walkFiles')
+  // 断言保证：pack-check 必须经 listSharedDts 枚举期望清单（与复制谓词同源）
+  const packCheck = readFileSync(join(root, 'scripts', 'gate', 'pack-check.ts'), 'utf8')
+  assert.match(packCheck, /listSharedDts\(ROOT\)/, 'pack-check 必须经 listSharedDts 枚举期望清单')
+  // 共享 walkFiles 自身行为基准（防 lib 重构误伤）
+  const { dir, cleanup } = tempDir()
+  try {
+    fixtureShared(dir)
+    const walked = walkFiles(join(dir, 'shared'), (f) => f.endsWith('.d.ts'))
+    assert.deepEqual(walked, ['client/i18n.d.ts', 'host/plugin-skeleton.d.ts', 'loopback.d.ts'])
+  } finally {
+    cleanup()
+  }
+})


### PR DESCRIPTION
## 变更

遗留 #461 L2：pack-check 对新增 shared 模块 d.ts 补随包断言，把「机制保证」提升为「断言保证」。

### 现状

`scripts/gate/pack-check.ts` 的 shared 递归副本探针只硬编码断言 `shared/host/plugin-skeleton.d.ts` 单文件；
新增 `shared/client/i18n.d.ts` 与 `shared/placement-math.d.ts` 随包仅依赖 `bundle-host.ts` 的 walkFiles
递归复制机制（#378 合并放行时以「机制保证」备注）。

### 改动

- **`scripts/lib/walk-files.ts`（新增）**：把 `bundle-host.ts` 私有 `walkFiles` 提取为共享实现，
  复制机制与断言枚举同源，杜绝两处遍历逻辑漂移。
- **`scripts/lib/shared-dts-lib.ts`（新增）**：
  - `listSharedDts(root)`：枚举仓库 `shared/` 下全部 `.d.ts`（递归，含 `host/`、`client/` 子目录）；
  - `assertSharedDtsPresent(pkgSharedDir, expected)`：tarball 副本逐一比对，返回缺失清单。
- **`scripts/gate/pack-check.ts`**：硬编码单文件探针升级为枚举比对——新增 shared 子目录/文件
  漏打包时 fail-loud（机制保证 → 断言保证）。
- **`scripts/build/bundle-host.ts`**：复用共享 `walkFiles`，删除私有实现（行为零变化）。
- **`scripts/test/shared-dts.test.ts`（新增）**：5 用例——枚举正确（含子目录、排除 .js）、
  缺文件报错、完整通过、真实仓库清单含 `client/i18n.d.ts`、bundle-host 同源防漂移。

### 验收对照（#461）

- [x] pack-check 对含 `shared/client/` 副本的包断言通过
- [x] 人为删除 `shared/client/i18n.d.ts` 副本后 pack-check 红（已本地实证：
  `FAIL @wingsky-1/dsh-mcp-manager | 缺 shared 声明副本: client/i18n.d.ts`）

### 门禁

本地七连全绿：`pnpm test` / `pnpm contract` / `pnpm pack:check` / `pnpm typecheck` /
`pnpm aggregate:check` / `pnpm docs:check` / `node --test scripts/test/*.test.ts`（82 用例，含新增 5 例）。

Closes #461 的 L2 项（T4 行为级实测走 dsh-verify-isolated 单独跟进，不在此 PR 内）。
