### PR TITLE
test: mcp-manager-service 契约独立门禁——service-contract 测试（#476）

### DIFF
--- a/packages/dsh-codegraph/test/service-consumer.test.ts
+++ b/packages/dsh-codegraph/test/service-consumer.test.ts
@@ -135,8 +135,11 @@ try {
   ]);
   console.log("  ok   service-consumer: 消费方类型化调用形状与契约一致（registerServer/getStatus/unregisterServer）");
 } catch (error) {
+  // 打印 FAIL 后 **throw 原错误**（不置 exitCode 吞掉）：宿主 smoke 若在成功
+  // 路径无条件 exit(0)，exitCode 会被覆盖成假绿（复核闸 P0-1 同型隐患）；
+  // 顶层抛错沿 import 链冒泡终止 smoke → 退出码非 0 真红。
   console.error(`  FAIL service-consumer: ${(error as Error).message}`);
-  process.exitCode = 1;
+  throw error;
 }
 
 // ─────────────────────── 无直连 shared 静态断言 ───────────────────────

--- a/packages/dsh-codegraph/test/service-consumer.test.ts
+++ b/packages/dsh-codegraph/test/service-consumer.test.ts
@@ -1,0 +1,189 @@
+/**
+ * dsh-codegraph — mcp-manager 服务消费方契约测试（issue #476，service-consumer）。
+ *
+ * 消费方合规锁（codegraph 经 mcp-manager **公开入口**消费 ctx.mcpManager 服务）：
+ * 1. 编译期：经 `@wingsky-1/dsh-mcp-manager` 公开入口（exports["./types"] →
+ *    lib/index.d.ts → service.d.ts → shared 单一事实源）强类型 import
+ *    `McpManagerService`/`McpManagerServerInput`，对 mock 服务做**类型化调用**
+ *    （registerServer 携带 toolDefinitions + description、getStatus 收窄、
+ *    unregisterServer）——消费面类型演进不同步（方法被删/签名变更）→ 本文件
+ *    被 tsc 编译即红。类型断言在 Node 直跑时擦除，须由编译面执行（接线：
+ *    scripts/test/service-contract-wiring.test.ts spawn tsc -p test/tsconfig.json）。
+ * 2. 静态锁：src 无直连 `shared/` 引用（消费入口合规）；依赖解析链
+ *    （devDep workspace:* + 公开入口 types 指向 lib/index.d.ts）存在。
+ * 3. 运行时：mock 服务记录类型化调用并回放契约返回——注册/注销路径的
+ *    「调用形状」在 smoke 运行时同样被执行（本文件被 test/smoke.ts import）。
+ *
+ * 红线（#476）：不改 shared 契约层、不改两包 src——本文件只锁消费现状。
+ * 无 @ts-nocheck：编译期断言必须真实参与类型检查。
+ */
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+// 消费方视角：与 src/index.ts 同款公开入口（真实依赖解析链：workspace devDep +
+// exports["./types"]）。共享类型不在此入口导出（仅 ServerInput/Service 两型），
+// 结构经 McpManagerService 的方法签名闭包可达。
+import type { McpManagerServerInput, McpManagerService } from "@wingsky-1/dsh-mcp-manager";
+import type { ToolDefinition } from "@deepseek-ai/dsh-tools";
+
+// ─────────────────────── 编译期消费面类型断言区 ───────────────────────
+type Assert<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+
+// 公开入口导出的两个类型存在（解析失败/入口断链 → import 即编译红，此处显式锚定）。
+type _HasServerInput = Assert<Equal<McpManagerServerInput["transport"], "stdio" | "streamable-http">>;
+type _HasService = Assert<McpManagerService extends { list(): readonly unknown[] } ? true : false>;
+// 消费用方法面锚定（registerServer 返回结构 / getStatus 可空 / 注销 void）。
+// 注：查询面返回类型（McpServerSummary/McpToolInfo）不在公开入口具名导出——消费
+// 方只经方法签名闭包感知其结构；此处用结构锚（ReturnType 形状）断言，不具名引用。
+type _HasRegisterReturn = Assert<Equal<Awaited<ReturnType<McpManagerService["registerServer"]>>, { name: string; existing: boolean }>>;
+type _HasGetStatus = Assert<
+  ReturnType<McpManagerService["getStatus"]> extends { name: string; status: string; tools: string[] } | undefined
+    ? true
+    : false
+>;
+type _HasUnregister = Assert<Equal<ReturnType<McpManagerService["unregisterServer"]>, Promise<void>>>;
+
+// 消费侧类型化调用编译锚（mock 服务 + 真实输入结构；调用面不同步 → 编译红）。
+declare const mock: McpManagerService;
+const serverInput: McpManagerServerInput = {
+  name: "codegraph",
+  transport: "stdio",
+  description: "codegraph 本地代码图谱",
+  command: "codegraph",
+  args: ["serve", "--mcp"],
+  toolCallTimeoutMs: 60000,
+  reconnect: {},
+  // toolDefinitions 形状与消费侧一致：封装工具定义数组（name/description/…）。
+  toolDefinitions: [] as ToolDefinition[],
+};
+async function consumeLikeCodegraph(): Promise<void> {
+  const { existing } = await mock.registerServer(serverInput);
+  const status = mock.getStatus("codegraph");
+  if (status !== undefined && status.status === "failed") {
+    void status.error;
+  }
+  await mock.unregisterServer("codegraph");
+  void existing;
+}
+
+// ─────────────────────── 运行时调用形状断言区 ───────────────────────
+// 构造可记录调用的 mock McpManagerService（结构上满足公开入口类型）。
+type RecordingService = McpManagerService & { __calls: string[] };
+function makeRecordingService(): RecordingService {
+  const calls: string[] = [];
+  const service: McpManagerService = {
+    registerServer: async (server) => {
+      calls.push(`registerServer(${server.name}, transport=${server.transport}, toolDefinitions=${server.toolDefinitions?.length ?? 0})`);
+      return { name: server.name, existing: false };
+    },
+    unregisterServer: async (name) => {
+      calls.push(`unregisterServer(${name})`);
+    },
+    connect: async (name) => {
+      calls.push(`connect(${name})`);
+    },
+    disconnect: async (name) => {
+      calls.push(`disconnect(${name})`);
+    },
+    reconnect: async (name) => {
+      calls.push(`reconnect(${name})`);
+    },
+    getStatus: (name) => {
+      calls.push(`getStatus(${name})`);
+      return undefined;
+    },
+    getTools: (name) => {
+      calls.push(`getTools(${name})`);
+      return [];
+    },
+    list: () => {
+      calls.push("list()");
+      return [];
+    },
+  };
+  return Object.assign(service, { __calls: calls }) as RecordingService;
+}
+
+// 顶层立即执行（被 smoke.ts import 即运行；与 mcp-manager 契约测试同形态）。
+try {
+  const recording = makeRecordingService();
+  // 复刻 codegraph src/index.ts 的消费序列（#363 补充 3 + #417 A2）：
+  // registerServer（携带 toolDefinitions+description）→ getStatus 收窄 → unregisterServer。
+  const input: McpManagerServerInput = {
+    name: "codegraph",
+    description: "codegraph 本地代码图谱：结构类查询",
+    transport: "stdio",
+    command: "codegraph",
+    args: ["serve", "--mcp"],
+    toolCallTimeoutMs: 60000,
+    reconnect: {},
+    toolDefinitions: [{ name: "codegraph_explore", description: "探索" }] as ToolDefinition[],
+  };
+  const { existing } = await recording.registerServer(input);
+  assert.equal(existing, false);
+  const status = recording.getStatus("codegraph");
+  assert.equal(status, undefined);
+  await recording.unregisterServer("codegraph");
+  assert.deepEqual(recording.__calls, [
+    "registerServer(codegraph, transport=stdio, toolDefinitions=1)",
+    "getStatus(codegraph)",
+    "unregisterServer(codegraph)",
+  ]);
+  console.log("  ok   service-consumer: 消费方类型化调用形状与契约一致（registerServer/getStatus/unregisterServer）");
+} catch (error) {
+  console.error(`  FAIL service-consumer: ${(error as Error).message}`);
+  process.exitCode = 1;
+}
+
+// ─────────────────────── 无直连 shared 静态断言 ───────────────────────
+// codegraph src 消费入口必须走包公开入口，禁止直连 shared/ 类型文件。
+// （放行注释内的命中——import 语句剔除行注释/块注释后匹配。）
+{
+  const pkgDir2 = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const srcDir = join(pkgDir2, "src");
+  const offenders: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(p);
+      } else if (/\.ts$/.test(entry.name)) {
+        const text = readFileSync(p, "utf8");
+        const code = text.replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, "");
+        for (const line of code.split("\n")) {
+          if (/from\s+["']\.{1,2}\/.*shared\//.test(line) || /import\s*\(\s*["'][^"']*shared\//.test(line)) {
+            offenders.push(`${p}: ${line.trim()}`);
+          }
+        }
+      }
+    }
+  };
+  walk(srcDir);
+  assert.deepEqual(offenders, [], "codegraph src 不得直连 shared/（消费入口必须走 @wingsky-1/dsh-mcp-manager 公开入口）");
+  console.log("  ok   service-consumer: codegraph src 无直连 shared/ 引用");
+}
+
+// ─────────────────────── 依赖解析链断言 ───────────────────────
+{
+  const pkgDir3 = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const pkgJson = JSON.parse(readFileSync(join(pkgDir3, "package.json"), "utf8")) as {
+    devDependencies?: Record<string, string>;
+    exports?: Record<string, { types?: string; default?: string } | string>;
+  };
+  // devDep 声明 workspace:*（依赖解析链源头）。
+  const dep = pkgJson.devDependencies?.["@wingsky-1/dsh-mcp-manager"];
+  assert.ok(dep !== undefined, "codegraph devDependencies 应声明 @wingsky-1/dsh-mcp-manager");
+  assert.ok(dep === "workspace:*", `codegraph 应声明 workspace:* 协议（实际 ${dep}）`);
+  // 公开入口 types 指向 lib/index.d.ts（解析链末端存在）。
+  const typesTarget =
+    typeof pkgJson.exports?.["."] === "string"
+      ? pkgJson.exports?.["."]
+      : (pkgJson.exports?.["."] as { types?: string } | undefined)?.types;
+  assert.ok(typeof typesTarget === "string" && typesTarget.endsWith("lib/index.d.ts"), "exports[.] 应含指向 lib/index.d.ts 的 types 条件");
+  assert.ok(existsSync(join(pkgDir3, typesTarget as string)), `类型入口文件应存在（${typesTarget}）`);
+  console.log("  ok   service-consumer: 依赖解析链完整（devDep workspace:* + exports[.].types → lib/index.d.ts）");
+}

--- a/packages/dsh-codegraph/test/smoke.ts
+++ b/packages/dsh-codegraph/test/smoke.ts
@@ -25,6 +25,11 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 
+// 服务消费方契约门禁（#476）：codegraph 经 mcp-manager 公开入口的类型化调用
+// 形状 + 无直连 shared + 依赖解析链（运行时断言；编译期断言经 scripts/test/
+// service-contract-wiring.test.ts 的 tsc 编译面执行）
+import "./service-consumer.test.ts";
+
 const pkgDir = join(new URL("..", import.meta.url).pathname);
 const mod = await import(pathToFileURL(join(pkgDir, "lib/index.js")).href);
 const { apply, name, inject } = mod;

--- a/packages/dsh-codegraph/test/tsconfig.json
+++ b/packages/dsh-codegraph/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/packages/dsh-mcp-manager/test/service-contract.test.ts
+++ b/packages/dsh-mcp-manager/test/service-contract.test.ts
@@ -1,0 +1,267 @@
+/**
+ * dsh-mcp-manager — 核心服务契约独立门禁（issue #476，service-contract）。
+ *
+ * 背景：`ctx.mcpManager` 服务类型面（shared/mcp-manager-service.d.ts）是单一
+ * 事实源，但提供方 apply.ts 的 provide 对象方法全是宽面签名（string /
+ * Record<string, unknown>），与类型面无编译期锚点；此前「契约签名变更未同步
+ * 测试」纯靠人工，改 shared 类型不触发任何检查（skipLibCheck + 消费方 import
+ * 不炸即绿）。
+ *
+ * 本文件 = 契约锁（tsd 风格零依赖双层）：
+ * 1. 编译期：测试内**自含契约签名清单**（下方类型区），与 shared 类型面逐方法 /
+ *    逐字段 `Equal` 精确比对——shared 类型漂移（改参/改返/删字段/加方法）→
+ *    本文件被 tsc 编译即红。本文件的类型断言在 Node 直跑（type stripping）时
+ *    被擦除，因此必须由编译面执行（接线见文件头注释链：scripts/test/
+ *    service-contract-wiring.test.ts spawn tsc -p test/tsconfig.json）。
+ * 2. 运行时：静态读取 apply.ts 源文本，提取 `ctx.provide("mcpManager", {...})`
+ *    对象的方法名集合 + 参数个数/可选位，与契约清单比对（不多不少）——提供方
+ *    删方法/改参数形状逃过 tsc 宽面签名时红。本文件被 test/smoke.ts import，
+ *    随 `pnpm test` 执行。
+ *
+ * 红线（#476）：不改 shared 契约层、不改两包 src——本文件只锁现状。
+ * 无 @ts-nocheck：编译期断言必须真实参与类型检查。
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+// 提供方视角（与 src/service.ts 同款相对路径）：shared 类型面单一事实源。
+import type {
+  McpManagerServerInput,
+  McpManagerService,
+  McpScope,
+  McpServerStatus,
+  McpServerSummary,
+  McpToolInfo,
+} from "../../../shared/mcp-manager-service.js";
+import type { ToolDefinition } from "@deepseek-ai/dsh-tools";
+
+// ─────────────────────────── 编译期类型断言区 ───────────────────────────
+// tsd 风格零依赖类型原语（自实现，不引第三方）。
+type Assert<T extends true> = T;
+/** 精确相等（含可选性/联合分布）。tsd 风格；用于字面量联合与函数类型。 */
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+/**
+ * 结构互含（双向子型）。interface 类型与匿名对象字面量的 tsd-Equal 存在
+ * TypeScript 表示层边界（实测 TS7.0 下 interface 整体 Equal 匿名对象会误红），
+ * 故对象结构断言用「双向 extends」替代：删字段/改字段类型/改联合/改方法签名
+ * 任意单向漂移都会破坏某一方向的子型关系 → 红。可选性语义上等价的边缘形态
+ * （`a?: T` vs `a: T | undefined`）不区分，属非破坏性漂移，可接受。
+ */
+type Same<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+// 类型面：6 个导出类型自含清单（与 shared/mcp-manager-service.d.ts 逐项比对；
+// 结构漂移 → 编译红）。标量/联合用 Equal 精确锁，对象结构用 Same 双向锁。
+type _SvcStatus = Assert<Equal<McpServerStatus, "connected" | "connecting" | "reconnecting" | "disabled" | "stopped" | "failed">>;
+type _SvcScope = Assert<Equal<McpScope, "global" | "project">>;
+type _SvcSummary = Assert<
+  Same<
+    McpServerSummary,
+    {
+      name: string;
+      transport: "stdio" | "streamable-http";
+      scope: McpScope;
+      status: McpServerStatus;
+      error?: string;
+      tools: string[];
+      enabled: boolean;
+    }
+  >
+>;
+type _SvcToolInfo = Assert<Same<McpToolInfo, { name: string; description?: string }>>;
+type _SvcServerInput = Assert<
+  Same<
+    McpManagerServerInput,
+    {
+      name: string;
+      transport: "stdio" | "streamable-http";
+      command?: string;
+      args?: string[];
+      url?: string;
+      headers?: Record<string, string>;
+      env?: Record<string, string>;
+      cwd?: string;
+      enabled?: boolean;
+      toolCallTimeoutMs?: number;
+      reconnect?: Record<string, unknown>;
+      description?: string;
+      toolDefinitions?: ToolDefinition[];
+    }
+  >
+>;
+
+// 服务面：8 方法签名的自含清单（函数类型，Equal 精确锁：改参/改返/删方法 → 红）。
+type _SvcRegister = Assert<
+  Equal<
+    McpManagerService["registerServer"],
+    (server: McpManagerServerInput) => Promise<{ name: string; existing: boolean }>
+  >
+>;
+type _SvcUnregister = Assert<Equal<McpManagerService["unregisterServer"], (name: string) => Promise<void>>>;
+type _SvcConnect = Assert<Equal<McpManagerService["connect"], (name: string, scope?: McpScope) => Promise<void>>>;
+type _SvcDisconnect = Assert<Equal<McpManagerService["disconnect"], (name: string, scope?: McpScope) => Promise<void>>>;
+type _SvcReconnect = Assert<Equal<McpManagerService["reconnect"], (name: string, scope?: McpScope) => Promise<void>>>;
+type _SvcGetStatus = Assert<Equal<McpManagerService["getStatus"], (name: string) => McpServerSummary | undefined>>;
+type _SvcGetTools = Assert<Equal<McpManagerService["getTools"], (name: string) => McpToolInfo[]>>;
+type _SvcList = Assert<Equal<McpManagerService["list"], () => McpServerSummary[]>>;
+
+// 服务接口总键集（方法名不多不少，与运行时断言同一清单源）。
+type _SvcKeys = Assert<Equal<keyof McpManagerService, "registerServer" | "unregisterServer" | "connect" | "disconnect" | "reconnect" | "getStatus" | "getTools" | "list">>;
+// 数据类型总键集（字段增减锁：漏加/漏删字段 → 红）。
+type _ServerInputKeys = Assert<
+  Equal<
+    keyof McpManagerServerInput,
+    "name" | "transport" | "command" | "args" | "url" | "headers" | "env" | "cwd" | "enabled" | "toolCallTimeoutMs" | "reconnect" | "description" | "toolDefinitions"
+  >
+>;
+type _SummaryKeys = Assert<Equal<keyof McpServerSummary, "name" | "transport" | "scope" | "status" | "error" | "tools" | "enabled">>;
+
+// ─────────────────────────── 运行时方法面断言区 ───────────────────────────
+// 契约清单（方法名 + 参数个数 + 可选参数个数）。单一事实源：与上方编译期清单
+// 同源同序；提供方 apply.ts 的 provide 对象若删方法/加方法/改参数形状 → 红。
+const CONTRACT_METHODS: ReadonlyArray<{ name: string; paramCount: number; optionalCount: number }> = [
+  { name: "registerServer", paramCount: 1, optionalCount: 0 },
+  { name: "unregisterServer", paramCount: 1, optionalCount: 0 },
+  { name: "connect", paramCount: 2, optionalCount: 1 },
+  { name: "disconnect", paramCount: 2, optionalCount: 1 },
+  { name: "reconnect", paramCount: 2, optionalCount: 1 },
+  { name: "getStatus", paramCount: 1, optionalCount: 0 },
+  { name: "getTools", paramCount: 1, optionalCount: 0 },
+  { name: "list", paramCount: 0, optionalCount: 0 },
+];
+
+const pkgDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * 从 apply.ts 源文本提取 provide("mcpManager", {...}) 对象的方法面。
+ * 说明：provide 对象字面量未导出、且 apply.ts 导入链重（不 import 运行时），
+ * 故用源文本级静态提取（v2 方案「c 兜底」层级：方法名存在性 + 参数形状即可抓
+ * 删方法/改参数量；不做 AST 级双真源）。括号配对跳过字符串与注释，防方法体
+ * 内大括号干扰对象边界。
+ */
+function extractProvidedServiceMethods(): Array<{ name: string; paramCount: number; optionalCount: number }> {
+  const src = readFileSync(join(pkgDir, "src", "apply.ts"), "utf8");
+  const marker = 'provide("mcpManager", {';
+  const markerIndex = src.indexOf(marker);
+  assert.ok(markerIndex >= 0, "apply.ts 应包含 ctx.provide(\"mcpManager\", {...}) 服务注入");
+
+  // 括号配对扫描：找到 provide 对象的完整区间（跳过字符串字面量与注释）。
+  const skip = (s: string, i: number): number => {
+    const c = s[i];
+    if (c === '"' || c === "'") {
+      const quote = c;
+      i += 1;
+      while (i < s.length) {
+        if (s[i] === "\\") { i += 2; continue; }
+        if (s[i] === quote) return i + 1;
+        i += 1;
+      }
+      return i;
+    }
+    if (c === "`") {
+      i += 1;
+      while (i < s.length) {
+        if (s[i] === "\\") { i += 2; continue; }
+        if (s[i] === "`") return i + 1;
+        if (s[i] === "$" && s[i + 1] === "{") {
+          // 模板插值内可能含括号——保守跳过到配对的 }（简单计数，测试源无嵌套插值）
+          let depth = 1;
+          i += 2;
+          while (i < s.length && depth > 0) {
+            if (s[i] === "{") depth += 1;
+            else if (s[i] === "}") depth -= 1;
+            i += 1;
+          }
+          continue;
+        }
+        i += 1;
+      }
+      return i;
+    }
+    if (c === "/" && s[i + 1] === "/") {
+      const nl = s.indexOf("\n", i);
+      return nl < 0 ? s.length : nl + 1;
+    }
+    if (c === "/" && s[i + 1] === "*") {
+      const end = s.indexOf("*/", i + 2);
+      return end < 0 ? s.length : end + 2;
+    }
+    return i;
+  };
+
+  let depth = 0;
+  let bodyStart = -1;
+  let bodyEnd = -1;
+  let i = markerIndex + marker.length - 1; // 指向 '{'
+  while (i < src.length) {
+    if (src[i] === "{" || src[i] === "}") {
+      depth += src[i] === "{" ? 1 : -1;
+      if (bodyStart < 0) bodyStart = i + 1;
+      if (depth === 0) {
+        bodyEnd = i;
+        break;
+      }
+      i += 1;
+      continue;
+    }
+    const next = skip(src, i);
+    i = next > i ? next : i + 1;
+  }
+  assert.ok(bodyStart >= 0 && bodyEnd > bodyStart, "provide 对象区间应可完整配对");
+  const body = src.slice(bodyStart, bodyEnd);
+
+  const methods: Array<{ name: string; paramCount: number; optionalCount: number }> = [];
+  // 顶层方法键行：`<key>: (<params>) => ...`（注释行以 / 开头天然不命中）。
+  const keyRe = /^\s*([A-Za-z_$][\w$]*)\s*:\s*\(([^)]*)\)\s*=>/gm;
+  let m: RegExpExecArray | null;
+  while ((m = keyRe.exec(body)) !== null) {
+    const params = m[2].trim();
+    const optionalCount = (params.match(/\?/g) ?? []).length;
+    // 参数按「顶层逗号」分割：类型标注里的泛型/对象字面量逗号（如
+    // `Record<string, unknown>`）不计入参数个数。
+    let paramCount = 0;
+    let depth = 0;
+    for (const ch of params) {
+      if (ch === "<" || ch === "[" || ch === "{") depth += 1;
+      else if (ch === ">" || ch === "]" || ch === "}") depth -= 1;
+      else if (ch === "," && depth === 0) paramCount += 1;
+    }
+    if (params !== "") paramCount += 1;
+    methods.push({ name: m[1], paramCount, optionalCount });
+  }
+  return methods;
+}
+
+// 顶层立即执行（被 smoke.ts import 即运行；不依赖 node:test runner——
+// 与同目录 unit-*.test.ts 的执行形态一致）。失败置 exitCode 并打印 FAIL，
+// 不中断 smoke 其余检查，但 `pnpm test` 最终退出码红。
+try {
+  const provided = extractProvidedServiceMethods();
+  const contractNames = CONTRACT_METHODS.map((x) => x.name);
+  const providedNames = provided.map((x) => x.name);
+  assert.deepEqual(
+    [...providedNames].sort(),
+    [...contractNames].sort(),
+    "apply.ts provide(\"mcpManager\") 方法名集合应与契约清单一致（不多不少）",
+  );
+  for (const expected of CONTRACT_METHODS) {
+    const actual = provided.find((x) => x.name === expected.name);
+    assert.ok(actual, `provide 对象应含契约方法 ${expected.name}`);
+    assert.equal(
+      actual.paramCount,
+      expected.paramCount,
+      `provide.${expected.name} 参数个数应与契约一致（契约=${expected.paramCount}）`,
+    );
+    assert.equal(
+      actual.optionalCount,
+      expected.optionalCount,
+      `provide.${expected.name} 可选参数个数应与契约一致（契约=${expected.optionalCount}）`,
+    );
+  }
+  console.log("  ok   service-contract: apply.ts provide 方法面与契约清单一致（8 方法/参数形状）");
+} catch (error) {
+  console.error(`  FAIL service-contract: ${(error as Error).message}`);
+  process.exitCode = 1;
+}

--- a/packages/dsh-mcp-manager/test/service-contract.test.ts
+++ b/packages/dsh-mcp-manager/test/service-contract.test.ts
@@ -143,6 +143,10 @@ const pkgDir = join(dirname(fileURLToPath(import.meta.url)), "..");
  */
 function extractProvidedServiceMethods(): Array<{ name: string; paramCount: number; optionalCount: number }> {
   const src = readFileSync(join(pkgDir, "src", "apply.ts"), "utf8");
+  // 锚定首个 `provide("mcpManager", {` marker（非 AST——测试刻意不做解析级双真源，
+  // 方法名存在性 + 参数个数即可抓「删方法/改参数量」）。当前 apply.ts 全文件仅此
+  // 一处该形态调用，indexOf 首个命中即目标；若未来 apply.ts 出现多处 provide
+  // 调用或形态变化导致本提取失配，测试会红并提示人工更新（fail-loud，不静默）。
   const marker = 'provide("mcpManager", {';
   const markerIndex = src.indexOf(marker);
   assert.ok(markerIndex >= 0, "apply.ts 应包含 ctx.provide(\"mcpManager\", {...}) 服务注入");
@@ -235,8 +239,11 @@ function extractProvidedServiceMethods(): Array<{ name: string; paramCount: numb
 }
 
 // 顶层立即执行（被 smoke.ts import 即运行；不依赖 node:test runner——
-// 与同目录 unit-*.test.ts 的执行形态一致）。失败置 exitCode 并打印 FAIL，
-// 不中断 smoke 其余检查，但 `pnpm test` 最终退出码红。
+// 与同目录 unit-*.test.ts 的执行形态一致）。
+// 失败处理：打印 FAIL 后 **throw 原错误**（不置 exitCode 吞掉）——宿主
+// smoke.ts 成功路径末尾无条件 process.exit(0)（#218 防挂起），若此处只置
+// process.exitCode=1 会被 exit(0) 覆盖成假绿（复核闸 P0-1 实证）；顶层抛错
+// 会沿 import 链冒泡终止 smoke → 进程退出码非 0 真红（与 unit 文件同形态）。
 try {
   const provided = extractProvidedServiceMethods();
   const contractNames = CONTRACT_METHODS.map((x) => x.name);
@@ -263,5 +270,5 @@ try {
   console.log("  ok   service-contract: apply.ts provide 方法面与契约清单一致（8 方法/参数形状）");
 } catch (error) {
   console.error(`  FAIL service-contract: ${(error as Error).message}`);
-  process.exitCode = 1;
+  throw error;
 }

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -77,6 +77,10 @@ import {
   assertSupportedOutputSchema,
 } from "../lib/index.js";
 
+// 服务契约门禁（#476）：apply.ts provide 方法面与 shared 类型面契约清单一致
+// （运行时方法名/参数形状断言；编译期类型断言经 scripts/test/
+// service-contract-wiring.test.ts 的 tsc 编译面执行）
+import "./service-contract.test.ts";
 // 结构化单元测试（#82 批次 1：清零未覆盖 CRAP 超阈热点）
 import "./unit-shared.test.ts";
 import "./unit-manager.test.ts";

--- a/scripts/test/service-contract-wiring.test.ts
+++ b/scripts/test/service-contract-wiring.test.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * mcp-manager-service 契约测试编译面接线（issue #476 service-contract）。
+ *
+ * 为什么存在：shared/mcp-manager-service.d.ts 是 ctx.mcpManager 服务类型面的
+ * 单一事实源，但提供方/消费方包的主 tsconfig（include src/**）不编译 test/，
+ * `pnpm typecheck`/`pnpm build` 的 tsc 面到不了契约测试文件；而 `pnpm test`/
+ * `pnpm test:scripts` 都是 Node 直跑 TS（type stripping 擦除类型断言）——若只
+ * 靠直跑，编译期 Equal/Same 断言是「假锁」（方案评审 P0-A 已实证）。
+ *
+ * 本文件 = 编译面接线器：spawn 仓库 tsc 以两包 test/tsconfig.json（noEmit，
+ * include 全量测试 ts）真实编译契约测试文件，断言退出码 0。类型断言失败 →
+ * tsc 非 0 → 本测试红。随 `pnpm test:scripts`（repo-gate 无条件步骤）执行，
+ * CI/本地对「shared 类型面 ↔ 契约测试清单」漂移零成本判红。
+ *
+ * 接线对象：
+ *   - packages/dsh-mcp-manager/test/tsconfig.json（既有文件，此前零引用）
+ *   - packages/dsh-codegraph/test/tsconfig.json（#476 同构新建）
+ * 两包测试文件均无 @ts-nocheck，类型断言真实参与检查。
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = join(import.meta.dirname, '..', '..')
+// tsc 真实 JS 入口（node_modules/.bin/tsc 是 shell shim，不能经 node 执行；
+// 用 typescript 包内的 bin 入口，node 直接加载）。
+const TSC = join(ROOT, 'node_modules', 'typescript', 'bin', 'tsc')
+
+const SUITES = [
+  {
+    name: 'dsh-mcp-manager（提供方契约 + apply provide 方法面）',
+    tsconfig: join(ROOT, 'packages', 'dsh-mcp-manager', 'test', 'tsconfig.json'),
+    expectFiles: ['service-contract.test.ts'],
+  },
+  {
+    name: 'dsh-codegraph（消费方公开入口契约）',
+    tsconfig: join(ROOT, 'packages', 'dsh-codegraph', 'test', 'tsconfig.json'),
+    expectFiles: ['service-consumer.test.ts'],
+  },
+]
+
+test('service-contract 编译面接线：契约测试文件被 tsc 真实编译（#476）', () => {
+  assert.ok(existsSync(TSC), `仓库 tsc 应存在（${TSC}）——pnpm install 后才有`)
+  for (const suite of SUITES) {
+    assert.ok(existsSync(suite.tsconfig), `tsconfig 应存在（${suite.tsconfig}）`)
+    for (const file of suite.expectFiles) {
+      const f = join(suite.tsconfig, '..', file)
+      assert.ok(existsSync(f), `契约测试文件应存在（${f}）`)
+    }
+    const result = spawnSync(process.execPath, [TSC, '-p', suite.tsconfig, '--noEmit'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      timeout: 120000,
+    })
+    assert.strictEqual(
+      result.status,
+      0,
+      `${suite.name}：tsc 编译契约测试失败（exit=${result.status}）——shared 类型面与契约测试清单漂移？\n${result.stdout}\n${result.stderr}`,
+    )
+    assert.ok(result.stdout.length >= 0)
+  }
+})

--- a/scripts/test/service-contract-wiring.test.ts
+++ b/scripts/test/service-contract-wiring.test.ts
@@ -63,6 +63,5 @@ test('service-contract 编译面接线：契约测试文件被 tsc 真实编译�
       0,
       `${suite.name}：tsc 编译契约测试失败（exit=${result.status}）——shared 类型面与契约测试清单漂移？\n${result.stdout}\n${result.stderr}`,
     )
-    assert.ok(result.stdout.length >= 0)
   }
 })


### PR DESCRIPTION
## 概要

mcp-manager-service 契约（`ctx.mcpManager`，单一事实源 `shared/mcp-manager-service.d.ts`）此前**无独立门禁**：改 shared 类型不触发任何检查（skipLibCheck + 消费方 import 不炸即绿），提供方 `apply.ts` provide 对象全是宽面签名、与类型面无编译期锚点。本 PR 按 issue #476 方案 v2（对抗评审后 P0-A 裁决 = 包内测试落点）实施 **service-contract 独立门禁**：提供方契约锁 + 消费方契约锁，双层（编译期类型断言 + 运行时方法面断言）。

**红线遵守**：不改 `.github/`、`package.json`、`pnpm-lock.yaml`、`shared/` 契约层、两包 src——纯新增 6 文件（5 测试/接线 + 1 同构 tsconfig）。

## 接线设计（重要：编译期断言如何被真实执行）

仓库现实（已勘察实证）：两包主 tsconfig（build/typecheck 共用）`include: src/**` 编译面**到不了 test/**；`pnpm test`/`pnpm test:scripts` 是 Node 直跑 TS（type stripping 擦除类型断言）——若只靠 smoke import，Equal/Same 断言是假锁（方案 P0-A 已指出）。npm 包 package.json 为红线禁改，无法给 typecheck 脚本加 `-p test/tsconfig.json`。

因此新增 **`scripts/test/service-contract-wiring.test.ts` 编译面接线器**：node:test + spawn 仓库 tsc，以两包 `test/tsconfig.json`（noEmit，include 全量测试 ts）**真实编译**契约测试文件，断言退出码 0。类型断言失败 → tsc 非 0 → 接线测试红。接线器随 `pnpm test:scripts` 执行（`node --test scripts/test/*.test.ts` glob 自动收录），CI repo-gate 的 `pnpm test:scripts`（ci.yml:622）**无条件必跑**——shared 类型面与契约清单漂移在 PR/本地零成本判红。

运行时断言接线：两包 `test/smoke.ts` 顶部 `import` 契约测试文件（既有 unit 同款执行形态），随 `pnpm test` 执行。

> 验收 4 反证命令说明：任务书「改 shared getStatus 返回 → mcp-manager typecheck 红」在红线内无法成立（typecheck 编译面 = src only 正是本契约缺口本质，`typecheck` 仍全绿=src 面不锚定 shared 类型）；反证等价路径为 **test:scripts（tsc 编译面）红**，见下。

## 全量断言表（对照 issue #476 方案 v2 验收清单）

| 验收条目（v2） | 结论 | 证据 |
|---|---|---|
| 硬性 1：新增 `packages/dsh-mcp-manager/test/service-contract.test.ts`（无 @ts-nocheck），编译期类型断言 + 运行时方法面断言通过 | PASS | 文件存在无 @ts-nocheck；`tsc -p packages/dsh-mcp-manager/test/tsconfig.json --noEmit` 退出 0；`node packages/dsh-mcp-manager/test/service-contract.test.ts` 退出 0（`ok service-contract: apply.ts provide 方法面与契约清单一致（8 方法/参数形状）`）；`pnpm --filter @wingsky-1/dsh-mcp-manager test` 全绿 |
| 硬性 2：新增 `packages/dsh-codegraph/test/service-consumer.test.ts`（无 @ts-nocheck），消费方公开入口类型化调用 + 无直连 shared 断言通过 | PASS | 文件存在无 @ts-nocheck；`tsc -p packages/dsh-codegraph/test/tsconfig.json --noEmit` 退出 0；`node packages/dsh-codegraph/test/service-consumer.test.ts` 退出 0（3 项 ok）；`pnpm --filter @wingsky-1/dsh-codegraph test` 全绿 |
| 硬性 3：人为改 shared 类型测试红 | PASS | 反证实测：`getStatus` 返回去掉 `\| undefined` → mcp-manager test tsc 报 `service-contract.test.ts(106,29) TS2344`、codegraph test tsc 报 1 error；还原后全绿（未提交） |
| 硬性 4：人为改 provide 对象测试红 | PASS | 反证实测（复核 P0-1 修复后，退出码实证）：删 `getTools` → `pnpm test`（mcp-manager smoke）**exit 1**（FAIL 方法名集合不一致）；`registerServer` 加第二必选参 → **exit 1**（FAIL 参数个数 2!==1）；还原后 exit 0 |
| 硬性 5：消费侧类型演进红 | PASS | 反证实测：`mock.nonexistentMethod("x")` → codegraph test tsc 报 `TS2339: Property 'nonexistentMethod' does not exist on type 'McpManagerService'`；还原后全绿 |
| 硬性 6：CI 收录验证 | PASS | 接线器经 `pnpm test:scripts`（`scripts/test/*.test.ts` glob）被 CI repo-gate 无条件执行（ci.yml:622）；两包 `test/smoke.ts` import 接线 → `pnpm test` 命中包即执行 |
| 硬性 7：无 workflow 改动 | PASS | `.github/` 零 diff |
| 硬性 8：全仓无新增 @ts-nocheck | PASS | 新增 3 个测试文件均无 @ts-nocheck（仅接线器按 scripts 层惯例带 @ts-nocheck，非测试断言文件） |
| 量级 9：契约锁覆盖 | PASS | 提供方 6 类型 + 8 方法编译期清单 + 运行时 8 方法形状断言；消费方 registerServer/getStatus/unregisterServer 3 方法调用面编译断言 + 静态锁（无直连 shared + 依赖解析链） |
| 量级 10：门禁增量耗时 | PASS | 接线器 tsc 编译两包 < 0.5s；`pnpm test:scripts` 全量 83 tests 1.0s；反证/全量均无 dsh 启动、零网络 |

## 反证路径设计（qa 复验指引）

| 反证 | 破坏动作（worktree 临时） | 预期红 | 实测 |
|---|---|---|---|
| R1 类型面漂移 | shared getStatus 返回 `McpServerSummary`（去 `\| undefined`） | `pnpm test:scripts` 红（tsc 编译 service-contract.test.ts TS2344 + codegraph TS error） | ✔（已还原） |
| R2 类型面字段增减 | shared McpServerSummary 加字段 `extra: string` | 同上（结构 Same + keyof 双断言红） | ✔（已还原） |
| R3 提供方删方法 | apply.ts provide 删 `getTools` | `pnpm test`（mcp-manager smoke）红：方法名集合不一致 | ✔ 实测 **SMOKE_EXIT=1**（FAIL 方法名集合不一致；P0-1 修复前假绿 0）已还原 |
| R4 提供方改参数量 | apply.ts registerServer 加第二必选参 | `pnpm test` 红：参数个数 2!==1 | ✔ 实测 **SMOKE_EXIT=1**（FAIL 参数个数 2!==1；P0-1 修复前假绿 0）已还原 |
| R5 消费方调不存在方法 | service-consumer.test.ts 加 `mock.nonexistentMethod()` | `pnpm test:scripts` 红（TS2339） | ✔（已还原） |

## 复核 P0-1 修复记录（push 更新 #492）

复核闸发现假绿：service-contract.test.ts 顶层 try/catch 失败只置 `process.exitCode=1`，但宿主 `test/smoke.ts` 成功路径无条件 `process.exit(0)`（#218 防挂起）→ exitCode 被覆盖成 0（删 getTools / 加必选参实测 exit 0 假绿）。**修复**：catch 改 `throw error`（打印 FAIL 后沿 import 链冒泡终止 smoke → 退出码非 0 真红，与同目录 unit-*.test.ts 顶层抛错形态一致）。codegraph service-consumer.test.ts 同型隐患一并改 throw。修复后红-绿实证：删 getTools → SMOKE_EXIT=1；加必选参 → SMOKE_EXIT=1；还原后两包 smoke exit 0。同目录 unit-*.test.ts 扫描：无 process.exitCode 用法、均顶层抛错形态，无同型隐患。接线器顺带删死代码断言（P2）。

## 五连门禁 + test:scripts 本地结果

```
pnpm build        → exit 0
pnpm test         → exit 0（全包 smoke，含新契约运行时断言）
pnpm contract     → exit 0
pnpm pack:check   → exit 0
pnpm typecheck    → exit 0
pnpm test:scripts → exit 0（83 pass，含接线器）
```

Closes #476

