### PR TITLE
refactor(shared): sseData 收敛 shared/host-utils——三包同构定义消除（#472）

### DIFF
--- a/packages/dsh-mcp-manager/src/apply.ts
+++ b/packages/dsh-mcp-manager/src/apply.ts
@@ -17,7 +17,8 @@ import { defaultStorePath, McpStore } from "./store.ts";
 import { DEFAULT_RESULT_TRUNCATE_BYTES } from "./supervisor.ts";
 import { normalizeMiddlewareMode, registerMiddlewareTools } from "./middleware.ts";
 import type { MiddlewareMode } from "./middleware-types.ts";
-import { makeRoutes, makeEventsRoute, makeHealthRoute, sseData, uiConfigChangedFrame } from "./routes.ts";
+import { makeRoutes, makeEventsRoute, makeHealthRoute, uiConfigChangedFrame } from "./routes.ts";
+import { sseData } from "../../../shared/host-utils.js";
 
 /** 向 Agent 宣告插件（announceToAgent 开启时注入）。能力清单由动态目录
  * （<available_mcp_servers>，见 L1）承担，此处只保留插件存在、安全边界与术语约定，

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -170,8 +170,8 @@ export type {
   DisabledToolsMap,
 } from "./middleware.ts";
 // 路由
-export { ROUTES, makeRoutes, makeEventsRoute, makeHealthRoute, sseData, uiConfigChangedFrame, broadcastFrame, SSE_HEARTBEAT_MS, SSE_PING_FRAME } from "./routes.ts";
+export { ROUTES, makeRoutes, makeEventsRoute, makeHealthRoute, uiConfigChangedFrame, broadcastFrame, SSE_HEARTBEAT_MS, SSE_PING_FRAME } from "./routes.ts";
 export { SCOPE_GLOBAL, SCOPE_PROJECT, normalizeScope } from "./scope.ts";
-// 仓库共享层（loopback 围栏 / writeJson / readJsonBody）
+// 仓库共享层（loopback 围栏 / writeJson / readJsonBody / sseData）
 export { isLoopbackRequest } from "../../../shared/loopback.js";
-export { writeJson, readJsonBody } from "../../../shared/host-utils.js";
+export { writeJson, readJsonBody, sseData } from "../../../shared/host-utils.js";

--- a/packages/dsh-mcp-manager/src/routes.ts
+++ b/packages/dsh-mcp-manager/src/routes.ts
@@ -8,9 +8,9 @@
  * 由 lib/index.js 组合根 re-export（ROUTES / makeRoutes）。
  */
 
-// 辅助函数统一来自仓库共享层（loopback 围栏 / writeJson / readJsonBody）。
+// 辅助函数统一来自仓库共享层（loopback 围栏 / writeJson / readJsonBody / sseData）。
 import { isLoopbackRequest } from "../../../shared/loopback.js";
-import { writeJson, readJsonBody } from "../../../shared/host-utils.js";
+import { writeJson, readJsonBody, sseData } from "../../../shared/host-utils.js";
 import { parseClaudeJson } from "./import.ts";
 import { SCOPE_PROJECT, normalizeScope } from "./scope.ts";
 import { parseFullServerName, MIDDLEWARE_GLOBAL_ROOT, normalizeToolName } from "./middleware-utils.ts";
@@ -419,10 +419,8 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
 
 // --------------------------------------------------------- 状态推送（SSE）
 
-/** 序列化一帧 SSE data 行。 */
-export function sseData(payload: unknown): string {
-  return `data: ${JSON.stringify(payload)}\n\n`;
-}
+// sseData 已收敛 shared/host-utils.js（#472）：本文件经顶部共享层 import 使用，
+// 导出面由组合根 src/index.ts re-export 保持 lib/index.js 不变。
 
 /** 配置变更 SSE 帧：客户端收到后重新 GET /api/dsh-mcp/config 就地更新浮窗位置。 */
 export function uiConfigChangedFrame(): string {

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -821,6 +821,15 @@ const main = async () => {
     assert.equal(uiConfigChangedFrame(), 'data: {"type":"ui-config-changed"}\n\n');
     assert.equal(sseData({ type: "ui-config-changed" }), uiConfigChangedFrame(), "与 sseData 同构");
   });
+  // #472 收敛锚定：lib/index.js 仍可 import sseData（re-export 面不漂移），
+  // 且输出与 shared/host-utils.js 单一事实源一致（防 re-export 链被误删/改指）。
+  await checkAsync("lib/index.js 导出 sseData 且输出与 shared/host-utils.js 一致（#472）", async () => {
+    const { sseData: libSseData } = await import("../lib/index.js");
+    const { sseData: sharedSseData } = await import("../../../shared/host-utils.js");
+    assert.equal(typeof libSseData, "function", "lib/index.js 可 import sseData");
+    assert.equal(libSseData({ type: "ui-config-changed" }), sharedSseData({ type: "ui-config-changed" }));
+    assert.equal(libSseData({ type: "ping" }), 'data: {"type":"ping"}\n\n');
+  });
   check("broadcastFrame 向全部连接写帧（掉线忽略）", () => {
     const written = [];
     const conn = { write: (chunk) => { written.push(chunk); } };

--- a/packages/dsh-notifier/src/server.ts
+++ b/packages/dsh-notifier/src/server.ts
@@ -10,7 +10,7 @@ import type { ChildProcess } from "node:child_process";
 import type { ServerResponse } from "node:http";
 import type { WebRoute } from "@deepseek-ai/dsh-host-webserver";
 import { isLoopbackRequest } from "../../../shared/loopback.js";
-import { writeJson, readBody, errorMessage } from "../../../shared/host-utils.js";
+import { writeJson, readBody, errorMessage, sseData } from "../../../shared/host-utils.js";
 import type { NotifyConfig } from "./config.ts";
 import { sanitizePatchSettings, validateSettings, redactConfigView, unmaskChannels } from "./config.ts";
 import type { HistoryStore } from "./history.ts";
@@ -26,11 +26,6 @@ export const ROUTES = {
   status: "/api/dsh-notifier/status",
   kinds: "/api/dsh-notifier/kinds",
 };
-
-/** SSE 帧。 */
-function sseData(payload: unknown): string {
-  return `data: ${JSON.stringify(payload)}\n\n`;
-}
 
 /** 写失败判死阈值：连续 ≥3 次写不动即销毁（理论 throw 兜底路径）。
  *  注意：真实 ServerResponse 对已断对端 write() 几乎不抛错（数据静默入队），

--- a/packages/dsh-notifier/test/routes.test.ts
+++ b/packages/dsh-notifier/test/routes.test.ts
@@ -37,6 +37,13 @@ try {
   const kindsRoute = routes.find((r) => r.path === ROUTES.kinds);
   assert.ok(configRoute && eventsRoute && healthRoute && testRoute && historyRoute && statusRoute && kindsRoute, "七条路由已注册（M2 增 status/kinds）");
 
+  // #472 收敛锚定：sseData 收敛 shared/host-utils.js 后 notifier 导出面不变——
+  // lib/index.js 不得新增 sseData 导出（现状从不导出，防未来误加导出面漂移）。
+  {
+    const lib = await import("../lib/index.js");
+    assert.ok(!("sseData" in lib), "lib/index.js 不得可见 sseData（notifier 从不导出该符号）");
+  }
+
   // 403（J1）——含 M2 新路由（围栏必项，评审缺口项）
   for (const route of [configRoute, eventsRoute, healthRoute, testRoute, historyRoute, statusRoute, kindsRoute]) {
     const { rec, res } = makeRes();

--- a/packages/dsh-provider-usage/src/apply.ts
+++ b/packages/dsh-provider-usage/src/apply.ts
@@ -22,7 +22,7 @@ import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { isLoopbackRequest } from "../../../shared/loopback.js";
-import { writeJson, readJsonBody, errorMessage } from "../../../shared/host-utils.js";
+import { writeJson, readJsonBody, errorMessage, sseData } from "../../../shared/host-utils.js";
 import { installSettingsNamespace } from "../../../shared/settings-namespace.js";
 import { Mutex } from "async-mutex";
 import type { Context } from "@deepseek-ai/cordis";
@@ -41,7 +41,7 @@ import { resolveProviderConfig } from "./provider-config.ts";
 import { HotReloadableAdapter } from "./hotreload.ts";
 import { resolvePath } from "./path-resolve.ts";
 import { Config, normalizeConfig } from "./config.ts";
-import { normalizeUiConfig, readUiConfig, writeUiConfig, sseData } from "./ui-config.ts";
+import { normalizeUiConfig, readUiConfig, writeUiConfig } from "./ui-config.ts";
 import { readAdapterStateResult, readUserAdapters, userAdaptersFile, writeAdapterState, resolveAddAdapterFile, type UserAdapterRecord } from "./user-adapters.ts";
 
 export const ROUTES: Record<string, string> = {

--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -93,8 +93,10 @@ export type { FloatBreakpoint, ViewportPoint, RectLike } from "./placement-math.
 // 面板锚点判定同为纯函数，随定位数学一起从单一事实源 re-export。
 export { panelAnchorForPlacement } from "./placement-math.ts";
 // 胶囊位置 UI 配置（#276 方案 A 阶段 3 拆出：纯函数 + 持久化读写）
-export { DEFAULT_UI_CONFIG, normalizeUiConfig, panelTopForAnchor, uiConfigFile, readUiConfig, writeUiConfig, sseData } from "./ui-config.ts";
+export { DEFAULT_UI_CONFIG, normalizeUiConfig, panelTopForAnchor, uiConfigFile, readUiConfig, writeUiConfig } from "./ui-config.ts";
 export type { UiPlacementConfig } from "./ui-config.ts";
+// sseData 已收敛 shared/host-utils.js（#472）：单独改指共享层，导出面保持不变
+export { sseData } from "../../../shared/host-utils.js";
 // 用户适配器持久化（#276 方案 A 阶段 3 拆出：清单/启用状态读写 + add 文件校验）
 export { userAdaptersFile, adapterStateFile, parseUserAdapters, readUserAdapters, readAdapterState, resolveAddAdapterFile } from "./user-adapters.ts";
 export type { UserAdapterRecord } from "./user-adapters.ts";

--- a/packages/dsh-provider-usage/src/ui-config.ts
+++ b/packages/dsh-provider-usage/src/ui-config.ts
@@ -85,8 +85,3 @@ export async function writeUiConfig(root: string, cfg: UiPlacementConfig): Promi
   await writeFile(tmp, JSON.stringify(normalizeUiConfig(cfg)), { mode: 0o600 });
   await rename(tmp, file);
 }
-
-/** 序列化一帧 SSE data 行（同 dsh-mcp-manager 的 sseData 语义）。 */
-export function sseData(payload: unknown): string {
-  return `data: ${JSON.stringify(payload)}\n\n`;
-}

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -684,7 +684,7 @@ export function formatPanel() { return "<p>x</p>"; }
 
   // lib/index.js 导出 v2 契约面
   const hostLib = readFileSync(join(pkgDir, "lib/index.js"), "utf8");
-  for (const name of ["isUsageStatsAdapter", "esc", "sanitizeHtml", "HistoryStore", "runV2Pipeline"]) {
+  for (const name of ["isUsageStatsAdapter", "esc", "sanitizeHtml", "HistoryStore", "runV2Pipeline", "sseData"]) {
     assert.ok(hostLib.includes(name), `宿主产物应含 ${name}`);
   }
 }

--- a/packages/dsh-provider-usage/test/unit-contract.test.ts
+++ b/packages/dsh-provider-usage/test/unit-contract.test.ts
@@ -40,6 +40,14 @@ assert.equal(sseData("hello"), "data: \"hello\"\n\n", "字符串 SSE 带转义")
 assert.equal(sseData([1, 2, 3]), "data: [1,2,3]\n\n", "数组 SSE 序列化");
 assert.equal(sseData(null), "data: null\n\n", "null SSE 序列化");
 
+// #472 收敛锚定：lib/index.js 的 sseData（re-export 自 shared/host-utils.js）
+// 输出与 shared 单一事实源一致（防 re-export 链被误删/改指后导出面漂移）。
+{
+  const { sseData: sharedSseData } = await import("../../../shared/host-utils.js");
+  assert.equal(typeof sseData, "function", "lib/index.js 可 import sseData");
+  assert.equal(sseData({ type: "ui-config-changed" }), sharedSseData({ type: "ui-config-changed" }), "lib 导出与 shared 输出一致");
+}
+
 // ---------------------------------------------------------------- parseUserAdapters
 
 assert.deepEqual(parseUserAdapters(undefined), [], "undefined 返回空数组");

--- a/scripts/test/shared-host-utils.test.ts
+++ b/scripts/test/shared-host-utils.test.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * shared/host-utils.js sseData 字面量契约单测（issue #472）。
+ *
+ * 锚定 sseData 对各类 payload 的输出字面量（防 shared 实现未来被改坏）：
+ * 三包历史实现逐字同构 `data: ${JSON.stringify(payload)}\n\n`，收敛后由
+ * shared 单一事实源承载。undefined 用例为对齐历史、非承诺契约（现状三处
+ * 均无调用点传 undefined，若未来收紧不视为破坏兼容——见 shared/host-utils.js jsdoc）。
+ *
+ * 运行：node --test scripts/test/shared-host-utils.test.ts（或 pnpm test:scripts）
+ * 载体：CI ci.yml 的 pnpm test:scripts 步骤（根 pnpm test 不含 scripts/test）。
+ * 零落盘：纯内存行为测试，无任何文件写入。
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { sseData } from '../../shared/host-utils.js'
+
+test('sseData：object payload 输出紧凑 JSON data 帧', () => {
+  assert.equal(sseData({ type: 'ping' }), 'data: {"type":"ping"}\n\n')
+  assert.equal(sseData({ type: 'ui-config-changed' }), 'data: {"type":"ui-config-changed"}\n\n')
+  assert.equal(sseData({ a: 1 }), 'data: {"a":1}\n\n')
+})
+
+test('sseData：数组 payload 输出 JSON 数组 data 帧', () => {
+  assert.equal(sseData([1, 2, 3]), 'data: [1,2,3]\n\n')
+  assert.equal(sseData([]), 'data: []\n\n')
+})
+
+test('sseData：字符串 payload 带引号与转义', () => {
+  assert.equal(sseData('hello'), 'data: "hello"\n\n')
+  assert.equal(sseData('a"b\\c'), 'data: "a\\"b\\\\c"\n\n', '引号与反斜杠按 JSON 转义')
+})
+
+test('sseData：null payload', () => {
+  assert.equal(sseData(null), 'data: null\n\n')
+})
+
+test('sseData：空串 payload', () => {
+  assert.equal(sseData(''), 'data: ""\n\n')
+})
+
+test('sseData：payload 含真实换行 → 输出 JSON 转义字面 \\n，不拆多行 data 帧', () => {
+  // payload 实参 "a\nb" 是含真实换行的字符串（JS 源码写单反斜杠）；
+  // 期望输出串中 JSON 转义后的 \n 必须写 "\\n"（双反斜杠 = 字面反斜杠+n 两字符）。
+  assert.equal(sseData({ msg: 'a\nb' }), 'data: {"msg":"a\\nb"}\n\n')
+})
+
+test('sseData：undefined payload 输出 data: undefined（对齐历史，非承诺契约）', () => {
+  // JSON.stringify(undefined) 返回 undefined，模板串拼接为 "undefined" 字面。
+  // 现状三处（mcp-manager / notifier / provider-usage）均无调用点传 undefined，
+  // 本行为仅为对齐历史、不额外兜底，非承诺契约——若未来 shared 收紧（抛错/省略）
+  // 不视为破坏兼容（需单开决策）。
+  assert.equal(sseData(undefined), 'data: undefined\n\n')
+})

--- a/shared/README.md
+++ b/shared/README.md
@@ -12,7 +12,7 @@ DSH 插件家族共用的模块（构建期 esbuild 内联进各插件包，不�
 | 文件 | 端 | 内容 | 消费方（登记快照） |
 |------|----|------|------|
 | `loopback.js` | 宿主 | `isLoopbackRequest` 安全围栏（路由 loopback 校验单一事实源） | lan-proxy / mcp-manager / notifier / provider-usage / web-file-preview |
-| `host-utils.js` | 宿主 | `writeJson` / `errorMessage` / `readBody`（限长显式化）/ `readJsonBody`（宽松版） | lan-proxy / mcp-manager / notifier / provider-usage / web-file-preview |
+| `host-utils.js` | 宿主 | `writeJson` / `errorMessage` / `readBody`（限长显式化）/ `readJsonBody`（宽松版）/ `sseData`（SSE data 帧序列化 `data: <json>\n\n`；undefined / 含 `\n` payload 行为对齐三包历史、非承诺契约；`sseData` 消费方：mcp-manager / notifier / provider-usage） | lan-proxy / mcp-manager / notifier / provider-usage / web-file-preview |
 | `frontmatter.js` | 宿主 | `parseFrontmatter` / `parseFrontmatterAll` / `setFrontmatterField` / `parseYamlBool` | 历史：commands-files / skill-explorer 同源复制统一；现生产消费已退役（verify-isolated 测试仍引用） |
 | `settings-namespace.js` | 宿主 | `installSettingsNamespace`（settings 服务面注入） | lan-proxy / mcp-manager / notifier / provider-usage |
 | `mcp-manager-service.d.ts` | 宿主 | MCP 管理器服务契约类型面（消费方只走公开入口） | mcp-manager / codegraph |

--- a/shared/host-utils.d.ts
+++ b/shared/host-utils.d.ts
@@ -4,6 +4,12 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 export declare function writeJson(res: ServerResponse, status: number, payload: unknown): void;
 
 /**
+ * 序列化一帧 SSE data 行（输出形如 `data: <json>\n\n`）。
+ * undefined / 含换行 payload 行为对齐三包历史实现、非承诺契约（#472）。
+ */
+export declare function sseData(payload: unknown): string;
+
+/**
  * 宽松读请求 body（JSON）：解析失败或超限返回 undefined（不抛错），由调用方决定响应。
  * @param limit 字节上限（默认 2MB）。
  */

--- a/shared/host-utils.js
+++ b/shared/host-utils.js
@@ -21,6 +21,20 @@ export function writeJson(res, status, payload) {
 }
 
 /**
+ * 序列化一帧 SSE data 行（输出形如 `data: <json>\n\n`）。
+ * 与 mcp-manager / notifier / provider-usage 三处历史实现逐字同构（#472 收敛）。
+ * JSON.stringify(undefined) 返回 undefined，拼接为 `data: undefined\n\n`；含真实
+ * 换行的 payload 由 JSON 转义为字面 `\n`，不拆多行 data 帧。现状三处均无调用点
+ * 传 undefined（payload 恒为对象字面量），该行为仅为对齐历史、不额外兜底，
+ * 非承诺契约——若未来收紧（抛错/省略）不视为破坏兼容（需单开决策）。
+ * @param {unknown} payload - 序列化为 JSON 的 SSE 帧负载。
+ * @returns {string} SSE data 帧文本。
+ */
+export function sseData(payload) {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+/**
  * 宽松读请求 body（JSON）：解析失败或超限返回 undefined（不抛错），
  * 由调用方决定响应。与 readBody 共用限长语义。
  * @param {import("node:http").IncomingMessage} req - Node http 请求对象（或 async-iterator 桩）。


### PR DESCRIPTION
## 实施摘要（按方案 v2，comment 5527396156）

`refactor(shared): sseData 收敛 shared/host-utils——三包同构定义消除（#472）`

三包（mcp-manager / provider-usage / notifier）的 SSE data 帧序列化同构定义收敛至 `shared/host-utils.js`，源码面定义唯一化，帧输出逐字节不变。

- **shared**：`host-utils.js` 新增导出 `sseData(payload)`（jsdoc 按 R5：undefined 为对齐历史非承诺契约）；`host-utils.d.ts` 同步声明 `(payload: unknown): string`；README host-utils 行登记。
- **mcp-manager**：`routes.ts` 删本地定义改 shared import；`apply.ts` import 面同步摘除改 shared；`index.ts` re-export 改指 shared（导出面不变）。
- **provider-usage**：`ui-config.ts` 删本地定义；`apply.ts` 同步改 shared；`index.ts:96` re-export 拆分（其余符号照旧）。events 广播通道为过期死代码（R1），仅做同构替换、不做帧级新旧断言、不删路由（通道清理属另一决策，建议维护者单开 issue）。
- **notifier**：`server.ts` 私有定义改 shared import；不新增导出。
- **测试**：新建 `scripts/test/shared-host-utils.test.ts`（7 用例：object / 数组 / 字符串转义 / null / 空串 / 真实换行→JSON 字面 `\n` / undefined→`data: undefined\n\n`，由 CI `pnpm test:scripts` 承载）；导出面正/负向锚定：mcp-manager smoke + provider-usage smoke/unit-contract 正向断言 lib import sseData 输出与 shared 一致，notifier routes.test.ts 负向断言 lib 不可见 sseData。

## coder 断言表（对照验收 v2）

| # | 条目 | 分级 | 证据 |
|---|---|---|---|
| 1 | shared sseData 逐字同构实现 + R5 jsdoc | 硬性 | host-utils.js:34；与三处原实现逐字一致 |
| 2 | d.ts 声明 `(payload: unknown): string` | 硬性 | host-utils.d.ts |
| 3 | 放置风格与 writeJson/readBody 一致 | 硬性 | diff 评审 |
| 4 | mcp-manager routes/apply/index 三点改接 | 硬性 | smoke 全绿 + checkAsync 锚定 |
| 5 | provider-usage ui-config/apply/index 三点改接 | 硬性 | unit-contract 四断言原样通过 + 正向锚定 |
| 6 | notifier server.ts 改接、导出面不变 | 硬性 | routes.test.ts 负向断言 `!("sseData" in lib)` |
| 7 | 活通道帧逐字节不变 | 硬性 | mcp smoke 帧文本断言 + notifier 路由测试原样通过 |
| 8 | 源码面无残留同构定义 | 硬性 | `grep -rn 'data: .*JSON.stringify' shared packages/*/src …` 仅命中 shared/host-utils.js:34 一处 |
| 9 | 新建 shared-host-utils.test.ts 被实跑 | 硬性 | `pnpm test:scripts` 126 tests / pass 126（文件实际被跑，非静默缺失） |
| 10 | 导出面正/负向锚定 | 硬性 | mcm/pu 正向 + notifier 负向（见上） |
| 11 | 既有 smoke/unit 全绿 | 硬性 | `pnpm test` 退出码 0 |
| 12 | 五连门禁全绿 | 硬性 | build/test/contract/pack:check/typecheck 退出码全 0 |
| 13 | pack-check 无 ../../shared 残留 + assertSharedDtsPresent | 硬性 | `pnpm pack:check` 退出码 0 |
| 14 | README host-utils 行登记 sseData 与三包消费 | 硬性 | shared/README.md diff |
| 15 | [观察] sseData 定义唯一化 | 观察 | 收敛前 3 处（routes.ts:424 / server.ts:32 / ui-config.ts:91）→ 后 1 处（shared） |
| 16 | [观察] 三包 lib/index.js 体积对比 | 观察 | 收敛前后逐字节相同（908838 / 210164 / 92343），印证 R6 净增量≈0 |

**观察项 16 说明**：esbuild 单文件内联下函数本就在三包产物内，收敛仅是定义位置迁移（R6，不判红）。

Closes #472

## 复核结论（复核闸 + qa 双通道）

- **qa 独立复核**：硬性 14/14 PASS（lib 导出面动态 import 实证 mcm/pu 正向 + notifier 负向 `'sseData' in lib === false`；锚定断言防漂移力确认非恒真装饰；验收 8 grep 唯一性；R7 双反斜杠写法核实；126 tests 实跑）。
- **复核闸评审**：通过（P0 0 / P1 0 / P2 3 + 1 观察），P2 处置：
  - **P2-2 载体说明**：pu 正向锚定实落 `unit-contract.test.ts:43-49`（经 smoke.ts:25 import 聚合进 `pnpm test` 门禁），防漂移力与「包级 smoke」等价；已在 issue #472 评论留痕闭环。
  - **P2-3 方案外微改声明**：`ui-config.ts` 删定义同时补文件尾换行（消除 `\ No newline at end of file`），lint 卫生性质。
  - **P2-1 遗留**：notifier routes.test 帧面为结构级正则、无帧文本字面断言（验收 7「帧文本断言」在 notifier 侧无对应物）——合并后随遗留清单跟踪（补 1-2 条字面断言，约 10 行）。
- 观察：体积对比数值出自 coder 本地产物，复核闸实测一致且每包恰一份内联副本（R6 观察项不判红）。
