### PR TITLE
fix(dsh-lan-proxy): TLS 单边清除留半套——固化成对语义（#467）

### DIFF
--- a/packages/dsh-lan-proxy/src/config-routes.ts
+++ b/packages/dsh-lan-proxy/src/config-routes.ts
@@ -73,15 +73,15 @@ export async function applyConfigPatch(deps: ConfigRouteDeps, payload: unknown):
     return { ok: false, status: 400, code: "invalid", details: "非法配置值（未知键或类型错误）" };
   }
   const rawSrc = (typeof rawPatch === "object" && rawPatch !== null ? rawPatch : {}) as Record<string, unknown>;
-  // 证书成对约束（P2-1）：raw 层先判「显式给出的两侧必须同形态」——一侧空串
-  // 而另一侧非空字符串时直接拒绝。否则单边空串经 sanitize 剔除后，剩余的单侧
-  // 值会绕过下方 sanitize 后的成对校验（如 {tlsCertFile:"", tlsKeyFile:"/x"}）。
-  const rawCert = typeof rawSrc.tlsCertFile === "string" ? rawSrc.tlsCertFile : undefined;
-  const rawKey = typeof rawSrc.tlsKeyFile === "string" ? rawSrc.tlsKeyFile : undefined;
-  const mixedTlsPair =
-    (rawCert === "" && (rawKey ?? "") !== "") ||
-    (rawKey === "" && (rawCert ?? "") !== "");
-  if (mixedTlsPair) {
+  // 证书成对约束（#467 固化成对语义）：raw 层按「键是否显式出现」判定形态——
+  // 只显式给出单侧（另一侧未提交 = undefined）即拒绝；"一空一缺"与"一非空一缺"
+  // 同属单侧出现。注意须用键存在性（rawSrc[key] !== undefined）而非字符串判型：
+  // 单侧显式空串意在清除，另一侧缺席时若漏判会进入 clearingTls 分支，删除循环
+  // 只剔"显式空串"侧，user 层残留另一侧孤儿（半套证书）。"同空（双空串）"=
+  // 整套清除、"同非空"= 整套设置，均两侧同时显式出现，不落此分支。
+  const rawCertExplicit = rawSrc.tlsCertFile !== undefined;
+  const rawKeyExplicit = rawSrc.tlsKeyFile !== undefined;
+  if (rawCertExplicit !== rawKeyExplicit) {
     return { ok: false, status: 400, code: "tls-pair", details: "证书文件与私钥文件必须成对提供（或都留空以使用自签名证书）" };
   }
   // 成对约束第二层（sanitize 后判定，口径与历史版本一致）：只给单侧值。
@@ -93,8 +93,10 @@ export async function applyConfigPatch(deps: ConfigRouteDeps, payload: unknown):
     if (clearingTls) {
       const { user } = deps.readUser();
       const section: Record<string, unknown> = { ...user };
+      // #467：清除语义固化为"整套成对剔除"（同空 = 整套清除）——raw 层已保证
+      // 显式空串两侧同现，但仍整体剔除两键，杜绝单侧剔除遗留另一半的可能。
       for (const key of TLS_PAIR_KEYS) {
-        if (rawSrc[key] === "") delete section[key];
+        if (rawSrc[key] === "" || user[key] !== undefined) delete section[key];
       }
       await deps.replace({ ...section, ...(sanitized as Record<string, unknown>) }, expectedRevision);
     } else {

--- a/packages/dsh-lan-proxy/test/smoke.ts
+++ b/packages/dsh-lan-proxy/test/smoke.ts
@@ -905,6 +905,9 @@ const main = async () => {
             Object.assign(state.user, patch);
           },
           replace: async (section: Record<string, unknown>, expectedRevision?: number) => {
+            // 与 update 同口径注入写入失败/乐观并发冲突（清除路径走 replace）。
+            if (opts.broken) throw new Error("disk full");
+            if (opts.conflict) throw Object.assign(new Error("stale"), { code: "SETTINGS_CONFLICT" });
             state.replaces.push({ section, expectedRevision });
             state.user = { ...section };
           },
@@ -958,7 +961,79 @@ const main = async () => {
     (unavail.deps as any).writable = () => false;
     const na = await applyConfigPatch(unavail.deps, { patch: { port: 4000 } });
     check("settings 服务不可用时写入 503 拒绝", () => assert.equal(na.ok === false && (na as any).status, 503));
-    // 写入异常与乐观并发冲突映射（P2-2：响应 details 固定文案，原文只进日志）。
+    // ── #467 验收：TLS 成对清除语义（只清 cert / 只清 key / 双清 / 清除遇 409 /
+    //    user 层已不完整）。
+    const clearCertOnly = await applyConfigPatch(
+      makeDeps({ tlsCertFile: "/x.pem", tlsKeyFile: "/x-key.pem", port: 4000 }).deps,
+      { patch: { tlsCertFile: "" } },
+    );
+    check("#467 只清 cert（另一侧未提交）400 tls-pair 拒绝，不落盘", () => {
+      assert.equal(clearCertOnly.ok, false, JSON.stringify(clearCertOnly));
+      assert.equal((clearCertOnly as any).status, 400);
+      assert.equal((clearCertOnly as any).code, "tls-pair");
+    });
+    const clearKeyOnly = await applyConfigPatch(
+      makeDeps({ tlsCertFile: "/x.pem", tlsKeyFile: "/x-key.pem", port: 4000 }).deps,
+      { patch: { tlsKeyFile: "" } },
+    );
+    check("#467 只清 key（另一侧未提交）400 tls-pair 拒绝，不落盘", () => {
+      assert.equal(clearKeyOnly.ok, false, JSON.stringify(clearKeyOnly));
+      assert.equal((clearKeyOnly as any).status, 400);
+      assert.equal((clearKeyOnly as any).code, "tls-pair");
+    });
+    const clearBoth = await applyConfigPatch(
+      makeDeps({ tlsCertFile: "/x.pem", tlsKeyFile: "/x-key.pem", port: 4000 }).deps,
+      { patch: { tlsCertFile: "", tlsKeyFile: "", printBanner: false } },
+    );
+    check("#467 双清（同空）整套成对剔除，user 层不留任何 tls 键", () => {
+      assert.equal(clearBoth.ok, true, JSON.stringify(clearBoth));
+      assert.equal((clearBoth as any).value.user.tlsCertFile, undefined, "tlsCertFile 已剔除");
+      assert.equal((clearBoth as any).value.user.tlsKeyFile, undefined, "tlsKeyFile 已剔除");
+      assert.equal((clearBoth as any).value.user.port, 4000, "其余键保留");
+      assert.equal((clearBoth as any).value.user.printBanner, false);
+    });
+    const clearConflict = await applyConfigPatch(
+      makeDeps({ tlsCertFile: "/x.pem", tlsKeyFile: "/x-key.pem" }, { conflict: true }).deps,
+      { patch: { tlsCertFile: "", tlsKeyFile: "" } },
+    );
+    check("#467 清除遇 SETTINGS_CONFLICT 映射 409/conflict 固定文案", () => {
+      assert.equal(clearConflict.ok, false, JSON.stringify(clearConflict));
+      assert.equal((clearConflict as any).status, 409);
+      assert.equal((clearConflict as any).code, "conflict");
+      assert.equal((clearConflict as any).details, "设置已被其他窗口修改，请刷新后重试");
+    });
+    const brokenUser = await applyConfigPatch(
+      makeDeps({ tlsCertFile: "/x.pem", tlsKeyFile: "/x-key.pem", port: 4000 }).deps,
+      { patch: { tlsCertFile: "", tlsKeyFile: "" } },
+    );
+    check("#467 双清不会产生含 undefined 段的路径（user 层干净成对）", () => {
+      const user = (brokenUser as any).value.user;
+      const fsPath = join(user?.tlsCertFile ?? "", user?.tlsKeyFile ?? "");
+      assert.ok(!fsPath.includes("undefined"), `不得产生含 undefined 段的路径，实际 ${fsPath}`);
+    });
+    const inPair = await applyConfigPatch(
+      makeDeps({ tlsCertFile: "/x.pem", tlsKeyFile: "/x-key.pem", port: 4000 }).deps,
+      { patch: { tlsKeyFile: "/new-key.pem", printBanner: false } },
+    );
+    check("#467 只设 key 亦被拒（任一单侧显式即 400，含未清除意图）", () => {
+      assert.equal(inPair.ok, false, JSON.stringify(inPair));
+      assert.equal((inPair as any).code, "tls-pair");
+    });
+    // 场景 5：user 层已不完整（历史孤儿 { tlsCertFile: "/x.pem" } 残留）时，
+    // 双清仍整体剔除两键并走 replace 自愈；单侧清除请求仍被 raw 层拒绝（双清是唯一出口）。
+    const orphanPair = makeDeps({ tlsCertFile: "/x.pem", port: 4000 });
+    const orphanRes = await applyConfigPatch(orphanPair.deps, { patch: { tlsCertFile: "", tlsKeyFile: "" } });
+    check("#467 user 层已不完整（孤儿单侧残留）双清 replace 自愈，无孤儿留存", () => {
+      assert.equal(orphanRes.ok, true, JSON.stringify(orphanRes));
+      assert.equal((orphanRes as any).value.user.tlsCertFile, undefined);
+      assert.equal((orphanRes as any).value.user.tlsKeyFile, undefined);
+      assert.equal(orphanPair.state.replaces.length, 1, "走 replace 整节替换");
+    });
+    const orphanLone = await applyConfigPatch(makeDeps({ tlsCertFile: "/x.pem", port: 4000 }).deps, { patch: { tlsCertFile: "" } });
+    check("#467 user 层已不完整时单侧清除仍被拒（不落盘半套）", () => {
+      assert.equal(orphanLone.ok, false, JSON.stringify(orphanLone));
+      assert.equal((orphanLone as any).code, "tls-pair");
+    });
     const logWarns: string[] = [];
     const brokenDeps = makeDeps({}, { broken: true });
     (brokenDeps.deps as any).logWarn = (m: string) => logWarns.push(m);


### PR DESCRIPTION
## 修复说明

`applyConfigPatch`（packages/dsh-lan-proxy/src/config-routes.ts）的 TLS 成对校验原来只在「显式给出的两侧都为空/非空字符串」层面判定：只清 cert / 只清 key（一侧显式空串、另一侧未提交）会绕过 raw 层判据进入 `clearingTls` 分支，删除循环只剔「显式空串」侧，user 层残留另一侧孤儿证书路径（半套证书）。本次固化成对语义：

- raw 层按「两侧键必须同时显式出现」判定——只显式给单侧（无论清除或设置意图）一律 400 `tls-pair` 拒绝，不落盘半套；
- 清除分支删除循环固化为「整套成对剔除」——双清（同空）即整套清除，user 层即使已有单侧孤儿残留，双清也能经 replace 整节替换自愈；
- 清除遇 `SETTINGS_CONFLICT` 沿用既有 409 `conflict` 映射，与普通写入冲突约定一致。

改动范围克制：仅 `packages/dsh-lan-proxy/src/config-routes.ts` 与 `test/smoke.ts`（含 makeDeps fake 的 replace 注入 conflict 的测试辅助扩展）。未触碰 `.github/`、package.json、pnpm-lock.yaml、shared/ 契约层。

## 全量断言表

| 验收条目 | 结论 | 证据或漂移解释 |
|---|---|---|
| 只清 cert（`{tlsCertFile:""}`，key 未提交）→ 400 拒绝、不落盘 | PASS | test/smoke.ts:970-977 断言 400/`tls-pair` |
| 只清 key（`{tlsKeyFile:""}`，cert 未提交）→ 400 拒绝、不落盘 | PASS | test/smoke.ts:979-986 断言 400/`tls-pair` |
| 双清（`{tlsCertFile:"", tlsKeyFile:""}`）= 整套清除 | PASS | test/smoke.ts:988-997 user 层两键均剔除、其余键保留；追加 :1009-1016 无含 `undefined` 段路径断言（#218 零污染纪律） |
| 清除遇 409（SETTINGS_CONFLICT 映射） | PASS | test/smoke.ts:999-1007 断言 409/`conflict` 固定文案；makeDeps fake `replace` 补 conflict 注入（:907-915） |
| user 层已不完整（孤儿残留）→ 不落盘半套、可自愈 | PASS | test/smoke.ts:1026-1031（孤儿 user 双清 replace 自愈两键全清）+ :1033-1039（孤儿 user 单侧清除仍 400） |

漂移说明：验收条目「只清 cert / 只清 key」原文以「半套残留」为核心现象，落实为「400 拒绝 + 不落盘」两段断言（拒绝本身即保证不落盘）；「user 层已不完整」场景补了「双清自愈」与「单侧清除仍拒绝」两条，覆盖新语义下已存在孤儿时的两条路径。另补一条「只设 key 亦被拒」防御断言（:1018-1024，锁定单侧显式一律 400、不限清除意图）。

## 验证

五连门禁本地全绿：`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck`（退出码均 0）；lan-proxy 包 smoke 连跑 10 次无 flake。

Closes #467
