### PR TITLE
refactor(shared): loopback+method 低阶守卫收敛批1——guard 落地 shared+notifier/lan-proxy 迁移（#473）

### DIFF
--- a/packages/dsh-lan-proxy/src/apply.ts
+++ b/packages/dsh-lan-proxy/src/apply.ts
@@ -10,8 +10,7 @@ import { homedir, networkInterfaces } from "node:os";
 import { join } from "node:path";
 import { mkdirSync } from "node:fs";
 import type { Context } from "@deepseek-ai/cordis";
-import { isLoopbackRequest } from "../../../shared/loopback.js";
-import { writeJson, errorMessage } from "../../../shared/host-utils.js";
+import { writeJson, errorMessage, guardLoopbackMethod } from "../../../shared/host-utils.js";
 import { createLanProxy, DEFAULT_OPTIONS, DEFAULT_DEFLATE_POLICY } from "./proxy.ts";
 import type { TlsMaterials, LanProxy } from "./proxy.ts";
 import { ensureSelfSignedTls, loadTlsFromFiles } from "./cert.ts";
@@ -400,7 +399,7 @@ export function apply(ctx: Context, config: LanProxyConfig = {}): void {
     path: ROUTES.health,
     kind: "exact",
     handler(req, res) {
-      if (!isLoopbackRequest(req)) return writeJson(res, 403, { error: "forbidden: loopback-only" });
+      if (!guardLoopbackMethod(req, res, ["GET"])) return;
       if (req.method !== "GET") return writeJson(res, 405, { error: "method not allowed: " + req.method });
       const v = resolve();
       // 压缩快照与 GET /config 同源（compressSnapshot 单一来源）。

--- a/packages/dsh-lan-proxy/src/config-routes.ts
+++ b/packages/dsh-lan-proxy/src/config-routes.ts
@@ -6,8 +6,7 @@
  * apply.ts：config-routes 与 apply 都要引用 ROUTES，放在本模块可避免
  * apply ↔ config-routes 循环引用（apply.ts 不得 import index.ts 的同一纪律）。
  */
-import { isLoopbackRequest } from "../../../shared/loopback.js";
-import { writeJson, readBody, errorMessage } from "../../../shared/host-utils.js";
+import { writeJson, readBody, errorMessage, guardLoopbackMethod } from "../../../shared/host-utils.js";
 import type { WebRoute } from "@deepseek-ai/dsh-host-webserver";
 import { sanitizeSettings, validateSettings } from "./config.ts";
 import type { HttpCompressSnapshot, ResolvedConfig } from "./config.ts";
@@ -124,7 +123,7 @@ export function buildConfigRoutes(deps: ConfigRouteDeps): WebRoute[] {
     kind: "exact",
     path: ROUTES.config,
     handler: async (req, res) => {
-      if (!isLoopbackRequest(req)) return writeJson(res, 403, { error: "forbidden: loopback-only" });
+      if (!guardLoopbackMethod(req, res, ["GET", "PUT"])) return;
       if (req.method === "GET") {
         const { user, revision } = deps.readUser();
         writeJson(res, 200, {

--- a/packages/dsh-lan-proxy/test/smoke.ts
+++ b/packages/dsh-lan-proxy/test/smoke.ts
@@ -1093,9 +1093,17 @@ const main = async () => {
       });
 
     const forbidden = await callRoute("GET", { socket: { remoteAddress: "192.168.1.9" } });
-    check("config 路由非回环 403", () => assert.equal(forbidden.status, 403));
+    check("config 路由非回环 403", () => {
+      assert.equal(forbidden.status, 403);
+      // #473 批 1（B1-4）：403 body 围栏文案（守卫收敛后逐字节锁定）
+      assert.equal(JSON.parse(forbidden.body).error, "forbidden: loopback-only");
+    });
     const notAllowed = await callRoute("POST", {}, { patch: {} });
-    check("config 路由 POST 405（仅 GET/PUT）", () => assert.equal(notAllowed.status, 405));
+    check("config 路由 POST 405（仅 GET/PUT）", () => {
+      assert.equal(notAllowed.status, 405);
+      // #473 批 1（B1-3）：405 body 文案断言
+      assert.equal(JSON.parse(notAllowed.body).error, "method not allowed: POST");
+    });
 
     const got = await callRoute("GET");
     check("GET 返回 user 层 + effective 生效值 + 压缩快照 + revision（只读面不收缩）", () => {
@@ -1215,9 +1223,17 @@ const main = async () => {
       assert.equal(payload.writable, true);
     });
     const cfg403 = await callRoute("GET", { socket: { remoteAddress: "192.168.100.9" } });
-    check("config 路由非回环 403", () => assert.equal(cfg403.status, 403));
+    check("config 路由非回环 403", () => {
+      assert.equal(cfg403.status, 403);
+      // #473 批 1（B1-4）：403 body 围栏文案（守卫收敛后逐字节锁定）
+      assert.equal(JSON.parse(cfg403.body).error, "forbidden: loopback-only");
+    });
     const cfg405 = await callRoute("DELETE");
-    check("config 路由 DELETE 405", () => assert.equal(cfg405.status, 405));
+    check("config 路由 DELETE 405", () => {
+      assert.equal(cfg405.status, 405);
+      // #473 批 1（B1-3）：405 body 文案断言
+      assert.equal(JSON.parse(cfg405.body).error, "method not allowed: DELETE");
+    });
     // PUT 写入：经路由 → deps.update（fake scope）→ watch 触发。
     const put = await callRoute("PUT", {}, { patch: { printBanner: false }, expectedRevision: settingsState.revision });
     check("PUT 经路由写入官方存储并触发 watch 回调", () => {
@@ -1245,7 +1261,11 @@ const main = async () => {
     check("health 403 for non-loopback", () => assert.equal(res403.status(), 403));
     const res405 = fakeRes();
     healthRoute.handler(fakeReq({ method: "POST" }), res405);
-    check("health 405 for non-GET", () => assert.equal(res405.status(), 405));
+    check("health 405 for non-GET", () => {
+      assert.equal(res405.status(), 405);
+      // #473 批 1（B1-3）：health（GET 白名单）405 body 文案断言
+      assert.equal(JSON.parse(res405.body()).error, "method not allowed: POST");
+    });
     const res200 = fakeRes();
     healthRoute.handler(fakeReq(), res200);
     check("health 200 with status summary", () => {

--- a/packages/dsh-lan-proxy/test/unit-apply.test.ts
+++ b/packages/dsh-lan-proxy/test/unit-apply.test.ts
@@ -723,9 +723,22 @@ const { createServer } = await import("node:http");
       return lastWrite;
     };
     // E1: 围栏与方法白名单。
-    assert.equal((await callRoute("GET", { socket: { remoteAddress: "10.0.0.9" } })).status, 403, "非回环 403");
-    assert.equal((await callRoute("DELETE")).status, 405, "DELETE 405");
-    assert.equal((await callRoute("POST", {}, { patch: {} })).status, 405, "POST 405");
+    // #473 批 1（B1-4/B1-3）：403 body 围栏文案 + 405 body 文案断言（守卫收敛后逐字节锁定）
+    {
+      const forbidden = await callRoute("GET", { socket: { remoteAddress: "10.0.0.9" } });
+      assert.equal(forbidden.status, 403, "非回环 403");
+      assert.equal(JSON.parse(forbidden.body).error, "forbidden: loopback-only", "403 body 围栏文案");
+    }
+    {
+      const del405 = await callRoute("DELETE");
+      assert.equal(del405.status, 405, "DELETE 405");
+      assert.equal(JSON.parse(del405.body).error, "method not allowed: DELETE", "DELETE 405 body 文案");
+    }
+    {
+      const post405 = await callRoute("POST", {}, { patch: {} });
+      assert.equal(post405.status, 405, "POST 405");
+      assert.equal(JSON.parse(post405.body).error, "method not allowed: POST", "POST 405 body 文案");
+    }
     // E2: GET 快照字段全集（user/effective/compress/revision/writable）。
     {
       const snap = JSON.parse((await callRoute("GET")).body);

--- a/packages/dsh-notifier/src/server.ts
+++ b/packages/dsh-notifier/src/server.ts
@@ -9,8 +9,7 @@ import { spawn, execFile } from "node:child_process";
 import type { ChildProcess } from "node:child_process";
 import type { ServerResponse } from "node:http";
 import type { WebRoute } from "@deepseek-ai/dsh-host-webserver";
-import { isLoopbackRequest } from "../../../shared/loopback.js";
-import { writeJson, readBody, errorMessage, sseData } from "../../../shared/host-utils.js";
+import { writeJson, readBody, errorMessage, sseData, guardLoopbackMethod } from "../../../shared/host-utils.js";
 import type { NotifyConfig } from "./config.ts";
 import { sanitizePatchSettings, validateSettings, redactConfigView, unmaskChannels } from "./config.ts";
 import type { HistoryStore } from "./history.ts";
@@ -390,7 +389,7 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
     kind: "exact",
     path: ROUTES.config,
     handler: async (req, res) => {
-      if (!isLoopbackRequest(req)) return writeJson(res, 403, { error: "forbidden: loopback-only" });
+      if (!guardLoopbackMethod(req, res, ["GET", "PUT"])) return;
       if (req.method === "GET") {
         const { user, revision } = readUser();
         // 凭据脱敏单一出口（评审 P0-1）：user 与 effective 双视图都经
@@ -446,10 +445,7 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
     kind: "exact",
     path: ROUTES.events,
     handler: (req, res) => {
-      if (!isLoopbackRequest(req)) {
-        writeJson(res, 403, { error: "forbidden: loopback-only" });
-        return;
-      }
+      if (!guardLoopbackMethod(req, res, ["GET"])) return;
       if (req.method !== "GET") {
         writeJson(res, 405, { error: `method not allowed: ${req.method}` });
         return;
@@ -497,7 +493,7 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
     kind: "exact",
     path: ROUTES.health,
     handler: (req, res) => {
-      if (!isLoopbackRequest(req)) return writeJson(res, 403, { error: "forbidden: loopback-only" });
+      if (!guardLoopbackMethod(req, res, ["GET"])) return;
       if (req.method !== "GET") return writeJson(res, 405, { error: `method not allowed: ${req.method}` });
       const current = resolve();
       writeJson(res, 200, {
@@ -533,7 +529,7 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
     kind: "exact",
     path: ROUTES.test,
     handler: async (req, res) => {
-      if (!isLoopbackRequest(req)) return writeJson(res, 403, { error: "forbidden: loopback-only" });
+      if (!guardLoopbackMethod(req, res, ["POST"])) return;
       if (req.method !== "POST") return writeJson(res, 405, { error: `method not allowed: ${req.method}` });
       let channelId: string | undefined;
       try {
@@ -564,7 +560,7 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
     kind: "exact",
     path: ROUTES.status,
     handler: async (req, res) => {
-      if (!isLoopbackRequest(req)) return writeJson(res, 403, { error: "forbidden: loopback-only" });
+      if (!guardLoopbackMethod(req, res, ["GET"])) return;
       if (req.method !== "GET") return writeJson(res, 405, { error: `method not allowed: ${req.method}` });
       const channels = await statusReader();
       writeJson(res, 200, { ok: true, channels });
@@ -580,7 +576,7 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
     kind: "exact",
     path: ROUTES.kinds,
     handler: async (req, res) => {
-      if (!isLoopbackRequest(req)) return writeJson(res, 403, { error: "forbidden: loopback-only" });
+      if (!guardLoopbackMethod(req, res, ["GET", "POST"])) return;
       if (req.method === "GET") {
         writeJson(res, 200, { ok: true, kinds: listKinds() });
         return;
@@ -621,7 +617,7 @@ export function buildRoutes(deps: RouteDeps): WebRoute[] {
     kind: "exact",
     path: ROUTES.history,
     handler: async (req, res) => {
-      if (!isLoopbackRequest(req)) return writeJson(res, 403, { error: "forbidden: loopback-only" });
+      if (!guardLoopbackMethod(req, res, ["GET", "DELETE"])) return;
       if (req.method === "GET") {
         const records = await history.read();
         writeJson(res, 200, { ok: true, records });

--- a/packages/dsh-notifier/test/routes.test.ts
+++ b/packages/dsh-notifier/test/routes.test.ts
@@ -45,10 +45,12 @@ try {
   }
 
   // 403（J1）——含 M2 新路由（围栏必项，评审缺口项）
+  // #473 批 1（B1-4）：403 body 文案断言（守卫收敛后逐字节锁定）
   for (const route of [configRoute, eventsRoute, healthRoute, testRoute, historyRoute, statusRoute, kindsRoute]) {
     const { rec, res } = makeRes();
     await route.handler(fakeReq({ socket: { remoteAddress: "10.0.0.2" } }), res);
     assert.equal(rec.status, 403);
+    assert.equal(JSON.parse(rec.text).error, "forbidden: loopback-only", "403 body 围栏文案");
   }
 
   // 405（J2）：test 路由仅 POST；history 路由仅 GET；health 仅 GET；status 仅 GET；kinds 仅 GET/POST
@@ -59,15 +61,26 @@ try {
     const { rec: rec2, res: res2 } = makeRes();
     await historyRoute.handler(fakeReq({ method: "POST" }), res2);
     assert.equal(rec2.status, 405);
+    // #473 批 1（B1-3）：history（GET/DELETE 白名单）POST → 405 + error 文案
+    assert.equal(JSON.parse(rec2.text).error, "method not allowed: POST", "history POST 405 body 文案");
     const { rec: rec3, res: res3 } = makeRes();
     await healthRoute.handler(fakeReq({ method: "DELETE" }), res3);
     assert.equal(rec3.status, 405);
+    // #473 批 1（B1-4）：单方法端点 405 body 文案断言
+    assert.equal(JSON.parse(rec3.text).error, "method not allowed: DELETE", "health DELETE 405 body 文案");
     const { rec: rec4, res: res4 } = makeRes();
     await statusRoute.handler(fakeReq({ method: "POST" }), res4);
     assert.equal(rec4.status, 405);
     const { rec: rec5, res: res5 } = makeRes();
     await kindsRoute.handler(fakeReq({ method: "DELETE" }), res5);
     assert.equal(rec5.status, 405);
+    // #473 批 1（B1-3）：kinds（GET/POST 白名单）DELETE → 405 + error 文案
+    assert.equal(JSON.parse(rec5.text).error, "method not allowed: DELETE", "kinds DELETE 405 body 文案");
+    // #473 批 1（B1-3）：config（GET/PUT 白名单）补非法方法锚 DELETE → 405 + error 文案
+    const { rec: rec6, res: res6 } = makeRes();
+    await configRoute.handler(fakeReq({ method: "DELETE" }), res6);
+    assert.equal(rec6.status, 405);
+    assert.equal(JSON.parse(rec6.text).error, "method not allowed: DELETE", "config DELETE 405 body 文案");
   }
 
   // health：配置摘要与 sseConnections

--- a/scripts/test/shared-host-utils-guard.test.ts
+++ b/scripts/test/shared-host-utils-guard.test.ts
@@ -1,0 +1,103 @@
+// @ts-check
+/**
+ * shared/host-utils.js — guardLoopbackMethod 守卫单测（issue #473 批 1）。
+ *
+ * 载体：CI `pnpm test:scripts`（.github/workflows/ci.yml test:scripts 步骤；
+ * 本地门禁同命令）。命名与 #472 的 shared-host-utils.test.ts 错开（S1），
+ * 各测各的函数互不覆盖。
+ *
+ * 覆盖（#473 方案 v2 G4①/R6）：
+ * - 403 文案逐字节：非 loopback → `{"error":"forbidden: loopback-only"}` + false；
+ * - 405 文案逐字节：方法不在白名单 → `{"error":"method not allowed: <METHOD>"}`
+ *   + false（多方法插值全覆盖）；
+ * - 无 method 字段（fakeReq 缺省覆盖）→ 405 + `method not allowed: undefined`
+ *   ——锚定 fail-closed（R6：防未来实现加回 `?? "GET"` 宽松归一化）；
+ * - 放行正例：loopback + 白名单内方法 → true 且不写响应。
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { guardLoopbackMethod } from "../../shared/host-utils.js";
+
+/** loopback 合法请求桩；overrides 逐键覆盖顶层字段。 */
+function fakeReq(overrides = {}) {
+  return {
+    method: "GET",
+    socket: { remoteAddress: "127.0.0.1" },
+    headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+    ...overrides,
+  };
+}
+
+/** 响应收集桩：rec.status / rec.body（writeJson 经 writeHead+end 落字）。 */
+function fakeRes() {
+  const rec = { status: 0, body: "" };
+  return {
+    rec,
+    res: {
+      writeHead(status) {
+        rec.status = status;
+      },
+      end(payload) {
+        if (payload !== undefined) rec.body += String(payload);
+      },
+    },
+  };
+}
+
+test("非 loopback → 403 + 逐字节文案 + false", () => {
+  const { rec, res } = fakeRes();
+  const allow = guardLoopbackMethod(fakeReq({ socket: { remoteAddress: "10.0.0.2" } }), res, ["GET"]);
+  assert.equal(allow, false, "非 loopback 返回 false");
+  assert.equal(rec.status, 403);
+  assert.equal(rec.body, '{"error":"forbidden: loopback-only"}', "403 body 逐字节");
+});
+
+test("loopback Host 不合法 → 403 + 逐字节文案 + false", () => {
+  const { rec, res } = fakeRes();
+  const allow = guardLoopbackMethod(fakeReq({ headers: { host: "evil.example:3080" } }), res, ["GET"]);
+  assert.equal(allow, false);
+  assert.equal(rec.status, 403);
+  assert.equal(rec.body, '{"error":"forbidden: loopback-only"}', "403 body 逐字节");
+});
+
+test("loopback + 方法不在白名单 → 405 + 逐字节文案 + false", () => {
+  for (const [method, whitelist] of [
+    ["POST", ["GET"]],
+    ["DELETE", ["GET", "PUT"]],
+    ["PATCH", ["GET", "POST"]],
+    ["PUT", ["GET", "POST"]],
+    ["OPTIONS", ["GET"]],
+  ]) {
+    const { rec, res } = fakeRes();
+    const allow = guardLoopbackMethod(fakeReq({ method }), res, whitelist);
+    assert.equal(allow, false, `${method} 不在 [${whitelist}] 返回 false`);
+    assert.equal(rec.status, 405, `${method} → 405`);
+    assert.equal(rec.body, `{"error":"method not allowed: ${method}"}`, `${method} 405 body 逐字节`);
+  }
+});
+
+test("无 method 字段 → 405 + method not allowed: undefined（fail-closed，R6）", () => {
+  const { rec, res } = fakeRes();
+  const { method, ...noMethod } = fakeReq();
+  assert.equal(method, "GET", "前置：桩本有 method，此处刻意删除");
+  const allow = guardLoopbackMethod(noMethod, res, ["GET"]);
+  assert.equal(allow, false, "无 method 字段不放行（fail-closed）");
+  assert.equal(rec.status, 405);
+  assert.equal(rec.body, '{"error":"method not allowed: undefined"}', "405 body 逐字节锚定 undefined 插值");
+});
+
+test("loopback + 白名单内方法 → true 放行且不写响应", () => {
+  for (const [method, whitelist] of [
+    ["GET", ["GET"]],
+    ["GET", ["GET", "PUT"]],
+    ["PUT", ["GET", "PUT"]],
+    ["POST", ["GET", "POST"]],
+    ["DELETE", ["GET", "DELETE"]],
+  ]) {
+    const { rec, res } = fakeRes();
+    const allow = guardLoopbackMethod(fakeReq({ method }), res, whitelist);
+    assert.equal(allow, true, `${method} ∈ [${whitelist}] 放行`);
+    assert.equal(rec.status, 0, "放行时不写任何响应");
+    assert.equal(rec.body, "", "放行时不写任何 body");
+  }
+});

--- a/shared/README.md
+++ b/shared/README.md
@@ -12,7 +12,7 @@ DSH 插件家族共用的模块（构建期 esbuild 内联进各插件包，不�
 | 文件 | 端 | 内容 | 消费方（登记快照） |
 |------|----|------|------|
 | `loopback.js` | 宿主 | `isLoopbackRequest` 安全围栏（路由 loopback 校验单一事实源） | lan-proxy / mcp-manager / notifier / provider-usage / web-file-preview |
-| `host-utils.js` | 宿主 | `writeJson` / `errorMessage` / `readBody`（限长显式化）/ `readJsonBody`（宽松版）/ `sseData`（SSE data 帧序列化 `data: <json>\n\n`；undefined / 含 `\n` payload 行为对齐三包历史、非承诺契约；`sseData` 消费方：mcp-manager / notifier / provider-usage） | lan-proxy / mcp-manager / notifier / provider-usage / web-file-preview |
+| `host-utils.js` | 宿主 | `writeJson` / `errorMessage` / `readBody`（限长显式化）/ `readJsonBody`（宽松版）/ `sseData`（SSE data 帧序列化 `data: <json>\n\n`；undefined / 含 `\n` payload 行为对齐三包历史、非承诺契约；`sseData` 消费方：mcp-manager / notifier / provider-usage）/ `guardLoopbackMethod`（loopback+方法白名单守卫；403 先于 405 为守卫自身执行顺序，仅适用于套守卫端点） | lan-proxy / mcp-manager / notifier / provider-usage / web-file-preview |
 | `frontmatter.js` | 宿主 | `parseFrontmatter` / `parseFrontmatterAll` / `setFrontmatterField` / `parseYamlBool` | 历史：commands-files / skill-explorer 同源复制统一；现生产消费已退役（verify-isolated 测试仍引用） |
 | `settings-namespace.js` | 宿主 | `installSettingsNamespace`（settings 服务面注入） | lan-proxy / mcp-manager / notifier / provider-usage |
 | `mcp-manager-service.d.ts` | 宿主 | MCP 管理器服务契约类型面（消费方只走公开入口） | mcp-manager / codegraph |

--- a/shared/host-utils.d.ts
+++ b/shared/host-utils.d.ts
@@ -24,3 +24,11 @@ export declare function errorMessage(error: unknown): string;
  * @param limit 字节上限（默认 256KB）。
  */
 export declare function readBody(req: IncomingMessage, limit?: number): Promise<object>;
+
+/**
+ * Loopback + 方法白名单低阶路由守卫：非 loopback → 403，方法不在白名单 → 405，
+ * 否则放行（403 先于 405 为本守卫执行顺序，仅对套守卫端点成立）。
+ * @param methods 允许的 HTTP 方法白名单。
+ * @returns 是否放行（true 时调用方继续处理请求）。
+ */
+export declare function guardLoopbackMethod(req: IncomingMessage, res: ServerResponse, methods: string[]): boolean;

--- a/shared/host-utils.js
+++ b/shared/host-utils.js
@@ -6,6 +6,32 @@
 
 import { Buffer } from "node:buffer";
 
+import { isLoopbackRequest } from "./loopback.js";
+
+/**
+ * Loopback + 方法白名单低阶路由守卫。
+ *
+ * **对本守卫的执行顺序**：非 loopback → 403；方法不在白名单 → 405；否则放行
+ * （403 先于 405）。该顺序仅对**套本守卫的端点**成立——个别端点（如
+ * mcp-manager /config）是端点级方法分流先于 loopback 的刻意例外，不适用。
+ *
+ * @param {import("node:http").IncomingMessage} req - Node http 请求对象。
+ * @param {import("node:http").ServerResponse} res - 响应对象。
+ * @param {string[]} methods - 允许的 HTTP 方法白名单。
+ * @returns {boolean} 是否放行（true 时调用方继续处理请求）。
+ */
+export function guardLoopbackMethod(req, res, methods) {
+  if (!isLoopbackRequest(req)) {
+    writeJson(res, 403, { error: "forbidden: loopback-only" });
+    return false;
+  }
+  if (!methods.includes(req.method)) {
+    writeJson(res, 405, { error: `method not allowed: ${req.method}` });
+    return false;
+  }
+  return true;
+}
+
 /**
  * 写 JSON 响应（统一带 referrer-policy 头，防 referrer 泄露）。
  * @param {import("node:http").ServerResponse} res - 响应对象。


### PR DESCRIPTION
## 实施摘要（按方案 v2 comment 5527633574，批 1）

`refactor(shared): loopback+method 低阶守卫收敛批1——guard 落地 shared+notifier/lan-proxy 迁移（#473）`

- **shared**：`host-utils.js` 新增导出 `guardLoopbackMethod(req, res, methods)`（内部 import `./loopback.js`；非 loopback → 403 `forbidden: loopback-only`，方法不在白名单 → 405 `method not allowed: <METHOD>`，否则放行；jsdoc 按 R2 限定「403 先于 405 仅对套守卫端点成立」）；`host-utils.d.ts` 同步声明；README host-utils 行登记（含 R2 行为契约措辞）。
- **notifier**：server.ts 7 守卫点替换（config `["GET","PUT"]`；events/health/status `["GET"]`；test `["POST"]`；kinds `["GET","POST"]`；history `["GET","DELETE"]`）；结构 α 的尾部 else 405 死代码按方案保留最小 diff；routes 文件不再 import isLoopbackRequest（index.ts:129 re-export 保留 = T2 导出面零变化）。
- **lan-proxy**：config-routes.ts config `["GET","PUT"]` + apply.ts health `["GET"]`。
- **测试**：新建 `scripts/test/shared-host-utils-guard.test.ts`（S1 与 #472 的 shared-host-utils.test.ts 错开命名）：403/405 文案逐字节（G4①，两构造路径 + 5 组方法×白名单矩阵）+ R6「无 method 字段 → 405 `method not allowed: undefined`」fail-closed 锚定 + 放行正例；B1-3 多方法端点补 405+文案断言（notifier config DELETE / kinds DELETE / history POST、lan-proxy config DELETE/POST、health POST）；B1-4 403 body 文案断言 10+ 处、405 文案 8 处。

## 实施顺序（S2）

本 PR 为批 1（guard 落地 + notifier/lan-proxy）；#472（PR #496，sseData）已先合（`7ee382f`），本分支已 rebase 其上——解消 host-utils.js 同文件追加与 README 行双 append 冲突（冲突解消后六门禁重跑全绿）；批 2（wfp+pu）→ 批 3（mcp-manager）后续 PR 依次 rebase；任一批单独回滚不拖累 shared。

## coder 断言表（对照验收 v2）

| # | 条目 | 结论 | 证据 |
|---|---|---|---|
| G1 | shared guard 实现 + R2 限定措辞 jsdoc | PASS | host-utils.js（内部 import ./loopback.js；403→405 顺序） |
| G2 | d.ts 声明 + README 登记 | PASS | host-utils.d.ts `(req, res, methods): boolean`；README host-utils 行 |
| G3 | 无新增抽象层（仅 +1 函数） | PASS | diff 无新 shared 文件、无中间件 |
| G4 | 文案逐字节组合论证 | PASS | ① shared 单测 5 用例逐字节；② `grep -rn "if (!isLoopbackRequest" packages/*/src` notifier/lan-proxy 零命中（剩余 21 处均在批 2/3 范围：mcm 5 / pu 9 / wfp 7） |
| G5 | 单测载体 shared-host-utils-guard.test.ts | PASS | test:scripts 实跑含该文件 |
| B1-1 | notifier 7 点替换 | PASS | routes.test.ts 全绿 |
| B1-2 | lan-proxy 2 点替换 | PASS | smoke + unit-apply.test.ts 全绿 |
| B1-3 | 多方法端点 405+文案 | PASS | notifier config/kinds/history + lan-proxy config/health 断言补齐 |
| B1-4 | 403/405 body 文案断言 | PASS | 403 文案 10+ 处、405 文案 8 处 |
| B1-5 | 门禁 | PASS | 六门禁 exit 0 |
| S1 | 测试文件名错开 | PASS | 文件系统核对（不占用 #472 的 shared-host-utils.test.ts） |

## rebase 后门禁（冲突解消重跑）

```
pnpm build → 0   pnpm test → 0   pnpm contract → 0
pnpm pack:check → 0   pnpm typecheck → 0   pnpm test:scripts → 0（131 tests / 131 pass / 0 fail）
```

## 复核通道结论

- **qa 独立复核**：PASS 13/13（G1-G5/B1-1..5/T2 部分/S1 全过；六门禁独立重跑全 0；导出面动态 import 实证；lan-proxy EADDRINUSE 首跑为 base 既有固定端口用例的环境 flake，重跑 3 次全绿）。
- **复核闸评审**：通过（P0 0 / P1 0 / P2 1）——语义等价性 9/9 逐点比对（结构 α 全覆盖无 β 混入、白名单无多列漏列、文案逐字节一致）、host-utils 冲突解消核对、断言真实可失败核验。
  - **P2-1 遗留（桶③）**：notifier routes.test.ts:56 既有注释「history 路由仅 GET」与实际白名单 GET/DELETE 不符（base 既有历史遗留，非本 PR 引入）——随批 2 顺手清理。

Partially addresses #473（多子项 issue，批 2/3 合入后关闭）
