### PR TITLE
fix(dsh-notifier): 配置未知键透传保留前向兼容策略（#470）

### DIFF
--- a/packages/dsh-notifier/README.en.md
+++ b/packages/dsh-notifier/README.en.md
@@ -94,6 +94,47 @@ the original file is renamed `dsh-notifier.json.migrated.bak` (corrupt files are
 renamed `.corrupted.bak` without being written). The self-maintained read/write path
 is retired.
 
+**Unknown-key semantics (forward compatibility, issue #470)**: dsh-notifier applies a
+**"pass-through and preserve"** policy to configuration keys it does **not recognize** —
+read and write behave consistently; unknown keys are never dropped, validated or
+rewritten (except for composition-layer assembly keys, see boundaries below):
+
+- **Reading**: `GET /api/dsh-notifier/config` returns unknown keys verbatim in both
+  `user` (the raw settings user layer) and `effective` (the resolved config), keeping
+  future-version / third-party keys visible.
+- **Writing**: `PUT /api/dsh-notifier/config` is an incremental patch — it merges the
+  submitted known keys only; unknown keys already in the user layer are **not affected
+  by saving known keys**, and unknown keys carried in the current patch are **preserved
+  verbatim** (never silently dropped). A patch with only unknown keys (e.g.
+  `{"futureKey":1}`) returns **200** and is written; only an empty patch `{}` (or a
+  patch with nothing writable after filtering, e.g. only assembly keys) returns **400**
+  "need at least one config key".
+- **Upgrade path**: when a key is unknown in version vN (already passed through into the
+  user layer) and becomes a known key in vN+1 — stale dirty values in the user layer are
+  **not auto-cleaned** (an upgrade never overwrites fields the user has already set);
+  on read, normalize falls back to defaults for invalid known-key values (dirty values
+  do not affect the effective config or other keys); a **400 + hint** is only raised when
+  you **actively submit** that key with an invalid value. To clear a leftover dirty key,
+  delete it manually in `settings.yaml`.
+- **Legacy migration**: unknown keys in the old `dsh-notifier.json` are **preserved
+  through migration** — written when missing from the user layer, never overwriting
+  existing ones; a legacy file containing only unknown keys is no longer treated as
+  "no valid keys".
+- **Boundary exceptions**:
+  - Composition-layer assembly keys (`configFile` / `toastScript` / `historyFile` /
+    `statusFile` / `enabled`) are cordis composition/startup parameters and **never
+    enter the settings user layer** — PUT and migration drop same-named keys; entry
+    composition goes through the whitelist filter.
+  - Reserved Bark channel keys (`device_key` / `device_keys` / `ciphertext`) are still
+    always stripped / rejected; unknown channel params only pass through as
+    string/number values.
+  - Unknown keys take no part in validation (invalid known keys still return
+    400 + hint).
+
+Consequence: after an upgrade, if the settings page does not show a field that still
+exists in `settings.yaml`, that is the intended preserve behavior — saving other known
+settings will not lose it.
+
 Example values (defaults):
 
 ```json

--- a/packages/dsh-notifier/README.en.md
+++ b/packages/dsh-notifier/README.en.md
@@ -121,6 +121,12 @@ rewritten (except for composition-layer assembly keys, see boundaries below):
   existing ones; a legacy file containing only unknown keys is no longer treated as
   "no valid keys".
 - **Boundary exceptions**:
+  - `patch` **must be an object**: non-object shapes (arrays, `null`, numbers, etc.)
+    always return 400 — arrays are never passed through as numeric-index dirty keys.
+  - Prototype-chain / special member keys (`__proto__`, `constructor`, `prototype`,
+    `toString`, `hasOwnProperty`, `valueOf`, etc., which JSON text can inject as own
+    keys) are always stripped from both the read pass-through and the write channels —
+    never validated and never written.
   - Composition-layer assembly keys (`configFile` / `toastScript` / `historyFile` /
     `statusFile` / `enabled`) are cordis composition/startup parameters and **never
     enter the settings user layer** — PUT and migration drop same-named keys; entry

--- a/packages/dsh-notifier/README.md
+++ b/packages/dsh-notifier/README.md
@@ -108,6 +108,35 @@ context filter checks」）。取舍如下（issue #290）：
 `dsh-notifier.json.migrated.bak`（损坏则改名 `.corrupted.bak`，不写入），
 自建读写链路已废弃。
 
+**未知键语义（前向兼容，issue #470）**：dsh-notifier 对配置中**无法识别的键**
+采取「透传保留」策略——读取与写入口径一致，未知键不会被丢弃，也不会被校验
+或改写（仅组合层装配键名例外，见下）：
+
+- **读取**：`GET /api/dsh-notifier/config` 的 `user`（settings 用户层原始节）与
+  `effective`（生效配置）均原样返回未知键，供未来版本/第三方键保持可见；
+- **写入**：`PUT /api/dsh-notifier/config` 为增量 patch——仅合并提交的已知键；
+  存量 user 层中已有的未知键**不受已知键保存影响**，本次 patch 中携带的未知键
+  **一并原样保留**（不会静默丢弃）。纯未知键 patch（如 `{"futureKey":1}`）返回
+  **200** 并写入；仅空 patch `{}`（或无任何可写键，如只含装配键）返回 **400**
+  「需至少包含一个配置键」；
+- **升级路径**：某键在某版本还是未知键（已透传进 user 层）、下一版本成为已知键
+  时——旧脏键**不会被自动清洗**（升级本身不覆盖用户已表态字段）；读取时
+  normalize 对已知键非法值丢弃回默认（脏值不影响生效配置与其他键）；你**主动
+  提交**该键且值非法时才返回 400 + hint。若想清除残留脏键，可在
+  `settings.yaml` 中手动删除；
+- **存量迁移**：旧 `dsh-notifier.json` 的未知键在迁移时**透传保留**——user 层
+  缺失则补写、已存在不覆盖；纯未知键 legacy 不再被当作「无有效键」丢弃；
+- **边界例外**：
+  - 组合层装配键（`configFile` / `toastScript` / `historyFile` / `statusFile` /
+    `enabled`）是 cordis 组合层/启动参数，**不进入 settings 用户层**——PUT 与
+    迁移提交同名键一律剔除，entry 组合层走白名单过滤；
+  - Bark 频道实例内 `device_key` / `device_keys` / `ciphertext` 保留键仍一律
+    剔除/写拒，未知参数仅透传 string/number 值；
+  - 未知键不参与合法性校验（已知键非法仍返回 400 + hint）。
+
+后果提示：升级后若设置页未显示某字段但 `settings.yaml` 中仍在，属预期保留
+行为，不会因保存其他已知配置而丢失。
+
 配置项示例（默认值；`channels` / `kindRoutes` / `allowKinds` 为 M2 新增键）：
 
 ```json

--- a/packages/dsh-notifier/README.md
+++ b/packages/dsh-notifier/README.md
@@ -127,6 +127,11 @@ context filter checks」）。取舍如下（issue #290）：
 - **存量迁移**：旧 `dsh-notifier.json` 的未知键在迁移时**透传保留**——user 层
   缺失则补写、已存在不覆盖；纯未知键 legacy 不再被当作「无有效键」丢弃；
 - **边界例外**：
+  - `patch` **必须是对象**：数组、`null` 等非对象形态一律 400（数组不会按数字
+    索引透传成脏键）；
+  - 原型链/特殊成员键（`__proto__`、`constructor`、`prototype`、`toString`、
+    `hasOwnProperty`、`valueOf` 等，JSON 文本可注入为自有键）在读取透传与写入
+    通道中一律剔除，不参与校验也不写入；
   - 组合层装配键（`configFile` / `toastScript` / `historyFile` / `statusFile` /
     `enabled`）是 cordis 组合层/启动参数，**不进入 settings 用户层**——PUT 与
     迁移提交同名键一律剔除，entry 组合层走白名单过滤；

--- a/packages/dsh-notifier/src/client/index.ts
+++ b/packages/dsh-notifier/src/client/index.ts
@@ -36,6 +36,32 @@ declare module "@deepseek-ai/dsh-client-ui-slots" {
 /** 本插件字典命名空间（宿主 locale 服务注册用）。 */
 const NS = "notifier";
 
+/**
+ * 基线 diff 纯函数（issue #470 复核 P1-2）：返回 settings 相对 baseLine 中
+ * **值不同**的键集合（增量 patch，只提交变更键——A4 防组合层 base 被默认值
+ * 回写覆盖）。深比较用 JSON.stringify（值同序同即视为未变，UI 编辑对象字段
+ * 时键序稳定）。settings 中不存在于 baseLine 的新增键（diff 语义下的新增）
+ * 与值不同的既有键都会被提交；baseLine 中已删除的键不提交删除（增量 merge
+ * patch 无删除语义）。
+ *
+ * 导出为纯函数供测试直测（与 save() 共用同一实现——routes.test 整链模拟不再
+ * 手写近似）。
+ * @param settings 当前 UI 编辑态（effective 深拷贝起点）。
+ * @param baseLine 加载基线（loadCard 时的 effective 深拷贝）。
+ */
+function diffSettingsPayload(settings: Record<string, any>, baseLine: Record<string, any> | null): Record<string, any> {
+  var payload: Record<string, any> = {};
+  if (baseLine === null) return payload;
+  for (var key in settings) {
+    if (!Object.prototype.hasOwnProperty.call(settings, key)) continue;
+    var cur = settings[key];
+    var base = baseLine[key];
+    var same = JSON.stringify(cur) === JSON.stringify(base);
+    if (!same) payload[key] = cur;
+  }
+  return payload;
+}
+
   /** i18n 翻译函数（apply 时由 ctx.locale.bind(NS) 装配；未装配回落 key 本体，行为零变化）。 */
   var t: any = function (key: string, params?: any) {
     if (params === undefined) return key;
@@ -609,18 +635,10 @@ const NS = "notifier";
       setSaved("");
     }
 
-    /** 基线 diff：只提交与加载基线不同的键（A4，防组合层 base 被默认值回写覆盖）。 */
+    /** 基线 diff：只提交与加载基线不同的键（A4，防组合层 base 被默认值回写覆盖）。
+     *  逻辑收敛在模块级纯函数 diffSettingsPayload（#470 复核 P1-2，供测试直测）。 */
     function diffPayload(): Record<string, any> {
-      var payload: Record<string, any> = {};
-      var baseLine = baselineRef.current;
-      for (var key in settings) {
-        if (baseLine === null) break;
-        var cur = settings[key];
-        var base = baseLine[key];
-        var same = JSON.stringify(cur) === JSON.stringify(base);
-        if (!same) payload[key] = cur;
-      }
-      return payload;
+      return diffSettingsPayload(settings, baselineRef.current);
     }
 
     function save() {
@@ -1400,6 +1418,9 @@ const NS = "notifier";
   // ------------------------------------------------------------ 装配
 
 export function apply(ctx: any) {
+    // 测试直测挂载面（#470 复核 P1-2）：diffSettingsPayload 是模块级纯函数，
+    // 经 apply 暴露给 smoke 测试引用——保证「测试即产品实现」而非手写近似。
+    (apply as any).diffSettingsPayload = diffSettingsPayload;
     try {
       injectStyle();
 

--- a/packages/dsh-notifier/src/config.ts
+++ b/packages/dsh-notifier/src/config.ts
@@ -606,15 +606,19 @@ export function sanitizeSettings(raw: unknown): Partial<NotifyConfig> | null {
  * 净化 PUT /config 与存量迁移的增量 patch（透传通道，#470）：已知键按
  * validateSettings 同口径校验（任一非法 → 整体拒绝返回 null）；**未知键原样
  * 透传保留**（前向兼容——GET 读得到的未来/第三方键 PUT 回得去，迁移不丢
- * legacy 未来键），但组合层装配键名（ASSEMBLY_SETTING_KEYS）一律剔除（静默，
- * 与 Bark 保留键同口径）。返回对象非空即代表有可写键；纯未知键 patch 透传后
- * 同样非空（区别于空 patch {} → 空对象由调用方按 400 处理）。
+ * legacy 未来键；任意 JSON 值含 null——与读面 normalizeConfig 透传口径一致，
+ * #470 qa 复核发现 2），但组合层装配键名（ASSEMBLY_SETTING_KEYS）一律剔除
+ * （静默，与 Bark 保留键同口径）。返回对象非空即代表有可写键；纯未知键 patch
+ * 透传后同样非空（区别于空 patch {} → 空对象由调用方按 400 处理）。
  *
  * 安全边界（#470 复核 P0）：patch 必须为**普通对象**（数组直接返回 null——
  * 数组会被 Object.keys 当对象把数字索引透传成 "0":"1" 式脏键）；原型链成员
  * 键（constructor/prototype/toString/hasOwnProperty/valueOf/__proto__）一律
  * 剔除不写入——查表前用 hasOwn 判自有键防误触原型链校验器（抛 TypeError 致
  * 500），写入经 hasOwn 校验防把 Object.prototype 方法当未知键透传脏写 user 层。
+ * null 值语义：已知键值为 null 沿用既有跳过语义（validateSettings 同口径，
+ * 视同未提交）；**未知键值为 null 透传保留**（读面 normalizeConfig 本就透传
+ * null，写面不留空档——否则 GET 读到的 null 键 PUT 回去会静默消失）。
  */
 export function sanitizePatchSettings(raw: unknown): Partial<NotifyConfig> | null {
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
@@ -624,15 +628,18 @@ export function sanitizePatchSettings(raw: unknown): Partial<NotifyConfig> | nul
     if ((ASSEMBLY_SETTING_KEYS as readonly string[]).includes(key)) continue;
     if (!Object.prototype.hasOwnProperty.call(src, key)) continue;
     const value = src[key];
-    if (value === undefined || value === null) continue;
     if ((PROTOTYPE_POLLUTION_KEYS as readonly string[]).includes(key)) continue;
     if (Object.hasOwn(SETTING_VALIDATORS, key)) {
+      // 已知键：null 沿用既有跳过语义（与 validateSettings/sanitizeSettings 一致）
+      if (value === undefined || value === null) continue;
       const validator = SETTING_VALIDATORS[key];
       if (!validator(value)) return null;
       out[key] = value;
       continue;
     }
-    // 未知键透传保留：任意 JSON 值原样并入（顶层未来键形状不可预知）
+    // 未知键透传保留：任意 JSON 值（含 null/undefined 不存在于 JSON 文本；
+    // null 显式透传）原样并入——顶层未来键形状不可预知
+    if (value === undefined) continue;
     out[key] = value;
   }
   return out;

--- a/packages/dsh-notifier/src/config.ts
+++ b/packages/dsh-notifier/src/config.ts
@@ -296,7 +296,7 @@ function normalizeAllowKinds(v: unknown): string[] {
   return [...seen];
 }
 
-/** 合并配置（未知键丢弃，默认值兜底；深拷贝防默认值被污染）。 */
+/** 合并配置（未知键透传保留，默认值兜底；深拷贝防默认值被污染）。 */
 export function normalizeConfig(input: unknown): NotifyConfig {
   const base: NotifyConfig = { ...DEFAULT_CONFIG, quietHours: { ...DEFAULT_CONFIG.quietHours } };
   if (typeof input !== "object" || input === null) return base;
@@ -548,11 +548,18 @@ export function validateSettings(raw: unknown): SettingInvalid | null {
 }
 
 /**
- * 净化提交的配置（PUT 保存通道与存量迁移共用）：只接受已知键；任一已知键
- * 类型非法 → 整体拒绝（返回 null，避免静默丢键造成「保存了但没生效」的
- * 困惑；迁移场景则等价于「无有效键 → 只标记不写入」）。未知键丢弃（写入
- * 通道白名单语义——不把组合层装配键如 configFile 等混入 user 层；与
- * lan-proxy sanitizeSettings 同口径，normalizeConfig 的透传仅服务读取渲染）。
+ * 组合层装配键名（sanitizePatchSettings 透传通道的保留键排除表）：这些键是
+ * cordis 组合层 / apply 入口的装配键（开关与路径覆盖），不属于 settings user
+ * 层的配置契约——PUT /config 与存量迁移提交同名键时一律剔除，防 user 层被
+ * 无意义装配键污染，也杜绝未来某版本误把 user 层 configFile 等当配置来源
+ * （#470 P1-3：PUT 透传不能成为绕过 entry 白名单的路径）。
+ */
+const ASSEMBLY_KEYS: readonly string[] = ["configFile", "toastScript", "historyFile", "statusFile", "enabled"];
+
+/**
+ * 净化组合层 entry 配置（apply 装配通道专用）：白名单语义不变——只取已知
+ * 配置键，装配键/未知键一律丢弃（现状 index.ts:140 行为保留，#470 P1-3
+ * 双通道拆分后本函数不再服务 PUT / 迁移）。
  */
 export function sanitizeSettings(raw: unknown): Partial<NotifyConfig> | null {
   if (typeof raw !== "object" || raw === null) return null;
@@ -562,6 +569,34 @@ export function sanitizeSettings(raw: unknown): Partial<NotifyConfig> | null {
     const value = src[key];
     if (value === undefined || value === null) continue;
     if (!SETTING_VALIDATORS[key](value)) return null;
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * 净化 PUT /config 与存量迁移的增量 patch（透传通道，#470）：已知键按
+ * validateSettings 同口径校验（任一非法 → 整体拒绝返回 null）；**未知键原样
+ * 透传保留**（前向兼容——GET 读得到的未来/第三方键 PUT 回得去，迁移不丢
+ * legacy 未来键），但组合层装配键名（ASSEMBLY_KEYS）一律剔除（静默，与
+ * Bark 保留键同口径）。返回对象非空即代表有可写键；纯未知键 patch 透传后
+ * 同样非空（区别于空 patch {} → 空对象由调用方按 400 处理）。
+ */
+export function sanitizePatchSettings(raw: unknown): Partial<NotifyConfig> | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const src = raw as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(src)) {
+    if ((ASSEMBLY_KEYS as readonly string[]).includes(key)) continue;
+    const value = src[key];
+    if (value === undefined || value === null) continue;
+    const validator = SETTING_VALIDATORS[key];
+    if (validator !== undefined) {
+      if (!validator(value)) return null;
+      out[key] = value;
+      continue;
+    }
+    // 未知键透传保留：任意 JSON 值原样并入（顶层未来键形状不可预知）
     out[key] = value;
   }
   return out;

--- a/packages/dsh-notifier/src/config.ts
+++ b/packages/dsh-notifier/src/config.ts
@@ -102,6 +102,25 @@ export interface NotifierApplyConfig {
   statusFile?: string;
 }
 
+/**
+ * 组合层装配键名（sanitizePatchSettings 透传通道的保留键排除表，单一事实源）：
+ * 这些键是 cordis 组合层 / apply 入口的装配键（开关与路径覆盖），不属于
+ * settings user 层的配置契约——PUT /config 与存量迁移提交同名键时一律剔除，
+ * 防 user 层被无意义装配键污染，也杜绝未来某版本误把 user 层 configFile 等当
+ * 配置来源（#470 P1-3：PUT 透传不能成为绕过 entry 白名单的路径；新增装配键
+ * 只加 NotifierApplyConfig 不加本表 → 下方编译期断言直接报错）。
+ */
+export const ASSEMBLY_SETTING_KEYS = ["configFile", "toastScript", "historyFile", "statusFile", "enabled"] as const;
+
+// 编译期契约锁（#470 复核 P1-3）：ASSEMBLY_SETTING_KEYS 必须与
+// NotifierApplyConfig 键集**双向完全一致**——任一方向漏/多都让赋值类型错误。
+type AssemblyKey = (typeof ASSEMBLY_SETTING_KEYS)[number];
+type ApplyConfigKey = keyof NotifierApplyConfig;
+type AssertAssemblyComplete = Exclude<ApplyConfigKey, AssemblyKey> extends never ? true : false;
+type AssertAssemblyNoExtra = Exclude<AssemblyKey, ApplyConfigKey> extends never ? true : false;
+const assemblyKeysComplete: AssertAssemblyComplete = true;
+const assemblyKeysNoExtra: AssertAssemblyNoExtra = true;
+
 /** 默认配置。 */
 export const DEFAULT_CONFIG: NotifyConfig = {
   notifyAsk: true,
@@ -141,6 +160,16 @@ export const DEFAULT_CONFIG: NotifyConfig = {
 
 /** 布尔配置键（单一事实源：normalizeConfig 白名单与客户端渲染依赖它）。 */
 export const CONFIG_KEYS: readonly BooleanKeys[] = ["notifyAsk", "notifyQuestion", "notifyTaskDone", "notifySubagentDone", "notifyTaskError", "notifyTurnEnd", "systemNotify", "browserNotify", "notifyWhenVisible", "notifySound"];
+
+/**
+ * 原型链污染/特殊成员键名（读透传与写通道共用保留键，#470 复核 P0）：这些键
+ * 经 JSON.parse 可成为**自有键**，但作为未知键透传会误触 Object.prototype
+ * 成员——constructor/prototype/toString/hasOwnProperty/valueOf 被原样写进
+ * user 层/运行时镜像属脏写，__proto__ 赋值还会改对象原型（原型污染）。config
+ * 契约不识别这些键，读取透传与写入通道一律剔除（与 Bark 保留键、
+ * isBarkLevelsStrict/isKindRoutes 既有剔除口径一致）。
+ */
+const PROTOTYPE_POLLUTION_KEYS: readonly string[] = ["__proto__", "constructor", "prototype", "toString", "hasOwnProperty", "valueOf", "isPrototypeOf", "propertyIsEnumerable", "toLocaleString"];
 
 /** 配置存储路径（旧版自建 json；issue #76 后仅作存量迁移源，不再读写）。 */
 export function configFile() {
@@ -339,8 +368,12 @@ export function normalizeConfig(input: unknown): NotifyConfig {
   if (Array.isArray(src.allowKinds)) base.allowKinds = normalizeAllowKinds(src.allowKinds);
   // 未知键透传：白名单之外的键原样保留（此插件在旧版本运行或手改配置时会
   // 出现未来版本/第三方键），避免「降级丢键」——只归一化你认识的键。
+  // #470 复核 P0：原型链污染/特殊成员键（__proto__/constructor/toString 等）
+  // 一律剔除——JSON.parse 能让它们成为自有键，透传会脏写运行时镜像或改原型。
   const out = base as NotifyConfig & Record<string, unknown>;
   for (const key of Object.keys(src)) {
+    if ((PROTOTYPE_POLLUTION_KEYS as readonly string[]).includes(key)) continue;
+    if (!Object.prototype.hasOwnProperty.call(src, key)) continue;
     if ((CONFIG_KEYS as readonly string[]).includes(key)) continue;
     // 已归一化过的键不再透传（否则非法值会以原样覆盖归一化结果）
     if (key === "quietHours" || key === "errorMergeWindowMs" || key === "askRemindMin" || key === "doneMergeWindowMs" || key === "historyMaxAgeDays" || key === "maxConnections") continue;
@@ -533,9 +566,13 @@ export interface SettingInvalid {
  * 校验提交的配置（写入前，不净化）：返回首个非法键与其合法范围，全部合法
  * 返回 null（H6：非法值 400 拒绝 + hint，不再静默丢弃回默认）。遍历顺序
  * 与 sanitizeSettings 一致（SETTING_VALIDATORS 键序）。导出供 smoke 单测。
+ * 非对象/数组 payload 命中 key="(payload)" 分支（400 + 「patch 必须是对象」，
+ * #470 复核 P1-4：文案与 README 边界声明逐句一致）。
  */
 export function validateSettings(raw: unknown): SettingInvalid | null {
-  if (typeof raw !== "object" || raw === null) return { key: "(payload)", hint: "需为配置对象" };
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return { key: "(payload)", hint: "patch 必须是对象（数组/非对象形态不支持）" };
+  }
   const src = raw as Record<string, unknown>;
   for (const key of Object.keys(SETTING_VALIDATORS)) {
     const value = src[key];
@@ -546,15 +583,6 @@ export function validateSettings(raw: unknown): SettingInvalid | null {
   }
   return null;
 }
-
-/**
- * 组合层装配键名（sanitizePatchSettings 透传通道的保留键排除表）：这些键是
- * cordis 组合层 / apply 入口的装配键（开关与路径覆盖），不属于 settings user
- * 层的配置契约——PUT /config 与存量迁移提交同名键时一律剔除，防 user 层被
- * 无意义装配键污染，也杜绝未来某版本误把 user 层 configFile 等当配置来源
- * （#470 P1-3：PUT 透传不能成为绕过 entry 白名单的路径）。
- */
-const ASSEMBLY_KEYS: readonly string[] = ["configFile", "toastScript", "historyFile", "statusFile", "enabled"];
 
 /**
  * 净化组合层 entry 配置（apply 装配通道专用）：白名单语义不变——只取已知
@@ -578,20 +606,28 @@ export function sanitizeSettings(raw: unknown): Partial<NotifyConfig> | null {
  * 净化 PUT /config 与存量迁移的增量 patch（透传通道，#470）：已知键按
  * validateSettings 同口径校验（任一非法 → 整体拒绝返回 null）；**未知键原样
  * 透传保留**（前向兼容——GET 读得到的未来/第三方键 PUT 回得去，迁移不丢
- * legacy 未来键），但组合层装配键名（ASSEMBLY_KEYS）一律剔除（静默，与
- * Bark 保留键同口径）。返回对象非空即代表有可写键；纯未知键 patch 透传后
+ * legacy 未来键），但组合层装配键名（ASSEMBLY_SETTING_KEYS）一律剔除（静默，
+ * 与 Bark 保留键同口径）。返回对象非空即代表有可写键；纯未知键 patch 透传后
  * 同样非空（区别于空 patch {} → 空对象由调用方按 400 处理）。
+ *
+ * 安全边界（#470 复核 P0）：patch 必须为**普通对象**（数组直接返回 null——
+ * 数组会被 Object.keys 当对象把数字索引透传成 "0":"1" 式脏键）；原型链成员
+ * 键（constructor/prototype/toString/hasOwnProperty/valueOf/__proto__）一律
+ * 剔除不写入——查表前用 hasOwn 判自有键防误触原型链校验器（抛 TypeError 致
+ * 500），写入经 hasOwn 校验防把 Object.prototype 方法当未知键透传脏写 user 层。
  */
 export function sanitizePatchSettings(raw: unknown): Partial<NotifyConfig> | null {
-  if (typeof raw !== "object" || raw === null) return null;
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
   const src = raw as Record<string, unknown>;
   const out: Record<string, unknown> = {};
   for (const key of Object.keys(src)) {
-    if ((ASSEMBLY_KEYS as readonly string[]).includes(key)) continue;
+    if ((ASSEMBLY_SETTING_KEYS as readonly string[]).includes(key)) continue;
+    if (!Object.prototype.hasOwnProperty.call(src, key)) continue;
     const value = src[key];
     if (value === undefined || value === null) continue;
-    const validator = SETTING_VALIDATORS[key];
-    if (validator !== undefined) {
+    if ((PROTOTYPE_POLLUTION_KEYS as readonly string[]).includes(key)) continue;
+    if (Object.hasOwn(SETTING_VALIDATORS, key)) {
+      const validator = SETTING_VALIDATORS[key];
       if (!validator(value)) return null;
       out[key] = value;
       continue;
@@ -609,10 +645,20 @@ export function sanitizePatchSettings(raw: unknown): Partial<NotifyConfig> | nul
  * 掩码为 SECRET_MASK。GET /config 的 user 与 effective、PUT 成功响应的 user 一律
  * 经此函数输出——调用方不得绕过（契约测试深度扫描锁死）。
  *
+ * #470 复核 P0/P2：读出口同时剔除原型链/特殊成员自有键（constructor/prototype/
+ * toString/hasOwnProperty/valueOf/__proto__ 等）——settings user 层原始节可能被
+ * 手改 yaml 注入这类键，读出口一律不暴露（与写通道剔除口径一致，防 UI/脚本
+ * 看到并回写脏键）。
+ *
  * 模板类型仅约束输入输出同构；实现按结构化克隆 + 单键覆写，对任意 JSON 值安全。
  */
 export function redactConfigView<T>(value: T): T {
   const clone = JSON.parse(JSON.stringify(value ?? null)) as T & { channels?: Array<Record<string, unknown>> };
+  if (clone && typeof clone === "object") {
+    for (const key of PROTOTYPE_POLLUTION_KEYS) {
+      if (Object.prototype.hasOwnProperty.call(clone, key)) delete (clone as unknown as Record<string, unknown>)[key];
+    }
+  }
   if (Array.isArray(clone?.channels)) {
     for (const ch of clone.channels) {
       if (ch && typeof ch === "object" && typeof ch.deviceKey === "string") ch.deviceKey = SECRET_MASK;

--- a/packages/dsh-notifier/src/index.ts
+++ b/packages/dsh-notifier/src/index.ts
@@ -2,7 +2,7 @@
  * dsh-notifier — 审批/完成/错误事件通知（宿主端）。
  *
  * 本文件只做装配：apply + 事件订阅 + 生命周期清理。职责划分：
- * - config.ts      配置契约/默认值/validateSettings/sanitizeSettings/迁移源路径
+ * - config.ts      配置契约/默认值/validateSettings/sanitize*Settings/迁移源路径
  * - quiet-hours.ts 免打扰判定（parseHHMM / isInQuietHours）
  * - message.ts     通知文案单表/脱敏/格式化/agent 事件读取（纯函数）
  * - history.ts     通知历史 jsonl 存储（滚动/按天清理/原子写）
@@ -86,7 +86,7 @@ export const inject = ["webServer"];
 
 export { QUIET_ALLOW_KINDS, isInQuietHours, parseHHMM } from "./quiet-hours.ts";
 export type { QuietHoursConfig } from "./quiet-hours.ts";
-export { CONFIG_KEYS, DEFAULT_CONFIG, configFile, historyFile, statusFile, normalizeConfig, sanitizeSettings, validateSettings, toastScriptPath, normalizeBarkBaseUrl, normalizeBarkLevels, redactConfigView, unmaskChannels, SECRET_MASK, BARK_ID_PATTERN, BARK_RESERVED_KEYS } from "./config.ts";
+export { CONFIG_KEYS, DEFAULT_CONFIG, configFile, historyFile, statusFile, normalizeConfig, sanitizeSettings, sanitizePatchSettings, validateSettings, toastScriptPath, normalizeBarkBaseUrl, normalizeBarkLevels, redactConfigView, unmaskChannels, SECRET_MASK, BARK_ID_PATTERN, BARK_RESERVED_KEYS } from "./config.ts";
 export type { NotifierApplyConfig, NotifyConfig, SettingInvalid, BarkChannelConfig, BarkLevel } from "./config.ts";
 export { HISTORY_LIMIT } from "./history.ts";
 export { SETTINGS_NS, installNotifierSettings } from "./settings.ts";

--- a/packages/dsh-notifier/src/index.ts
+++ b/packages/dsh-notifier/src/index.ts
@@ -86,7 +86,7 @@ export const inject = ["webServer"];
 
 export { QUIET_ALLOW_KINDS, isInQuietHours, parseHHMM } from "./quiet-hours.ts";
 export type { QuietHoursConfig } from "./quiet-hours.ts";
-export { CONFIG_KEYS, DEFAULT_CONFIG, configFile, historyFile, statusFile, normalizeConfig, sanitizeSettings, sanitizePatchSettings, validateSettings, toastScriptPath, normalizeBarkBaseUrl, normalizeBarkLevels, redactConfigView, unmaskChannels, SECRET_MASK, BARK_ID_PATTERN, BARK_RESERVED_KEYS } from "./config.ts";
+export { CONFIG_KEYS, DEFAULT_CONFIG, ASSEMBLY_SETTING_KEYS, configFile, historyFile, statusFile, normalizeConfig, sanitizeSettings, sanitizePatchSettings, validateSettings, toastScriptPath, normalizeBarkBaseUrl, normalizeBarkLevels, redactConfigView, unmaskChannels, SECRET_MASK, BARK_ID_PATTERN, BARK_RESERVED_KEYS } from "./config.ts";
 export type { NotifierApplyConfig, NotifyConfig, SettingInvalid, BarkChannelConfig, BarkLevel } from "./config.ts";
 export { HISTORY_LIMIT } from "./history.ts";
 export { SETTINGS_NS, installNotifierSettings } from "./settings.ts";

--- a/packages/dsh-notifier/src/migrate.ts
+++ b/packages/dsh-notifier/src/migrate.ts
@@ -7,9 +7,10 @@
  *
  * 分流（R1）：
  * - 合法 json：改名 `.migrated.bak`（即 `dsh-notifier.json.migrated.bak`）后
- *   sanitize 过滤，再经 owner scope.update **逐字段缺失补齐**写入
+ *   sanitize 过滤（#470 起走 sanitizePatchSettings 透传通道：未知键保留补写，
+ *   装配键剔除），再经 owner scope.update **逐字段缺失补齐**写入
  *   （#468：不是无脑全量覆盖——只补写 user 层尚缺失的键）；
- * - 损坏/非对象/无有效键：只改名 `.corrupted.bak` 标记，不写入（防把 schema
+ * - 损坏/非对象/无任何键：只改名 `.corrupted.bak` 标记，不写入（防把 schema
  *   默认值固化进 user 层、压制后续默认值演进）；
  * - 中断态：`.migrated.bak` 存在而 json 不存在 → 从 bak 重放
  *   （解析 → sanitize → 逐字段缺失补齐）——迁移是否「已完成」不再以
@@ -18,8 +19,8 @@
  *   「不重复写入」）；
  * - 写入失败：回滚改名（bak 还原为 json）并 warn，下次启动重试（E6）。
  *
- * 冲突策略（#468，用户改值优先；字段粒度 = 顶层配置键，sanitize 白名单）：
- * - 迁移只补写 user 层**缺失**的键（sanitize 白名单 ∩ bak 显式键 − user 层
+ * 冲突策略（#468，用户改值优先；字段粒度 = 顶层配置键，sanitize 透传通道）：
+ * - 迁移只补写 user 层**缺失**的键（sanitize 结果 ∩ bak 显式键 − user 层
  *   已存在的键）；用户已改/已存在的字段一律不被迁移覆盖，与 PUT /config
  *   之后重启不再被迁移抢回的语义一致（E2 依赖的幂等判定本来就是「user 层
  *   已有值 = 不重复写入」）；
@@ -36,6 +37,10 @@
  * - 若用户确实想要 bak 里的旧值，官方 settings 是唯一事实源——迁移不写
  *   用户键，bak 原样保留可手动核对。
  *
+ * 无有效键判据（#470 P2-1）：legacy 含**未知键**不再是「无有效键」——透传
+ * 通道下未知键会补写进 user 层（升级不丢未来键）；仅「无任何键 / 非法 JSON /
+ * 非对象」才走 corrupted 只标记不写入。
+ *
  * 并发说明（#468 P1-3）：迁移 update 不传 expectedRevision——官方 update 是
  * 串行写队列 + merge over 最新 user section，迁移与用户 PUT 并发时各自 merge，
  * 迁移不会用旧快照覆盖用户新值；但「写入前 readUser 幂等判定」存在 TOCTOU
@@ -45,7 +50,7 @@
  */
 import { existsSync, readFileSync, renameSync, unlinkSync } from "node:fs";
 import { errorMessage } from "../../../shared/host-utils.js";
-import { sanitizeSettings } from "./config.ts";
+import { sanitizePatchSettings } from "./config.ts";
 
 /** 已迁移备份文件名后缀（幂等标记：存在且 user 层有值 = 已处理）。 */
 export const MIGRATED_BAK_SUFFIX = ".migrated.bak";
@@ -155,9 +160,9 @@ export async function migrateLegacyConfig(legacyPath: string, deps: MigrateDeps,
       logger?.warn?.(`dsh-notifier: 检测到未完成的迁移残留 ${MIGRATED_BAK_SUFFIX}，但内容不是合法 JSON — 无法自动恢复，请手动检查该备份（原始配置应在其内）或将其改名 ${CORRUPTED_BAK_SUFFIX}`);
       return { performed: false, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: true };
     }
-    const sanitized = sanitizeSettings(parsed);
+    const sanitized = sanitizePatchSettings(parsed);
     if (sanitized === null || Object.keys(sanitized).length === 0) {
-      logger?.warn?.(`dsh-notifier: 未完成的迁移残留 ${MIGRATED_BAK_SUFFIX} 无可迁移的有效键 — 已跳过，确认无误后可手动删除该备份`);
+      logger?.warn?.(`dsh-notifier: 未完成的迁移残留 ${MIGRATED_BAK_SUFFIX} 无可迁移的配置键 — 已跳过，确认无误后可手动删除该备份`);
       return { performed: false, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: true };
     }
     const patch = diffMissingKeys(sanitized, deps.readUser());
@@ -198,13 +203,13 @@ export async function migrateLegacyConfig(legacyPath: string, deps: MigrateDeps,
     }
     return { performed: true, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: false };
   }
-  const sanitized = sanitizeSettings(parsed);
+  const sanitized = sanitizePatchSettings(parsed);
   if (sanitized === null || Object.keys(sanitized).length === 0) {
     try {
       renameOver(legacyPath, corruptedBak);
-      logger?.warn?.(`dsh-notifier: 存量配置无有效键 — 改名 ${CORRUPTED_BAK_SUFFIX} 标记，不写入设置`);
+      logger?.warn?.(`dsh-notifier: 存量配置无任何键可迁移 — 改名 ${CORRUPTED_BAK_SUFFIX} 标记，不写入设置`);
     } catch (err) {
-      logger?.warn?.(`dsh-notifier: 无有效键配置改名失败（${errorMessage(err)}）— 原文件保留原位，请手动处理`);
+      logger?.warn?.(`dsh-notifier: 无键可迁移配置改名失败（${errorMessage(err)}）— 原文件保留原位，请手动处理`);
     }
     return { performed: true, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: false };
   }

--- a/packages/dsh-notifier/src/server.ts
+++ b/packages/dsh-notifier/src/server.ts
@@ -12,7 +12,7 @@ import type { WebRoute } from "@deepseek-ai/dsh-host-webserver";
 import { isLoopbackRequest } from "../../../shared/loopback.js";
 import { writeJson, readBody, errorMessage } from "../../../shared/host-utils.js";
 import type { NotifyConfig } from "./config.ts";
-import { sanitizeSettings, validateSettings, redactConfigView, unmaskChannels } from "./config.ts";
+import { sanitizePatchSettings, validateSettings, redactConfigView, unmaskChannels } from "./config.ts";
 import type { HistoryStore } from "./history.ts";
 import { buildSystemCommand } from "./message.ts";
 
@@ -317,7 +317,8 @@ export type PatchResult =
  * 配置保存纯函数（PUT /config 的主体，独立导出供 smoke 单测）：
  * channels[].deviceKey 掩码按 id 对齐回填 user 层原值（评审 P0-2：必须先于
  * 校验，掩码不是合法 key 语义）→ validateSettings 定位首个非法键（400 + hint）
- * → sanitizeSettings 净化 → 经 settings 服务 update 增量写入（expectedRevision
+ * → sanitizePatchSettings 净化（已知键校验 + 未知键透传保留、装配键剔除，
+ * #470）→ 经 settings 服务 update 增量写入（expectedRevision
  * 可选做乐观并发）。错误映射（R3）：SETTINGS_CONFLICT → 409 固定文案；settings
  * 缺失 → 503 settings-unavailable；写入异常原文只进服务端日志（P2-2）。
  * 成功响应的 user 经 redactConfigView 统一脱敏（评审 P0-1 单一出口）。
@@ -354,8 +355,16 @@ export async function applyConfigPatch(deps: RouteDeps, payload: unknown): Promi
   if (invalid !== null) {
     return { ok: false, status: 400, code: "invalid", response: { error: `配置校验失败: ${invalid.key}`, hint: invalid.hint } };
   }
-  const sanitized = sanitizeSettings(effectivePatch);
+  // #470 双通道拆分后 PUT 走透传净化（未知键保留、装配键剔除）：
+  // 「至少一个有效配置键」判据改为「原始 patch 非空对象」——纯未知键 patch
+  // （如 {futureKey:1}）→ 200 透传写入；仅空 patch {}（无任何键可写）→ 400。
+  if (typeof rawPatch !== "object" || rawPatch === null || Object.keys(rawPatch).length === 0) {
+    return { ok: false, status: 400, code: "invalid", response: { error: "配置校验失败: patch", hint: "需至少包含一个配置键（patch 不能为空）" } };
+  }
+  const sanitized = sanitizePatchSettings(effectivePatch);
   if (sanitized === null || Object.keys(sanitized).length === 0) {
+    // null = 已知键非法（validateSettings 已拦，理论不可达兜底）；空对象 =
+    // 原始 patch 仅含装配键（剔除后无任何可写键）→ 同空 patch 语义 400
     return { ok: false, status: 400, code: "invalid", response: { error: "配置校验失败: patch", hint: "需至少包含一个有效配置键" } };
   }
   try {

--- a/packages/dsh-notifier/src/server.ts
+++ b/packages/dsh-notifier/src/server.ts
@@ -425,7 +425,17 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
           logger.warn(`dsh-notifier: 配置请求体读取失败: ${message}`);
           return;
         }
-        const result = await applyConfigPatch(deps, body);
+        // #470 复核 P0-2 兜底：applyConfigPatch 内部异常（理论不可达——净化/
+        // 校验/脱敏对任意输入均收敛为错误分支，此处防未来改动引入未捕获抛错）
+        // 不得让 handler 冒泡成宿主 500/悬挂——收敛 500 固定文案 + 服务端日志
+        let result: PatchResult;
+        try {
+          result = await applyConfigPatch(deps, body);
+        } catch (error) {
+          logger.warn(`dsh-notifier: 配置保存处理异常 — ${errorMessage(error)}`);
+          writeJson(res, 500, { ok: false, error: { error: "保存失败，请查看服务端日志" } });
+          return;
+        }
         if (!result.ok) {
           writeJson(res, result.status, { ok: false, error: result.response });
           return;

--- a/packages/dsh-notifier/test/client-contract.test.ts
+++ b/packages/dsh-notifier/test/client-contract.test.ts
@@ -365,3 +365,71 @@ const pkgDir = fileURLToPath(new URL("..", import.meta.url));
   assert.equal(visCount(), 0, "#469：disposer 二次调用后仍无监听");
   assert.equal(documentStub.title, "原始标题", "#469 P1-1：disposer 二次调用标题不复发闪烁");
 }
+
+// ---- issue #470 复核 P1-2：client diffSettingsPayload 真实产物直测 ----
+// 用 vm materialize 出的 mod.apply.diffSettingsPayload（apply 挂载的模块级纯函数）
+// 验证「真链」：以 GET effective（含未知键）为基线 → 只改已知键 → diff 不含
+// 未知键 →（PUT 行为在 routes.test.ts 全链断言）。不再允许测试手写近似 diff。
+{
+  const clientCode = readFileSync(new URL("../lib/client.js", import.meta.url), "utf8");
+  const sandbox = {
+    console: { ...console, warn: () => {} },
+    Symbol, Object, Array, JSON, Math, Date, Promise,
+    setTimeout, clearTimeout,
+    EventSource: function () {},
+    Notification: function () {},
+    fetch: () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+    document: {
+      visibilityState: "visible", title: "", hidden: false,
+      addEventListener() {}, removeEventListener() {},
+      getElementById: () => null,
+      createElement: () => ({ appendChild() {}, remove() {}, style: {}, dataset: {} }),
+      head: { appendChild() {} }, body: { appendChild() {} },
+    },
+    localStorage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
+    window: {},
+  };
+  sandbox.window = sandbox;
+  let loadedFactory = null;
+  sandbox.window.__ModuleLoader__ = { load(handoff) { loadedFactory = handoff.factory; } };
+  vm.createContext(sandbox);
+  vm.runInContext(clientCode, sandbox);
+  assert.ok(loadedFactory !== null, "#470 P1-2：产物 load 已注册 factory");
+  const fakeReactForDiff = { createElement: () => ({}) };
+  const mod = loadedFactory((spec) => {
+    if (spec === "react") return fakeReactForDiff;
+    throw new Error(`unexpected require: ${spec}`);
+  });
+  assert.equal(typeof mod.apply, "function", "#470 P1-2：materialize 后 exports.apply 为函数");
+  // 挂载赋值在 apply 函数体首行——先跑一次 apply（最小 ctx）才可读属性；
+  // 随后立即 disposer 卸载（停 SSE/监听，防句柄残留）。
+  const disposers2 = [];
+  mod.apply({
+    get() { return undefined; },
+    effect(fn) { const d = fn(); disposers2.push(d); return d; },
+  });
+  const diffFn = mod.apply.diffSettingsPayload;
+  assert.equal(typeof diffFn, "function", "#470 P1-2：apply 挂载 diffSettingsPayload 纯函数");
+  for (const d of disposers2.splice(0)) d();
+
+  // 基线含未知键：只改已知键 → payload 仅含变更已知键（不含未知键）
+  const effective = { notifyTaskDone: true, notifyAsk: true, futureKey: { k: 1 }, quietHours: { enabled: false, start: "22:00", end: "08:00" } };
+  const settingsView = JSON.parse(JSON.stringify(effective));
+  settingsView.notifyTaskDone = false;
+  const payload = diffFn(settingsView, effective);
+  // vm 沙箱 realm 对象原型与测试 realm 不同，deepStrictEqual 跨 realm 不等——用
+  // JSON 归一比对（diff 语义本就 JSON 序列化级）
+  assert.deepEqual(JSON.parse(JSON.stringify(payload)), { notifyTaskDone: false }, "#470 P1-2：diff 只含变更已知键（不含未知键 futureKey）");
+
+  // 未知键值被 UI 改动 → diff 会包含它（未来 UI 编辑未知键时透传可写）
+  const view2 = JSON.parse(JSON.stringify(effective));
+  view2.futureKey = { k: 2 };
+  const payload2 = diffFn(view2, effective);
+  assert.deepEqual(JSON.parse(JSON.stringify(payload2)), { futureKey: { k: 2 } }, "#470 P1-2：diff 含改动未知键（PUT 可透传写入）");
+
+  // 全等 → 空 payload（save 判定 unchanged）
+  assert.deepEqual(JSON.parse(JSON.stringify(diffFn(JSON.parse(JSON.stringify(effective)), effective))), {}, "#470 P1-2：全等基线 diff 为空");
+
+  // baseline 为 null（加载未完成）→ 空 payload（不误存）
+  assert.deepEqual(JSON.parse(JSON.stringify(diffFn(settingsView, null))), {}, "#470 P1-2：baseline null → 空 payload");
+}

--- a/packages/dsh-notifier/test/migration.test.ts
+++ b/packages/dsh-notifier/test/migration.test.ts
@@ -226,16 +226,28 @@ try {
       assert.deepEqual(out, { performed: false, migrated: false, rolledBack: false, skippedCorrupt: true, skippedIdempotent: false, resumed: true }, "E8：中断态 bak 损坏 → 标记跳过");
       assert.equal(d.updates.length, 0, "E8：损坏 bak 不写入");
     }
-    // 中断态重放失败：bak 无有效键 → skippedCorrupt+resumed
+    // 中断态重放：bak 仅含未知键 → #470 P2-1 透传补写（不再是「无有效键」，
+    // 升级不丢 legacy 未来键），skippedCorrupt=false
+    {
+      const d = deps();
+      const legacy = join(dir, "resume-future.json");
+      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({ futureKey: { a: 1 } }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.equal(out.resumed, true, "E8：纯未知键重放标记 resumed");
+      assert.equal(out.migrated, true, "E8：#470 纯未知键重放透传迁移（不再判无有效键）");
+      assert.equal(out.skippedCorrupt, false, "E8：#470 纯未知键不标记 corrupted");
+      assert.deepEqual(d.updates, [{ futureKey: { a: 1 } }], "E8：#470 纯未知键原样补写");
+    }
+    // 中断态重放失败：bak 无任何键 → skippedCorrupt+resumed
     {
       const d = deps();
       const legacy = join(dir, "resume-empty.json");
-      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({ evilKey: 1 }));
+      writeFileSync(legacy + MIGRATED_BAK_SUFFIX, JSON.stringify({}));
       const out = await migrateLegacyConfig(legacy, d);
-      assert.equal(out.resumed, true, "E8：无有效键重放标记 resumed");
-      assert.equal(out.migrated, false, "E8：无有效键重放不迁移");
-      assert.equal(out.skippedCorrupt, true, "E8：无有效键重放标记 corrupted");
-      assert.equal(d.updates.length, 0, "E8：无有效键不写入");
+      assert.equal(out.resumed, true, "E8：无键重放标记 resumed");
+      assert.equal(out.migrated, false, "E8：无键重放不迁移");
+      assert.equal(out.skippedCorrupt, true, "E8：无键重放标记 corrupted");
+      assert.equal(d.updates.length, 0, "E8：无键不写入");
     }
     // 损坏 json：只标记 .corrupted.bak，不写入（E4）
     {
@@ -335,6 +347,38 @@ try {
       assert.equal(out.migrated, true, "E9e：缺顶层键 notifySound → 迁移补齐");
       assert.deepEqual(d.updates, [{ notifySound: true }], "E9e：不补写 quietHours 嵌套子键（仅顶层缺失键）");
       assert.deepEqual(d.readUser().quietHours, { start: "07:00" }, "E9e：用户部分子键保持原样（不被 bak 子键覆盖）");
+    }
+    // #470 E9f：json 正常迁移含未知键 → user 层缺失则补写透传保留；
+    // 已存在（用户改过/已存在）→ 不覆盖（#468 不变）
+    {
+      const d = deps({ notifyAsk: true, futureKey: "user-value" }); // user 层已存在 futureKey
+      const legacy = join(dir, "future-mix.json");
+      writeFileSync(legacy, JSON.stringify({ notifyAsk: false, futureKey: "legacy-value", futureKey2: { a: 1 }, configFile: "/x" }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.equal(out.migrated, true, "E9f：纯未知键 json 正常迁移透传补写");
+      assert.deepEqual(d.updates, [{ futureKey2: { a: 1 } }], "E9f：缺失未知键补写、已存在未知键不覆盖、装配键 configFile 剔除");
+      assert.equal(d.readUser().futureKey, "user-value", "E9f：用户已存在未知键不被 legacy 覆盖");
+      assert.equal(d.readUser().notifyAsk, true, "E9f：用户已改 notifyAsk 不被覆盖（#468 不变）");
+      assert.ok(!("configFile" in d.readUser()), "E9f：装配键 configFile 不入 user 层");
+    }
+    // #470 E9g：纯未知键 legacy json（user 层空）→ 透传补写迁移（不再判无有效键 corrupt）
+    {
+      const d = deps();
+      const legacy = join(dir, "future-only.json");
+      writeFileSync(legacy, JSON.stringify({ futureKey: 1, bogus: "x" }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.equal(out.migrated, true, "E9g：纯未知键 legacy 不再判无有效键 → 透传迁移");
+      assert.deepEqual(d.updates, [{ futureKey: 1, bogus: "x" }], "E9g：未知键原样补写");
+    }
+    // #470 E9h：legacy json 仅含装配键 → 净化后无任何可写键 → 只标记 corrupted 不写入
+    {
+      const d = deps();
+      const legacy = join(dir, "assembly-only.json");
+      writeFileSync(legacy, JSON.stringify({ configFile: "/x", enabled: true }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.equal(out.migrated, false, "E9h：仅装配键 legacy 无键可迁移");
+      assert.equal(out.skippedCorrupt, true, "E9h：仅装配键 legacy 标记 corrupted");
+      assert.equal(d.updates.length, 0, "E9h：仅装配键不写入");
     }
     rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/dsh-notifier/test/migration.test.ts
+++ b/packages/dsh-notifier/test/migration.test.ts
@@ -412,6 +412,17 @@ try {
       assert.equal(out.skippedCorrupt, true, "E9j：数组 legacy 标记 corrupted");
       assert.equal(d.updates.length, 0, "E9j：数组 legacy 不写入");
     }
+    // #470 qa 复核：legacy 未知键 null 值透传补写（与 PUT 同净化通道一致）
+    {
+      const d = deps();
+      const legacy = join(dir, "null-future.json");
+      writeFileSync(legacy, JSON.stringify({ notifySound: true, nullFuture: null }));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.equal(out.migrated, true, "E9k：含 null 未知键 legacy 正常迁移");
+      assert.deepEqual(d.updates, [{ notifySound: true, nullFuture: null }], "E9k：已知键+null 未知键一并补写");
+      assert.equal(Object.prototype.hasOwnProperty.call(d.readUser(), "nullFuture"), true, "E9k：nullFuture 键入 user 层");
+      assert.equal(d.readUser().nullFuture, null, "E9k：nullFuture 值为 null");
+    }
     rmSync(dir, { recursive: true, force: true });
   }
 } finally {

--- a/packages/dsh-notifier/test/migration.test.ts
+++ b/packages/dsh-notifier/test/migration.test.ts
@@ -380,6 +380,38 @@ try {
       assert.equal(out.skippedCorrupt, true, "E9h：仅装配键 legacy 标记 corrupted");
       assert.equal(d.updates.length, 0, "E9h：仅装配键不写入");
     }
+    // #470 复核 P1-1：legacy 含原型链成员键（__proto__/constructor/toString 等
+    // 经 JSON.parse 的自有键）→ 不抛异常、不整体迁移崩、正常键照常补写；
+    // legacy 为数组 → 视为非对象（无键）标记 corrupted 不写入
+    {
+      const d = deps();
+      const legacy = join(dir, "proto-mix.json");
+      // 手动 JSON 文本：JSON.parse 后 __proto__/constructor 等均为**自有键**
+      // （对象字面量 __proto__ 是原型语法，测不到真实威胁形态）
+      writeFileSync(legacy, '{"notifyAsk":false,"futureKey":1,"constructor":2,"toString":3,"__proto__":{"polluted":1}}');
+      let threw = false;
+      let out;
+      try {
+        out = await migrateLegacyConfig(legacy, d);
+      } catch {
+        threw = true;
+      }
+      assert.equal(threw, false, "E9i：原型键 legacy 不抛异常（迁移不崩）");
+      assert.equal(out.migrated, true, "E9i：原型键 legacy 正常迁移（正常键补写）");
+      assert.deepEqual(d.updates, [{ notifyAsk: false, futureKey: 1 }], "E9i：原型键剔除、只写正常键");
+      assert.ok(Object.prototype.hasOwnProperty.call(d.readUser(), "constructor") === false && Object.prototype.hasOwnProperty.call(d.readUser(), "toString") === false, "E9i：原型键不写 user 层");
+      assert.equal(Object.prototype.polluted, undefined, "E9i：无全局原型污染");
+      assert.ok(existsSync(legacy + MIGRATED_BAK_SUFFIX), "E9i：正常迁移改名 migrated.bak（未因原型键中断）");
+    }
+    {
+      const d = deps();
+      const legacy = join(dir, "array-legacy.json");
+      writeFileSync(legacy, JSON.stringify([1, 2]));
+      const out = await migrateLegacyConfig(legacy, d);
+      assert.equal(out.migrated, false, "E9j：数组 legacy 不迁移（非对象语义）");
+      assert.equal(out.skippedCorrupt, true, "E9j：数组 legacy 标记 corrupted");
+      assert.equal(d.updates.length, 0, "E9j：数组 legacy 不写入");
+    }
     rmSync(dir, { recursive: true, force: true });
   }
 } finally {

--- a/packages/dsh-notifier/test/routes.test.ts
+++ b/packages/dsh-notifier/test/routes.test.ts
@@ -189,6 +189,18 @@ try {
       await cfgR.handler(bodyReq({ patch: { pureFuture: 1 } }), put2.res);
       assert.equal(put2.rec.status, 200, "纯未知键 patch 200 透传（不再 400）");
       assert.equal(nfSettings.getUser().pureFuture, 1, "纯未知键写入 user 层");
+      // #470 qa 复核：未知键 null 值透传（PUT {nullFuture:null} → 200，GET 可读回）
+      const putNull = makeRes();
+      await cfgR.handler(bodyReq({ patch: { nullFuture: null } }), putNull.res);
+      assert.equal(putNull.rec.status, 200, "纯未知键 null patch 200 透传");
+      assert.equal(Object.prototype.hasOwnProperty.call(nfSettings.getUser(), "nullFuture"), true, "settings user 层含 nullFuture 键");
+      assert.equal(nfSettings.getUser().nullFuture, null, "nullFuture 值为 null 原样保留");
+      const getNull = makeRes();
+      await cfgR.handler(fakeReq({}), getNull.res);
+      const getNullBody = JSON.parse(getNull.rec.text);
+      assert.equal(Object.prototype.hasOwnProperty.call(getNullBody.user, "nullFuture"), true, "GET user 读回 nullFuture");
+      assert.equal(getNullBody.user.nullFuture, null, "GET user nullFuture 值为 null");
+      assert.equal(Object.prototype.hasOwnProperty.call(getNullBody.effective, "nullFuture"), true, "GET effective 读回 nullFuture");
     }
 
     // (3) #470 验收 3 边界：空 patch {} → 仍 400（无变更可写）

--- a/packages/dsh-notifier/test/routes.test.ts
+++ b/packages/dsh-notifier/test/routes.test.ts
@@ -261,10 +261,13 @@ try {
       const baselineRef = JSON.parse(JSON.stringify(effective0));
       const settingsView = JSON.parse(JSON.stringify(effective0));
       settingsView.notifyTaskDone = false;
-      // diffPayload 只提交与基线不同的键（与 src/client/index.ts 同逻辑）
+      // diffPayload 只提交与基线不同的键——逻辑与 src/client/index.ts
+      // diffSettingsPayload 完全一致（无夹带守卫；真函数另有 client-contract
+      // #470 P1-2 产物直测，此处模拟同语义 diff 走 HTTP 整链）
       const payload = {};
       for (const key in settingsView) {
-        if (baselineRef[key] !== undefined && JSON.stringify(settingsView[key]) !== JSON.stringify(baselineRef[key])) {
+        if (!Object.prototype.hasOwnProperty.call(settingsView, key)) continue;
+        if (JSON.stringify(settingsView[key]) !== JSON.stringify(baselineRef[key])) {
           payload[key] = settingsView[key];
         }
       }
@@ -309,6 +312,98 @@ try {
     assert.equal(getBody.effective.notifyAsk, false, "entry 已知键经 base 层进 effective（装配键不干扰）");
     assert.equal(getBody.effective.quietHours.enabled, false, "effective 其余键默认值兜底");
     enDispose();
+  }
+
+  // (9) #470 复核 P0/P1 路由级回归：数组 patch 拒绝（不写脏数字键）；
+  //     原型链成员键（constructor/hasOwnProperty/__proto__…）不触发 500、
+  //     不脏写 user 层（既有 JSON.parse 注入形态）
+  {
+    function bodyReq(payload) {
+      const text = JSON.stringify(payload);
+      return {
+        method: "PUT",
+        url: "/",
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+        on(event, cb) {
+          if (event === "data") setTimeout(() => cb(Buffer.from(text)), 0);
+          else if (event === "end") setTimeout(cb, 1);
+          return this;
+        },
+        destroy() {},
+      };
+    }
+    const { routes: pfRoutes, settings: pfSettings, dispose: pfDispose } = makeNotifier(work, {
+      historyFile: join(work, "history-proto.jsonl"),
+    });
+    const cfgR3 = pfRoutes.find((r) => r.path === ROUTES.config);
+
+    // 数组 patch：[1,2] 不得被当对象透传 → 400，user 层无 "0"/"1" 脏键
+    const putArr = makeRes();
+    await cfgR3.handler(bodyReq({ patch: [1, 2] }), putArr.res);
+    assert.equal(putArr.rec.status, 400, "数组 patch → 400（不当对象透传）");
+    const arrUser = pfSettings.getUser();
+    assert.ok(!("0" in arrUser) && !("1" in arrUser), "数组 patch 不写脏数字索引键");
+    assert.deepEqual(arrUser, {}, "数组 patch 后 user 层保持空");
+    // 空数组同样 400
+    const putArr2 = makeRes();
+    await cfgR3.handler(bodyReq({ patch: [] }), putArr2.res);
+    assert.equal(putArr2.rec.status, 400, "空数组 patch → 400");
+
+    // 原型链成员键：逐个 PUT 不得抛异常（handler 捕获 → 400）、不脏写 user 层
+    for (const key of ["constructor", "hasOwnProperty", "prototype", "toString", "valueOf", "__proto__"]) {
+      const evil = JSON.parse(`{"${key}": 1}`);
+      const put = makeRes();
+      let threw = false;
+      try {
+        await cfgR3.handler(bodyReq({ patch: evil }), put.res);
+      } catch {
+        threw = true;
+      }
+      assert.equal(threw, false, `${key} patch 不抛未捕获异常（无 500/悬挂）`);
+      assert.equal(put.rec.status, 400, `${key} 纯原型键 patch → 400（净化后无键可写）`);
+      const userAfter = pfSettings.getUser();
+      assert.equal(Object.prototype.hasOwnProperty.call(userAfter, key), false, `${key} 不脏写 user 层`);
+    }
+    // 原型键 + 已知键混合：仅已知键生效、原型键剔除（200）
+    const mixed = JSON.parse('{"notifyAsk":false,"__proto__":{"polluted":1},"constructor":1}');
+    const putMix = makeRes();
+    await cfgR3.handler(bodyReq({ patch: mixed }), putMix.res);
+    assert.equal(putMix.rec.status, 200, "原型键+已知键混合 → 200（原型键剔除）");
+    const mixUser = pfSettings.getUser();
+    assert.equal(mixUser.notifyAsk, false, "混合提交已知键生效");
+    assert.equal(Object.prototype.hasOwnProperty.call(mixUser, "constructor"), false, "混合提交 constructor 不写入");
+    assert.equal({}.polluted, undefined, "无全局原型污染");
+
+    pfDispose();
+  }
+
+  // (10) #470 复核 P2 采纳：GET user/effective 不含特殊键（constructor/prototype/
+  //      __proto__/toString/hasOwnProperty/valueOf）契约扫描——即使存量 user 层
+  //      被外部手改注入特殊键（模拟 setUser 预置），读出口也不泄露（normalize 剔除）
+  {
+    const { routes: gfRoutes, settings: gfSettings, dispose: gfDispose } = makeNotifier(
+      work,
+      { historyFile: join(work, "history-getproto.jsonl") },
+      {
+        settings: {
+          user: JSON.parse('{"notifyAsk":true,"futureKey":1,"constructor":1,"prototype":2,"toString":3,"hasOwnProperty":4,"valueOf":5,"__proto__":{"polluted":1}}'),
+        },
+      },
+    );
+    const cfgR4 = gfRoutes.find((r) => r.path === ROUTES.config);
+    const get = makeRes();
+    await cfgR4.handler(fakeReq({}), get.res);
+    assert.equal(get.rec.status, 200, "存量 user 含特殊键 GET 正常 200（不崩）");
+    const body = JSON.parse(get.rec.text);
+    for (const badKey of ["constructor", "prototype", "toString", "hasOwnProperty", "valueOf", "__proto__"]) {
+      assert.equal(Object.prototype.hasOwnProperty.call(body.user, badKey), false, `GET user 不含特殊键 ${badKey}`);
+      assert.equal(Object.prototype.hasOwnProperty.call(body.effective, badKey), false, `GET effective 不含特殊键 ${badKey}`);
+    }
+    assert.equal(body.user.futureKey, 1, "GET user 普通未知键保留");
+    assert.equal(body.effective.notifyAsk, true, "GET effective 已知键正常");
+    assert.equal(Object.prototype.polluted, undefined, "GET 读出口无全局原型污染");
+    gfDispose();
   }
 
   // F4 expectedRevision 缺省：无冲突检测（不带 revision 的 PUT 成功）

--- a/packages/dsh-notifier/test/routes.test.ts
+++ b/packages/dsh-notifier/test/routes.test.ts
@@ -133,6 +133,184 @@ try {
     assert.deepEqual(lastCall.patch, { notifyAsk: false }, "service.update 只收到变更键（增量 patch，非整表）");
   }
 
+  // ===== #470：未知键透传保留（前向兼容）——PUT /config 行为 =====
+  {
+    function bodyReq(payload) {
+      const text = JSON.stringify(payload);
+      return {
+        method: "PUT",
+        url: "/",
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+        on(event, cb) {
+          if (event === "data") setTimeout(() => cb(Buffer.from(text)), 0);
+          else if (event === "end") setTimeout(cb, 1);
+          return this;
+        },
+        destroy() {},
+      };
+    }
+    // 独立实例：预置 user 层存量未知键（模拟旧版本/手改 yaml 的未来键）
+    const { routes: nfRoutes, settings: nfSettings, dispose: nfDispose } = makeNotifier(
+      work,
+      { historyFile: join(work, "history-future.jsonl") },
+      { settings: { user: { notifyAsk: true, futureKey: "keepme" } } },
+    );
+    const cfgR = nfRoutes.find((r) => r.path === ROUTES.config);
+
+    // (1) #470 验收 2：存量 user 层未知键在保存已知键后不丢（读写闭合）
+    {
+      const put = makeRes();
+      await cfgR.handler(bodyReq({ patch: { notifyAsk: false } }), put.res);
+      assert.equal(put.rec.status, 200, "保存已知键成功");
+      const after = nfSettings.getUser();
+      assert.equal(after.notifyAsk, false, "已知键保存生效");
+      assert.equal(after.futureKey, "keepme", "存量未知键不被已知键保存清除");
+    }
+
+    // (2) #470 验收 3：PUT 携带顶层未知键 → 200 透传写入（GET 往返深等）；
+    //     纯未知键 patch 200（不再落入「至少一个有效键」400）
+    {
+      const put = makeRes();
+      await cfgR.handler(bodyReq({ patch: { futureKey2: { a: 1 }, notifySound: false } }), put.res);
+      assert.equal(put.rec.status, 200, "已知+未知混合 PUT 200");
+      const putBody = JSON.parse(put.rec.text);
+      assert.deepEqual(putBody.user.futureKey2, { a: 1 }, "PUT 响应 user 含透传未知键");
+      assert.deepEqual(nfSettings.getUser().futureKey2, { a: 1 }, "settings user 层含透传未知键（原样并入）");
+      // GET 往返：读到的键原样仍在（读写闭合）
+      const get = makeRes();
+      await cfgR.handler(fakeReq({}), get.res);
+      const getBody = JSON.parse(get.rec.text);
+      assert.deepEqual(getBody.user.futureKey2, { a: 1 }, "GET user 层保留透传未知键");
+      assert.deepEqual(getBody.effective.futureKey2, { a: 1 }, "GET effective 透传未知键（读面归一化保留）");
+      assert.equal(getBody.user.notifySound, false, "已知键同步生效");
+      // 纯未知键 patch → 200
+      const put2 = makeRes();
+      await cfgR.handler(bodyReq({ patch: { pureFuture: 1 } }), put2.res);
+      assert.equal(put2.rec.status, 200, "纯未知键 patch 200 透传（不再 400）");
+      assert.equal(nfSettings.getUser().pureFuture, 1, "纯未知键写入 user 层");
+    }
+
+    // (3) #470 验收 3 边界：空 patch {} → 仍 400（无变更可写）
+    {
+      const put = makeRes();
+      await cfgR.handler(bodyReq({ patch: {} }), put.res);
+      assert.equal(put.rec.status, 400, "空 patch 仍 400");
+      const body = JSON.parse(put.rec.text);
+      assert.match(body.error.error, /配置校验失败/, "空 patch 400 带配置校验失败");
+    }
+
+    // (4) #470 验收 4：PUT 透传排除装配键名——configFile/toastScript/historyFile/
+    //     statusFile/enabled 被剔除（不入 user 层）；组合层 entry 白名单语义不变
+    {
+      const put = makeRes();
+      await cfgR.handler(bodyReq({ patch: { configFile: "/x", toastScript: "/y", historyFile: "/z", statusFile: "/s", enabled: false } }), put.res);
+      assert.equal(put.rec.status, 400, "纯装配键 patch 净化后无任何可写键 → 400（同空 patch 语义）");
+      const user = nfSettings.getUser();
+      for (const key of ["configFile", "toastScript", "historyFile", "statusFile", "enabled"]) {
+        assert.ok(!(key in user), `装配键 ${key} 不入 user 层`);
+      }
+      // 装配键 + 已知键混合 → 200，装配键剔除、已知键生效
+      const put2 = makeRes();
+      await cfgR.handler(bodyReq({ patch: { configFile: "/x", notifyQuestion: false } }), put2.res);
+      assert.equal(put2.rec.status, 200, "装配键+已知键混合 200（装配键剔除）");
+      assert.ok(!("configFile" in nfSettings.getUser()), "混合提交后 configFile 仍未入 user 层");
+      assert.equal(nfSettings.getUser().notifyQuestion, false, "已知键生效");
+    }
+
+    // (5) #470 验收 5：已知键非法值仍 400 + hint；未知键存在不改变校验结果
+    {
+      const put = makeRes();
+      await cfgR.handler(bodyReq({ patch: { notifyAsk: "yes", futureKey3: 1 } }), put.res);
+      assert.equal(put.rec.status, 400, "非法已知键 400（未知键并存不改变结果）");
+      const body = JSON.parse(put.rec.text);
+      assert.match(body.error.error, /配置校验失败: notifyAsk/, "400 指明首个非法键 notifyAsk");
+      assert.ok(body.error.hint, "400 带 hint");
+      assert.ok(!("futureKey3" in nfSettings.getUser()), "被拒 patch 的未知键不写入");
+    }
+
+    // (6) #470 验收 6：user 层旧脏键不被自动清洗——透传键升为已知键后提交脏值
+    //     400 + hint；保存其他键不触发 400（脏键留 user 层，读面归一化兜底）
+    {
+      // 模拟 vN 未知键 futureFlag 已透传进 user 层、vN+1 升级为已知键（脏值 true 是
+      // 合法布尔，此处用类型非法值模拟旧脏键；直接 setUser 预置，模拟「升级前写入」）
+      nfSettings.setUser({ notifyAsk: true, futureKey: "keepme", futureKey2: { a: 1 }, pureFuture: 1, dirtyKnown: "yes" });
+      // 保存其他已知键（不提交 dirtyKnown）→ 200，脏键仍在
+      const put = makeRes();
+      await cfgR.handler(bodyReq({ patch: { notifySound: true } }), put.res);
+      assert.equal(put.rec.status, 200, "保存其他键不触发脏键 400");
+      assert.equal(nfSettings.getUser().dirtyKnown, "yes", "旧脏键不被自动清洗（留待用户主动改/手清）");
+      // 主动提交脏已知键（dirtyKnown 若为已知键需合法——此处用真的已知键 notifyAsk 字符串形态）
+      const put2 = makeRes();
+      await cfgR.handler(bodyReq({ patch: { notifyAsk: "yes" } }), put2.res);
+      assert.equal(put2.rec.status, 400, "主动提交脏已知键 400 + hint");
+      const b2 = JSON.parse(put2.rec.text);
+      assert.match(b2.error.error, /notifyAsk/, "400 指明脏已知键");
+    }
+
+    // (7) #470 验收 8（链路模拟）：GET effective（含未知键）→ 改已知键 →
+    //     diffPayload 不含未知键 → PUT → GET 未知键保留（client 只提交变更键）
+    {
+      // 预置未知键 + 已知键，读 GET effective 作为 UI 基线（client loadCard 语义）
+      const pre = makeRes();
+      await cfgR.handler(bodyReq({ patch: { chainFuture: { k: 1 }, notifyTaskDone: true } }), pre.res);
+      const get0 = makeRes();
+      await cfgR.handler(fakeReq({}), get0.res);
+      const effective0 = JSON.parse(get0.rec.text).effective;
+      // UI 以 effective 深拷贝为 settings 与 baselineRef：只改一个已知键
+      const baselineRef = JSON.parse(JSON.stringify(effective0));
+      const settingsView = JSON.parse(JSON.stringify(effective0));
+      settingsView.notifyTaskDone = false;
+      // diffPayload 只提交与基线不同的键（与 src/client/index.ts 同逻辑）
+      const payload = {};
+      for (const key in settingsView) {
+        if (baselineRef[key] !== undefined && JSON.stringify(settingsView[key]) !== JSON.stringify(baselineRef[key])) {
+          payload[key] = settingsView[key];
+        }
+      }
+      assert.deepEqual(payload, { notifyTaskDone: false }, "diff 只含变更已知键，不含未知键");
+      const put = makeRes();
+      await cfgR.handler(bodyReq({ patch: payload }), put.res);
+      assert.equal(put.rec.status, 200, "diff payload PUT 成功");
+      const get1 = makeRes();
+      await cfgR.handler(fakeReq({}), get1.res);
+      const finalUser = JSON.parse(get1.rec.text).user;
+      assert.deepEqual(finalUser.chainFuture, { k: 1 }, "GET→diff→PUT→GET 整链后未知键保留且值未变");
+      assert.equal(JSON.parse(get1.rec.text).effective.chainFuture.k, 1, "effective 同保未知键");
+      // 边界：diff 含未知键时 PUT 可透传（未知键作为 payload 一部分 → 200 写入）
+      const put2 = makeRes();
+      await cfgR.handler(bodyReq({ patch: { diffFuture: 2, notifyAsk: false } }), put2.res);
+      assert.equal(put2.rec.status, 200, "diff 含未知键可透传写入");
+      assert.equal(nfSettings.getUser().diffFuture, 2, "未知键经 PUT 透传并入 user 层");
+    }
+
+    nfDispose();
+  }
+
+  // (8) #470 验收 4（entry 白名单回归）：组合层装配键 configFile/enabled 不进
+  //     settings user 层（makeNotifier 的 entry 经 sanitizeSettings 白名单过滤，
+  //     base 层承载已知配置键、装配键被丢弃——不混入 user 层，也不进 GET user）
+  {
+    const { routes: enRoutes, settings: enSettings, dispose: enDispose } = makeNotifier(work, {
+      historyFile: join(work, "history-entry.jsonl"),
+      configFile: join(work, "entry-cfg.json"),
+      enabled: true,
+      notifyAsk: false,
+    });
+    const cfgR2 = enRoutes.find((r) => r.path === ROUTES.config);
+    const user = enSettings.getUser();
+    assert.deepEqual(user, {}, "组合层 entry 只进 base 层，user 层保持空（装配键与已知键都不入 user）");
+    const get = makeRes();
+    await cfgR2.handler(fakeReq({}), get.res);
+    const getBody = JSON.parse(get.rec.text);
+    for (const key of ["configFile", "toastScript", "historyFile", "statusFile", "enabled"]) {
+      assert.ok(!(key in getBody.user), `GET user 不含装配键 ${key}`);
+    }
+    assert.equal(getBody.effective.notifyAsk, false, "entry 已知键经 base 层进 effective（装配键不干扰）");
+    assert.equal(getBody.effective.quietHours.enabled, false, "effective 其余键默认值兜底");
+    enDispose();
+  }
+
   // F4 expectedRevision 缺省：无冲突检测（不带 revision 的 PUT 成功）
   {
     function bodyReq(payload) {

--- a/packages/dsh-notifier/test/unit-config.test.ts
+++ b/packages/dsh-notifier/test/unit-config.test.ts
@@ -149,6 +149,17 @@ try {
   assert.deepEqual(opaque.allowKinds, [], "allowKinds 非法回默认且不透传");
   assert.equal(opaque.bogus, 1, "其他未知键仍透传");
 
+  // #470 复核 P0（读面纵深）：normalizeConfig 透传剔除原型链成员自有键——
+  // 存量 user 层若含 JSON.parse 注入的 constructor/__proto__ 等键，不得脏写
+  // 运行时镜像、不得改原型
+  const readEvil = JSON.parse('{"constructor":1,"toString":2,"hasOwnProperty":3,"valueOf":4,"__proto__":{"polluted":1},"futureRead":9,"notifyAsk":true}');
+  const readOut = normalizeConfig(readEvil);
+  assert.equal(readOut.notifyAsk, true, "读面：已知键正常归一化");
+  assert.equal(readOut.futureRead, 9, "读面：普通未知键仍透传");
+  assert.equal(Object.prototype.hasOwnProperty.call(readOut, "constructor"), false, "读面：constructor 剔除不透传（非自有键）");
+  assert.equal(Object.prototype.hasOwnProperty.call(readOut, "toString"), false, "读面：toString 剔除不透传（非自有键）");
+  assert.equal(Object.getPrototypeOf(readOut), Object.prototype, "读面：normalizeConfig 输出原型未被污染");
+
   // ===== M2：凭据脱敏与掩码回填（评审 P0-1/P0-2）=====
   const withSecret = { channels: [{ id: "phone", type: "bark", baseUrl: "https://api.day.app", deviceKey: "realKey123", enabled: true }], notifyAsk: true };
   const redacted = redactConfigView(withSecret);
@@ -234,6 +245,16 @@ try {
   assert.equal(sanitizePatchSettings(null), null, "透传通道：非对象 → null");
   assert.deepEqual(sanitizePatchSettings({ notifyTaskDone: true }), { notifyTaskDone: true }, "透传通道：纯已知键与 entry 白名单同结果");
   assert.equal(sanitizePatchSettings({ channels: [{ ...okCh, volume: "0.7" }] }).channels[0].volume, "0.7", "透传通道：channels 内未知 string/number 参数保留（Bark 前向兼容不变）");
+  // #470 复核 P0：数组 patch 不得被当对象透传成数字索引脏键 → null（调用方 400）
+  assert.equal(sanitizePatchSettings([1, 2]), null, "透传通道：数组 patch → null（拒绝，不写脏 user 层）");
+  assert.equal(sanitizePatchSettings([]), null, "透传通道：空数组 → null");
+  // #470 复核 P0：原型链成员键经 JSON.parse 成为自有键 → 剔除不写入、不触发原型校验器
+  const protoEvil = JSON.parse('{"__proto__":{"polluted":1},"constructor":1,"prototype":2,"toString":3,"hasOwnProperty":4,"valueOf":5,"futureKey":7}');
+  const protoEvilOut = sanitizePatchSettings(protoEvil);
+  assert.deepEqual(protoEvilOut, { futureKey: 7 }, "透传通道：原型链成员键剔除、未知键仍透传");
+  assert.equal(Object.getPrototypeOf(protoEvilOut), Object.prototype, "透传通道：__proto__ 不改变 out 原型（无原型污染）");
+  const protoKnownEvil = JSON.parse('{"notifyAsk":false,"__proto__":{"polluted":1},"constructor":1}');
+  assert.deepEqual(sanitizePatchSettings(protoKnownEvil), { notifyAsk: false }, "透传通道：原型键与已知键混合 → 只留已知键");
 } finally {
   rmSync(work, { recursive: true, force: true });
 }

--- a/packages/dsh-notifier/test/unit-config.test.ts
+++ b/packages/dsh-notifier/test/unit-config.test.ts
@@ -11,7 +11,7 @@ import { join } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { mkdtempSync, rmSync } from "node:fs";
 import { assert } from "./helpers.ts";
-import { normalizeConfig, parseHHMM, isInQuietHours, DEFAULT_CONFIG, configFile, historyFile, toastScriptPath, normalizeBarkBaseUrl, redactConfigView, unmaskChannels, SECRET_MASK, BARK_ID_PATTERN, validateSettings, sanitizeSettings, QUIET_ALLOW_KINDS } from "../lib/index.js";
+import { normalizeConfig, parseHHMM, isInQuietHours, DEFAULT_CONFIG, configFile, historyFile, toastScriptPath, normalizeBarkBaseUrl, redactConfigView, unmaskChannels, SECRET_MASK, BARK_ID_PATTERN, validateSettings, sanitizeSettings, sanitizePatchSettings, QUIET_ALLOW_KINDS } from "../lib/index.js";
 
 const work = mkdtempSync(join(tmpdir(), "dnotify-unit-config-"));
 try {
@@ -218,7 +218,22 @@ try {
   assert.equal(validateSettings({ quietHours: { allowKinds: cap128 } }), null, "quietHours.allowKinds 恰 128 项通过");
   const sanitizedCh = sanitizeSettings({ channels: [{ ...okCh, volume: "0.7" }] });
   assert.ok(sanitizedCh && Array.isArray(sanitizedCh.channels) && sanitizedCh.channels.length === 1, "sanitizeSettings channels 往返");
-  assert.deepEqual(sanitizeSettings({ futureKey: 1 }), {}, "未来键写入白名单语义不变（读取归一化才透传）");
+  assert.deepEqual(sanitizeSettings({ futureKey: 1 }), {}, "entry 白名单通道：未来键仍丢弃（组合层装配专用，#470 双通道拆分）");
+
+  // ===== #470：sanitizePatchSettings（PUT/迁移透传通道）=====
+  assert.deepEqual(sanitizePatchSettings({ futureKey: 1 }), { futureKey: 1 }, "透传通道：纯未知键原样保留");
+  assert.deepEqual(sanitizePatchSettings({ notifyAsk: false, futureKey: { a: 1 } }), { notifyAsk: false, futureKey: { a: 1 } }, "透传通道：已知+未知混合双保留");
+  assert.deepEqual(sanitizePatchSettings({}), {}, "透传通道：空 patch 空对象（调用方按 400 语义处理）");
+  assert.equal(sanitizePatchSettings({ notifyAsk: "yes" }), null, "透传通道：已知键非法 → 整体拒绝 null");
+  assert.deepEqual(sanitizePatchSettings({ configFile: "/x", toastScript: "/y", historyFile: "/z", statusFile: "/s", enabled: false }), {}, "透传通道：装配键全部剔除（不入 user 层）");
+  assert.deepEqual(sanitizePatchSettings({ configFile: "/x", notifyQuestion: false, futureKey: 2 }), { notifyQuestion: false, futureKey: 2 }, "透传通道：混合提交剔除装配键、保留已知+未知");
+  // 透传通道不深改值（原样引用与深等）
+  const nested = { futureObj: { x: [1, 2] } };
+  const nestedOut = sanitizePatchSettings(nested);
+  assert.deepEqual(nestedOut, nested, "透传通道：任意 JSON 值原样并入");
+  assert.equal(sanitizePatchSettings(null), null, "透传通道：非对象 → null");
+  assert.deepEqual(sanitizePatchSettings({ notifyTaskDone: true }), { notifyTaskDone: true }, "透传通道：纯已知键与 entry 白名单同结果");
+  assert.equal(sanitizePatchSettings({ channels: [{ ...okCh, volume: "0.7" }] }).channels[0].volume, "0.7", "透传通道：channels 内未知 string/number 参数保留（Bark 前向兼容不变）");
 } finally {
   rmSync(work, { recursive: true, force: true });
 }

--- a/packages/dsh-notifier/test/unit-config.test.ts
+++ b/packages/dsh-notifier/test/unit-config.test.ts
@@ -168,6 +168,20 @@ try {
   assert.equal(redacted.notifyAsk, true, "其余字段原样");
   assert.deepEqual(redactConfigView({ a: 1 }), { a: 1 }, "无 channels 输入原样");
   assert.equal(redactConfigView(undefined), null, "null 输入兜底");
+  // #470 qa 复核发现 2：redactConfigView 特殊键剔除的函数级直测——用
+  // defineProperty 造**自有** constructor/__proto__ 键（JSON.stringify 会丢弃
+  // undefined 值但不会丢自有键；此处刻意让 stringify 保留它们，证明剔除是
+  // redactConfigView 自身逻辑而非序列化副效应）
+  const evilOwn = { keep: 1 };
+  Object.defineProperty(evilOwn, "constructor", { value: 1, enumerable: true });
+  Object.defineProperty(evilOwn, "__proto__", { value: { polluted: 1 }, enumerable: true });
+  Object.defineProperty(evilOwn, "toString", { value: "x", enumerable: true });
+  const evilOut = redactConfigView(evilOwn);
+  assert.equal(Object.prototype.hasOwnProperty.call(evilOut, "keep"), true, "读出口：普通键保留");
+  assert.equal(Object.prototype.hasOwnProperty.call(evilOut, "constructor"), false, "读出口：constructor 自有键剔除");
+  assert.equal(Object.prototype.hasOwnProperty.call(evilOut, "__proto__"), false, "读出口：__proto__ 自有键剔除");
+  assert.equal(Object.prototype.hasOwnProperty.call(evilOut, "toString"), false, "读出口：toString 自有键剔除");
+  assert.equal(Object.prototype.polluted, undefined, "读出口：无全局原型污染");
 
   const userChs = [{ id: "phone", deviceKey: "realKey123" }, { id: "pad", deviceKey: "padKey456" }];
   const unmasked = unmaskChannels(
@@ -255,6 +269,15 @@ try {
   assert.equal(Object.getPrototypeOf(protoEvilOut), Object.prototype, "透传通道：__proto__ 不改变 out 原型（无原型污染）");
   const protoKnownEvil = JSON.parse('{"notifyAsk":false,"__proto__":{"polluted":1},"constructor":1}');
   assert.deepEqual(sanitizePatchSettings(protoKnownEvil), { notifyAsk: false }, "透传通道：原型键与已知键混合 → 只留已知键");
+  // #470 qa 复核发现 1：null 值语义分层——未知键 null 透传保留（与读面一致），
+  // 已知键 null 沿用既有跳过语义（视同未提交）
+  assert.deepEqual(sanitizePatchSettings({ nullFuture: null, notifyAsk: null }), { nullFuture: null }, "透传通道：未知键 null 透传保留、已知键 null 跳过");
+  assert.deepEqual(sanitizePatchSettings({ notifyAsk: null }), {}, "透传通道：纯已知键 null patch 净化后空对象（调用方按 400 处理）");
+  assert.deepEqual(sanitizePatchSettings({ nullFuture: null }), { nullFuture: null }, "透传通道：纯未知键 null patch 非空（可写）");
+  // 读面 normalizeConfig 本就透传 null（与写面闭合）
+  const nullRead = normalizeConfig({ nullFuture: null });
+  assert.equal(Object.prototype.hasOwnProperty.call(nullRead, "nullFuture"), true, "读面：未知键 null 透传保留");
+  assert.equal(nullRead.nullFuture, null, "读面：未知键 null 值原样");
 } finally {
   rmSync(work, { recursive: true, force: true });
 }


### PR DESCRIPTION
## 修复说明

---

## qa 复核修复（v2-fix2）——11 PASS + 1 部分 PASS 返工完成

qa 判定 11 条 PASS + 1 条部分 PASS（P0/P1 修复全复验通过），两个 P2 发现已修复（commit `fe370aa`，rebase 至最新 main `46a17df`，7 commits 线性）：

- **发现 1（null 值未知键，方案 a 裁决）**：`sanitizePatchSettings` 对未知键值为 `null` 改为**透传保留**——与读面 `normalizeConfig` 透传 null 口径闭合（原实现 continue 剔除导致「GET 读到的 null 键 PUT 回去静默消失」，README「未知键原样保留/never silently dropped」声明失实）。已知键 null 沿用既有跳过语义（validateSettings/sanitizeSettings 同口径，视同未提交）——null 值分层：已知键分支保留 null skip、未知键分支透传 null。
  - 断言：unit-config（`{nullFuture:null, notifyAsk:null}` → `{nullFuture:null}` 分层透传；纯已知键 null → 空对象 400 语义；读面 normalizeConfig 本就透传 null）；routes（PUT `{nullFuture:null}` → 200、settings user 层含键值 null、GET user/effective 可读回 null——PUT→GET 往返闭合）；migration E9k（legacy null 未知键补写保留，同净化通道）。
  - README 无需改：文档「任意 JSON 值原样保留」声明保持，实现已对齐（qa 裁决）。
- **发现 2（读出口扫描空转风险）**：补 `redactConfigView` **函数级直测**（unit-config）——用 `Object.defineProperty` 造**自有** `constructor`/`__proto__`/`toString` 可枚举键（非 JSON 串行输入），断言剔除是函数自身逻辑（`hasOwnProperty` 删除）而非 `JSON.stringify` 副效应，且无全局原型污染。

**五连门禁（rebase 至 main 46a17df 后复核）**：build=0 / test=0 / contract=0 / pack:check=0 / typecheck=0。


---



实施 GitHub issue #470

---

## 复核修复（v2-fix）——P0/P1/P2 全量返工完成

主控复核闸与对抗子 Agent 双源发现 P0×2 / P1×4 / P2×1，已全部修复并补回归（新增 3 commits：`3190c9c` fix / `e65280b` test / `df015f1` docs）：

- **P0-1（数组 patch 脏写）**：`sanitizePatchSettings` 拒绝数组（`Array.isArray` → null）——PUT `[1]` 现返回 400 + 「patch 必须是对象」，不再把数字索引透传成 `"0":1` 脏键；空数组同 400。
- **P0-2（原型链成员键）**：写通道一律剔除 `__proto__`/`constructor`/`prototype`/`toString`/`hasOwnProperty`/`valueOf` 等；`SETTING_VALIDATORS` 查表改 `Object.hasOwn`（防误触原型链校验器抛 TypeError → 500）；混合提交只写已知键。
- **P0-2 补充（handler 异常兜底）**：PUT handler 的 `applyConfigPatch` 包 try/catch 收敛 500 固定文案 + 服务端日志，防未捕获异常冒泡宿主 500/悬挂。
- **P1-1（迁移同根因）**：迁移通道随 P0 同愈——legacy 含自有 `__proto__`/`constructor` 键不再崩、正常键照常补写、rename 正常完成。
- **P1-2（client diff 真链）**：`diffPayload` 收敛为模块级纯函数 `diffSettingsPayload`（apply 挂载导出）；routes.test 整链模拟去掉夹带守卫 `baselineRef[key] !== undefined`；client-contract 用 vm materialize 真实产物直测（基线含未知键只改已知键 → diff 不含未知键；改动未知键可 diff）。
- **P1-3（ASSEMBLY_KEYS 平行维护）**：改为导出 `ASSEMBLY_SETTING_KEYS`（`as const`）+ 与 `NotifierApplyConfig` 键集**编译期双向一致断言**——新增装配键只加接口不加列表即编译错误。
- **P1-4（README 失实 + 文案）**：`validateSettings` 非对象/数组 hint 修正为「patch 必须是对象（数组/非对象形态不支持）」（不再输出 `(payload)` 占位符），与 README 逐句对账一致；中英 README 边界例外补「patch 必须对象」+「原型链/特殊成员键剔除」两条。
- **P2（读出口特殊键扫描）**：`redactConfigView` 统一读出口（GET user/effective + PUT 响应 user）剔除原型链特殊自有键——存量 user 层手改注入也不泄露；routes (10) 契约扫描断言 + normalizeConfig 读面纵深剔除。

**mutation**（dsh-notifier-config 段，config/migrate/settings）：covered **66.80** ≥ threshold 60 达标；新增守卫无定向存活变异体（幸存均属既有 Bark/表达式级固有）。

**五连门禁（v2-fix 后提交态复核）**：build=0 / test=0 / contract=0 / pack:check=0 / typecheck=0。


---

## 原始修复说明（v2，前 3 commits）

（notifier 配置未知键前向兼容策略——透传保留，方案修订 v2 全量落实）。

**核心改动**（基于最新 origin/main `d174089` rebase，3 commits）：

1. **双通道净化拆分**（`config.ts`）：`sanitizeSettings` 保持 entry 组合层白名单语义（`index.ts` apply 装配用，行为不变）；新增 `sanitizePatchSettings` 服务 PUT /config 与存量迁移——已知键按 `SETTING_VALIDATORS` 校验（任一非法整体 400/null），**未知键任意 JSON 值原样透传保留**，但装配键名（`configFile`/`toastScript`/`historyFile`/`statusFile`/`enabled`）一律剔除（防 user 层污染、杜绝未来误把 user 层装配键当配置来源）。
2. **PUT 判据**（`server.ts`）：净化空对象 400 改为「原始 patch 非空对象」+「净化后非空」双判据——纯未知键 patch（如 `{"futureKey":1}`）→ **200 透传写入**；仅空 patch `{}` / 仅装配键 patch（剔除后无可写键）→ 400。
3. **迁移通道**（`migrate.ts`）：改用透传净化——legacy 未知键在 user 层缺失则补写、已存在**不覆盖**（#468 冲突策略不变）；纯未知键 legacy 不再判「无有效键」corrupt，仅「无任何键/非法 JSON/非对象」才 corrupted 标记。
4. **注释修正**：`config.ts` 文件头 `normalizeConfig`「未知键丢弃」→「未知键透传保留」（与实现一致）；sanitize 注释改述双通道语义。
5. **README 中英双语**「配置」节新增未知键语义声明（透传保留 + 升级路径 + 三边界 + 纯未知键 200/空 patch 400 响应语义）。

**冲突策略声明**：与 #468（迁移只补缺失不覆盖）兼容——未知键补写走同一 `diffMissingKeys`「user 层缺失才写」路径；已存在未知键/用户改值一律不被覆盖。升级路径不自动清洗 user 层（P1-2 裁决）：读面 normalizeConfig 对已知脏值丢回默认（既有行为），仅主动提交脏已知键 400 + hint。

## 验收断言表（v2 全量 12 条）

| # | 验收条目（v2） | 结论 | 证据 |
|---|---|---|---|
| 1 | README.md + README.en.md「配置」节未知键语义声明（透传保留三面一致 + 边界 + 200/400 响应语义） | PASS | `docs:check` 通过；README.md:111-139 / README.en.md:97-125 声明（措辞与 v2 第三节草案语义一致） |
| 2 | 存量 user 层未知键保存已知键后不丢 | PASS | `routes.test.ts` #470 块 (1)：预置 `futureKey:"keepme"` → PUT `{notifyAsk:false}` → user 层原值保留 |
| 3 | PUT 顶层未知键 200 透传（GET user/effective 深等）；空 patch {} 仍 400；纯未知键 patch 200 | PASS | `routes.test.ts` #470 块 (2)(3) + `unit-config.test.ts` sanitizePatchSettings 纯函数断言 |
| 4 | PUT 透传排除装配键（不入 user 层）；entry 白名单语义不变 | PASS | `routes.test.ts` #470 块 (4)(8)：五装配键剔除、纯装配键 400、混合仅已知键生效、GET user 无装配键；`unit-config.test.ts` |
| 5 | 已知键非法值语义不变：400 + hint，未知键存在不改变结果 | PASS | `routes.test.ts` #470 块 (5)：`{notifyAsk:"yes", futureKey3:1}` → 400 指明 notifyAsk + hint，未知键不写入 |
| 6 | 透传键升级处理：读归一化脏值丢默认 / 主动提交脏已知键 400 / user 层不自动清洗（README 声明） | PASS | `routes.test.ts` #470 块 (6)：setUser 脏键预置 → 保存其他键 200 不清洗；主动提交 `notifyAsk:"yes"` 400；`unit-config.test.ts:43` 既有脏值归一化断言保持绿 |
| 7 | 迁移：legacy 未知键缺失补写/已存在不覆盖；纯未知键不再判无有效键；无任何键维持标记 | PASS | `migration.test.ts` E8 纯未知键重放迁移、E9f/E9g 正常迁移透传补写不覆盖、E9h 仅装配键 corrupted、E9c/E9d 既有 #468 覆盖保护绿 |
| 8 | client diff 回写整链：GET effective 基线 → 改已知键 → diffPayload 不含未知键 → PUT → GET 未知键保留；diff 含未知键可透传 | PASS | `routes.test.ts` #470 块 (7)：链路模拟断言 payload 仅 `{notifyTaskDone:false}`、未知键保留；边界 diff 含未知键 200 |
| 9 | Bark 频道边界不回归 | PASS | 既有断言全绿：`unit-config.test.ts` unknown string/number 透传 / 保留键剔除 / 掩码回填；`service-contract` ⑥ bark 透传 |
| 10 | 过时注释修正：config.ts:299 未知键透传表述 + sanitize 注释双通道语义 | PASS | code review：`normalizeConfig` 注释「未知键透传保留」；`sanitizeSettings`/`sanitizePatchSettings` 双函数注释 |
| 11 | 基于最新 origin/main（d174089）rebase；migrate.ts 行号以 rebase 后为准 | PASS | 分支基于 `d174089`（rebase 后 HEAD），migrate.ts 两处调用点已换透传通道 |
| 12 | 全部用例并入 smoke：五连门禁全绿 | PASS | `pnpm build` 0 / `pnpm test` 0（全仓含 dsh-notifier smoke OK）/ `pnpm contract` 0 / `pnpm pack:check` 0 / `pnpm typecheck` 0 |

**行为一致性总判据**：文档声明 = 代码行为 = 测试锁定，三条一致（#470 验收清单要求）。

Closes #470


