### PR TITLE
feat(scripts): 配置平行事实源——包内字段覆盖矩阵门禁（#471）

### DIFF
--- a/packages/dsh-lan-proxy/README.md
+++ b/packages/dsh-lan-proxy/README.md
@@ -57,6 +57,7 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-lan-proxy
 
 | 键 | 默认 | 说明 |
 |---|---|---|
+| `enabled` | `true` | 总开关（关闭后转发器停止监听） |
 | `host` | `0.0.0.0` | 监听地址 |
 | `port` | `3081` | HTTP 监听端口 |
 | `httpsPort` | `3443` | HTTPS 监听端口 |
@@ -64,8 +65,10 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-lan-proxy
 | `targetPort` | 自动 | 上游端口（默认取 web 服务器实际绑定端口） |
 | `httpsEnabled` | `true` | 是否并存 HTTPS |
 | `tlsCertFile` / `tlsKeyFile` | 无 | 自定义证书（mkcert 等） |
+| `printBanner` | `true` | 启动时是否在终端打印监听横幅（LAN 访问地址等） |
 | `wsCompressEnabled` | `true` | 是否对命中 `wsCompressPaths` 的 WebSocket 做压缩桥接 |
 | `wsCompressPaths` | `/api/remote.mux` | 参与 WebSocket 压缩的路径白名单 |
+| `wsDeflatePolicy` | `{browser:true, uaDeny:[iPhone…]}` | WS 压缩协商策略：`browser` 为 false 全局关压缩；`uaDeny` 为不协商压缩的 UA 片段列表（iOS Safari 默认拦截，见「WebSocket 压缩」节） |
 | `httpCompressEnabled` | `true` | HTTP 响应压缩总开关（Brotli/gzip 自适应协商，合并自 dsh-gzip） |
 | `httpCompressLevel` | `1` | 压缩档位预设 0..3：`0` 默认 / `1` 低（gzip 1 / br 2，最快）· `2` 中（gzip 5 / br 5，均衡）/ `3` 高（gzip 9 / br 9，最高压缩比），对 gzip 与 Brotli **同时生效**；旧配置整数 4..9 自动迁移为 3 |
 | `injectToken` | `true` | 自动注入启动令牌（issue #380）：LAN 设备首次访问 `GET /` 由转发层自动补当前 token 铸造会话 cookie，固定设备免手工拿 token；带失效 cookie 的请求在上游 401 后自动重放自愈。安全语义见「安全模型」 |

--- a/scripts/gate/contract-check.ts
+++ b/scripts/gate/contract-check.ts
@@ -132,21 +132,29 @@ if (checked === 0) {
 }
 
 // config-matrix（issue #471）：配置平行事实源字段覆盖矩阵门禁。并入本文件内部
-// （P0-A 裁决：根 package.json 命令字符串零改动、.github/ 零改动），输出作为
-// 既有逐包行/汇总行之后的**追加段落**（P2 裁决：既有输出逐字节不变）。失败
-// 计入 failed → exit 1（与既有 FAIL 语义一致）。
+// （P0-A 裁决：根 package.json 命令字符串零改动、.github/ 零改动）。复核裁决
+// （qa #11）：矩阵段必须位于既有最终汇总行「客户端契约：全部通过/失败」**之后**
+// ——旧输出整体逐字节不变、矩阵段成为真正末段。故矩阵失败用独立计数 matrixFailed
+// 计数，不并入 failed（并入会改写汇总行文案），仅追加 FAIL config-matrix 行 +
+// 末行状态 + exit 1（与既有 FAIL 语义一致）。
 // 提取器与矩阵逻辑在 scripts/lib/config-matrix-lib.ts / config-matrix-gate.ts
 // （esbuild+acorn AST 提取，零新增依赖；root 参数化供负向副本测试复用）。
+console.log(failed === 0 ? '客户端契约：全部通过' : `客户端契约：${failed} 个失败`)
 {
   const matrix = runConfigMatrix(ROOT)
   console.log('\nconfig-matrix:')
   for (const line of matrix.lines) console.log(`  ${line}`)
+  // 量级 #12（README 键集一致性）：缺/多键仅 warn 不判红（防文档漂移提示）。
+  for (const w of matrix.warnings) console.log(`warn config-matrix | ${w}`)
   for (const problem of matrix.problems) {
-    failed++
     console.log(`FAIL config-matrix | ${problem}`)
   }
-  console.log(matrix.pass ? 'config-matrix | PASS' : `config-matrix | ${matrix.problems.length} 个失败`)
+  // 量级 #13：报错附「四同步清单」指引（不改判红语义）。
+  if (matrix.problems.length > 0) {
+    console.log('hint config-matrix | 新增/修改配置键请四同步——① 事实源表（lan-proxy Config / notifier DEFAULT_CONFIG）② validators/hints ③ normalize 白名单与透传排除 ④ 客户端渲染/编辑 + smoke 断言 + README 配置节；补齐后重跑 pnpm contract')
+  }
+  const matrixFailed = matrix.problems.length > 0
+  if (matrixFailed) failed++ // 仅用于 exit code（汇总行文案在矩阵段前已打印，不受影响）
+  console.log(matrixFailed ? `config-matrix | ${matrix.problems.length} 个失败` : 'config-matrix | PASS')
 }
-
-console.log(failed === 0 ? '客户端契约：全部通过' : `客户端契约：${failed} 个失败`)
 process.exit(failed === 0 ? 0 : 1)

--- a/scripts/gate/contract-check.ts
+++ b/scripts/gate/contract-check.ts
@@ -19,6 +19,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { assertClientContract } from '../lib/client-contract-lib.ts'
 import { filterOutRetiredDirs, listPluginDirs, loadManifest } from '../lib/plugins-manifest-lib.ts'
+import { runConfigMatrix } from '../lib/config-matrix-gate.ts'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const packagesDir = join(ROOT, 'packages')
@@ -128,6 +129,23 @@ if (checked === 0) {
   } else {
     console.log('PASS @deepseek-ai/@wingsky-1 仅类型导入 | src 下无运行时值导入')
   }
+}
+
+// config-matrix（issue #471）：配置平行事实源字段覆盖矩阵门禁。并入本文件内部
+// （P0-A 裁决：根 package.json 命令字符串零改动、.github/ 零改动），输出作为
+// 既有逐包行/汇总行之后的**追加段落**（P2 裁决：既有输出逐字节不变）。失败
+// 计入 failed → exit 1（与既有 FAIL 语义一致）。
+// 提取器与矩阵逻辑在 scripts/lib/config-matrix-lib.ts / config-matrix-gate.ts
+// （esbuild+acorn AST 提取，零新增依赖；root 参数化供负向副本测试复用）。
+{
+  const matrix = runConfigMatrix(ROOT)
+  console.log('\nconfig-matrix:')
+  for (const line of matrix.lines) console.log(`  ${line}`)
+  for (const problem of matrix.problems) {
+    failed++
+    console.log(`FAIL config-matrix | ${problem}`)
+  }
+  console.log(matrix.pass ? 'config-matrix | PASS' : `config-matrix | ${matrix.problems.length} 个失败`)
 }
 
 console.log(failed === 0 ? '客户端契约：全部通过' : `客户端契约：${failed} 个失败`)

--- a/scripts/lib/config-matrix-gate.ts
+++ b/scripts/lib/config-matrix-gate.ts
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * config-matrix-gate — 配置平行事实源「字段覆盖矩阵」门禁编排（issue #471）。
+ *
+ * runConfigMatrix({ root }) 对两包真实 src 文件执行全部矩阵断言，返回结构化
+ * 结果 { pass, problems: string[], lines: string[] }——不直接 console/exit，
+ * 由调用方（contract-check.ts 追加段 / 负向自测）决定输出与退出码；文件树以
+ * root 参数化，负向测试可对 mkdtemp 副本注入后复用同一逻辑（副本等效性：
+ * 矩阵输入仅 src/config.ts / src/client/index.ts 文本，无 import 解析、
+ * 无 lib 产物依赖）。
+ *
+ * 断言清单（对齐 issue #471 v2 验收 2/3/4/5/6/7）：
+ *   L1 lan-proxy：Config / FILE_CONFIG_VALIDATORS / SETTING_FIELD_HINTS 三表
+ *      键集全等（双向，现 16）
+ *   L2 lan-proxy：client DEFAULTS ⊆ schema；schema − DEFAULTS 差集 ==
+ *      LAN_PROXY_UI_EXEMPT；豁免带原因注释 + 单包 ≤8；豁免残留（键已 UI 化）
+ *      亦红
+ *   N1 notifier：DEFAULT_CONFIG / SETTING_VALIDATORS / SETTING_HINTS 全等
+ *      （双向，现 19）
+ *   N2 notifier：CONFIG_KEYS == DEFAULT_CONFIG 全部布尔键（现 10/10）
+ *   N3 notifier：normalizeConfig 分支目标键（显式分支 ∪ qh 子键 ∪ 排除表
+ *      判定 ∪ CONFIG_KEYS）⊇ DEFAULT_CONFIG；quietHours 嵌套子键
+ *      enabled/start/end/allowKinds ∈ 分支目标
+ *   N4 notifier：客户端 UI 引用键 ⊆ SETTING_VALIDATORS；反向差集 ==
+ *      NOTIFIER_UI_EXEMPT（豁免带注释 + ≤8；豁免残留亦红）
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  parseTs, findTopVar, findTopFn, objectKeysOf, booleanKeysOfObject,
+  collectNormalizeBranchKeys, collectClientUiKeys, diffKeys, sourceLineOf,
+} from './config-matrix-lib.ts'
+
+// 豁免白名单（P1-2 三条件收敛：服务端/组合层键或客户端不渲染键；单包 ≤8；
+// 每条带「文件:行 + 理由」原因注释——结构自检缺失即红）。
+export const LAN_PROXY_UI_EXEMPT = {
+  // 原因: 组合层装配键（绑定地址默认取 DEFAULT_OPTIONS.host，见 config.ts:80）；
+  //   GUI 卡片不渲染绑定地址，README 安全模型说明。
+  host: 'packages/dsh-lan-proxy/src/config.ts:80 组合层装配键（绑定地址），GUI 卡片不编辑',
+  // 原因: 组合层装配键（回环上游主机；转发安全红线仅允许回环，见 config.ts:96）。
+  targetHost: 'packages/dsh-lan-proxy/src/config.ts:96 组合层装配键（回环上游），GUI 卡片不编辑',
+  // 原因: 组合层装配键（上游端口缺省随 web 端口，见 config.ts:97-102 注释）。
+  targetPort: 'packages/dsh-lan-proxy/src/config.ts:102 组合层装配键（上游端口随 web 端口），GUI 卡片不编辑',
+  // 原因: 服务端 WS 压缩协商策略键（browser/uaDeny 子结构，见 config.ts:119）；
+  //   GUI 无对应控件（wsCompressPaths 白名单已可编辑）。
+  wsDeflatePolicy: 'packages/dsh-lan-proxy/src/config.ts:119 服务端策略键（协商子结构），GUI 无控件',
+}
+
+// notifier：顶层 allowKinds 由 POST /kinds 确认流服务端管理（动态 kind 清单），
+// 设置卡不直接渲染/编辑该顶层键（quietHours.allowKinds 子键在客户端免打扰块内
+// 编辑，属 quietHours 内部不作顶层断言）。唯一豁免，条数 ≤8 满足。
+export const NOTIFIER_UI_EXEMPT = {
+  allowKinds: 'packages/dsh-notifier/src/config.ts:139 服务端动态 kind 确认清单（POST /kinds 管理），客户端不直接渲染顶层键',
+}
+
+/** 豁免白名单结构自检：≤8 键 + 每条原因注释（含「文件:行」+ 一句理由）。 */
+function checkExempts(pkg, exempt) {
+  const problems = []
+  if (Object.keys(exempt).length > 8) {
+    problems.push(`${pkg} 豁免白名单 ${Object.keys(exempt).length} 键 > 8（超限即红，强制走评审）`)
+  }
+  for (const [k, reason] of Object.entries(exempt)) {
+    if (typeof reason !== 'string' || reason.length === 0 || !/:\d+/.test(reason)) {
+      problems.push(`${pkg} 豁免键 ${k} 缺原因注释（须含「文件:行 + 一句理由」）`)
+    }
+  }
+  return problems
+}
+
+/** 读取表键（容错返回 err；附带 text/ast/init/line 供下游派生断言）。 */
+function loadTable(filePath, name, shape) {
+  let text
+  try {
+    text = readFileSync(filePath, 'utf8')
+  } catch (e) {
+    return { err: `文件不可读: ${filePath}（${e.message}）` }
+  }
+  const line = sourceLineOf(text, name)
+  const ast = parseTs(text)
+  const init = findTopVar(ast, name)
+  if (init === null) {
+    return { err: `${name} 声明缺失 @ ${filePath}${line ? `:${line}` : ''}（提取器失效或声明被删）` }
+  }
+  let keys
+  if (shape === 'object') {
+    keys = objectKeysOf(init)
+  } else {
+    keys = init.type === 'ArrayExpression'
+      ? init.elements.filter((e) => e && e.type === 'Literal' && typeof e.value === 'string').map((e) => e.value)
+      : []
+  }
+  if (keys.length === 0) {
+    return { err: `${name} 键集为空 @ ${filePath}:${line}（提取器可能失效或表被掏空）` }
+  }
+  return { text, ast, init, keys, line }
+}
+
+/** 差集 → 缺/多键报错行。 */
+function diffProblems(scope, tableName, filePath, line, d, hint = '') {
+  const out = []
+  for (const k of d.missing) out.push(`${scope} ${tableName} 缺键（相对基准）: ${k} @ ${filePath}:${line}${hint ? `（${hint}）` : ''}`)
+  for (const k of d.extra) out.push(`${scope} ${tableName} 多键（基准之外）: ${k} @ ${filePath}:${line}${hint ? `（${hint}）` : ''}`)
+  return out
+}
+
+/** lan-proxy 矩阵；返回 { problems, lines }。 */
+function runLanProxy(root) {
+  const problems = []
+  const lines = []
+  const cfgPath = join(root, 'packages/dsh-lan-proxy/src/config.ts')
+  const clientPath = join(root, 'packages/dsh-lan-proxy/src/client/index.ts')
+
+  const schema = loadTable(cfgPath, 'Config', 'object')
+  const validators = loadTable(cfgPath, 'FILE_CONFIG_VALIDATORS', 'object')
+  const hints = loadTable(cfgPath, 'SETTING_FIELD_HINTS', 'object')
+  const defaults = loadTable(clientPath, 'DEFAULTS', 'object')
+  const failed = [schema, validators, hints, defaults].filter((t) => t.err)
+  if (failed.length > 0) {
+    for (const t of failed) problems.push(t.err)
+    return { problems, lines }
+  }
+
+  // L1：三表两两全等（16 键）
+  const pairs = [
+    ['Config', schema, 'FILE_CONFIG_VALIDATORS', validators],
+    ['Config', schema, 'SETTING_FIELD_HINTS', hints],
+    ['FILE_CONFIG_VALIDATORS', validators, 'SETTING_FIELD_HINTS', hints],
+  ]
+  for (const [na, ta, nb, tb] of pairs) {
+    problems.push(...diffProblems('lan-proxy', nb, cfgPath, tb.line, diffKeys(ta.keys, tb.keys), `与 ${na} 不一致`))
+    problems.push(...diffProblems('lan-proxy', na, cfgPath, ta.line, diffKeys(tb.keys, ta.keys), `与 ${nb} 不一致`))
+  }
+
+  // L2：DEFAULTS ⊆ schema；schema − DEFAULTS == 豁免；豁免结构自检
+  const exempt = LAN_PROXY_UI_EXEMPT
+  problems.push(...checkExempts('lan-proxy', exempt))
+  const exemptKeys = Object.keys(exempt)
+  const d = diffKeys(schema.keys, defaults.keys)
+  // DEFAULTS 出现 schema 外键 → 红（客户端提交未知键被宿主白名单静默丢弃）
+  for (const k of d.extra) problems.push(`lan-proxy client DEFAULTS 多键（Config 之外）: ${k} @ ${clientPath}:${defaults.line}`)
+  // schema − DEFAULTS 缺键必须恰为豁免集合（新增可编辑键漏 UI → 红）
+  for (const k of d.missing) {
+    if (!exemptKeys.includes(k)) problems.push(`lan-proxy client DEFAULTS 缺键（相对 Config，非豁免）: ${k} @ ${clientPath}:${defaults.line}（新增可编辑键漏 UI）`)
+  }
+  // 豁免残留：豁免键出现在客户端 DEFAULTS 中 = 键已 UI 化但白名单未删
+  // （注意判据是「∈ DEFAULTS」而非「∉ 差集」——豁免键从 schema 删除时差集自然
+  // 不含它，此时不算残留）
+  for (const k of exemptKeys) {
+    if (defaults.keys.includes(k)) problems.push(`lan-proxy 豁免键 ${k} 已在客户端 DEFAULTS 中（豁免残留，应移除豁免或改豁免原因）`)
+  }
+
+  lines.push(`lan-proxy ${schema.keys.length} 键 × [schema/validators/hints] 全等 + client DEFAULTS ${defaults.keys.length}(豁免 ${exemptKeys.length})`)
+  return { problems, lines }
+}
+
+/** notifier 矩阵；返回 { problems, lines }。 */
+function runNotifier(root) {
+  const problems = []
+  const lines = []
+  const cfgPath = join(root, 'packages/dsh-notifier/src/config.ts')
+  const clientPath = join(root, 'packages/dsh-notifier/src/client/index.ts')
+
+  const def = loadTable(cfgPath, 'DEFAULT_CONFIG', 'object')
+  const validators = loadTable(cfgPath, 'SETTING_VALIDATORS', 'object')
+  const hints = loadTable(cfgPath, 'SETTING_HINTS', 'object')
+  const configKeys = loadTable(cfgPath, 'CONFIG_KEYS', 'arrayStrings')
+  const failed = [def, validators, hints, configKeys].filter((t) => t.err)
+  if (failed.length > 0) {
+    for (const t of failed) problems.push(t.err)
+    return { problems, lines }
+  }
+  const base = def.keys
+
+  // N1：三表两两全等（19 键）
+  const pairs = [
+    ['DEFAULT_CONFIG', def, 'SETTING_VALIDATORS', validators],
+    ['DEFAULT_CONFIG', def, 'SETTING_HINTS', hints],
+    ['SETTING_VALIDATORS', validators, 'SETTING_HINTS', hints],
+  ]
+  for (const [na, ta, nb, tb] of pairs) {
+    problems.push(...diffProblems('notifier', nb, cfgPath, tb.line, diffKeys(ta.keys, tb.keys), `与 ${na} 不一致`))
+    problems.push(...diffProblems('notifier', na, cfgPath, ta.line, diffKeys(tb.keys, ta.keys), `与 ${nb} 不一致`))
+  }
+
+  // N2：CONFIG_KEYS == DEFAULT_CONFIG 全部布尔键（从 DEFAULT_CONFIG 字面量推导）
+  const boolKeys = booleanKeysOfObject(def.init)
+  const d2a = diffKeys(boolKeys, configKeys.keys)
+  for (const k of d2a.missing) problems.push(`notifier CONFIG_KEYS 漏布尔键: ${k} @ ${cfgPath}:${configKeys.line}（新增布尔键忘进 CONFIG_KEYS）`)
+  for (const k of d2a.extra) problems.push(`notifier CONFIG_KEYS 多键（非布尔键）: ${k} @ ${cfgPath}:${configKeys.line}`)
+  const d2b = diffKeys(configKeys.keys, boolKeys)
+  for (const k of d2b.missing) problems.push(`notifier DEFAULT_CONFIG 布尔键未入 CONFIG_KEYS: ${k} @ ${cfgPath}:${def.line}`)
+
+  // N3：normalizeConfig 分支目标键 ⊇ DEFAULT_CONFIG（CONFIG_KEYS ∪ 显式分支 ∪ M2）
+  const fnNode = findTopFn(def.ast, 'normalizeConfig')
+  const normalizeLine = sourceLineOf(def.text, 'normalizeConfig')
+  if (!fnNode) {
+    problems.push(`notifier normalizeConfig 声明缺失 @ ${cfgPath}${normalizeLine ? `:${normalizeLine}` : ''}`)
+  } else {
+    const branch = collectNormalizeBranchKeys(fnNode)
+    // 归一化「真实发生」的静态证据 = base.<key> 赋值键（显式分支把归一化结果写回
+    // base）∪ CONFIG_KEYS（布尔键经 base[key]=src[key] 动态索引，静态只见键数组）。
+    // src.<key> 读取与排除表 === 字面量只证明「读过/排除过」，不证明归一化赋值——
+    // 不作为覆盖证据（防删归一化行仍假绿），仅用于下方孤儿键诊断。
+    const baseKeys = new Set(branch.members.base ?? [])
+    const target = new Set([...baseKeys, ...configKeys.keys])
+    const d3 = diffKeys(base, [...target])
+    for (const k of d3.missing) {
+      problems.push(`notifier normalizeConfig 漏分支键: ${k} @ ${cfgPath}:${normalizeLine ?? '?'}（base.<key> 归一化赋值 ∪ CONFIG_KEYS 未覆盖该键）`)
+    }
+    // 排除表孤儿键：=== "键" 判定列出的**配置键名**（∈ DEFAULT_CONFIG 全集，typeof
+    // 类型串 object/boolean/string 天然不在键集内不参与）既不在 base 赋值也不在
+    // CONFIG_KEYS = 该键已不再归一化却仍在排除表（会被丢弃而非透传），属行为级洞
+    const baseSet = new Set(base)
+    for (const k of branch.eqLiterals) {
+      if (!baseSet.has(k)) continue // 非配置键名的 === 字面量（typeof 判定等）忽略
+      if (!baseKeys.has(k) && !configKeys.keys.includes(k)) {
+        problems.push(`notifier normalizeConfig 透传排除表孤儿键: ${k} @ ${cfgPath}:${normalizeLine ?? '?'}（排除表列了不再归一化的键）`)
+      }
+    }
+    // quietHours 嵌套子键不变量（enabled/start/end/allowKinds 均须有 qh 分支目标）
+    const qhMembers = branch.members.qh ?? []
+    for (const q of ['enabled', 'start', 'end', 'allowKinds']) {
+      if (!qhMembers.includes(q)) problems.push(`notifier normalizeConfig quietHours 漏子键分支: ${q} @ ${cfgPath}:${normalizeLine ?? '?'}`)
+    }
+  }
+
+  // N4：客户端 UI 引用键 ⊆ SETTING_VALIDATORS；反向差集 == 豁免（allowKinds）
+  let clientText
+  try {
+    clientText = readFileSync(clientPath, 'utf8')
+  } catch (e) {
+    problems.push(`notifier 客户端文件不可读: ${clientPath}（${e.message}）`)
+    return { problems, lines }
+  }
+  const cAst = parseTs(clientText)
+  const uiKeys = collectClientUiKeys(cAst)
+  const exempt = NOTIFIER_UI_EXEMPT
+  problems.push(...checkExempts('notifier', exempt))
+  const exemptKeys = Object.keys(exempt)
+  // 客户端出现 validators 之外键（新增客户端键忘进服务端表）→ 红
+  const d4 = diffKeys(validators.keys, uiKeys)
+  for (const k of d4.extra) {
+    problems.push(`notifier 客户端 UI 引用键不在 SETTING_VALIDATORS: ${k} @ ${clientPath}（新增客户端键须同步服务端表）`)
+  }
+  // validators 键未在客户端引用：除豁免外 → 红（漏 UI 化/渲染）
+  const missingUi = diffKeys(validators.keys, uiKeys).missing
+  for (const k of missingUi) {
+    if (!exemptKeys.includes(k)) problems.push(`notifier 客户端 UI 未引用配置键 ${k} @ ${clientPath}（非豁免键漏渲染/编辑面）`)
+  }
+  // 豁免残留：豁免键已在客户端引用 → 红
+  for (const k of exemptKeys) {
+    if (!missingUi.includes(k)) problems.push(`notifier 豁免键 ${k} 已在客户端引用（豁免残留，应移除）`)
+  }
+
+  const summary = `notifier ${base.length} 键 × [default/validators/hints] 全等 + CONFIG_KEYS ${configKeys.keys.length}/${boolKeys.length} + normalize 覆盖 + client UI 覆盖 ${uiKeys.length}(豁免 ${exemptKeys.length})`
+  lines.push(summary)
+  return { problems, lines }
+}
+
+/**
+ * 运行两包矩阵门禁（root 参数化：真实仓库根或 mkdtemp 副本根）。
+ * @returns {{ pass: boolean, problems: string[], lines: string[] }}
+ */
+export function runConfigMatrix(root) {
+  const problems = []
+  const lines = []
+  for (const run of [runLanProxy, runNotifier]) {
+    const r = run(root)
+    problems.push(...r.problems)
+    lines.push(...r.lines)
+  }
+  return { pass: problems.length === 0, problems, lines }
+}

--- a/scripts/lib/config-matrix-gate.ts
+++ b/scripts/lib/config-matrix-gate.ts
@@ -32,6 +32,7 @@ import { join } from 'node:path'
 import {
   parseTs, findTopVar, findTopFn, objectKeysOf, booleanKeysOfObject,
   collectNormalizeBranchKeys, collectClientUiKeys, diffKeys, sourceLineOf,
+  extractReadmeConfigKeys,
 } from './config-matrix-lib.ts'
 
 // 豁免白名单（P1-2 三条件收敛：服务端/组合层键或客户端不渲染键；单包 ≤8；
@@ -153,7 +154,19 @@ function runLanProxy(root) {
   }
 
   lines.push(`lan-proxy ${schema.keys.length} 键 × [schema/validators/hints] 全等 + client DEFAULTS ${defaults.keys.length}(豁免 ${exemptKeys.length})`)
-  return { problems, lines }
+
+  // 量级 #12：README 配置表键集一致性——代码键缺文档仅 warn 不判红（防文档漂移提示）
+  const warnings = []
+  const readmePath = join(root, 'packages/dsh-lan-proxy/README.md')
+  let readmeText = null
+  try { readmeText = readFileSync(readmePath, 'utf8') } catch { readmeText = null }
+  if (readmeText !== null) {
+    const { keys: docKeys } = extractReadmeConfigKeys(readmeText, 'lan-proxy')
+    for (const k of diffKeys(schema.keys, docKeys).missing) {
+      warnings.push(`lan-proxy README 配置表缺文档键: ${k}（docs/README 与代码键集不一致，仅提示）`)
+    }
+  }
+  return { problems, warnings, lines }
 }
 
 /** notifier 矩阵；返回 { problems, lines }。 */
@@ -257,20 +270,34 @@ function runNotifier(root) {
 
   const summary = `notifier ${base.length} 键 × [default/validators/hints] 全等 + CONFIG_KEYS ${configKeys.keys.length}/${boolKeys.length} + normalize 覆盖 + client UI 覆盖 ${uiKeys.length}(豁免 ${exemptKeys.length})`
   lines.push(summary)
-  return { problems, lines }
+
+  // 量级 #12：README JSON 样例键集一致性——代码键缺文档仅 warn 不判红
+  const warnings = []
+  const readmePath = join(root, 'packages/dsh-notifier/README.md')
+  let readmeText = null
+  try { readmeText = readFileSync(readmePath, 'utf8') } catch { readmeText = null }
+  if (readmeText !== null) {
+    const { keys: docKeys } = extractReadmeConfigKeys(readmeText, 'notifier')
+    for (const k of diffKeys(base, docKeys).missing) {
+      warnings.push(`notifier README JSON 样例缺文档键: ${k}（docs/README 与代码键集不一致，仅提示）`)
+    }
+  }
+  return { problems, warnings, lines }
 }
 
 /**
  * 运行两包矩阵门禁（root 参数化：真实仓库根或 mkdtemp 副本根）。
- * @returns {{ pass: boolean, problems: string[], lines: string[] }}
+ * @returns {{ pass: boolean, problems: string[], warnings: string[], lines: string[] }}
  */
 export function runConfigMatrix(root) {
   const problems = []
+  const warnings = []
   const lines = []
   for (const run of [runLanProxy, runNotifier]) {
     const r = run(root)
     problems.push(...r.problems)
+    warnings.push(...(r.warnings ?? []))
     lines.push(...r.lines)
   }
-  return { pass: problems.length === 0, problems, lines }
+  return { pass: problems.length === 0, problems, warnings, lines }
 }

--- a/scripts/lib/config-matrix-lib.ts
+++ b/scripts/lib/config-matrix-lib.ts
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * config-matrix-lib — 配置平行事实源「字段覆盖矩阵」门禁的共享提取器与纯逻辑
+ * （issue #471）。
+ *
+ * 背景：lan-proxy / notifier 的配置键存在多张平行维护表（schema / validators /
+ * hints / normalize 分支 / 客户端渲染面），表间没有任何程序化同一性保证——
+ * 新增配置键漏改一表即不一致。本模块从**源码 AST** 提取各表键集并做一致性
+ * 断言（不 import 包 src、不依赖 lib/ 产物）。
+ *
+ * 提取管线（P1-1 裁决，弃纯正则）：
+ *   1. esbuild.transformSync(src, { loader: 'ts' })（仓库既有 devDep）——TS →
+ *     JS，实测会把带类型注解的 `export const Config: z<...> = z.object({...})`
+ *     拆成「普通 const + 文件尾 export list」，因此收集器面向任意顶层
+ *     VariableDeclaration（含 var/const/let，含 esbuild 提升后的模块级 var，
+ *     客户端 apply 内的 var 在 transform 后亦提升到模块顶层）；
+ *   2. acorn.parse(js, { ecmaVersion: 'latest', sourceType: 'module' })（仓库
+ *     既有 devDep，self-cov / crap-check 同款）——AST 按 key.name 取键，
+ *     对中文 \uXXXX 转义、模板串、z.object().default({...}) 嵌套一律免疫。
+ *
+ * 全部函数**文件路径 / 文本参数化**（不读仓库全局路径），保证负向自测可对
+ * mkdtemp 副本注入并复用同一门禁逻辑（副本等效性：矩阵输入仅源文本，无
+ * import 解析 / 无运行时）。
+ *
+ * 矩阵语义（对齐 issue #471 v2 方案，P1-2/P2 裁决）：
+ *   - lan-proxy：Config / FILE_CONFIG_VALIDATORS / SETTING_FIELD_HINTS 三表
+ *     全等（16 键）；客户端 DEFAULTS ⊆ schema，差集 == 豁免白名单
+ *     {host,targetHost,targetPort,wsDeflatePolicy}（每条豁免带原因注释，≤8）；
+ *   - notifier：DEFAULT_CONFIG / SETTING_VALIDATORS / SETTING_HINTS 全等
+ *     （19 键）；CONFIG_KEYS == DEFAULT_CONFIG 全部布尔键（10）；normalizeConfig
+ *     分支目标键 ⊇ DEFAULT_CONFIG（CONFIG_KEYS ∪ 显式分支 ∪ M2 三键）；
+ *     客户端 UI 引用键 ⊆ SETTING_VALIDATORS，反向差集 == 豁免白名单
+ *     {allowKinds}；
+ *   - 豁免白名单收敛三条件：服务端/组合层键或客户端不渲染键 + 单包 ≤8 + 每条
+ *     带原因注释（缺失即红）。
+ */
+import { transformSync } from 'esbuild'
+import * as acorn from 'acorn'
+import { readFileSync } from 'node:fs'
+
+/** esbuild transform + acorn parse（含 loc），返回 AST 程序节点。 */
+export function parseTs(text) {
+  const js = transformSync(text, { loader: 'ts', format: 'esm' }).code
+  return acorn.parse(js, { ecmaVersion: 'latest', sourceType: 'module', locations: true })
+}
+
+/** 从源码文本定位声明行号（1-based）：`[(export )](const|var|let) NAME` / `function NAME`。
+ *  行首空白只允许空格/制表（\s 会跨行吞空行致行号错位）。 */
+export function sourceLineOf(text, name) {
+  const re = new RegExp(`^[ \\t]*(?:export[ \\t]+)?(?:const|var|let)[ \\t]+${name}\\b|^[ \\t]*(?:export[ \\t]+)?(?:async[ \\t]+)?function[ \\t]+${name}\\b`, 'm')
+  const m = text.match(re)
+  if (!m) return null
+  let line = 1
+  for (let i = 0; i < m.index; i += 1) if (text[i] === '\n') line += 1
+  return line
+}
+
+/** 顶层 VariableDeclaration 中名为 name 的声明 init 节点（esbuild 提升后覆盖
+ *  模块级 var——客户端 apply 内 var 亦在顶层）。 */
+export function findTopVar(ast, name) {
+  for (const n of ast.body) {
+    if (n.type !== 'VariableDeclaration') continue
+    for (const d of n.declarations) {
+      if (d.id?.type === 'Identifier' && d.id.name === name) return d.init ?? null
+    }
+  }
+  return null
+}
+
+/** 顶层名为 name 的函数节点（FunctionDeclaration / var fn = function / export fn）。 */
+export function findTopFn(ast, name) {
+  for (const n of ast.body) {
+    if (n.type === 'FunctionDeclaration' && n.id?.name === name) return n
+    if (n.type === 'VariableDeclaration') {
+      for (const d of n.declarations) {
+        if (d.id?.type === 'Identifier' && d.id.name === name
+          && (d.init?.type === 'FunctionExpression' || d.init?.type === 'ArrowFunctionExpression')) return d.init
+      }
+    }
+    if (n.type === 'ExportNamedDeclaration' && n.declaration) {
+      const d = n.declaration
+      if (d.type === 'FunctionDeclaration' && d.id?.name === name) return d
+    }
+  }
+  return null
+}
+
+/** 递归剥壳（CallExpression 下钻第一实参 / TSAs / TSSatisfies / Paren）后取对象
+ *  字面量键（保序，去重）。z.object({...})、z.record(...)、as const 包装均免疫。 */
+export function objectKeysOf(node) {
+  let cur = node
+  for (let i = 0; i < 12; i += 1) {
+    if (!cur) return []
+    if (cur.type === 'ObjectExpression') break
+    if (cur.type === 'ParenthesizedExpression') { cur = cur.expression; continue }
+    if (cur.type === 'TSAsExpression' || cur.type === 'TSSatisfiesExpression' || cur.type === 'TypeCastExpression') { cur = cur.expression; continue }
+    if (cur.type === 'CallExpression') { cur = cur.arguments?.[0] ?? null; continue }
+    return []
+  }
+  if (cur?.type !== 'ObjectExpression') return []
+  const out = []
+  for (const p of cur.properties) {
+    if (p.type !== 'Property') continue
+    const k = p.key?.type === 'Identifier' ? p.key.name : p.key?.type === 'Literal' ? String(p.key.value) : null
+    if (k !== null && !out.includes(k)) out.push(k)
+  }
+  return out
+}
+
+/** 一维字符串数组字面量键（CONFIG_KEYS 形态：readonly string[] + as const）。 */
+export function arrayStringKeys(node) {
+  if (node?.type !== 'ArrayExpression') return []
+  const out = []
+  for (const e of node.elements) {
+    if (e?.type === 'Literal' && typeof e.value === 'string') out.push(e.value)
+  }
+  return out
+}
+
+/** 二维字符串数组首列键（notifier 客户端 EVENT_KEYS：[["notifyAsk","evtAsk"],…]）。 */
+export function arrayFirstColKeys(node) {
+  if (node?.type !== 'ArrayExpression') return []
+  const out = []
+  for (const e of node.elements) {
+    if (e?.type === 'ArrayExpression' && e.elements[0]?.type === 'Literal' && typeof e.elements[0].value === 'string') {
+      out.push(e.elements[0].value)
+    }
+  }
+  return out
+}
+
+/** 便捷入口：按 shape 提取名为 name 的顶层声明键集（'object' | 'arrayStrings' |
+ *  'arrayFirstCol'）。文件缺失/声明缺失返回 { found:false } 而非抛错——门禁侧
+ *  fail-loud 报「声明缺失」。 */
+export function extractNamedKeys(text, name, shape = 'object') {
+  const ast = parseTs(text)
+  const init = findTopVar(ast, name)
+  if (init === null) return { found: false, keys: [] }
+  if (shape === 'object') return { found: true, keys: objectKeysOf(init) }
+  if (shape === 'arrayStrings') return { found: true, keys: arrayStringKeys(init) }
+  if (shape === 'arrayFirstCol') return { found: true, keys: arrayFirstColKeys(init) }
+  return { found: false, keys: [] }
+}
+
+/**
+ * normalizeConfig 分支目标键收集（P1-1 第 3 条：不收集全函数任意字符串，防
+ * object/boolean/string 等类型串误报）。目标键 = 函数体内对局部源对象
+ * （src / base / qh / out）的 MemberExpression 成员键 ∪ `=== "字面量"` 判定键
+ * （透传排除表）。CONFIG_KEYS 经 for..of 遍历属运行时索引，静态不可见——由
+ * 调用方另行并入 CONFIG_KEYS 键集（本模块返回结构含 bases 供矩阵侧组合）。
+ */
+export function collectNormalizeBranchKeys(fnNode) {
+  const members = new Map() // 基名 → Set(键)
+  const eqLiterals = new Set()
+  const walk = (n) => {
+    if (!n || typeof n.type !== 'string') return
+    if (n.type === 'MemberExpression' && !n.computed && n.property?.type === 'Identifier'
+      && n.object?.type === 'Identifier' && ['src', 'base', 'qh', 'out'].includes(n.object.name)) {
+      if (!members.has(n.object.name)) members.set(n.object.name, new Set())
+      members.get(n.object.name).add(n.property.name)
+    }
+    if (n.type === 'BinaryExpression' && n.operator === '===') {
+      // typeof X === "object"/"boolean"/"string" 的类型串判定不属于「配置键排除表」——
+      // 排除表形态是 key === "配置键名"（Identifier 与 Literal 比较）
+      const isTypeofSide = (s) => s?.type === 'UnaryExpression' && s.operator === 'typeof'
+      if (!isTypeofSide(n.left) && !isTypeofSide(n.right)) {
+        for (const side of [n.left, n.right]) {
+          if (side?.type === 'Literal' && typeof side.value === 'string') eqLiterals.add(side.value)
+        }
+      }
+    }
+    for (const k of Object.keys(n)) {
+      if (k === 'loc' || k === 'start' || k === 'end' || k === 'range') continue
+      const v = n[k]
+      if (Array.isArray(v)) { for (const c of v) walk(c) } else if (v && typeof v.type === 'string') walk(v)
+    }
+  }
+  walk(fnNode)
+  const union = new Set()
+  for (const set of members.values()) for (const k of set) union.add(k)
+  for (const k of eqLiterals) union.add(k)
+  return {
+    union: [...union],
+    members: Object.fromEntries([...members.entries()].map(([k, s]) => [k, [...s]])),
+    eqLiterals: [...eqLiterals],
+  }
+}
+
+/**
+ * 客户端 UI 引用键收集（notifier 形态；lan-proxy 由 DEFAULTS 单表承载不适用）：
+ *  = 顶层 EVENT_KEYS 二维数组首列（事件开关渲染）
+ *  ∪ builtinCard("…") / switchControl("…") 调用首参字符串（内置卡/行为参数）
+ *  ∪ patch({…}) 字面量对象键（顶层配置键增量提交；chPatch 为 Bark 频道子键，
+ *    刻意不收——与 SETTING_VALIDATORS 顶层键不同面）
+ *  ∪ settings.<静态键> MemberExpression（渲染/读取面）。
+ * 覆盖全模块（esbuild 提升后 var 已顶层；函数内 var settings 仍可被遍历到——
+ *  全树扫描不依赖作用域分析，收集的是「键引用面」而非绑定语义）。
+ */
+export function collectClientUiKeys(ast) {
+  const keys = new Set()
+  const walk = (n) => {
+    if (!n || typeof n.type !== 'string') return
+    if (n.type === 'CallExpression' && n.callee?.type === 'Identifier') {
+      const callee = n.callee.name
+      if ((callee === 'builtinCard' || callee === 'switchControl') && n.arguments[0]?.type === 'Literal' && typeof n.arguments[0].value === 'string') {
+        keys.add(n.arguments[0].value)
+      }
+      if (callee === 'patch' && n.arguments[0]?.type === 'ObjectExpression') {
+        for (const p of n.arguments[0].properties) {
+          if (p.key?.type === 'Identifier') keys.add(p.key.name)
+        }
+      }
+    }
+    if (n.type === 'MemberExpression' && n.object?.type === 'Identifier' && n.object.name === 'settings'
+      && !n.computed && n.property?.type === 'Identifier') {
+      keys.add(n.property.name)
+    }
+    for (const k of Object.keys(n)) {
+      if (k === 'loc' || k === 'start' || k === 'end' || k === 'range') continue
+      const v = n[k]
+      if (Array.isArray(v)) { for (const c of v) walk(c) } else if (v && typeof v.type === 'string') walk(v)
+    }
+  }
+  for (const n of ast.body) {
+    // 顶层 EVENT_KEYS 二维首列
+    if (n.type === 'VariableDeclaration') {
+      for (const d of n.declarations) {
+        if (d.id?.type === 'Identifier' && d.id.name === 'EVENT_KEYS') {
+          for (const k of arrayFirstColKeys(d.init)) keys.add(k)
+        }
+      }
+    }
+  }
+  walk(ast)
+  return [...keys]
+}
+
+/** 矩阵行级差异（保序、可读）：缺键（base 有、table 无）与多键（table 有、
+ *  base 无）。 */
+export function diffKeys(base, table) {
+  const b = new Set(base)
+  const t = new Set(table)
+  return {
+    missing: [...b].filter((k) => !t.has(k)),
+    extra: [...t].filter((k) => !b.has(k)),
+  }
+}
+
+/**
+ * 读文件并提取表键（容错：文件缺失/声明缺失不抛——返回 err 由调用方报红）。
+ * @returns {{ err?: string, keys?: string[], line?: number|null }}
+ */
+export function readTableKeys(filePath, name, shape = 'object', label = name) {
+  let text
+  try {
+    text = readFileSync(filePath, 'utf8')
+  } catch {
+    return { err: `文件不可读: ${filePath}` }
+  }
+  const line = sourceLineOf(text, name)
+  const { found, keys } = extractNamedKeys(text, name, shape)
+  if (!found) {
+    return { err: `${label} 声明缺失（找不到顶层声明 ${name}，文件 ${filePath}${line ? `:${line}` : ''}）` }
+  }
+  if (keys.length === 0) {
+    return { err: `${label} 键集为空（提取器可能失效或表被掏空，文件 ${filePath}:${line}）` }
+  }
+  return { keys, line }
+}
+
+/** 从 DEFAULT_CONFIG 对象值推断「布尔键」：值字面量为 true/false 的键。 */
+export function booleanKeysOfObject(initNode) {
+  let cur = initNode
+  for (let i = 0; i < 12; i += 1) {
+    if (!cur) return []
+    if (cur.type === 'ObjectExpression') break
+    if (cur.type === 'ParenthesizedExpression') { cur = cur.expression; continue }
+    if (cur.type === 'TSAsExpression' || cur.type === 'TSSatisfiesExpression' || cur.type === 'TypeCastExpression') { cur = cur.expression; continue }
+    if (cur.type === 'CallExpression') { cur = cur.arguments?.[0] ?? null; continue }
+    return []
+  }
+  if (cur?.type !== 'ObjectExpression') return []
+  const out = []
+  for (const p of cur.properties) {
+    if (p.type !== 'Property') continue
+    const val = p.value?.type === 'Literal' && typeof p.value.value === 'boolean' ? p.value.value : null
+    if (val === null) continue
+    const k = p.key?.type === 'Identifier' ? p.key.name : p.key?.type === 'Literal' ? String(p.key.value) : null
+    if (k !== null) out.push(k)
+  }
+  return out
+}

--- a/scripts/lib/config-matrix-lib.ts
+++ b/scripts/lib/config-matrix-lib.ts
@@ -293,3 +293,49 @@ export function booleanKeysOfObject(initNode) {
   }
   return out
 }
+
+/**
+ * README 配置节键提取（量级 #12：键集一致性仅 warn 不判红）。包形态不同：
+ *   - lan-proxy：markdown 表格（`## 配置` 节），行首 `` | `key` | `` 或
+ *     `` | `a` / `b` | ``（斜杠合并多键）；
+ *   - notifier：首个 ```json 样例块顶层键。
+ * 只取「代码表键形态」（camelCase token），防 GET/api/true 等非键 token 误收。
+ * @returns { keys: string[], section: string|null } section=定位到的节（诊断用）。
+ */
+export function extractReadmeConfigKeys(text, pkg) {
+  if (pkg === 'lan-proxy') {
+    // 逐行截「## 配置」节（到下一个二级/三级标题止），避免 JS 正则无 \Z 的坑
+    const lines = text.split('\n')
+    const start = lines.findIndex((l) => /^## 配置[ \t]*$/.test(l))
+    if (start === -1) return { keys: [], section: null }
+    const secLines = []
+    for (let i = start + 1; i < lines.length; i += 1) {
+      if (/^#{2,3}[ \t]/.test(lines[i])) break
+      secLines.push(lines[i])
+    }
+    const keys = []
+    for (const line of secLines) {
+      // 取表格行首列（第一个 | 与第二个 | 之间），支持合并键 `a` / `b`
+      const tm = line.match(/^\|\s*([^|]+?)\s*\|/)
+      if (!tm) continue
+      for (const span of tm[1].matchAll(/`([^`]+)`/g)) {
+        for (const part of span[1].split('/')) {
+          const k = part.trim()
+          if (/^[a-z][A-Za-z0-9]*$/.test(k) && !keys.includes(k)) keys.push(k)
+        }
+      }
+    }
+    return { keys, section: '## 配置' }
+  }
+  if (pkg === 'notifier') {
+    const m = text.match(/```json\n([\s\S]*?)\n```/)
+    if (!m) return { keys: [], section: '```json' }
+    const keys = []
+    for (const line of m[1].split('\n')) {
+      const km = line.match(/^\s*"([a-z][A-Za-z0-9]*)":/)
+      if (km && !keys.includes(km[1])) keys.push(km[1])
+    }
+    return { keys, section: '```json' }
+  }
+  return { keys: [], section: null }
+}

--- a/scripts/test/config-matrix-extractor.test.ts
+++ b/scripts/test/config-matrix-extractor.test.ts
@@ -21,6 +21,7 @@ import assert from 'node:assert/strict'
 import {
   parseTs, findTopVar, findTopFn, objectKeysOf, arrayStringKeys, arrayFirstColKeys,
   extractNamedKeys, collectNormalizeBranchKeys, collectClientUiKeys, booleanKeysOfObject, sourceLineOf, diffKeys,
+  extractReadmeConfigKeys,
 } from '../lib/config-matrix-lib.ts'
 
 // 简单 fixture：普通对象 + 数组
@@ -182,4 +183,34 @@ test('diffKeys 缺/多键', () => {
   const d = diffKeys(['a', 'b', 'c'], ['a', 'c', 'z'])
   assert.deepEqual(d.missing, ['b'])
   assert.deepEqual(d.extra, ['z'])
+})
+
+// README 配置键提取（量级 #12：lan-proxy 表 + notifier JSON + 合并键 + 噪音免疫）
+test('README lan-proxy 配置表键提取（含合并键、排除非键 token）', () => {
+  const readme = `## 配置
+
+| 键 | 默认 | 说明 |
+|---|---|---|
+| \`enabled\` | \`true\` | 总开关 |
+| \`tlsCertFile\` / \`tlsKeyFile\` | 无 | 证书 |
+| \`wsCompressPaths\` | \`/api/remote.mux\` | 白名单（见 \`GET /health\`） |
+| \`httpCompressLevel\` | \`1\` | 档位 |
+`
+  const { keys } = extractReadmeConfigKeys(readme, 'lan-proxy')
+  assert.deepEqual(keys, ['enabled', 'tlsCertFile', 'tlsKeyFile', 'wsCompressPaths', 'httpCompressLevel'])
+})
+
+test('README notifier JSON 样例键提取（仅顶层键）', () => {
+  const readme = `## 配置
+
+\`\`\`json
+{
+  "notifyAsk": true,
+  "quietHours": { "enabled": false },
+  "channels": []
+}
+\`\`\`
+`
+  const { keys } = extractReadmeConfigKeys(readme, 'notifier')
+  assert.deepEqual(keys, ['notifyAsk', 'quietHours', 'channels'])
 })

--- a/scripts/test/config-matrix-extractor.test.ts
+++ b/scripts/test/config-matrix-extractor.test.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * config-matrix-extractor 提取器自检（issue #471 P1-4：防提取器静默失效→矩阵假绿）。
+ *
+ * 用已知键集 fixture（迷你 TS 片段）对照提取结果，锁定三条提取路径：
+ *   A. 顶层对象键提取（objOf：普通对象 / z.object 下钻 / 带类型注解 export 被
+ *      esbuild 拆成普通 const + 尾部 export list / TSAs 包装 / Parenthesized）；
+ *   B. 数组键提取（一维字符串数组 CONFIG_KEYS 形态 / 二维首列 EVENT_KEYS 形态）；
+ *   C. normalizeConfig 分支目标键提取（base.<key> 赋值 / src.<key> 读取 /
+ *      qh 子键 / === 排除表字面量——须不含 typeof 类型串误报）。
+ * 另有 sourceLineOf 行号定位、booleanKeysOfObject 布尔键推导、diffKeys 差异。
+ *
+ * 运行：node --test scripts/test/config-matrix-extractor.test.ts（随 pnpm test:scripts）
+ * 零落盘：纯内存 fixture，无任何文件写入。
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  parseTs, findTopVar, findTopFn, objectKeysOf, arrayStringKeys, arrayFirstColKeys,
+  extractNamedKeys, collectNormalizeBranchKeys, collectClientUiKeys, booleanKeysOfObject, sourceLineOf, diffKeys,
+} from '../lib/config-matrix-lib.ts'
+
+// 简单 fixture：普通对象 + 数组
+test('fixture: 普通对象与数组字面量键', () => {
+  const ast = parseTs('const A = { x: 1, y: 2 };\nconst B = ["m", "n"];\n')
+  assert.deepEqual(objectKeysOf(findTopVar(ast, 'A')), ['x', 'y'])
+  assert.deepEqual(arrayStringKeys(findTopVar(ast, 'B')), ['m', 'n'])
+  assert.deepEqual(extractNamedKeys('const A = { x: 1 };\n', 'A', 'object').keys, ['x'])
+  assert.deepEqual(extractNamedKeys('const A = { x: 1 };\n', 'A', 'arrayStrings').keys, [])
+})
+
+// z.object 下钻（CallExpression 第一实参 ObjectExpression）
+test('z.object 嵌套下钻提取（CallExpression 剥壳）', () => {
+  const src = `
+import z from "schemastery";
+const Config = z.object({
+  enabled: z.boolean().default(true),
+  host: z.string(),
+  nested: z.object({ a: z.string() }).default({ a: "x" }),
+});
+`
+  const keys = extractNamedKeys(src, 'Config', 'object').keys
+  assert.deepEqual(keys, ['enabled', 'host', 'nested'], '嵌套 z.object 的默认对象不得混入顶层键')
+})
+
+// 带类型注解 export const：esbuild 拆成普通 const + 尾部 export list——顶层收集须不依赖 export 形态
+test('带类型注解 export const（esbuild 拆分形态）仍可提取', () => {
+  const src = `
+interface T { a?: boolean; b?: string }
+export const Config: z<T> = z.object({
+  a: z.boolean().default(true),
+  b: z.string(),
+});
+`
+  const ast = parseTs(src)
+  // esbuild 拆后：顶层 VariableDeclaration（const Config）+ 尾部 export list
+  assert.ok(findTopVar(ast, 'Config'), '拆后仍为顶层普通 const')
+  assert.deepEqual(extractNamedKeys(src, 'Config', 'object').keys, ['a', 'b'])
+})
+
+// TSAs / Satisfies / 括号包装剥壳
+test('TSAs/Satisfies/Parenthesized 包装剥壳', () => {
+  const src = `
+const A = { p: 1, q: 2 } as const;
+const B = ({ r: 1 } satisfies Record<string, number>);
+const C = ({ s: 1 });
+`
+  const ast = parseTs(src)
+  assert.deepEqual(objectKeysOf(findTopVar(ast, 'A')), ['p', 'q'], 'as const 剥壳')
+  assert.deepEqual(objectKeysOf(findTopVar(ast, 'B')), ['r'], 'satisfies 剥壳')
+  assert.deepEqual(objectKeysOf(findTopVar(ast, 'C')), ['s'], '括号剥壳')
+})
+
+// 数组键：一维（CONFIG_KEYS）+ 二维首列（EVENT_KEYS）
+test('一维/二维数组键提取', () => {
+  const src = `
+const CONFIG_KEYS: readonly string[] = ["a", "b", "c"];
+const EVENT_KEYS = [
+  ["notifyA", "evtA"],
+  ["notifyB", "evtB"],
+];
+`
+  const ast = parseTs(src)
+  assert.deepEqual(arrayStringKeys(findTopVar(ast, 'CONFIG_KEYS')), ['a', 'b', 'c'])
+  assert.deepEqual(arrayFirstColKeys(findTopVar(ast, 'EVENT_KEYS')), ['notifyA', 'notifyB'])
+  assert.deepEqual(extractNamedKeys(src, 'CONFIG_KEYS', 'arrayStrings').keys, ['a', 'b', 'c'])
+})
+
+// normalizeConfig 分支目标键：base 赋值 + src 读取 + qh 子键 + === 排除表字面量；
+// 不收集 typeof 类型串（object/boolean/string 误报回归锁）
+test('normalizeConfig 分支目标键提取（含 typeof 类型串不误收）', () => {
+  const src = `
+export function normalizeConfig(input: unknown): any {
+  const base: any = { ...DEFAULT_CONFIG };
+  if (typeof input !== "object" || input === null) return base;
+  const src = input as Record<string, unknown>;
+  for (const key of CONFIG_KEYS) {
+    if (typeof src[key] === "boolean") base[key] = src[key];
+  }
+  if (Number.isFinite(src.errorMergeWindowMs)) base.errorMergeWindowMs = Math.round(src.errorMergeWindowMs);
+  if (typeof src.quietHours === "object" && src.quietHours !== null) {
+    const qh = src.quietHours as Record<string, unknown>;
+    if (typeof qh.enabled === "boolean") base.quietHours.enabled = qh.enabled;
+    if (typeof qh.start === "string") base.quietHours.start = qh.start;
+  }
+  if (Array.isArray(src.channels)) base.channels = normalizeChannels(src.channels);
+  const out = base;
+  for (const key of Object.keys(src)) {
+    if ((CONFIG_KEYS as readonly string[]).includes(key)) continue;
+    if (key === "quietHours" || key === "channels") continue;
+    out[key] = src[key];
+  }
+  return out;
+}
+`
+  const fn = findTopFn(parseTs(src), 'normalizeConfig')
+  assert.ok(fn, 'normalizeConfig 声明可定位')
+  const branch = collectNormalizeBranchKeys(fn)
+  // base 赋值键 = 显式归一化目标（errorMergeWindowMs/quietHours/channels）
+  assert.deepEqual([...branch.members.base].sort(), ['channels', 'errorMergeWindowMs', 'quietHours'])
+  // qh 子键
+  assert.deepEqual([...branch.members.qh].sort(), ['enabled', 'start'])
+  // union 含 src 读取键与 === 字面量；但不得含 typeof 类型串
+  assert.ok(branch.union.includes('errorMergeWindowMs'))
+  assert.ok(branch.union.includes('quietHours'))
+  assert.ok(!branch.union.includes('object'), 'typeof 类型串 object 不得被收集')
+  assert.ok(!branch.union.includes('boolean'), 'typeof 类型串 boolean 不得被收集')
+  assert.ok(!branch.union.includes('string'), 'typeof 类型串 string 不得被收集')
+  // eqLiterals = === "键" 判定（排除表）；同样不含类型串
+  assert.deepEqual([...branch.eqLiterals].sort(), ['channels', 'quietHours'])
+})
+
+// 客户端 UI 引用键（EVENT_KEYS 首列 + builtinCard/switchControl 参数 + patch 对象键 + settings.<键>）
+test('客户端 UI 引用键收集（EVENT_KEYS/内置卡/patch/settings 形态）', () => {
+  const src = `
+var EVENT_KEYS = [
+  ["notifyAsk", "evtAsk"],
+  ["notifyTurnEnd", "evtTurnEnd"],
+];
+function apply(ctx: any) {
+  function patch(p: any) { setSettings(p); }
+  function builtinCard(cfgKey: string, label: string) { return null; }
+  function switchControl(key: string) { return null; }
+  builtinCard("browserNotify", "x");
+  extras.push(row("sound", switchControl("notifySound")));
+  patch({ errorMergeWindowMs: Number(x) });
+  patch({ quietHours: { enabled: true } });
+  var qh = settings.quietHours || {};
+  chPatch(idx, { sound: v }); // 频道子键——不得收集
+}
+`
+  const ui = collectClientUiKeys(parseTs(src))
+  assert.ok(ui.includes('notifyAsk') && ui.includes('notifyTurnEnd'), 'EVENT_KEYS 首列')
+  assert.ok(ui.includes('browserNotify'), 'builtinCard 参数')
+  assert.ok(ui.includes('notifySound'), 'switchControl 参数')
+  assert.ok(ui.includes('errorMergeWindowMs') && ui.includes('quietHours'), 'patch 字面量对象键')
+  assert.ok(ui.includes('quietHours'), 'settings.<键> 引用')
+  assert.ok(!ui.includes('sound'), 'chPatch 频道子键不得收集')
+})
+
+// sourceLineOf 行号（1-based，含 export 前缀）
+test('sourceLineOf 定位声明行号', () => {
+  const src = '// 注释\n\nconst A = {};\nexport const Config = z.object({});\nfunction normalizeConfig() {}\n'
+  assert.equal(sourceLineOf(src, 'A'), 3)
+  assert.equal(sourceLineOf(src, 'Config'), 4)
+  assert.equal(sourceLineOf(src, 'normalizeConfig'), 5)
+  assert.equal(sourceLineOf(src, 'NotExist'), null)
+})
+
+// booleanKeysOfObject：从默认值字面量推导布尔键
+test('booleanKeysOfObject 从对象值推导布尔键', () => {
+  const src = 'const D = { a: true, b: false, c: 3, d: "x", e: { f: true } };'
+  const ast = parseTs(src)
+  assert.deepEqual(booleanKeysOfObject(findTopVar(ast, 'D')), ['a', 'b'], '仅顶层布尔字面量键')
+})
+
+// diffKeys
+test('diffKeys 缺/多键', () => {
+  const d = diffKeys(['a', 'b', 'c'], ['a', 'c', 'z'])
+  assert.deepEqual(d.missing, ['b'])
+  assert.deepEqual(d.extra, ['z'])
+})

--- a/scripts/test/config-matrix-negative.test.ts
+++ b/scripts/test/config-matrix-negative.test.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * config-matrix-negative 负向自测（issue #471 P1-3：漏表方向注入 → 门禁红 +
+ * 报错含键名）。
+ *
+ * 负向用例对**真实 src/config.ts / src/client/index.ts 的 mkdtemp 副本**注入
+ * （删键 / 加假键），再跑与 contract-check 同一 runConfigMatrix(root)——副本
+ * 等效性论证：矩阵提取器输入仅源文本（无 import 解析、无运行时、无 lib 产物
+ * 依赖），复制文件即等价于真实文件；注入后断言矩阵 pass=false 且 problems
+ * 含被注入键名。零污染：临时目录随测试结束 rmSync（#218 纪律）。
+ *
+ * 覆盖方向（每方向至少一例，合计 ≥6）：
+ *   lan-proxy ① 删 FILE_CONFIG_VALIDATORS 一键 → 红 ② DEFAULTS 增 schema 外键
+ *     → 红 ③ 删 Config schema 键 → 红 ④ DEFAULTS 删非豁免键 → 红
+ *   notifier ⑤ 删 DEFAULT_CONFIG 一键 → 红 ⑥ SETTING_HINTS 加假键 → 红
+ *     ⑦ CONFIG_KEYS 漏布尔键 → 红 ⑧ normalizeConfig 漏归一化分支 → 红
+ *     ⑨ 客户端 EVENT_KEYS 删事件键 → 红 ⑩ 客户端渲染 validators 外键 → 红
+ *     ⑪ 客户端引用豁免键（豁免残留）→ 红
+ * 另含「纯副本不改动 → pass」正对照（防注入函数自身破坏文件）。
+ *
+ * 运行：node --test scripts/test/config-matrix-negative.test.ts（随 pnpm test:scripts）
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, cpSync, writeFileSync, rmSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { runConfigMatrix } from '../lib/config-matrix-gate.ts'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+/** mkdtemp 副本仓库：复制两包 src/config.ts + src/client/index.ts（仅矩阵输入面）。 */
+function fakeRepo() {
+  const root = mkdtempSync(join(tmpdir(), 'cfgmtx-'))
+  try {
+    for (const pkg of ['dsh-lan-proxy', 'dsh-notifier']) {
+      mkdirSync(join(root, 'packages', pkg, 'src', 'client'), { recursive: true })
+    }
+    const srcs = [
+      ['dsh-lan-proxy', 'config.ts'],
+      ['dsh-lan-proxy', 'client/index.ts'],
+      ['dsh-notifier', 'config.ts'],
+      ['dsh-notifier', 'client/index.ts'],
+    ]
+    for (const [pkg, rel] of srcs) {
+      cpSync(join(ROOT, 'packages', pkg, 'src', rel), join(root, 'packages', pkg, 'src', rel))
+    }
+  } catch (e) {
+    rmSync(root, { recursive: true, force: true })
+    throw e
+  }
+  return root
+}
+
+function edit(root, pkg, rel, fn) {
+  const f = join(root, 'packages', pkg, 'src', rel)
+  writeFileSync(f, fn(readFileSync(f, 'utf8')))
+}
+
+/** 通用断言：注入后矩阵红 + problems 含 expectKey；若 expectKey 为数组则逐一断言。 */
+function assertRed(label, mutate, expectKeys) {
+  const root = fakeRepo()
+  try {
+    mutate(root)
+    const r = runConfigMatrix(root)
+    assert.equal(r.pass, false, `${label}: 注入后门禁应红`)
+    const joined = r.problems.join('\n')
+    for (const k of (Array.isArray(expectKeys) ? expectKeys : [expectKeys])) {
+      assert.ok(joined.includes(k), `${label}: 报错应含键名 ${k}。实际: ${r.problems[0] ?? '(无)'}`)
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+test('正对照：纯副本不改动矩阵 pass', () => {
+  const root = fakeRepo()
+  try {
+    const r = runConfigMatrix(root)
+    assert.equal(r.pass, true, '真实文件副本矩阵应绿（存量 16/19 无洞）')
+    assert.ok(r.lines.some((l) => l.includes('lan-proxy 16 键')), 'lan-proxy 摘要含 16 键计数')
+    assert.ok(r.lines.some((l) => l.includes('notifier 19 键')), 'notifier 摘要含 19 键计数')
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+// ---- lan-proxy 方向 ----
+
+test('lan-proxy: 删 FILE_CONFIG_VALIDATORS 一键 → 红且报错含键名', () => {
+  assertRed('lan-proxy 删 validators.enabled', (root) => {
+    edit(root, 'dsh-lan-proxy', 'config.ts', (s) => s.replace(/  enabled: \(v\) => typeof v === "boolean",\n/, ''))
+  }, 'enabled')
+})
+
+test('lan-proxy: DEFAULTS 增 schema 外键 → 红且报错含键名', () => {
+  assertRed('lan-proxy DEFAULTS 加 fakeKey', (root) => {
+    edit(root, 'dsh-lan-proxy', 'client/index.ts', (s) =>
+      s.replace('  var DEFAULTS: Record<string, any> = {', '  var DEFAULTS: Record<string, any> = {\n    fakeKey: 1,'))
+  }, 'fakeKey')
+})
+
+test('lan-proxy: 删 Config schema 键 → 红且报错含键名', () => {
+  assertRed('lan-proxy 删 schema.host', (root) => {
+    edit(root, 'dsh-lan-proxy', 'config.ts', (s) => s.replace(/  host: z\.string\(\)\.default\(DEFAULT_OPTIONS\.host\),\n/, ''))
+  }, 'host')
+})
+
+test('lan-proxy: DEFAULTS 删非豁免可编辑键 → 红且报错含键名', () => {
+  assertRed('lan-proxy DEFAULTS 删 tlsCertFile', (root) => {
+    edit(root, 'dsh-lan-proxy', 'client/index.ts', (s) => s.replace(/    tlsCertFile: "",\n/, ''))
+  }, 'tlsCertFile')
+})
+
+// ---- notifier 方向 ----
+
+test('notifier: 删 DEFAULT_CONFIG 一键 → 红且报错含键名', () => {
+  assertRed('notifier 删 DEFAULT_CONFIG.maxConnections', (root) => {
+    edit(root, 'dsh-notifier', 'config.ts', (s) => s.replace(/  maxConnections: 16,\n/, ''))
+  }, 'maxConnections')
+})
+
+test('notifier: SETTING_HINTS 加假键 → 红且报错含键名', () => {
+  assertRed('notifier SETTING_HINTS 加 bogusKey', (root) => {
+    edit(root, 'dsh-notifier', 'config.ts', (s) =>
+      s.replace('const SETTING_HINTS: Record<string, string> = {', 'const SETTING_HINTS: Record<string, string> = {\n  bogusKey: "x",'))
+  }, 'bogusKey')
+})
+
+test('notifier: CONFIG_KEYS 漏布尔键 → 红且报错含键名', () => {
+  assertRed('notifier CONFIG_KEYS 删 notifySound', (root) => {
+    edit(root, 'dsh-notifier', 'config.ts', (s) => s.replace(/,\s*"notifySound"\]/, ']'))
+  }, 'notifySound')
+})
+
+test('notifier: normalizeConfig 漏归一化分支 → 红且报错含键名', () => {
+  assertRed('notifier normalize 漏 channels', (root) => {
+    edit(root, 'dsh-notifier', 'config.ts', (s) =>
+      s.replace(/  if \(Array\.isArray\(src\.channels\)\) base\.channels = normalizeBarkChannels\(src\.channels\);\n/, ''))
+  }, 'channels')
+})
+
+test('notifier: normalizeConfig 漏安静时段内嵌子键分支 → 红', () => {
+  assertRed('notifier normalize 漏 qh.start 子键', (root) => {
+    edit(root, 'dsh-notifier', 'config.ts', (s) => {
+      // 整行删除：以 base.quietHours.start 赋值 + 前导行片段为锚
+      const lines = s.split('\n')
+      const idx = lines.findIndex((l) => l.includes('base.quietHours.start = qh.start'))
+      assert.notEqual(idx, -1, 'fixture 应含 quietHours.start 归一化行')
+      lines.splice(idx, 1)
+      return lines.join('\n')
+    })
+  }, 'start')
+})
+
+test('notifier: 客户端 EVENT_KEYS 删事件键 → 红且报错含键名', () => {
+  assertRed('notifier 客户端删 notifyTurnEnd', (root) => {
+    edit(root, 'dsh-notifier', 'client/index.ts', (s) => s.replace(/    \["notifyTurnEnd", "evtTurnEnd"\],\n/, ''))
+  }, 'notifyTurnEnd')
+})
+
+test('notifier: 客户端渲染 validators 外键 → 红且报错含键名', () => {
+  assertRed('notifier 客户端 settings.ghostKey', (root) => {
+    edit(root, 'dsh-notifier', 'client/index.ts', (s) =>
+      s.replace('    var qh = settings.quietHours || {};', '    var ghost = settings.ghostKey || {};\n    var qh = settings.quietHours || {};'))
+  }, 'ghostKey')
+})
+
+test('notifier: 客户端引用豁免键（豁免残留）→ 红且报错含豁免键名', () => {
+  assertRed('notifier 客户端引用 allowKinds', (root) => {
+    edit(root, 'dsh-notifier', 'client/index.ts', (s) =>
+      s.replace('    var qh = settings.quietHours || {};', '    var ak = settings.allowKinds || [];\n    var qh = settings.quietHours || {};'))
+  }, 'allowKinds')
+})

--- a/scripts/test/config-matrix-negative.test.ts
+++ b/scripts/test/config-matrix-negative.test.ts
@@ -176,3 +176,27 @@ test('notifier: 客户端引用豁免键（豁免残留）→ 红且报错含豁
       s.replace('    var qh = settings.quietHours || {};', '    var ak = settings.allowKinds || [];\n    var qh = settings.quietHours || {};'))
   }, 'allowKinds')
 })
+
+// 量级 #12：README 键集一致性仅 warn 不判红（缺文档键 → warnings 含键名，pass 仍 true）
+test('量级: README 配置表缺键 → warn 不红（pass 仍 true）', () => {
+  const root = fakeRepo()
+  try {
+    // 复制真实 README 进副本（矩阵 README warn 需要文件存在）
+    cpSync(join(ROOT, 'packages/dsh-lan-proxy/README.md'), join(root, 'packages/dsh-lan-proxy/README.md'))
+    cpSync(join(ROOT, 'packages/dsh-notifier/README.md'), join(root, 'packages/dsh-notifier/README.md'))
+    // 基线（README 与代码键集一致）：零 warn
+    let r = runConfigMatrix(root)
+    assert.equal(r.pass, true)
+    assert.deepEqual(r.warnings, [], 'README 与代码键集一致时应零 warn')
+    // 注入：删 lan-proxy README 配置表一行（enabled）→ warn 含键名、pass 仍 true
+    const readmePath = join(root, 'packages/dsh-lan-proxy/README.md')
+    const text = readFileSync(readmePath, 'utf8')
+    writeFileSync(readmePath, text.replace(/^\| `enabled` \| `true` \| 总开关.*\n/m, ''))
+    r = runConfigMatrix(root)
+    assert.equal(r.pass, true, 'README 缺键仅 warn，不判红')
+    assert.ok(r.warnings.some((w) => w.includes('enabled') && w.includes('lan-proxy')), `warn 应含键名 enabled: ${r.warnings.join(';')}`)
+    assert.ok(r.problems.length === 0, 'README 缺键不应产生 problems')
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## 修复说明

issue #471（#378 分诊 T7）：配置平行事实源——lan-proxy / notifier 的配置键在
schema / validators / hints / normalize 分支 / 客户端渲染面多表平行维护，新增键
漏改一表即不一致。本 PR 落地「包内字段覆盖矩阵门禁」：新增配置键漏表即红，
存量 16/19 键矩阵闭合无洞（先绿后锁）。

> 本 PR 经 qa 复核返工一轮：① config-matrix 段输出位移修复（现为文件真正末段，
> A/B 逐字节对比留痕见下）；② 量级 #12/#13 落地（README 键集一致性 warn + 报错
> 附四同步指引，并补齐 lan-proxy README 缺失的 `enabled`/`printBanner`/
> `wsDeflatePolicy` 三行文档）；③ 断言表口径对齐 issue 实列 **13 条**（硬性 11 /
> 量级 2），勘误评论见 issue #471 评论区。

### 实现形态（P0-A / P1-1 / P2 裁决落地）

- **门禁并入 `scripts/gate/contract-check.ts` 文件内部**：根 `package.json` 命令
  字符串零改动、`.github/` 零改动；`pnpm contract`（repo-gate 无条件全量）必跑。
  **输出契约（qa #11 修复后）**：既有逐包行 + `检查覆盖` + 类型导入行 +
  最终汇总行「客户端契约：全部通过/失败」**逐字节不变**且顺序不变；config-matrix
  段作为**文件真正末段**追加在汇总行之后（失败仍 exit 1，矩阵失败独立计数不
  改写汇总行文案）。
- **提取器弃纯正则**：`scripts/lib/config-matrix-lib.ts` = esbuild transform（TS→JS）
  + acorn parse 两段式 AST（两者均为根既有 devDep，零新增依赖）。处理：带类型
  注解 `export const` 被 esbuild 拆普通 const + 尾部 export list（收集任意顶层
  VariableDeclaration）；`z.object({...})` CallExpression 下钻第一实参；TSAs /
  TSSatisfies / Parenthesized 剥壳；`normalizeConfig` 按「base.<key> 归一化赋值 ∪
  CONFIG_KEYS ∪ 排除表 === 键字面量（typeof 类型串免疫）」提取分支目标键，不收集
  全函数字符串（防 object/boolean 误报——已实测并回归锁定）。
- `scripts/lib/config-matrix-gate.ts`：矩阵编排纯逻辑（root 参数化——负向自测对
  mkdtemp 真实文件副本注入复用同一逻辑，副本等效性：矩阵输入仅源文本）；
  豁免白名单三条件：服务端/组合层键或客户端不渲染键 + 单包 ≤8 + 每条带
  「文件:行 + 理由」注释；豁免残留（键已 UI 化但白名单未删）亦红。
- 客户端 UI 键覆盖（notifier）：EVENT_KEYS 首列 ∪ builtinCard/switchControl 参数
  ∪ patch({…}) 对象键 ∪ settings.<键> 引用，与 SETTING_VALIDATORS 求差 == 豁免
  {allowKinds}（POST /kinds 服务端管理）。
- 量级 #12：README 配置节键集一致性（lan-proxy 配置表 / notifier JSON 样例）——
  代码键缺文档仅 warn 不判红；首轮基线校准补齐 lan-proxy README 缺失三行
  （`enabled` / `printBanner` / `wsDeflatePolicy`，均为真文档缺口：前两者 GUI
  可编辑键漏表，后者服务端策略键补说明），当前 warn 零基线。
- 量级 #13：矩阵红时末尾附「四同步清单」指引（① 事实源表 ② validators/hints
  ③ normalize 白名单与透传排除 ④ 客户端渲染/编辑 + smoke + README），不改变
  判红语义。

### 验收断言表（13 条，对齐 issue v2 实列口径：硬性 11 / 量级 2）

| # | 验收条目（v2） | 结论 | 证据 |
|---|---|---|---|
| 1 | 矩阵门禁并入 contract-check.ts；提取器 esbuild+acorn 零新增依赖，不 import 包 src、不依赖 lib 产物 | PASS | `scripts/gate/contract-check.ts` 末段调用 `runConfigMatrix`；`scripts/lib/config-matrix-lib.ts`（esbuild transformSync + acorn.parse，根 devDeps 既有 acorn/esbuild）；负向副本直读 src 文本验证（无 lib 产物依赖） |
| 2 | lan-proxy Config/FILE_CONFIG_VALIDATORS/SETTING_FIELD_HINTS AST 键集全等（16）→ 缺/多键 exit 1 + 报错含 表名+文件:行+键名 | PASS | gate L1 双向 diff；负向测试「删 validators.enabled」红且含 `enabled`+`config.ts:行` |
| 3 | lan-proxy client DEFAULTS ⊆ schema，差集 == 豁免 {host,targetHost,targetPort,wsDeflatePolicy}；豁免带原因注释、单包 ≤8 | PASS | gate L2 差集恰等 + 豁免残留红；豁免 4 键各带注释；负向「DEFAULTS 加 fakeKey」「删 Config.host」「DEFAULTS 删 tlsCertFile（非豁免）」均红 |
| 4 | notifier DEFAULT_CONFIG/SETTING_VALIDATORS/SETTING_HINTS 全等（19） | PASS | gate N1 双向 diff；负向「删 DEFAULT_CONFIG.maxConnections」「SETTING_HINTS 加 bogusKey」红 |
| 5 | notifier CONFIG_KEYS == DEFAULT_CONFIG 全部布尔键（10/10） | PASS | gate N2 booleanKeysOfObject 推导对照；负向「CONFIG_KEYS 删 notifySound」红含键名 |
| 6 | notifier normalizeConfig 分支目标键 ⊇ DEFAULT_CONFIG（CONFIG_KEYS ∪ 显式分支 ∪ M2；现 19/19） | PASS | gate N3 base.<key> 归一化赋值 ∪ CONFIG_KEYS 覆盖 + 排除表孤儿键 + qh 子键不变量；负向「漏 channels 归一化」「漏 qh.start 子键」红 |
| 7 | notifier 客户端 UI 键 ⊆ SETTING_VALIDATORS 且可编辑键有渲染/提交闭环；豁免带注释 | PASS | gate N4 collectClientUiKeys 双向差集；豁免 allowKinds 注释；负向「删 EVENT_KEYS 事件键」「渲染 ghostKey」「引用豁免键（残留）」红 |
| 8 | 门禁经 pnpm contract 必跑；package.json/.github 零改动 | PASS | 根 package.json scripts 未变（git diff 仅 scripts/ + 包 README）；.github/ 未变；CI repo-gate Contract 步骤无条件全量 |
| 9 | 提取器自检 config-matrix-extractor.test.ts（普通对象/z.object/export 注解/TSAs/数组/分支键六路径） | PASS | `scripts/test/config-matrix-extractor.test.ts` 12 test() 全绿（fixture 对照，含 typeof 不误收回归锁 + README 键提取 2 用例） |
| 10 | 负向自测对真实 src/config.ts mkdtemp 副本注入（删键/加假键）→ exit 1 + 报错含键名；两包 ≥3 方向（合计 ≥6） | PASS | `scripts/test/config-matrix-negative.test.ts` 14 test() 全绿：lan-proxy 4 方向 + notifier 7 方向 + 正对照 + README warn 语义；零污染（mkdtemp 随测 rmSync） |
| 11 | 门禁对存量现状 exit 0，追加段矩阵摘要（lan-proxy 16×4、notifier 19×6 各表键计数 + 豁免清单）；**输出契约：旧输出整体逐字节不变、矩阵段为真正末段** | PASS | `pnpm contract` exit 0；A/B 逐字节对比：origin/main 版 contract-check 输出 == 新版输出的严格前缀（old 1751B 全含于 new 2000B 头），追加字节恰为矩阵段且位于「客户端契约：全部通过」之后（留痕见下） |
| 12 | [量级] README 配置节键集一致性纳入门禁（缺键仅 warn 不判红；基线随 PR 校准） | PASS | gate 读 README 配置表/JSON 样例提取键，代码键 − README 键 → warn 不红；负向「README 删 enabled 行 → warn 含键名且 pass true」；首轮校准补齐 lan-proxy README 三行，当前 warn 零基线 |
| 13 | [量级] 报错行附「四同步清单」指引（normalize/透传排除 + 客户端渲染 + smoke + README），不改判红语义 | PASS | 矩阵红时末尾输出 `hint config-matrix | 新增/修改配置键请四同步——① 事实源表 ② validators/hints ③ normalize 白名单与透传排除 ④ 客户端渲染/编辑 + smoke 断言 + README 配置节`；判红语义不变（负向测试确认红仍红） |

（qa 复核三要素已按推荐①落地：README 一致性 warn + 四同步指引均实现；口径
勘误见 issue #471 评论区。）

### 矩阵门禁实测输出（追加段，contract 末段）

```text
客户端契约：全部通过

config-matrix:
  lan-proxy 16 键 × [schema/validators/hints] 全等 + client DEFAULTS 12(豁免 4)
  notifier 19 键 × [default/validators/hints] 全等 + CONFIG_KEYS 10/10 + normalize 覆盖 + client UI 覆盖 18(豁免 1)
config-matrix | PASS
```

豁免清单：lan-proxy `{host, targetHost, targetPort, wsDeflatePolicy}`（组合层/服务端
键，GUI 不编辑）；notifier `{allowKinds}`（POST /kinds 服务端管理）。

### A/B 输出契约逐字节留痕（qa #11 复验引用）

- 基线 A：`origin/main:scripts/gate/contract-check.ts`（main 既有版，无矩阵段）。
- 实测（worktree 含 build 产物）：A 输出 1751 字节 exit 0；B（本 PR）输出 2000
  字节 exit 0；`B.startswith(A) == true`——旧输出整体逐字节不变且顺序不变；
  追加 249 字节 = `\nconfig-matrix:\n  …摘要…\nconfig-matrix | PASS\n`（文件真正末段）。

### 门禁退出码（本地五连）

build=0 / contract=0 / test:scripts 26 test() 全绿 / pack:check=0 / typecheck=0
（pnpm test 全量 smoke 上轮已绿，本轮改动限 scripts/README 不触包产物）

Closes #471
