### PR TITLE
refactor(routes): loopback+method 守卫收敛批3——mcp-manager 迁移+全收敛收尾（#473）

### DIFF
--- a/packages/dsh-mcp-manager/src/routes.ts
+++ b/packages/dsh-mcp-manager/src/routes.ts
@@ -9,8 +9,7 @@
  */
 
 // 辅助函数统一来自仓库共享层（loopback 围栏 / writeJson / readJsonBody / sseData）。
-import { isLoopbackRequest } from "../../../shared/loopback.js";
-import { writeJson, readJsonBody, sseData } from "../../../shared/host-utils.js";
+import { writeJson, readJsonBody, sseData, guardLoopbackMethod } from "../../../shared/host-utils.js";
 import { parseClaudeJson } from "./import.ts";
 import { SCOPE_PROJECT, normalizeScope } from "./scope.ts";
 import { parseFullServerName, MIDDLEWARE_GLOBAL_ROOT, normalizeToolName } from "./middleware-utils.ts";
@@ -86,17 +85,6 @@ function queryParam(url: URL, name: string): string | undefined {
 
 /** 组装 /api/dsh-mcp/* 路由。cwd 参数仅用于兼容旧调用（不再被路由使用）。 */
 export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRoute[] {
-  const guard = (req: Parameters<WebRoute["handler"]>[0], res: Parameters<WebRoute["handler"]>[1], method: string): boolean => {
-    if (!isLoopbackRequest(req)) {
-      writeJson(res, 403, { error: "forbidden: loopback-only" });
-      return false;
-    }
-    if (req.method !== method) {
-      writeJson(res, 405, { error: `method not allowed: ${req.method}` });
-      return false;
-    }
-    return true;
-  };
   const handleError = (res: Parameters<WebRoute["handler"]>[1], error: unknown) => {
     writeJson(res, 400, { error: error instanceof Error ? error.message : String(error) });
   };
@@ -127,10 +115,7 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
         // 经设置命名空间落盘（Config.ui），触发 scope.watch → onChange → SSE 广播一帧，
         // 客户端收到后重新 GET /config 就地更新浮窗位置，无需重启/轮询。
         if (req.method === "POST") {
-          if (!isLoopbackRequest(req)) {
-            writeJson(res, 403, { error: "forbidden: loopback-only" });
-            return;
-          }
+          if (!guardLoopbackMethod(req, res, ["POST"])) return;
           let body: unknown;
           try {
             body = await readJsonBody(req);
@@ -161,6 +146,9 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
           }
           return;
         }
+        // 端点级方法分流先于 loopback 的刻意例外（#473 R2 结构 β）：本 else 对
+        // 白名单外方法（PUT/DELETE/OPTIONS 等）直接 405、不查 loopback——非
+        // loopback+PUT 返回 405 而非 403 是契约行为，禁止误套守卫（会漂移为 403）。
         writeJson(res, 405, { error: `method not allowed: ${req.method}` });
       },
     },
@@ -170,10 +158,7 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
       handler: async (req, res) => {
         const url = new URL(req.url ?? "/", "http://localhost");
         const method = req.method ?? "GET";
-        if (!isLoopbackRequest(req)) {
-          writeJson(res, 403, { error: "forbidden: loopback-only" });
-          return;
-        }
+        if (!guardLoopbackMethod(req, res, ["GET", "POST", "PATCH", "DELETE"])) return;
         if (method === "GET") {
           try {
             // 变更点驱动（#111/#228）：GET /servers 是纯读快照，零副作用——
@@ -238,7 +223,7 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
       kind: "exact",
       path: ROUTES.session,
       handler: async (req, res) => {
-        if (!guard(req, res, "POST")) return;
+        if (!guardLoopbackMethod(req, res, ["POST"])) return;
         const body = await readJsonBody(req);
         if (body === undefined || typeof (body as Record<string, unknown>).cwd !== "string") {
           writeJson(res, 400, { error: "body must include a cwd string" });
@@ -256,7 +241,7 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
       kind: "exact",
       path: ROUTES.resume,
       handler: async (req, res) => {
-        if (!guard(req, res, "POST")) return;
+        if (!guardLoopbackMethod(req, res, ["POST"])) return;
         try {
           if (typeof manager.resumeReconnect !== "function") throw new Error("resumeReconnect unavailable");
           await manager.resumeReconnect();
@@ -270,7 +255,7 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
       kind: "exact",
       path: ROUTES.connect,
       handler: async (req, res) => {
-        if (!guard(req, res, "POST")) return;
+        if (!guardLoopbackMethod(req, res, ["POST"])) return;
         const url = new URL(req.url ?? "/", "http://localhost");
         const name = queryParam(url, "name");
         if (name === undefined || name === "") {
@@ -290,7 +275,7 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
       kind: "exact",
       path: ROUTES.disconnect,
       handler: async (req, res) => {
-        if (!guard(req, res, "POST")) return;
+        if (!guardLoopbackMethod(req, res, ["POST"])) return;
         const url = new URL(req.url ?? "/", "http://localhost");
         const name = queryParam(url, "name");
         if (name === undefined || name === "") {
@@ -310,7 +295,7 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
       kind: "exact",
       path: ROUTES.reconnect,
       handler: async (req, res) => {
-        if (!guard(req, res, "POST")) return;
+        if (!guardLoopbackMethod(req, res, ["POST"])) return;
         const url = new URL(req.url ?? "/", "http://localhost");
         const name = queryParam(url, "name");
         if (name === undefined || name === "") {
@@ -330,7 +315,7 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
       kind: "exact",
       path: ROUTES.importJson,
       handler: async (req, res) => {
-        if (!guard(req, res, "POST")) return;
+        if (!guardLoopbackMethod(req, res, ["POST"])) return;
         const body = await readJsonBody(req);
         if (body === undefined || typeof (body as Record<string, unknown>).json !== "string") {
           writeJson(res, 400, { error: "body must include a json string" });
@@ -368,7 +353,7 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
       kind: "exact",
       path: ROUTES.toolDisable,
       handler: async (req, res) => {
-        if (!guard(req, res, "PATCH")) return;
+        if (!guardLoopbackMethod(req, res, ["PATCH"])) return;
         const url = new URL(req.url ?? "/", "http://localhost");
         const body = await readJsonBody(req);
         if (body === undefined || typeof body !== "object" || body === null) {
@@ -465,14 +450,7 @@ export function makeEventsRoute(manager: RoutesManager, options?: { heartbeatMs?
     kind: "exact",
     path: ROUTES.events,
     handler: (req, res) => {
-      if (!isLoopbackRequest(req)) {
-        writeJson(res, 403, { error: "forbidden: loopback-only" });
-        return;
-      }
-      if (req.method !== "GET") {
-        writeJson(res, 405, { error: `method not allowed: ${req.method}` });
-        return;
-      }
+      if (!guardLoopbackMethod(req, res, ["GET"])) return;
       const connections = manager.sseConnections ??= new Set();
       res.writeHead(200, {
         "content-type": "text/event-stream",
@@ -521,14 +499,7 @@ export function makeHealthRoute(manager: RoutesManager): WebRoute {
     kind: "exact",
     path: ROUTES.health,
     handler: (req, res) => {
-      if (!isLoopbackRequest(req)) {
-        writeJson(res, 403, { error: "forbidden: loopback-only" });
-        return;
-      }
-      if (req.method !== "GET") {
-        writeJson(res, 405, { error: `method not allowed: ${req.method}` });
-        return;
-      }
+      if (!guardLoopbackMethod(req, res, ["GET"])) return;
       let servers = 0;
       let connected = 0;
       let tools = 0;

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -1657,6 +1657,70 @@ const main = async () => {
         await find(ROUTES.toolDisable).handler(fakeReq("GET", ROUTES.toolDisable), res405);
         assert.equal(res405.state.status, 405);
       });
+      await checkAsync("白名单外方法 → 405 + error 文案逐字（每端点 ≥1 锚；servers 为最大写面补缺）", async () => {
+        // servers（R3 最大写面端点）：白名单 GET/POST/PATCH/DELETE 之外的方法 → 405+文案
+        // 逐字——防守卫白名单误多列方法（围栏实质放宽而 403 用例仍绿）。
+        for (const method of ["OPTIONS", "PUT"] as const) {
+          const res = fakeRes();
+          await find(ROUTES.servers).handler(fakeReq(method, ROUTES.servers), res);
+          assert.equal(res.state.status, 405, `servers ${method} → 405`);
+          assert.equal(
+            JSON.parse(res.state.body).error,
+            `method not allowed: ${method}`,
+            `servers ${method} 405 文案逐字`,
+          );
+        }
+        // config（结构 β）：PUT 405 由 else 分支直出（不查 loopback），文案同源逐字。
+        const cfgPut = fakeRes();
+        await find(ROUTES.config).handler(fakeReq("PUT", ROUTES.config, { position: "bottom-right" }), cfgPut);
+        assert.equal(cfgPut.state.status, 405);
+        assert.equal(JSON.parse(cfgPut.state.body).error, "method not allowed: PUT", "config PUT 405 文案逐字");
+        const cfgOptions = fakeRes();
+        await find(ROUTES.config).handler(fakeReq("OPTIONS", ROUTES.config), cfgOptions);
+        assert.equal(cfgOptions.state.status, 405);
+        assert.equal(
+          JSON.parse(cfgOptions.state.body).error,
+          "method not allowed: OPTIONS",
+          "config OPTIONS 405 文案逐字",
+        );
+        // 单方法端点：每端点 ≥1 非法方法 405+文案（守卫收口后错误文案统一出自 shared）。
+        // events/health 不在 makeRoutes 返回列表（独立工厂路由），单独取 handler。
+        const wrong: Array<[string, string, string]> = [
+          ["session", ROUTES.session, "GET"],
+          ["resume", ROUTES.resume, "GET"],
+          ["connect", ROUTES.connect, "GET"],
+          ["disconnect", ROUTES.disconnect, "GET"],
+          ["reconnect", ROUTES.reconnect, "GET"],
+          ["importJson", ROUTES.importJson, "GET"],
+          ["toolDisable", ROUTES.toolDisable, "GET"],
+        ];
+        for (const [label, path, method] of wrong) {
+          const res = fakeRes();
+          await find(path).handler(fakeReq(method, path), res);
+          assert.equal(res.state.status, 405, `${label} ${method} → 405`);
+          assert.equal(
+            JSON.parse(res.state.body).error,
+            `method not allowed: ${method}`,
+            `${label} 405 文案逐字`,
+          );
+        }
+        const eventsWrong = fakeRes();
+        await makeEventsRoute(manager).handler(fakeReq("POST", ROUTES.events), eventsWrong);
+        assert.equal(eventsWrong.state.status, 405);
+        assert.equal(
+          JSON.parse(eventsWrong.state.body).error,
+          "method not allowed: POST",
+          "events 405 文案逐字",
+        );
+        const healthWrong = fakeRes();
+        await makeHealthRoute(manager).handler(fakeReq("POST", ROUTES.health), healthWrong);
+        assert.equal(healthWrong.state.status, 405);
+        assert.equal(
+          JSON.parse(healthWrong.state.body).error,
+          "method not allowed: POST",
+          "health 405 文案逐字",
+        );
+      });
       await checkAsync("resume：POST 合法 → 200 + 调用 resumeReconnect；围栏 403 / GET 405", async () => {
         const before = managerState.resumed;
         const res = fakeRes();


### PR DESCRIPTION
## 实施摘要（按方案 v2 comment 5527633574，批 3 = 最后一批）

`refactor(routes): loopback+method 守卫收敛批3——mcp-manager 迁移+全收敛收尾（#473）`

- **B3-1 删局部 guard**：routes.ts:89-99 局部 `guard` 函数删除；12 个守卫点全部收口 `guardLoopbackMethod`（session/resume/connect/disconnect/reconnect/importJson `["POST"]`；toolDisable `["PATCH"]`；servers `["GET","POST","PATCH","DELETE"]`；events/health `["GET"]`）；loopback.js import 摘除（index.ts:176 re-export 保留 = T2 导出面零变化）。
- **B3-2 config 结构 β 例外保持**（R2）：GET 白名单直出不套守卫原样；POST 分支套 `guardLoopbackMethod(req,res,["POST"])`；**else 405 保留且不套守卫**（非 loopback+PUT 仍 405 不漂移 403）；注释显式标注「端点级方法分流先于 loopback 的刻意例外（#473 R2 结构 β）」。
- **B3-3 servers 补缺 + 每端点 ≥1 非法方法 405+文案**：smoke.ts:1660-1723 集中用例——servers OPTIONS/PUT 逐字文案（R3）；config PUT 补文案（R4）；session/resume/connect/disconnect/reconnect/importJson/toolDisable GET 405+文案；events/health POST 405+文案；既有锚全部维持。
- **B3-5 全收敛达成**：`grep -rn "if (!isLoopbackRequest" packages/*/src` **全仓零命中**；`isLoopbackRequest` 仅剩 notifier:129 / mcp-manager:176 两行 index.ts re-export（R5 含 import 行口径）。
- **批 2 复核闸顺带项**：wfp 403 文案逐字断言已在批 2 补齐（本 PR 无需重复）。

## 批次链（S2/R10）

#472（`7ee382f`）→ 批 1（#497，`56be1e5`）→ 批 2（#500，`76ddb07`）→ 本 PR（批 3，基于 76ddb07 之上，diff 仅 mcm 2 文件 +79/−44）。

## coder 断言表（对照验收 v2 批 3 条目）

| # | 条目 | 结论 | 证据 |
|---|---|---|---|
| B3-1 | 删局部 guard + 7 处调用 + 裸样板收口 | PASS | routes.ts diff（59 行变更）；grep 无局部 guard 定义 |
| B3-2 | config β 例外结构保持 | PASS | GET 直出/else 405 均不套守卫 + 显式注释；smoke 非 loopback GET→200 / POST 403 / PUT→405 全绿 |
| B3-3 | servers OPTIONS/PUT 405+文案 + 每端点 ≥1 非法方法锚 | PASS | smoke.ts:1660-1723 集中用例 |
| B3-4 | 既有围栏断言维持 | PASS | servers 403 / config POST 403 / config PUT 405 / events/health / resume / tool-disable 全绿 |
| B3-5 | 全收敛 grep（R5 含 import 行） | PASS | 零 `if (!isLoopbackRequest`；仅 2 行 re-export |
| B3-6 | 门禁 | PASS | 六门禁 exit 0（rebase 后重跑） |
| T1/T2 | pack-check 断言绿 + re-export 保留 | PASS | pack:check 0；index.ts:176 保留 |

## 复核通道结论

- **qa 独立复核**：B3-1..B3-6 + T1/T2 全 PASS（β 结构四象限行为对照与实跑、B3-3 断言逐条核对状态码+文案双断言、六门禁独立重跑全 0、B3-5 双 grep 一致、T2 导出面零变化实证、零污染）。
- **复核闸评审**：复核 subagent 运行中途中止，未产出完整报告——**主控替代执行并留痕理由**：① qa 通道已全维度独立覆盖（含本批最高风险点 β 结构）；② 同型改动（守卫样板→guard 收敛）的复核闸方法论已在批 1（语义等价 16/16）、批 2（16/16 + uiConfig 四象限）两轮验证；③ diff 仅 2 文件 +79/−44。主控亲自抽验补位：config β 端点段逐行核读——GET 直出无守卫（:105-112）、POST 分支套 `guardLoopbackMethod(req,res,["POST"])`（:117-118）、else 405 无守卫 + 「禁止误套守卫（会漂移为 403）」防误改注释（:149-151）——结构与方案 R2 完全一致，无发现。
- **桶③遗留**：servers 结构 α else 405 死代码保留（方案允许，后续 cleaner 清理）。

Closes #473
