### PR TITLE
fix(dsh-notifier): 中断迁移逐字段缺失补齐防漏迁（#468）

### DIFF
--- a/packages/dsh-notifier/src/index.ts
+++ b/packages/dsh-notifier/src/index.ts
@@ -733,15 +733,14 @@ export function apply(ctx: Context, config: NotifierApplyConfig = {}): void {
       attachedScope = scope;
       attachedService = service;
       // 迁移（rename-first 幂等；损坏/中断/回滚均在 migrate.ts 内处理并 warn，
-      // 失败不阻塞启动——E6）。hasUserValues 判定「user 层已有值 = 迁移已完成」。
+      // 失败不阻塞启动——E6）。迁移完成判定 = 逐字段缺失补齐（#468：不再以
+      // 「user 层已有任意值 = 迁移已完成」整体跳过——部分写入中断后剩余 legacy
+      // 字段会永久漏迁）；readUser 供 diffMissingKeys 只补写 user 层缺失键。
       void migrateLegacyConfig(
         storeFile,
         {
           update: (patch) => service.update(SETTINGS_NS, patch),
-          hasUserValues: () => {
-            const { user } = readUser();
-            return user !== undefined && Object.keys(user).length > 0;
-          },
+          readUser: () => readUser().user,
         },
         ctx.logger
       ).catch((err) => {

--- a/packages/dsh-notifier/src/migrate.ts
+++ b/packages/dsh-notifier/src/migrate.ts
@@ -1,5 +1,5 @@
 /**
- * dsh-notifier — 存量自建配置一次性迁移（issue #76，E1-E7/R1）。
+ * dsh-notifier — 存量自建配置一次性迁移（issue #76，E1-E7/R1；#468 逐字段补齐）。
  *
  * 旧版配置位于 `~/.dsh/dsh-notifier.json`（自建读写链路，现已废弃）；本模块
  * 在 settings 命名空间 attach 后（installNotifierSettings 的 onScope 内）把
@@ -7,13 +7,25 @@
  *
  * 分流（R1）：
  * - 合法 json：改名 `.migrated.bak`（即 `dsh-notifier.json.migrated.bak`）后
- *   sanitize 过滤经 owner scope.update 增量写入（只写文件里显式存在的键）；
+ *   sanitize 过滤，再经 owner scope.update **逐字段缺失补齐**写入
+ *   （#468：不是无脑全量覆盖——只补写 user 层尚缺失的键）；
  * - 损坏/非对象/无有效键：只改名 `.corrupted.bak` 标记，不写入（防把 schema
  *   默认值固化进 user 层、压制后续默认值演进）；
  * - 中断态：`.migrated.bak` 存在而 json 不存在 → 从 bak 重放
- *   （解析 → sanitize → update）——但若 settings user 层已有该命名空间的值
- *   （迁移已完成）则幂等跳过，避免重复写入（E2 断言「不重复写入」）；
+ *   （解析 → sanitize → 逐字段缺失补齐）——迁移是否「已完成」不再以
+ *   「user 层任意键存在」为标志（#468：部分写入中断会漏掉剩余 legacy 字段），
+ *   而是逐字段比对 user 层缺失键后补写，全部已齐才幂等跳过（E2 断言
+ *   「不重复写入」）；
  * - 写入失败：回滚改名（bak 还原为 json）并 warn，下次启动重试（E6）。
+ *
+ * 冲突策略（#468，用户改值优先）：
+ * - 迁移只补写 user 层**缺失**的键（sanitize 白名单 ∩ bak 显式键 − user 层
+ *   已存在的键）；用户已改/已存在的字段（含值为 undefined 的键）一律不被
+ *   迁移覆盖，与 PUT /config 之后重启不再被迁移抢回的语义一致（E2 依赖的
+ *   幂等判定本来就是「user 层已有值 = 不重复写入」）；
+ * - json 正常迁移与中断重放共用同一补齐写入路径，天然收敛到终态；
+ * - 若用户确实想要 bak 里的旧值，官方 settings 是唯一事实源——迁移不写
+ *   用户键，bak 原样保留可手动核对。
  */
 import { existsSync, readFileSync, renameSync, unlinkSync } from "node:fs";
 import { errorMessage } from "../../../shared/host-utils.js";
@@ -40,12 +52,30 @@ export interface MigrationOutcome {
   resumed: boolean;
 }
 
-/** migrateLegacyConfig 的依赖（scope.update 面 + user 层存在性判定）。 */
+/** migrateLegacyConfig 的依赖（scope.update 面 + user 层读取）。 */
 export interface MigrateDeps {
   /** 增量 merge patch 进 settings user 层。 */
   update(patch: object): Promise<void>;
-  /** settings user 层该命名空间是否已有任何键（幂等跳过判定）。 */
-  hasUserValues(): boolean;
+  /**
+   * settings user 层该命名空间当前值（迁移完成判定 = 逐字段比对依据，#468）。
+   * 返回空对象 = 尚无该命名空间的 user 值。
+   */
+  readUser(): Record<string, unknown>;
+}
+
+/**
+ * 从 sanitize 白名单结果中挑出 user 层尚缺失的键（#468 冲突策略：只补缺失键，
+ * 用户已改/已存在的键不被迁移覆盖）。字段是否「已迁移」按**键存在性**判定
+ * （与官方解析 mergeLayers 的语义一致：user 键值为 undefined 也代表用户已表态）。
+ *
+ * @returns 待补写 patch；空对象 = 无缺失键（迁移已完成，调用方幂等跳过）。
+ */
+function diffMissingKeys(sanitized: Record<string, unknown>, user: Record<string, unknown>): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+  for (const key of Object.keys(sanitized)) {
+    if (!(key in user)) patch[key] = sanitized[key];
+  }
+  return patch;
 }
 
 /**
@@ -66,16 +96,16 @@ function renameOver(previous: string, next: string): void {
 /**
  * 存量 dsh-notifier.json 一次性迁移到官方 settings 命名空间。
  *
- * 时序（issue #76 R1）：
+ * 时序（issue #76 R1；#468 补写语义）：
  * 0. 损坏标记态（只有 `.corrupted.bak`）→ 幂等跳过；
  * 1. json 不存在：
  *    - 无 migrated bak → 稳态，幂等返回；
- *    - migrated bak 存在 → 若 user 层已有值（迁移已完成，E2）跳过；
- *      否则视为迁移中断（E3），从 bak 重放「解析 → sanitize → update」；
+ *    - migrated bak 存在 → 解析 bak：损坏/无有效键 → 标记跳过；合法 →
+ *      逐字段缺失补齐（user 层缺失键才 update），全部已齐 → 幂等跳过（E2）；
  * 2. json 存在：读 + 解析；损坏/非对象/无有效键 → 改名 `.corrupted.bak`
  *    （只标记不写入，E4）；
  * 3. 合法 → 先改名 `.migrated.bak`（rename-first marker，改名成功即视为
- *    已处理）→ sanitize 过滤 → owner scope.update 增量写入；
+ *    已处理）→ sanitize 过滤 → 逐字段缺失补齐写入（只写 user 层缺失的键）；
  * 4. 写入失败 → 回滚改名（bak 还原为 json）并 warn，下次启动重试（E6）。
  *
  * 必须在 settings 服务 attach 后调用（onScope 内），且先于一切 enabled 判定
@@ -95,11 +125,10 @@ export async function migrateLegacyConfig(legacyPath: string, deps: MigrateDeps,
     if (!existsSync(migratedBak)) {
       return { performed: false, migrated: false, rolledBack: false, skippedCorrupt: false, skippedIdempotent: true, resumed: false };
     }
-    // 中断态/已迁移：user 层已有值 → 幂等跳过（E2，不重复写入）；
-    // 否则视为中断，从 bak 重放（E3）。
-    if (deps.hasUserValues()) {
-      return { performed: false, migrated: false, rolledBack: false, skippedCorrupt: false, skippedIdempotent: true, resumed: false };
-    }
+    // 中断态：从 bak 重放「解析 → sanitize → 逐字段缺失补齐」（#468）。
+    // 迁移完成判定不再用「user 层任意键存在」——部分写入中断后剩余 legacy
+    // 字段会永久漏迁；改为逐字段比对：user 层缺失的键补写，全部已齐才幂等
+    // 跳过（E2「不重复写入」语义保持）。
     let parsed: unknown;
     try {
       parsed = JSON.parse(readFileSync(migratedBak, "utf8"));
@@ -112,9 +141,14 @@ export async function migrateLegacyConfig(legacyPath: string, deps: MigrateDeps,
       logger?.warn?.(`dsh-notifier: 未完成的迁移残留 ${MIGRATED_BAK_SUFFIX} 无可迁移的有效键 — 已跳过，确认无误后可手动删除该备份`);
       return { performed: false, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: true };
     }
+    const patch = diffMissingKeys(sanitized, deps.readUser());
+    if (Object.keys(patch).length === 0) {
+      // 全部字段已迁齐（含用户改值后重启——见冲突策略）：幂等跳过（E2）
+      return { performed: false, migrated: false, rolledBack: false, skippedCorrupt: false, skippedIdempotent: true, resumed: false };
+    }
     try {
-      await deps.update(sanitized as Record<string, unknown>);
-      logger?.warn?.(`dsh-notifier: 检测到上次未完成的迁移 — 已从 ${MIGRATED_BAK_SUFFIX} 重放写入设置；确认运行正常后可手动删除该备份`);
+      await deps.update(patch);
+      logger?.warn?.(`dsh-notifier: 检测到上次未完成的迁移 — 已从 ${MIGRATED_BAK_SUFFIX} 补齐缺失字段 ${Object.keys(patch).join(", ")}；确认运行正常后可手动删除该备份`);
       return { performed: false, migrated: true, rolledBack: false, skippedCorrupt: false, skippedIdempotent: false, resumed: true };
     } catch (err) {
       logger?.warn?.(`dsh-notifier: 未完成迁移从 ${MIGRATED_BAK_SUFFIX} 重放写入失败（${errorMessage(err)}）— 配置仍保留在该备份中，排查后重启重试或手动恢复`);
@@ -156,15 +190,23 @@ export async function migrateLegacyConfig(legacyPath: string, deps: MigrateDeps,
     return { performed: true, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: false };
   }
 
-  // 3. 合法：rename-first marker 后再写入
+  // 3. 合法：rename-first marker 后逐字段缺失补齐写入（#468——正常迁移与
+  //    中断重放同一补齐语义：不覆盖用户已改/已存在的键，见文件头冲突策略；
+  //    首迁 user 层为空 → patch = 全量 sanitized 键集，与改造前行为一致）
   try {
     renameOver(legacyPath, migratedBak);
   } catch (err) {
     logger?.warn?.(`dsh-notifier: 存量配置改名失败（${errorMessage(err)}）— 本次跳过，下次启动重试`);
     return { performed: false, migrated: false, rolledBack: false, skippedCorrupt: false, skippedIdempotent: false, resumed: false };
   }
+  const patch = diffMissingKeys(sanitized, deps.readUser());
+  if (Object.keys(patch).length === 0) {
+    // 改名后才发现所有字段均已迁齐（用户经 PUT /config 全量保存过且键全在）
+    // → 不重复写入，幂等结束（bak 保留供核对）
+    return { performed: true, migrated: false, rolledBack: false, skippedCorrupt: false, skippedIdempotent: true, resumed: false };
+  }
   try {
-    await deps.update(sanitized as Record<string, unknown>);
+    await deps.update(patch);
     return { performed: true, migrated: true, rolledBack: false, skippedCorrupt: false, skippedIdempotent: false, resumed: false };
   } catch (err) {
     // 4. 写入失败：回滚改名（bak 还原为 json），下次启动重试

--- a/packages/dsh-notifier/src/migrate.ts
+++ b/packages/dsh-notifier/src/migrate.ts
@@ -18,14 +18,30 @@
  *   「不重复写入」）；
  * - 写入失败：回滚改名（bak 还原为 json）并 warn，下次启动重试（E6）。
  *
- * 冲突策略（#468，用户改值优先）：
+ * 冲突策略（#468，用户改值优先；字段粒度 = 顶层配置键，sanitize 白名单）：
  * - 迁移只补写 user 层**缺失**的键（sanitize 白名单 ∩ bak 显式键 − user 层
- *   已存在的键）；用户已改/已存在的字段（含值为 undefined 的键）一律不被
- *   迁移覆盖，与 PUT /config 之后重启不再被迁移抢回的语义一致（E2 依赖的
- *   幂等判定本来就是「user 层已有值 = 不重复写入」）；
+ *   已存在的键）；用户已改/已存在的字段一律不被迁移覆盖，与 PUT /config
+ *   之后重启不再被迁移抢回的语义一致（E2 依赖的幂等判定本来就是「user 层
+ *   已有值 = 不重复写入」）；
+ * - user 层键以**任何形态存在**（含空对象/仅部分嵌套子键）即视为用户已接管
+ *   该字段**整组**（含其嵌套子键）——迁移不补写其嵌套子键。原因：sanitize
+ *   对嵌套对象（如 quietHours）输出恒为完整对象（base 默认值兜底），子键级
+ *   补齐会把 schema 默认值固化进 user 层（压制后续默认值演进），且会覆盖
+ *   「用户只 PUT 部分子键 = 其余用默认」的合法意图；用户整组接管后 bak 保留
+ *   人工恢复路径；
+ * - 顶层标量键的键存在性判定与官方 mergeLayers 对顶层键的语义一致（user 键
+ *   值为 undefined 也代表用户已表态）；该证据**仅对顶层键成立**——官方解析
+ *   对嵌套对象会剥离空对象内部并回落 base，故冲突粒度不延伸到子键级；
  * - json 正常迁移与中断重放共用同一补齐写入路径，天然收敛到终态；
  * - 若用户确实想要 bak 里的旧值，官方 settings 是唯一事实源——迁移不写
  *   用户键，bak 原样保留可手动核对。
+ *
+ * 并发说明（#468 P1-3）：迁移 update 不传 expectedRevision——官方 update 是
+ * 串行写队列 + merge over 最新 user section，迁移与用户 PUT 并发时各自 merge，
+ * 迁移不会用旧快照覆盖用户新值；但「写入前 readUser 幂等判定」存在 TOCTOU
+ * 窗口：极端并发下可能对同一缺失键多补一次（update 内不含该键才补）。补写
+ * 是幂等 merge 且永不覆盖已存在键，多补一次危害低（仅多一次无害写入），
+ * 不做乐观并发。
  */
 import { existsSync, readFileSync, renameSync, unlinkSync } from "node:fs";
 import { errorMessage } from "../../../shared/host-utils.js";
@@ -65,8 +81,11 @@ export interface MigrateDeps {
 
 /**
  * 从 sanitize 白名单结果中挑出 user 层尚缺失的键（#468 冲突策略：只补缺失键，
- * 用户已改/已存在的键不被迁移覆盖）。字段是否「已迁移」按**键存在性**判定
- * （与官方解析 mergeLayers 的语义一致：user 键值为 undefined 也代表用户已表态）。
+ * 用户已改/已存在的键不被迁移覆盖）。字段粒度 = **顶层配置键**（sanitize 白名单）；
+ * user 层键以任何形态存在（含空对象/部分嵌套子键）即视为用户已接管该字段整组，
+ * 迁移不补写其嵌套子键。顶层标量键的键存在性判定与官方 mergeLayers 对顶层键的
+ * 语义一致（user 键值为 undefined 也代表用户已表态）——该证据不延伸到嵌套子键级
+ * （官方解析对嵌套对象会剥离空对象内部并回落 base，见文件头冲突策略）。
  *
  * @returns 待补写 patch；空对象 = 无缺失键（迁移已完成，调用方幂等跳过）。
  */
@@ -202,7 +221,8 @@ export async function migrateLegacyConfig(legacyPath: string, deps: MigrateDeps,
   const patch = diffMissingKeys(sanitized, deps.readUser());
   if (Object.keys(patch).length === 0) {
     // 改名后才发现所有字段均已迁齐（用户经 PUT /config 全量保存过且键全在）
-    // → 不重复写入，幂等结束（bak 保留供核对）
+    // → 不重复写入，幂等结束（bak 保留供核对：如需旧值见该备份）
+    logger?.warn?.(`dsh-notifier: 存量配置字段在 user 层均已存在，跳过写入（不改动用户已设值；如需旧值见 ${legacyPath.split(/[\\/]/).pop()}${MIGRATED_BAK_SUFFIX}）`);
     return { performed: true, migrated: false, rolledBack: false, skippedCorrupt: false, skippedIdempotent: true, resumed: false };
   }
   try {

--- a/packages/dsh-notifier/test/migration.test.ts
+++ b/packages/dsh-notifier/test/migration.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 /**
- * dsh-notifier — e2e：存量配置迁移（issue #76 E1-E7 / R1）。
+ * dsh-notifier — e2e：存量配置迁移（issue #76 E1-E7 / R1；#468 逐字段补齐）。
  *
  * 覆盖：
  * - E1 旧 json 存在 → 一次性迁移至官方 settings user 层，原文改名 .migrated.bak；
@@ -9,7 +9,11 @@
  * - E4 损坏/非对象/无有效键 → 改名 .corrupted.bak，不写入；
  * - E5 Windows rename 目标已存在 → 先 unlink 旧 bak 再 rename；
  * - E6 迁移写入失败 → 回滚改名（json 还原）+ warn，不阻塞启动；
- * - E7 迁移前置于 enabled 判定（禁用态也迁移，路由/命名空间照常注册）。
+ * - E7 迁移前置于 enabled 判定（禁用态也迁移，路由/命名空间照常注册）；
+ * - E8 migrateLegacyConfig outcome 精确断言（#468 起迁移完成判定 = 逐字段缺失
+ *   补齐，不再是「user 层任意键存在」整体跳过）；
+ * - E9 #468 回归：中断部分写入后重跑补齐剩余字段；用户改值不被迁移覆盖
+ *   （冲突策略：只补写 user 层缺失的键，用户已改/已存在的键不被覆盖）。
  */
 import { join } from "node:path";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
@@ -158,14 +162,16 @@ try {
   // 布尔结果字段翻转/逻辑运算符/条件分支的存活变异体由 outcome 深比较杀灭）
   {
     const dir = mkdtempSync(join(tmpdir(), "dnotify-migrate-outcome-"));
-    const deps = (userHasValues = false, failUpdate = false) => {
+    // 直测注入面（#468 起 readUser）：user 层当前值可预置（模拟部分写入/用户改值）
+    const deps = (user = {}, failUpdate = false) => {
       const updates = [];
       return {
         updates,
-        hasUserValues: () => userHasValues,
+        readUser: () => user,
         async update(patch) {
           if (failUpdate) throw new Error("io boom");
           updates.push(patch);
+          Object.assign(user, patch);
         },
       };
     };
@@ -188,18 +194,18 @@ try {
       assert.deepEqual(out, CORRUPT_ONLY, "E8：损坏标记态 → skippedCorrupt+skippedIdempotent");
       assert.equal(d.updates.length, 0, "E8：损坏标记态不写入");
     }
-    // migrated.bak 存在 + user 层已有值 → 幂等跳过（E2）
+    // migrated.bak 存在 + user 层全量有值 → 幂等跳过（E2）
     {
-      const d = deps(true);
+      const d = deps({ notifyAsk: false, notifySound: true });
       const legacy = join(dir, "bak-user.json");
-      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({ notifyAsk: false }));
+      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({ notifyAsk: false, notifySound: true }));
       const out = await migrateLegacyConfig(legacy, d);
-      assert.deepEqual(out, IDLE, "E8：bak 存在 + user 有值 → 幂等跳过");
+      assert.deepEqual(out, IDLE, "E8：bak 存在 + user 已全量 → 幂等跳过");
       assert.equal(d.updates.length, 0, "E8：幂等跳过不写入");
     }
     // 中断态重放成功：bak 存在 + user 空 + bak 合法 → resumed+migrated
     {
-      const d = deps(false);
+      const d = deps();
       const legacy = join(dir, "resume-ok.json");
       writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({ notifySound: false }));
       const out = await migrateLegacyConfig(legacy, d);
@@ -208,7 +214,7 @@ try {
     }
     // 中断态重放失败：bak 非法 JSON → skippedCorrupt+resumed，不写入
     {
-      const d = deps(false);
+      const d = deps();
       const legacy = join(dir, "resume-bad.json");
       writeFileSync(legacy + MIGRATED_BAK_SUFFIX, "{bad json");
       const out = await migrateLegacyConfig(legacy, d);
@@ -217,7 +223,7 @@ try {
     }
     // 中断态重放失败：bak 无有效键 → skippedCorrupt+resumed
     {
-      const d = deps(false);
+      const d = deps();
       const legacy = join(dir, "resume-empty.json");
       writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({ evilKey: 1 }));
       const out = await migrateLegacyConfig(legacy, d);
@@ -259,13 +265,59 @@ try {
     }
     // 写入失败 → 回滚改名（E6）：json 还原 + rolledBack
     {
-      const d = deps(false, true);
+      const d = deps({}, true);
       const legacy = join(dir, "rollback.json");
       writeFileSync(legacy, JSON.stringify({ notifyAsk: true }));
       const out = await migrateLegacyConfig(legacy, d, { warn: () => {} });
       assert.deepEqual(out, { performed: true, migrated: false, rolledBack: true, skippedCorrupt: false, skippedIdempotent: false, resumed: false }, "E8：写入失败回滚 outcome");
       assert.ok(existsSync(legacy), "E8：回滚后原 json 还原");
       assert.ok(!existsSync(legacy + MIGRATED_BAK_SUFFIX), "E8：回滚后 migrated.bak 已还原为 json");
+    }
+    // #468 E9a：json 迁移部分写入中断（user 层只落了部分键）→ 重跑补齐剩余字段
+    {
+      const d = deps({ notifyAsk: false }); // 上次迁移只写进 notifyAsk 就被打断
+      const legacy = join(dir, "partial.json");
+      writeFileSync(legacy, JSON.stringify({ notifyAsk: false, notifySound: true, quietHours: { enabled: true, start: "23:00", end: "07:00" } }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, { performed: true, migrated: true, rolledBack: false, skippedCorrupt: false, skippedIdempotent: false, resumed: false }, "E9a：部分写入中断后重跑 → 继续迁移");
+      assert.deepEqual(d.updates, [{ notifySound: true, quietHours: { enabled: true, start: "23:00", end: "07:00" } }], "E9a：只补写 user 层缺失字段（已写 notifyAsk 不重写）");
+    }
+    // #468 E9b：中断态（bak-only）部分写入 → 重跑补齐，全部齐后再跑幂等跳过
+    {
+      const d = deps({ notifyAsk: false }); // 上次重放只写进 notifyAsk 就被打断
+      const legacy = join(dir, "resume-partial.json");
+      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({ notifyAsk: false, notifySound: true }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, { performed: false, migrated: true, rolledBack: false, skippedCorrupt: false, skippedIdempotent: false, resumed: true }, "E9b：中断态部分写入后重跑 → 补齐 + resumed");
+      assert.deepEqual(d.updates, [{ notifySound: true }], "E9b：只补缺失字段 notifySound");
+      // 再跑一次（user 层已全量）→ 幂等跳过，不再写
+      const out2 = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out2, { performed: false, migrated: false, rolledBack: false, skippedCorrupt: false, skippedIdempotent: true, resumed: false }, "E9b：补齐后再次运行 → 幂等跳过");
+      assert.equal(d.updates.length, 1, "E9b：幂等运行不重复写入");
+    }
+    // #468 E9c：用户改值不被迁移覆盖（冲突策略：只补 user 层缺失键）
+    // 中断态：bak 里 notifyAsk=false，用户已改为 true 且已保存 notifySound——
+    // 两条都存在 → 幂等跳过；只缺 quietHours → 只补 quietHours，不动用户值
+    {
+      const d = deps({ notifyAsk: true, notifySound: false }); // 用户改值后的 user 层
+      const legacy = join(dir, "user-conflict.json");
+      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({ notifyAsk: false, notifySound: true, quietHours: { enabled: false, start: "22:00", end: "08:00" } }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.equal(out.migrated, true, "E9c：缺 quietHours → 迁移补齐");
+      assert.deepEqual(d.updates, [{ quietHours: { enabled: false, start: "22:00", end: "08:00" } }], "E9c：只补缺失键 quietHours");
+      assert.equal(d.readUser().notifyAsk, true, "E9c：用户改过的 notifyAsk 不被迁移覆盖");
+      assert.equal(d.readUser().notifySound, false, "E9c：用户已存在的 notifySound 不被迁移覆盖");
+    }
+    // #468 E9d：json 正常迁移 + user 键全量已存在（经 PUT /config 保存过）→
+    // 改名后幂等跳过，不重复写入、不覆盖用户值
+    {
+      const d = deps({ notifyAsk: true }); // 用户已把该键改成 true
+      const legacy = join(dir, "valid-user.json");
+      writeFileSync(legacy, JSON.stringify({ notifyAsk: false })); // legacy 里是 false
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.deepEqual(out, { performed: true, migrated: false, rolledBack: false, skippedCorrupt: false, skippedIdempotent: true, resumed: false }, "E9d：user 全量存在 → 改名后幂等跳过");
+      assert.equal(d.updates.length, 0, "E9d：不重复写入");
+      assert.equal(d.readUser().notifyAsk, true, "E9d：用户改值不被迁移覆盖");
     }
     rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/dsh-notifier/test/migration.test.ts
+++ b/packages/dsh-notifier/test/migration.test.ts
@@ -170,6 +170,11 @@ try {
         readUser: () => user,
         async update(patch) {
           if (failUpdate) throw new Error("io boom");
+          // #468 P1-4：锁死「只补缺失键」语义——update 提交的每个键在写入前
+          // 必须不存在于 user 层（防未来实现改成快照全量/覆盖写导致漏报）
+          for (const key of Object.keys(patch)) {
+            assert.equal(key in user, false, `E9：update 不得提交 user 层已存在的键 ${key}`);
+          }
           updates.push(patch);
           Object.assign(user, patch);
         },
@@ -318,6 +323,18 @@ try {
       assert.deepEqual(out, { performed: true, migrated: false, rolledBack: false, skippedCorrupt: false, skippedIdempotent: true, resumed: false }, "E9d：user 全量存在 → 改名后幂等跳过");
       assert.equal(d.updates.length, 0, "E9d：不重复写入");
       assert.equal(d.readUser().notifyAsk, true, "E9d：用户改值不被迁移覆盖");
+    }
+    // #468 E9e：冲突策略字段粒度 = 顶层配置键——user 层 quietHours 以部分子键
+    // 形态存在（用户只 PUT 过子键 start）即视为用户已接管整组：不补写嵌套
+    // 子键（bak 的 enabled/end 不覆盖不补），迁移只补顶层缺失键 notifySound
+    {
+      const d = deps({ notifyAsk: true, quietHours: { start: "07:00" } }); // 用户部分子键接管
+      const legacy = join(dir, "subkey-owner.json");
+      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({ notifyAsk: false, notifySound: true, quietHours: { enabled: false, start: "22:00", end: "08:00" } }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.equal(out.migrated, true, "E9e：缺顶层键 notifySound → 迁移补齐");
+      assert.deepEqual(d.updates, [{ notifySound: true }], "E9e：不补写 quietHours 嵌套子键（仅顶层缺失键）");
+      assert.deepEqual(d.readUser().quietHours, { start: "07:00" }, "E9e：用户部分子键保持原样（不被 bak 子键覆盖）");
     }
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## v2 follow-up（复核闸 P1-2/P1-3/P1-4/P2-1，commit `62c29f1`）

按主控复核裁决补充（顶层字段粒度冲突策略已接受，未返工子键级补齐）：

- **P1-2 注释修正**：migrate.ts 文件头冲突策略 + `diffMissingKeys` JSDoc 已改为明示「字段粒度 = 顶层配置键（sanitize 白名单）；user 层键以任何形态存在（含空对象/仅部分子键）即视为用户已接管该字段整组，迁移不补写其嵌套子键；顶层标量键的键存在性判定与官方 mergeLayers 对顶层键的语义一致（该证据仅对顶层键成立，官方对嵌套对象会剥离空对象内部回落 base，故不延伸到子键级）」。
- **P1-3 并发说明**：migrate.ts 文件头补「迁移 update 不传 expectedRevision——官方 update 为串行写队列 + merge over 最新 user section，与用户 PUT 并发不重复覆盖用户值；写入前 readUser 幂等判定存在 TOCTOU 窗口，极端并发可能对同一缺失键多补一次（幂等 merge、不覆盖已存在键，危害低，不做乐观并发）」。
- **P1-4 测试锁死**：migration.test.ts E8/E9 共用 fake `update` 内断言「patch 的每个键在 update 调用前不存在于 user 层」（`test/migration.test.ts:176`），把「只补缺失键、不覆盖已存在键」锁死进测试辅助——未来若改成快照全量/覆盖写直接红。
- **P2-1 warn 增强**：json 正常迁移改名后发现字段全部已存在（E9d 场景）时输出 warn，附 bak 文件名提示「如需旧值见 `<文件名>.migrated.bak`」（`src/migrate.ts:225`）。
- **P2-2 顺手补 E9e 用例**：冲突策略字段粒度 = 顶层键的显式回归——user 层 `quietHours` 仅部分子键 `{start}` 存在 → 视为整组接管：迁移不补写 quietHours 任何子键、仅补顶层缺失键，用户子键原样保留（`test/migration.test.ts:327-338`）。

## 修复说明

**缺陷**：中断迁移以「任意 user 值存在」为完成标志（`packages/dsh-notifier/src/migrate.ts` 旧 `hasUserValues()` + `src/index.ts` 依赖注入），若 `update` 非原子或部分写入后中断（如写入部分键后被杀），剩余 legacy 字段被永久漏迁（`skippedIdempotent` 跳过重放）。

**修复**（改逐字段缺失补齐，与现有 rename-first marker 最贴合）：
- 迁移完成判定从「user 层任意键存在」改为**逐字段比对**：`sanitize` 白名单 ∩ bak 显式键 − user 层已存在的键 = 待补写 patch；
- 正常迁移（json 存在，rename-first 后）与中断态重放（bak-only）**共用同一补齐路径**，且天然收敛——部分写入后重跑只补剩余字段；
- 全部字段已齐 → `skippedIdempotent` 幂等跳过（E2「不重复写入」语义保持），已迁移 bak 不再重复 update；
- 只补缺失键，已存在键（含值为 `undefined` 的键）不重写（顶层键存在性判定与官方解析 mergeLayers 对顶层键的语义一致）。

**冲突策略（#468，用户改值优先）**：
- **字段粒度 = 顶层配置键**（sanitize 白名单）。迁移**只补写 user 层缺失的顶层键**；
- user 层键以**任何形态存在**（含空对象/仅部分嵌套子键）即视为用户已接管该字段**整组**（含嵌套子键）——迁移不补写其嵌套子键（sanitize 对嵌套对象输出恒为完整对象含 base 默认值，子键级补齐会把 schema 默认值固化进 user 层、且会覆盖「用户只 PUT 部分子键 = 其余用默认」的合法意图）；
- 用户已改/已存在的字段（顶层键）一律不被迁移覆盖，bak 原样保留可手动核对（如需旧值：settings user 层是唯一事实源，可手动 PUT；bak 在 `.migrated.bak` 备份中）。

**范围**：仅 `packages/dsh-notifier/src/migrate.ts` + `src/index.ts` + `test/migration.test.ts`；未触碰 `.github/`、`package.json`、`pnpm-lock.yaml`、`shared/` 契约层。

## 全量断言表

| 验收条目 | 结论 | 证据或漂移解释 |
|---|---|---|
| 迁移中断/部分写入后重跑可补齐剩余字段（json 部分写入中断） | PASS | E9a：`test/migration.test.ts:281-288`，user 层预置 `notifyAsk` → outcome `migrated`、update patch 仅 `{notifySound, quietHours}`（缺啥补啥） |
| 迁移中断/部分写入后重跑可补齐剩余字段（中断态 bak-only 部分写入） | PASS | E9b：`test/migration.test.ts:290-301`，user 层预置 `notifyAsk` → 补 `{notifySound}` 后再次运行 `skippedIdempotent` 且 update 数不增 |
| 用户改值不被迁移覆盖（或按声明的冲突策略处理） | PASS | E9c/E9d：`test/migration.test.ts:303-325`——bak/legacy 与 user 层同键不同值 → user 值保留（`notifyAsk:true` 不被 bak `false` 覆盖），只补缺失键；已全量存在则改名后幂等跳过不重复写入 |
| 冲突策略字段粒度 = 顶层配置键（部分子键 = 用户整组接管，不补嵌套子键） | PASS | E9e：`test/migration.test.ts:327-338`——user `quietHours:{start}` → 只补顶层缺失键 `notifySound`，quietHours 子键零写入、用户子键原样保留 |
| 「只补缺失键、不覆盖已存在键」实现锁死（防未来改快照全量） | PASS | `test/migration.test.ts:176`——fake update 内断言 patch 每键在写入前不存在于 user 层（E8/E9 全部 update 走此断言） |
| E2 幂等语义保持（迁移完成后二次启动不重复写入） | PASS | E9b 第二跑 + E8「bak 存在 + user 已全量 → IDLE 幂等跳过」outcome 精确断言；既有 E2（apply 二次不触发 update）不变 |
| E1/E3/E4/E5/E6/E7 既有迁移行为不回归 | PASS | 同文件既有断言原样通过（E1 合法 json 改名 `.migrated.bak` 写入、E3 空 user 重放、E4 损坏标记、E6 回滚、E7 禁用态迁移）；`pnpm test` 退出码 0 |
| 红线范围克制 | PASS | `git diff origin/main...HEAD` 仅 3 文件（`src/migrate.ts`/`src/index.ts`/`test/migration.test.ts`）；无 `.github/`、`package.json`、`pnpm-lock.yaml`、`shared/` 改动 |
| 五连门禁全绿（v2） | PASS | `pnpm build`、`pnpm test`、`pnpm contract`、`pnpm pack:check`、`pnpm typecheck` 均退出码 0（本地逐命令独立记录） |

## 提交

- `fix(dsh-notifier): 中断迁移逐字段缺失补齐防漏迁（#468）`（`23067b4`）
- `test(dsh-notifier): 迁移中断部分写入与用户改值回归用例（#468）`（`14463e0`）
- `fix(dsh-notifier): 迁移冲突策略注释修正与只补缺失键测试锁死（#468 复核 P1-2/P1-3/P1-4/P2-1）`（`62c29f1`，v2 follow-up）

Closes #468
