### PR TITLE
docs+test(scripts): d.ts X1 机制补文档与深层路径/retired 残留测试（#478）

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -116,14 +116,55 @@ scripts/                   # 仓库维护脚本（*.ts，Node 直跑；按职能
 `scripts/build/bundle-host.ts` 编排单包构建：
 1. esbuild 内联 `shared/*` 进 `lib/index.js`（宿主端自包含单文件）。
 2. 客户端经 `scripts/build/build-client.ts`（唯一契约外壳/注入点）构建 `lib/client.js`。
-3. d.ts X1：改写 `../../../shared` → 包内副本，`shared/*.d.ts` 随包。
-   shared 层因此保持 **js + d.ts 双写**（tsc `rootDir` 硬约束，shared 不可 TS 化）。
+3. d.ts X1：shared 声明随包机制（见下小节）。
 4. 拷贝资源（非 TS 文件）+ LICENSE。
 5. 第三方 license 归集：扫描产物中 esbuild 的 node_modules 模块注释，把真实被内联
    的第三方库（含传递依赖）license 文本写入 `lib/THIRD-PARTY-LICENSES`
    （`scripts/build/collect-licenses.ts`）。**运行时依赖 = 构建期内联**——内联在法律上
    等于分发该库副本，必须随发布物附其 license 文本与版权声明；`pack:check` 断言
    「有内联 ⇒ 清单存在、非空、含 MIT/BSD/Apache 字样且覆盖每个被内联的包名」。
+
+<a id="dts-x1"></a><a id="user-content-dts-x1"></a>
+### d.ts X1：shared 声明随包机制（#478）
+
+宿主端共享层（shared/）是 **js + d.ts 双写**（tsc `rootDir` 硬约束，shared 不可
+TS 化）：`.js` 实现经 esbuild 内联进各包运行时，`.d.ts` 声明则经 X1 随包发布。
+X1 在 bundle-host 构建宿主产物时对 **tsc 声明产物**做两件事（纯类型层，运行时无关）：
+
+- **2a 路径改写**（`scripts/lib/rewrite-dts-paths.ts`，`rewriteDtsPaths`）：改写
+  `lib/**/*.d.ts` 中所有指向**仓库外 shared/** 的相对引用——tsc 从 src/ 原样写入
+  声明的 `../../shared/` 等（实际形态 `(?:\\.\\.\\/)+shared/`）→ 指向**包内副本**。
+  前缀按当前文件在 lib/ 下的目录深度归一为 `'../'.repeat(depth + 1)`：整体吞掉任意
+  深度 `../` 前缀后按文件深度重算——顶层 `lib/x.d.ts`（depth 0）→ `../shared/`，
+  子目录 `lib/client/x.d.ts`（depth 1）→ `../../shared/`。引用原深度与文件深度无
+  对应关系（归一化语义：一律按**文件**深度）。顺带把相对 `.ts` 后缀 import 回写
+  `.js`（rewriteRelativeImportExtensions 的 d.ts 不回写缺口，issue #276；未启用该
+  flag 的包无匹配，天然无操作）。发布后 d.ts 不再引用包外路径，类型解析全部落在
+  包内副本。
+- **2b 声明副本进包**：把仓库根 `shared/` 下全部 `.d.ts`（递归，含子目录 `host/`、
+  `client/` 等）复制进 `packages/<pkg>/shared/`（保留相对目录结构），随包发布。
+  复制谓词与遍历实现 = `scripts/lib/walk-files.ts` 的 `walkFiles`（单一事实源）。
+
+**副本清单来源**：不是包内静态清单——每次构建**实时枚举仓库 shared/**（`walkFiles`
+谓词 `.d.ts`）。包根 `shared/` 不入 git、属构建产物（.gitignore
+`packages/*/shared/`；clean-lib 只清 lib/ 不清包根 shared/），经各包 package.json
+`files` 白名单 `shared/**/*.d.ts` 发布。
+
+**与 shared 准入规则的关系**：X1 是 shared 契约的**发布面强制器**——准入规则
+（shared/README.md 准入 1-7：≥2 稳定消费者、无包级常量依赖、跨 apply 状态语义明确、
+无泄漏、登记消费方与行为契约、独立测试、显式废弃两步走）约束**哪些模块有资格进
+shared**；X1 保证**已准入的模块随每个消费包完整发布**（机制保证）。「准入审核 →
+进 shared → 自动随包」，使 shared 单点维护而各包发布物自包含不断链。
+
+**断言链**（`scripts/lib/shared-dts-lib.ts` + `pack:check`）：
+- `listSharedDts(ROOT)` 用与 2b **同一 walkFiles 谓词**枚举仓库 shared/ 全部 .d.ts
+  相对路径；pack:check 打包每个插件后逐包比对 tarball：
+  - `assertSharedDtsPresent` 查缺：新增 shared 子目录/文件漏随包 → fail-loud；
+  - `assertSharedDtsNoExtras` 查多（#478）：**retired 残留**——shared 模块退休
+    （DEPRECATED 两步走 → 移除）后，旧声明副本残留在包内 shared/（bundle-host 每次
+    构建覆盖写入新副本但从不清理已移除者，files 白名单仍会把它带进 tarball，过期
+    声明随包发布 = 陈旧类型面）→ 报「shared 副本残留」fail-loud。
+  枚举与复制同源，杜绝两处漂移；双向（缺/多）断言把「机制保证」升级为「断言保证」。
 
 宿主端类型一律用官方类型层（pnpm-workspace catalog 锁版：`@deepseek-ai/cordis`
 的 `Context` + `@deepseek-ai/dsh-host-webserver` 的 `WebRoute`/ctx.webServer 增强 +

--- a/scripts/build/bundle-host.ts
+++ b/scripts/build/bundle-host.ts
@@ -21,6 +21,7 @@ import { dirname, join, relative, resolve, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { build } from 'esbuild'
 import { buildClient, buildMermaidChunk, copyClientResources } from './build-client.ts'
+import { rewriteDtsPaths } from '../lib/rewrite-dts-paths.ts'
 import { walkFiles } from '../lib/walk-files.ts'
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
@@ -176,26 +177,9 @@ function cleanFreeFloatingJs(dir, isRoot) {
 cleanFreeFloatingJs(libDir, true)
 
 // 2a. d.ts 路径改写（X1，递归且按文件深度感知）：shared 相对引用 → 包内副本。
-// 顶层 lib/x.d.ts 引用包内副本为 ../shared/；
-// 子目录 lib/a/b.d.ts 引用为 ../../shared/（深度 +1 级）。
-function rewriteDtsPaths(dir, depth) {
-  const prefix = '../'.repeat(depth + 1)
-  // rewriteRelativeImportExtensions 的 d.ts 缺口修正（#276 方案 A）：TS（5.9/7.x
-  // 实测一致）只把相对 .ts 后缀 specifier 回写到 JS emit，声明文件不回写——
-  // 源码 .ts 后缀原样进入 lib/*.d.ts，会指向发布包内不存在的文件。统一改回 .js。
-  // 对未启用该 flag / 未迁移的包无匹配，天然无操作。
-  const TS_SUFFIX = /(from\s+|import\s*\(\s*)(["'])(\.\.?\/[^"'\s]+)\.ts\2/g
-  for (const f of readdirSync(dir, { withFileTypes: true })) {
-    const abs = join(dir, f.name)
-    if (f.isDirectory()) { rewriteDtsPaths(abs, depth + 1); continue }
-    if (!f.name.endsWith('.d.ts')) continue
-    const p = join(dir, f.name)
-    const t = readFileSync(p, 'utf8')
-      .replace(/(?:\.\.\/)+shared\//g, `${prefix}shared/`)
-      .replace(TS_SUFFIX, '$1$2$3.js$2')
-    writeFileSync(p, t)
-  }
-}
+// 实现单一事实源在 scripts/lib/rewrite-dts-paths.ts（issue #478 提纯，供测试 import）：
+//   - 顶层 lib/x.d.ts 引用包内副本为 ../shared/；
+//   - 子目录 lib/a/b.d.ts 引用为 ../../shared/（深度 +1 级，逐层递增）。
 rewriteDtsPaths(libDir, 0)
 // 2b. shared 声明副本进包（递归：shared/ 下所有 .d.ts，含子目录如 host/）
 mkdirSync(join(pkgDir, 'shared'), { recursive: true })

--- a/scripts/gate/pack-check.ts
+++ b/scripts/gate/pack-check.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'node:url'
 import { executeClient } from '../lib/client-contract-lib.ts'
 import { extractInlinedPackages, readMermaidChunkRefs } from '../build/collect-licenses.ts'
 import { AGGREGATE_NAME, checkAggregateConsistency, filterOutRetiredDirs, listPluginDirs, loadManifest, warnUnknownEntries } from '../lib/plugins-manifest-lib.ts'
-import { assertSharedDtsPresent, listSharedDts } from '../lib/shared-dts-lib.ts'
+import { assertSharedDtsNoExtras, assertSharedDtsPresent, listSharedDts } from '../lib/shared-dts-lib.ts'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
@@ -72,6 +72,13 @@ for (const p of plugins) {
     const missingSharedDts = assertSharedDtsPresent(join(pkgRoot, 'shared'), SHARED_DTS_EXPECTED)
     if (missingSharedDts.length > 0) {
       problems.push(`缺 shared 声明副本: ${missingSharedDts.join(', ')}（shared 递归副本未随包）`)
+    }
+    // 查多（issue #478）：retired 模块移除后旧声明副本不得残留在包内——「源 shared/
+    // 移除某 d.ts 后旧副本仍随包发布」属过期类型面（files 白名单 shared/**/*.d.ts
+    // 仍会带走），查缺出口对残留静默放行，此处 fail-loud。
+    const extraSharedDts = assertSharedDtsNoExtras(join(pkgRoot, 'shared'), SHARED_DTS_EXPECTED)
+    if (extraSharedDts.length > 0) {
+      problems.push(`shared 副本残留: ${extraSharedDts.join(', ')}（源 shared/ 已无此文件，须清理）`)
     }
     const idx = readFileSync(join(pkgRoot, 'lib', 'index.js'), 'utf8')
     // 只匹配 import 语句中的仓库外相对引用（esbuild 模块注释含路径文本，不算断链）

--- a/scripts/lib/rewrite-dts-paths.ts
+++ b/scripts/lib/rewrite-dts-paths.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * rewrite-dts-paths — bundle-host d.ts X1 2a 段「shared 相对引用改写」共享库（issue #478）。
+ *
+ * 从 bundle-host.ts 私有函数提纯（#463 walkFiles 先例）：bundle-host 运行时产物语义
+ * 零变化，本库只承载字符串改写 + 目录遍历两层纯逻辑，供测试直接 import。
+ *
+ * 语义：tsc 从 src/ 原样写入声明的 shared 相对引用（`../../shared/` 等）指向仓库外
+ * shared/——发布后断链。2a 把 `(?:\\.\\.\\/)+shared/` 前缀整体吞掉后，按当前 d.ts
+ * 在 lib/ 下的目录深度归一为 `'../'.repeat(depth + 1)shared/`：
+ *   - 顶层 lib/x.d.ts（depth 0）→ ../shared/
+ *   - 子目录 lib/a/b.d.ts（depth 2）→ ../../../shared/
+ * 引用里的 `../` 深度与文件所在目录深度无关（极端输入也按文件深度归一）。
+ *
+ * 顺带（issue #276）：rewriteRelativeImportExtensions 只回写 JS emit 的 .ts 后缀
+ * import，声明文件不回写——源码 .ts 后缀原样进入 lib/*.d.ts 会指向包内不存在的
+ * 文件，统一改回 .js（未启用该 flag 的包无匹配，天然无操作）。
+ */
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * 改写单份 d.ts 文本：shared 相对引用按文件目录深度归一 + 相对 .ts 后缀回写 .js。
+ * @param {string} text 原始 .d.ts 文本
+ * @param {number} depth 该文件在 lib/ 下的目录深度（顶层 0，子目录逐级 +1）
+ * @returns {string} 改写后文本
+ */
+export function rewriteDtsText(text, depth) {
+  const prefix = '../'.repeat(depth + 1)
+  // rewriteRelativeImportExtensions 的 d.ts 缺口修正（#276 方案 A）：TS（5.9/7.x
+  // 实测一致）只把相对 .ts 后缀 specifier 回写到 JS emit，声明文件不回写——
+  // 源码 .ts 后缀原样进入 lib/*.d.ts，会指向发布包内不存在的文件。统一改回 .js。
+  // 对未启用该 flag / 未迁移的包无匹配，天然无操作。
+  const TS_SUFFIX = /(from\s+|import\s*\(\s*)(["'])(\.\.?\/[^"'\s]+)\.ts\2/g
+  return text
+    .replace(/(?:\.\.\/)+shared\//g, `${prefix}shared/`)
+    .replace(TS_SUFFIX, '$1$2$3.js$2')
+}
+
+/**
+ * 递归遍历目录改写全部 *.d.ts（bundle-host d.ts X1 2a 的完整目录遍历面）。
+ * 深度传参即本函数与字符串层的接缝：每进一层子目录 depth + 1（顶目录 depth=0）。
+ * @param {string} dir 起始目录（bundle-host 传 libDir，depth=0）
+ * @param {number} depth 当前目录深度
+ */
+export function rewriteDtsPaths(dir, depth) {
+  for (const f of readdirSync(dir, { withFileTypes: true })) {
+    const abs = join(dir, f.name)
+    if (f.isDirectory()) { rewriteDtsPaths(abs, depth + 1); continue }
+    if (!f.name.endsWith('.d.ts')) continue
+    const p = join(dir, f.name)
+    writeFileSync(p, rewriteDtsText(readFileSync(p, 'utf8'), depth))
+  }
+}

--- a/scripts/lib/shared-dts-lib.ts
+++ b/scripts/lib/shared-dts-lib.ts
@@ -13,11 +13,13 @@
  * 本库把断言升级为「仓库 shared/ 枚举清单 与 tarball 内 shared/ 副本逐一比对」：
  *   - listSharedDts(root)：枚举仓库 shared/ 下全部 .d.ts 相对路径（与
  *     bundle-host 2b 复制谓词同源，walk-files 单一事实源）；
- *   - assertSharedDtsPresent(pkgSharedDir, expected)：tarball 缺哪个文件报哪个。
+ *   - assertSharedDtsPresent(pkgSharedDir, expected)：tarball 缺哪个文件报哪个（查缺）；
+ *   - assertSharedDtsNoExtras(pkgSharedDir, expected)：报包内 shared/ 中期望清单之外
+ *     的残留 .d.ts（查多，issue #478：retired 模块移除后旧副本不得残留在包内）。
  * 未来 shared 新增子目录/文件自动纳入断言，无需再改 pack-check。
  */
-import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync, readdirSync, statSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
 import { walkFiles } from './walk-files.ts'
 
 /**
@@ -38,4 +40,31 @@ export function listSharedDts(root) {
  */
 export function assertSharedDtsPresent(pkgSharedDir, expected) {
   return expected.filter((rel) => !existsSync(join(pkgSharedDir, rel)))
+}
+
+/**
+ * 查多：返回包内 shared/ 中「期望清单之外」的残留 .d.ts（相对路径列表，空 = 无残留）。
+ *
+ * retired 残留场景（issue #478）：shared 模块退休（DEPRECATED 两步走 → 移除）后，旧
+ * 声明副本残留在包内 shared/——包根 shared/ 不入 git，clean-lib 只清 lib/ 不清包根
+ * shared/，bundle-host 每次构建覆盖写入新副本但从不清理已移除者；files 白名单
+ * shared/glob 双星 .d.ts 仍会把它带进发布 tarball（过期声明随包发布，陈旧类型面）。
+ * assertSharedDtsPresent 只查「缺」不查「多」——本出口补「多」向，pack-check 接入后
+ * 残留 fail-loud。
+ */
+export function assertSharedDtsNoExtras(pkgSharedDir, expected) {
+  const expectedSet = new Set(expected)
+  const out = []
+  const visit = (cur) => {
+    for (const f of readdirSync(cur, { withFileTypes: true })) {
+      const abs = join(cur, f.name)
+      if (f.isDirectory()) { visit(abs); continue }
+      if (!f.name.endsWith('.d.ts')) continue
+      // 包内目录相对 shared/ 根的路径（walkFiles 同款归一：relative + / 分隔）
+      const rel = relative(pkgSharedDir, abs).split(sep).join('/')
+      if (!expectedSet.has(rel)) out.push(rel)
+    }
+  }
+  if (existsSync(pkgSharedDir) && statSync(pkgSharedDir).isDirectory()) visit(pkgSharedDir)
+  return out
 }

--- a/scripts/test/bundle-host-x1.test.ts
+++ b/scripts/test/bundle-host-x1.test.ts
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * bundle-host d.ts X1 机制回归（node:test，issue #478）。
+ *
+ * X1 = bundle-host 构建宿主产物时对 tsc 声明产物做的两件事（运行时无关）：
+ *   2a 路径改写（rewriteDtsPaths）：lib/**\/*.d.ts 中指向仓库外 shared/ 的相对引用
+ *      （tsc 原样写入的 `../../shared/` 等）改写为指向包内副本——前缀按当前文件在
+ *      lib/ 下的目录深度归一为 '../'.repeat(depth + 1)（整体吞掉任意 ../ 前缀后按
+ *      文件深度重算），另把相对 .ts 后缀 import 回写 .js（#276）；
+ *   2b 声明副本进包：仓库根 shared/ 全部 .d.ts（递归，含子目录 host/ client/）
+ *      复制进包内 shared/（保留相对目录结构），谓词/遍历 = scripts/lib/walk-files.ts。
+ *
+ * 覆盖（spec v2）：
+ *   - 归一化极端：同文件内引用深度 ≠ 文件深度（任意 ../ 深度混写 + import() 动态
+ *     形态）→ 全部按文件目录深度归一为固定 prefix；
+ *   - 目录级集成：真实 mkdtemp 目录树跑完整递归遍历（锁 depth+1 传参），
+ *     d=0 → ../shared/、d=1 → ../../shared/、d=2 → ../../../shared/、d=3 → 4 个 ../；
+ *   - 边界：非 shared 相对引用零误伤；无 shared 引用的文件内容原样；.ts 回写 .js；
+ *   - 2b 深层子目录复制：shared/<d>/<d>/x.d.ts 连同目录结构原样复制进包
+ *     （walkFiles 同源谓词，目录级验证复制落点）。
+ * 运行：node --test scripts/test/bundle-host-x1.test.ts（或 pnpm test:scripts）
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { cpSync, existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { rewriteDtsPaths, rewriteDtsText } from '../lib/rewrite-dts-paths.ts'
+import { listSharedDts } from '../lib/shared-dts-lib.ts'
+import { walkFiles } from '../lib/walk-files.ts'
+
+const ROOT = join(import.meta.dirname, '..', '..')
+
+function tempDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'x1-test-'))
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
+}
+
+// 递归读目录下全部文件内容（相对路径 → 文本）
+function readTree(dir) {
+  const out = {}
+  const visit = (cur) => {
+    for (const f of readdirSync(cur, { withFileTypes: true })) {
+      const abs = join(cur, f.name)
+      if (f.isDirectory()) visit(abs)
+      else if (f.isFile()) out[abs] = readFileSync(abs, 'utf8')
+    }
+  }
+  visit(dir)
+  return out
+}
+
+// 复制真实仓库 shared/（含深层 host/ client/）到目标，返回目标 shared 目录
+function copyRealShared(destRoot) {
+  const src = join(ROOT, 'shared')
+  const dest = join(destRoot, 'shared')
+  cpSync(src, dest, { recursive: true })
+  return dest
+}
+
+// ---------- 纯函数层：字符串归一语义 ----------
+
+test('#3a 归一化极端：同文件内引用深度 ≠ 文件深度 → 全部按文件目录深度归一为固定 prefix', () => {
+  // 同文件（深度 0）内混写任意 ../ 深度的 shared 引用（极端输入）→ 全部归一为 ../shared/
+  const text = [
+    "import { a } from '../../shared/x.js';",
+    "import { b } from '../../../../shared/y.js';",
+    "import type { C } from '../../../shared/z.js';",
+    "const m = import('../../shared/dyn.js');",
+    "export { x } from '../shared/x.js';", // 浅引用（本不可能由 tsc 产出，防御输入）
+  ].join('\n')
+  const out = rewriteDtsText(text, 0)
+  assert.match(out, /from '\.\.\/shared\/x\.js'/, 'd=0 深度 2 引用 → ../shared/x.js')
+  assert.match(out, /from '\.\.\/shared\/y\.js'/, 'd=0 深度 4 引用 → ../shared/y.js')
+  assert.match(out, /from '\.\.\/shared\/z\.js'/, 'd=0 深度 3 引用 → ../shared/z.js')
+  assert.match(out, /import\('\.\.\/shared\/dyn\.js'\)/, 'd=0 动态 import 深度 2 → ../shared/dyn.js')
+  assert.match(out, /from '\.\.\/shared\/x\.js'/, '浅引用同样按文件深度归一')
+  assert.ok(!/\.\.\/\.\.\/shared/.test(out), '归一后不得残留多级 ../ 前缀')
+  assert.equal(out.split('\n').length, text.split('\n').length, '行数不变（只改前缀）')
+})
+
+test('#3b 归一化极端反向：深层文件内的浅引用 → 按文件深度（而非引用深度）归一', () => {
+  // d=2 文件内写浅引用 ../shared/x.js（防御输入）→ 仍归一为 ../../../shared/x.js
+  const out = rewriteDtsText("import { x } from '../shared/x.js';\n", 2)
+  assert.match(out, /from '\.\.\/\.\.\/\.\.\/shared\/x\.js'/, 'd=2 → 3 个 ../（按文件深度而非引用深度）')
+})
+
+test('#3c 归一化对非 shared 相对引用零误伤（含任意深度 ../ 前缀）', () => {
+  const text = [
+    "import { a } from './z.js';",
+    "import { b } from '../types.js';",
+    "import { c } from '../../deep/local.js';",
+    "import { d } from '../shared-not-this.js';", // shared 开头但不是 shared/ 目录
+  ].join('\n')
+  const out = rewriteDtsText(text, 1)
+  assert.match(out, /from '\.\/z\.js'/, './z.js 原样')
+  assert.match(out, /from '\.\.\/types\.js'/, '../types.js 原样')
+  assert.match(out, /from '\.\.\/\.\.\/deep\/local\.js'/, '../../deep/local.js 原样')
+  assert.match(out, /from '\.\.\/shared-not-this\.js'/, '非 shared/ 目录的 shared* 引用原样')
+})
+
+test('#5a 无 shared 引用的文件内容原样不变；.ts 后缀回写 .js（#276）', () => {
+  const noRef = "export declare const a: number;\n"
+  assert.equal(rewriteDtsText(noRef, 2), noRef, '无 shared 引用无匹配 → 原样')
+  // .ts 后缀回写（声明文件里 TS 不回写的 #276 修正）
+  const tsSuffix = "import { helper } from './helper.ts';\nimport('./mod.ts');\n"
+  const out = rewriteDtsText(tsSuffix, 0)
+  assert.match(out, /from '\.\/helper\.js'/, "相对 .ts 后缀 from → .js")
+  assert.match(out, /import\('\.\/mod\.js'\)/, "动态 import .ts 后缀 → .js")
+  assert.ok(!out.includes('.ts\''), '不得残留相对 .ts 后缀引用')
+})
+
+// ---------- 目录级集成：完整递归遍历（锁 depth+1 传参） ----------
+
+function makeLibTree(root) {
+  // 构造 lib/ 目录树（root 即 lib 目录）：顶层 + client/（d=1）+ a/b/（d=2）+ a/b/c/（d=3）
+  mkdirSync(join(root, 'client'), { recursive: true })
+  mkdirSync(join(root, 'a', 'b'), { recursive: true })
+  mkdirSync(join(root, 'a', 'b', 'c'), { recursive: true })
+  writeFileSync(join(root, 'index.d.ts'), "export { a } from '../../shared/x.js';\n")
+  writeFileSync(join(root, 'client', 'x.d.ts'), "export { b } from '../../shared/y.js';\n")
+  writeFileSync(join(root, 'a', 'b', 'c.d.ts'), "export { c } from '../../../shared/z.js';\n")
+  writeFileSync(join(root, 'a', 'b', 'c', 'deep.d.ts'), "export { d } from '../../../../shared/w.js';\n")
+  // 混入非 .d.ts 与无关引用（不得触碰）
+  writeFileSync(join(root, 'notes.txt'), "import { x } from '../../shared/ignored.js';\n")
+  writeFileSync(join(root, 'client', 'x.js'), "export {};\n")
+}
+
+test('#4 目录级集成：mkdtemp 目录树递归遍历按深度改写（d=0/1/2/3 全覆盖）', () => {
+  const { dir, cleanup } = tempDir()
+  try {
+    const lib = join(dir, 'lib')
+    makeLibTree(lib)
+    rewriteDtsPaths(lib, 0)
+    const out = readTree(lib)
+    assert.match(out[join(lib, 'index.d.ts')], /from '\.\.\/shared\/x\.js'/, 'd=0 → ../shared/（1 个 ../）')
+    assert.match(out[join(lib, 'client', 'x.d.ts')], /from '\.\.\/\.\.\/shared\/y\.js'/, 'd=1 → ../../shared/（2 个 ../）')
+    assert.match(out[join(lib, 'a', 'b', 'c.d.ts')], /from '\.\.\/\.\.\/\.\.\/shared\/z\.js'/, 'd=2 → ../../../shared/（3 个 ../）')
+    assert.match(out[join(lib, 'a', 'b', 'c', 'deep.d.ts')], /from '\.\.\/\.\.\/\.\.\/\.\.\/shared\/w\.js'/, 'd=3 → 4 个 ../')
+    // 非 .d.ts / 非目标文件不得改写
+    assert.match(out[join(lib, 'notes.txt')], /from '\.\.\/\.\.\/shared\/ignored\.js'/, '非 .d.ts 文件不改写')
+    assert.match(out[join(lib, 'client', 'x.js')], /export \{\};/, '.js 文件不改写')
+  } finally {
+    cleanup()
+  }
+})
+
+// ---------- 2b：shared 深层子目录复制 ----------
+
+test('#6 2b 复制含深层子目录：shared/<d>/<d>/x.d.ts 连同目录结构原样复制进包', () => {
+  const { dir, cleanup } = tempDir()
+  try {
+    // 构造仓库 shared/（模拟含 >1 级子目录的 shared 树）
+    mkdirSync(join(dir, 'shared', 'host'), { recursive: true })
+    mkdirSync(join(dir, 'shared', 'deep', 'deeper'), { recursive: true })
+    writeFileSync(join(dir, 'shared', 'loopback.d.ts'), '')
+    writeFileSync(join(dir, 'shared', 'host', 'mount-once.d.ts'), '')
+    writeFileSync(join(dir, 'shared', 'deep', 'deeper', 'x.d.ts'), '')
+    // 非 .d.ts 不得复制
+    writeFileSync(join(dir, 'shared', 'host', 'mount-once.js'), '')
+    // 复制落点 = 包内 shared/，保留相对目录结构（walkFiles 同源谓词）
+    const pkgDir = join(dir, 'pkg')
+    mkdirSync(pkgDir)
+    for (const rel of walkFiles(join(dir, 'shared'), (f) => f.endsWith('.d.ts'))) {
+      const dest = join(pkgDir, 'shared', rel)
+      mkdirSync(dirname(dest), { recursive: true })
+      cpSync(join(dir, 'shared', rel), dest)
+    }
+    assert.ok(existsSync(join(pkgDir, 'shared', 'loopback.d.ts')), '顶层 .d.ts 复制')
+    assert.ok(existsSync(join(pkgDir, 'shared', 'host', 'mount-once.d.ts')), '1 级子目录 .d.ts 复制')
+    assert.ok(existsSync(join(pkgDir, 'shared', 'deep', 'deeper', 'x.d.ts')), '2 级子目录 .d.ts 连同目录结构复制')
+    assert.ok(!existsSync(join(pkgDir, 'shared', 'host', 'mount-once.js')), '非 .d.ts 不复制')
+    // 与 listSharedDts 同源枚举一致（复制清单 == 期望清单）
+    assert.deepEqual(walkFiles(join(dir, 'shared'), (f) => f.endsWith('.d.ts')),
+      ['deep/deeper/x.d.ts', 'host/mount-once.d.ts', 'loopback.d.ts'])
+  } finally {
+    cleanup()
+  }
+})
+
+test('#4b 真实仓库方向：bundle-host 2b 复制谓词与 listSharedDts 同源且含深层子目录', () => {
+  // 真实仓库 shared/ 清单复制到临时目录后，包内副本结构与源逐一对应
+  const { dir, cleanup } = tempDir()
+  try {
+    const sharedDest = copyRealShared(dir)
+    const expected = listSharedDts(ROOT)
+    assert.ok(expected.length >= 3, '仓库 shared/ 至少含顶层 + host/ + client/ 的 d.ts')
+    // shared/<d>/<d>/ 至少一级深层（host/ client/ 均 >0 级）
+    assert.ok(expected.some((rel) => rel.includes('/')), '清单含子目录路径（深层复制面）')
+    for (const rel of expected) {
+      assert.ok(existsSync(join(sharedDest, rel)), `包内副本 ${rel} 存在且结构保留`)
+    }
+    // 包内除期望清单外无多余 .d.ts（同源复制）
+    const copied = walkFiles(sharedDest, (f) => f.endsWith('.d.ts'))
+    assert.deepEqual(copied.sort(), expected.slice().sort())
+  } finally {
+    cleanup()
+  }
+})

--- a/scripts/test/shared-dts.test.ts
+++ b/scripts/test/shared-dts.test.ts
@@ -22,7 +22,7 @@ import assert from 'node:assert/strict'
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { assertSharedDtsPresent, listSharedDts } from '../lib/shared-dts-lib.ts'
+import { assertSharedDtsNoExtras, assertSharedDtsPresent, listSharedDts } from '../lib/shared-dts-lib.ts'
 import { walkFiles } from '../lib/walk-files.ts'
 
 function tempDir() {
@@ -111,4 +111,39 @@ test('#5 同源防漂移：bundle-host 复用共享 walkFiles，无私有枚举�
   } finally {
     cleanup()
   }
+})
+
+test('#6 assertSharedDtsNoExtras 查多：包内预置残留副本 → 报出该文件（红）', () => {
+  const { dir, cleanup } = tempDir()
+  try {
+    const shared = fixtureShared(dir)
+    const expected = listSharedDts(dir)
+    // 模拟 retired 残留：源 shared/ 已移除某 d.ts，但包内 shared/ 仍残留旧副本
+    writeFileSync(join(shared, 'retired.d.ts'), '')
+    writeFileSync(join(shared, 'host', 'old-archived.d.ts'), '')
+    const extras = assertSharedDtsNoExtras(shared, expected)
+    assert.deepEqual(extras, ['host/old-archived.d.ts', 'retired.d.ts'])
+  } finally {
+    cleanup()
+  }
+})
+
+test('#6b assertSharedDtsNoExtras 查多：移除残留后出口为空（绿）', () => {
+  const { dir, cleanup } = tempDir()
+  try {
+    const shared = fixtureShared(dir)
+    const extras = assertSharedDtsNoExtras(shared, listSharedDts(dir))
+    assert.deepEqual(extras, [], '无残留 → 空清单')
+  } finally {
+    cleanup()
+  }
+})
+
+test('#7 同源防漂移：pack-check 每包接入查多出口（assertSharedDtsNoExtras fail-loud）', () => {
+  const root = join(import.meta.dirname, '..', '..')
+  const packCheck = readFileSync(join(root, 'scripts', 'gate', 'pack-check.ts'), 'utf8')
+  // 生产路径接入断言（防「检测出口不进生产路径」假绿回归）：pack-check 必须调用
+  // assertSharedDtsNoExtras 并对非空 extra 判 FAIL（残留 fail-loud）
+  assert.match(packCheck, /assertSharedDtsNoExtras/, 'pack-check 必须调用查多出口 assertSharedDtsNoExtras')
+  assert.match(packCheck, /shared 副本残留/, 'pack-check 对残留须报 fail-loud 文案')
 })

--- a/shared/README.md
+++ b/shared/README.md
@@ -32,6 +32,9 @@ DSH 插件家族共用的模块（构建期 esbuild 内联进各插件包，不�
 - **js + d.ts 双写**（tsc rootDir 硬约束）：shared 实现一律 `.js` + `.d.ts`（不可 TS 化），
   类型经 d.ts 解析、实现经 esbuild 内联；client 侧同理（`shared/client/`）。
 - 新增 shared 模块须满足下方准入规则；废弃走 DEPRECATED 两步走。
+- **发布面**：`.d.ts` 声明经 bundle-host **d.ts X1**（2a 引用改写 + 2b 副本随包）随每个
+  消费包发布，pack:check 双向断言（查缺 + 查多 retired 残留）兜底——机制说明见
+  [DEVELOPMENT.md d.ts X1 小节](../docs/DEVELOPMENT.md#user-content-dts-x1)，此处不重复。
 
 ## 准入规则（新增模块必须全部满足）
 


### PR DESCRIPTION
## 修复说明

实施 issue #478（#378 对抗评审分诊 T15）：d.ts X1 机制（`bundle-host` 构建宿主产物时对 tsc 声明产物的两件事——2a `rewriteDtsPaths` 路径改写 + 2b `walkFiles` 复制 shared .d.ts 进包）补文档 + 深层路径/retired 残留回归测试。按方案修订评论（issuecomment-5528345682）v2 口径实施。

### 改动

- **docs(scripts)**：`docs/DEVELOPMENT.md` §0 bundle-host 处新增独立小节「d.ts X1：shared 声明随包机制」（含双锚 `dts-x1`/`user-content-dts-x1`），覆盖职责（2a 改写 + 2b 复制）、副本清单来源（构建期实时枚举 walkFiles / 包内 shared/ 不入 git / files 白名单发布）、与 shared 准入规则及 pack-check/shared-dts-lib 断言链关系、retired 残留语义与方向性缺口；`shared/README.md`「使用约束」节补一句 X1 引用（单一事实源，指向 DEVELOPMENT.md 小节）。
- **refactor(scripts)**（提纯，产物语义零变化）：2a 改写逻辑从 `bundle-host.ts` 私有函数提纯为 `scripts/lib/rewrite-dts-paths.ts`（字符串层 `rewriteDtsText(text, depth)` + 目录遍历层 `rewriteDtsPaths(dir, depth)`，锁 depth+1 传参），bundle-host 调用之（2b 不提纯——shared-dts.test #5 断言 bundle-host 须直接 import 共享 walkFiles）。
- **refactor(scripts)**：`scripts/lib/shared-dts-lib.ts` 新增查多出口 `assertSharedDtsNoExtras(pkgSharedDir, expected)`（包内 shared/ 中不在期望清单的残留 .d.ts 相对路径列表）；`pack-check.ts` 每包接入——`extra` 非空即报「shared 副本残留: …」fail-loud。
- **test(scripts)**：新增 `scripts/test/bundle-host-x1.test.ts`（7 用例：归一化极端、目录级集成 d=0/1/2/3、零误伤/原样/.ts 回写、2b 深层复制同源）+ `shared-dts.test.ts` 追加 3 用例（查多红/绿 + pack-check 接入同源断言），原五用例保持绿。

### 产物 diff 回归（v2 #11 证据）

提纯前后对**全部 8 包**完整构建：`lib/**/*.d.ts` 与包内 `shared/` 副本**逐字一致（diff -r 为空）**，验证命令：

```sh
# 提纯前基线归档 /tmp/x1-baseline（每包 lib/ + shared/）
# 提纯 + C2/C3/C4 后重建，逐包 diff -r 比对
for b in /tmp/x1-baseline/*/; do
  name=$(basename "$b")
  diff -r "/tmp/x1-baseline/$name/lib" "packages/$name/lib" >/dev/null 2>&1 || echo "DIFF lib $name"
  diff -r "/tmp/x1-baseline/$name/shared" "packages/$name/shared" >/dev/null 2>&1 || echo "DIFF shared $name"
done  # 无输出 = 全部一致
# 实测输出：FINAL-ALL-PRODUCTS-IDENTICAL（8 包 lib + 包内 shared 逐字一致）
```

### 本地实测红（v2 #8 证据）

真实构建 dsh-mcp-manager 后在包内 `shared/` 人为放入残留副本 `retired-residual.d.ts` → `pnpm pack:check`：

```text
FAIL @wingsky-1/dsh-mcp-manager | shared 副本残留: retired-residual.d.ts（源 shared/ 已无此文件，须清理）
packcheck_exit=1
```

删除残留后恢复 PASS（exit 0）。

## 全量断言表（issue #478 方案 v2 验收 12 条，全部 PASS）

| # | 级别 | 验收条目 | 结论 | 证据 |
|---|------|---------|------|------|
| 1 | [硬性] | X1 机制说明文档落位 `docs/DEVELOPMENT.md`（§0 bundle-host 处独立小节），覆盖职责（2a 改写 + 2b 复制）、副本清单来源（构建期实时枚举 walkFiles、包内 shared/ 不入 git、files 白名单发布）、与 shared 准入规则（README 准入 1-7）及 pack-check/shared-dts-lib 断言链的关系 | PASS | docs/DEVELOPMENT.md「### d.ts X1：shared 声明随包机制（#478）」（L127-166）：职责 2a/2b、副本清单来源、准入规则 1-7 关系、断言链三要点齐全 |
| 2 | [硬性] | `shared/README.md`「使用约束」节新增一句 X1 引用（指向 DEVELOPMENT.md 小节）；标题/锚点规避纯中文 slug，按双锚补位惯例；合并前人工 GitHub 渲染核对可跳 | PASS | shared/README.md L34-36 新增引用句，链接 `../docs/DEVELOPMENT.md#user-content-dts-x1`（双锚）；`pnpm docs:check` 绿（exit 0）；人工点击核对留 PR 后核对项 |
| 3 | [硬性] | 归一化极端用例：同文件内引用深度 ≠ 文件深度（任意 `../` 深度混写）→ 全部按文件目录深度归一为固定 prefix；动态 `import()` 形态同规则 | PASS | bundle-host-x1.test.ts #3a/#3b：d=0 混写 2/3/4 级 `../` + 动态 import → 全部归一 `../shared/`；d=2 文件内浅引用 → `../../../shared/`（按文件深度） |
| 4 | [硬性] | 目录级集成：真实 mkdtemp 目录树跑完整递归遍历，`lib/index.d.ts`(d=0)→`../shared/`、`lib/client/x.d.ts`(d=1)→`../../shared/`、`lib/a/b/c.d.ts`(d=2)→`../../../shared/`、d=3 覆盖 4 个 `../` | PASS | bundle-host-x1.test.ts #4：真实 mkdtemp 目录树驱动 `rewriteDtsPaths(lib, 0)` 递归，逐文件断言 d=0/1/2/3 期望前缀（锁 depth+1 传参） |
| 5 | [硬性] | 边界行为：非 shared 相对引用零误伤；无 shared 引用文件内容原样；`.ts` 后缀回写 `.js`（#276）保持 | PASS | bundle-host-x1.test.ts #3c/#5a：`./z.js`/`../types.js`/`../../deep/local.js`/`../shared-not-this.js` 原样；无匹配内容 `assert.equal` 原样；`from './helper.ts'` + `import('./mod.ts')` → `.js` |
| 6 | [硬性] | 2b 复制含深层子目录：`shared/<d>/<d>/x.d.ts` 连同目录结构原样复制进包 | PASS | bundle-host-x1.test.ts #6：`shared/deep/deeper/x.d.ts` 复制落点 `pkg/shared/deep/deeper/x.d.ts`；#4b 真实仓库方向复制副本与 listSharedDts 清单逐一对齐 |
| 7 | [硬性] | `shared-dts-lib` 查多出口：fixture 包内预置残留副本 → 出口报出该文件（红）；移除后出口空（绿） | PASS | shared-dts.test.ts #6/#6b：预置 `retired.d.ts`+`host/old-archived.d.ts` → `['host/old-archived.d.ts','retired.d.ts']`；移除后 `deepEqual []` |
| 8 | [硬性] | `pack-check` 每包接入查多出口（`extra` 非空 fail-loud）；接入有同源防漂移断言（读源文本）；本地人为放残留副本 → `pnpm pack:check` 实测红（退出码非 0） | PASS | pack-check.ts L76-81 接入 `assertSharedDtsNoExtras` + 「shared 副本残留」文案；shared-dts.test.ts #7 读源文本断言接入；本地实测红 FAIL exit 1（见上） |
| 9 | [硬性] | 既有回归不破：`shared-dts.test.ts` 原五用例保持绿（单向缺件断言语义不变） | PASS | `pnpm test:scripts`：原五用例 + 追加共 8 用例全绿（shared-dts.test.ts） |
| 10 | [硬性] | `pnpm test:scripts` 全绿（含新测试；新文件被通配自动纳入，无 package.json 改动） | PASS | `pnpm test:scripts`：92 tests pass / 0 fail（exit 0），含 bundle-host-x1.test.ts 7 用例自动纳入；无 package.json 改动 |
| 11 | [硬性] | 提纯产物回归：提纯前后同一包完整构建，`lib/**/*.d.ts` 与包内 `shared/` 清单及内容逐字一致（diff 为空），证据留痕于 PR | PASS | 8 包 `lib` + 包内 `shared` 与提纯前基线 `diff -r` 全空（FINAL-ALL-PRODUCTS-IDENTICAL，命令记录见上） |
| 12 | [硬性] | 不触 `.github/`、shared/ 契约层、包 package.json、bundle-host 运行时产物语义（改动限 scripts/ 面与 docs）；fixture 全走 mkdtempSync 隔离，`git status` 无 `packages/*/undefined/`、无 *.jsonl | PASS | PR diff 限 8 文件：scripts/lib|build|gate|test + docs/DEVELOPMENT.md + shared/README.md（文档非契约源码）；bundle-host 产物 diff 逐字一致（#11）；测试全部 `mkdtempSync` 隔离 + cleanup；`git status` 干净 |

## 本地门禁

- `pnpm build`：exit 0（8 包 Done）
- `pnpm test`：exit 0
- `pnpm contract`：exit 0
- `pnpm pack:check`：exit 0（全部通过）
- `pnpm typecheck`：exit 0
- `pnpm test:scripts`：exit 0（92 pass）
- `pnpm docs:check`：exit 0

## 红线核对

- `.github/`：未改
- `shared/` 契约层源码（*.js / *.d.ts）：未改（仅 shared/README.md 文档加引用句，属 v2 验收 #2 指定动作）
- 包 package.json：未改
- `bundle-host.ts`：运行时产物语义零变化（提纯仅重构，产物 diff 回归为空）

Closes #478
