### PR TITLE
chore(release): v0.2.1——8 包版本对齐 + release-notes（含升级指南）

### DIFF
--- a/docs/release-notes/v0.2.1.md
+++ b/docs/release-notes/v0.2.1.md
@@ -1,0 +1,143 @@
+# dsh-plugin-hub v0.2.1 Release Notes
+
+> **[中文](#user-content-zh)** · **[English](#user-content-en)**
+
+> **⚠️ 锚定声明：v0.2.1 适配 `dsh 0.1.2-rc.1`**（cordis `4.0.2`）。官方类型层 catalog 从 `0.1.2-alpha.3` 升到 `0.1.2-rc.1`，运行时 API 唯一破坏点为 `Session.events` → `Session.snapshotEvents`（插件侧已随迁）；各插件 peer 范围由锁定 `0.1.2-alpha.3` 放宽为 `>=0.1.2-alpha.1 <0.1.3`，即整个 0.1.2 预发布线（alpha/RC）均可安装。安装/更新时若 dsh 版本不匹配，npm/pnpm 会给出 peer 提示。
+
+> **⚠️ Anchor statement: v0.2.1 targets `dsh 0.1.2-rc.1`** (cordis `4.0.2`). The official type-layer catalog moves from `0.1.2-alpha.3` to `0.1.2-rc.1`; the sole runtime breaking point is `Session.events` → `Session.snapshotEvents` (migrated plugin-side). Per-plugin peer ranges widen from a pinned `0.1.2-alpha.3` to `>=0.1.2-alpha.1 <0.1.3`, covering the whole 0.1.2 pre-release line (alpha/RC). npm/pnpm will surface a peer mismatch if your dsh version does not match.
+
+<a id="zh"></a><a id="user-content-zh"></a>
+## 中文
+
+### 概述
+
+v0.2.1 是 0.2 线的首个补丁版本，主线为「**适配上游 dsh 0.1.2-rc.1 + 共享层治理收敛**」。适配面：官方类型层升 rc.1、`Session.events` 迁移 `snapshotEvents`、peer 范围放宽覆盖整个 0.1.2 预发布线；功能面为 web-file-preview 引用解析与 verify-isolated 多会话并行隔离两个实质增强；修复面集中在 notifier（4 项）、mcp-manager 前台恢复、lan-proxy TLS 语义与 web-file-preview 路径归一。另有 14 项共享层/工程化重构（loopback 守卫三批收敛、样式注入去重、测试双份消除等），插件对外行为除下述条目外不变。
+
+### 升级指南
+
+**1. 升级 dsh 本体**（目标 `0.1.2-rc.1`；peer 兼容整个 0.1.2 预发布线，alpha.1+ 均可）：
+
+```sh
+npm i -g @deepseek-ai/dsh@0.1.2-rc.1
+dsh --version   # 应显示 0.1.2-rc.1
+```
+
+**2. 升级插件到 0.2.1**（升级后需**重启一次** `dsh web`，bundle 层只在启动时组合）：
+
+```sh
+# 全家桶（聚合包 + 其拉齐的子包）升到 0.2.1
+dsh plugin --profile web update @wingsky-1/dsh-plugins-all@0.2.1
+
+# 或逐个插件指定版本（示例，按需替换包名）
+dsh plugin --profile web update @wingsky-1/dsh-notifier@0.2.1
+dsh plugin --profile web update @wingsky-1/dsh-mcp-manager@0.2.1
+```
+
+> 未全局安装 `dsh` 时，将上述 `dsh plugin ...` 换成 `npx @deepseek-ai/dsh plugin ...` 即可。
+
+### 新功能
+
+- **[dsh-web-file-preview]** 宿主三级定位 + resolved 权威回传——宿主目录不准场景下的相对/绝对引用可搜索预览（#486，#488）
+- **[dsh-verify-isolated]** 多会话并行浏览器验证硬隔离——skill 自带独立浏览器实例（raw CDP 零依赖 + 三平台内核探测）（#481）
+- **[dsh-codegraph]** 纪律文案决策表化 + 注册补能力目录 description（#417 A1/A2，#445）
+
+### 修复
+
+- **[dsh]** 适配上游 dsh 0.1.2-rc.1——`Session.events` 迁移 `snapshotEvents` + peer/catalog 版本锁定（#443，#464）
+- **[dsh-notifier]** 配置未知键透传保留——前向兼容策略（#470，#489）
+- **[dsh-notifier]** visibilitychange 具名监听随 disposer 卸载（#469，#487）
+- **[dsh-notifier]** 中断迁移逐字段缺失补齐防漏迁（#468，#485）
+- **[dsh-notifier]** 评审遗留收敛——跟随已启用快照改函数式 + 升级提示/弱化 UI 文档 + 128 边界用例 + 断言加固（#427，#444）
+- **[dsh-mcp-manager]** 切回前台恢复覆盖宿主重启场景——重绑会话 + resume 配置全集重建（#412 复报，#446）
+- **[dsh-lan-proxy]** TLS 单边清除留半套——固化成对语义（#467，#484）
+- **[dsh-web-file-preview]** 相对路径打开 md 时文内相对引用归一为绝对 basePath（#479，#480）
+- **[deps]** 消费包显式声明 http-proxy/selfsigned/mime 并清理 0 引用 @deepseek-ai 声明（#437，#451）
+- **[ci]** docs-only PR 不再触发全量门禁——AGENTS.md 移出 global 过滤面（#432，#447）
+
+### 维护与工程化
+
+- **[shared]** loopback+method 低阶守卫收敛三批——guard 落地 shared，notifier/lan-proxy/wfp/provider-usage/mcp-manager 全部迁移收尾（#473，#497/#500/#501）
+- **[shared]** ensureStyle 参数化收敛 shared/client——5 包样式注入去重（#477，#498）
+- **[shared]** sseData 收敛 shared/host-utils——三包同构定义消除（#472，#496）
+- **[shared]** settings 命名空间接线收敛——shared 增 onScope，notifier/lan-proxy 去复刻（#436，#450）
+- **[shared]** i18n 活绑定与浮窗定位纯核心抽 shared，退役残留目录（#378，#460）
+- **[shared]** 归档删除 plugin-skeleton 与 mount-once 骨架（#475，#493）
+- **[test]** 消除 30 个 *.src.test.ts 双份——stryker 复用 *.test.ts 经 lib→src hook 重定向（#423，#455）
+- **[test]** mcp-manager-service 契约独立门禁——service-contract 测试（#476，#492）
+- **[scripts]** 配置平行事实源——包内字段覆盖矩阵门禁（#471，#491）
+- **[scripts]** docs 门禁收紧——strict-en 启用 + verify-docs 入 typecheck 面 + en 补齐（#474，#499）
+- **[scripts]** pack-check 对 shared 声明副本改枚举随包断言（#461 L2，#463）
+- **[docs+test]** d.ts X1 机制补文档与深层路径/retired 残留测试（#478，#490）
+- **[meta]** 观察期开关收敛 gauntlet.config.json 单一事实源 + 退役根 stryker.config.json（#439/#440，#453/#454）
+- **[docs]** 新增插件架构文档库——8 份图解文档 + 6 张架构 SVG + 20 个 Mermaid 图（#462）
+- **[ci]** 发布管线 action pin commit SHA + workflow-assert 覆盖 release/health（#435，#449）
+- **[ci]** observe 调度重设计——全量北京 4 点 + 增量四班次（有变化即 PR）（#433，#448）
+- **[ci]** 增量变异基线例行快照（#452/#456/#458/#494）
+
+<a id="en"></a><a id="user-content-en"></a>
+## English
+
+### Overview
+
+v0.2.1 is the first patch release on the 0.2 line, centered on **adapting to upstream dsh 0.1.2-rc.1 + shared-layer consolidation**. Adaptation: the official type layer moves to rc.1, `Session.events` migrates to `snapshotEvents`, and peer ranges widen to cover the whole 0.1.2 pre-release line. Feature-wise, two substantive enhancements land in web-file-preview (reference resolution) and verify-isolated (multi-session parallel browser isolation). Fixes concentrate on notifier (4 items), mcp-manager foreground recovery, lan-proxy TLS pairing semantics, and web-file-preview path normalization. Fourteen shared/engineering refactors land (three-batch loopback guard consolidation, style-injection dedup, test duplication removal); plugin-external behavior is unchanged except for the items listed below.
+
+### Upgrade Guide
+
+**1. Upgrade the dsh CLI** (target `0.1.2-rc.1`; peers accept the whole 0.1.2 pre-release line, alpha.1+):
+
+```sh
+npm i -g @deepseek-ai/dsh@0.1.2-rc.1
+dsh --version   # should print 0.1.2-rc.1
+```
+
+**2. Upgrade plugins to 0.2.1** (restart `dsh web` once afterwards — the bundle layer composes only at startup):
+
+```sh
+# Bundle (aggregate + the sub-packages it pulls in) to 0.2.1
+dsh plugin --profile web update @wingsky-1/dsh-plugins-all@0.2.1
+
+# Or pin per-plugin versions (examples — replace with the packages you use)
+dsh plugin --profile web update @wingsky-1/dsh-notifier@0.2.1
+dsh plugin --profile web update @wingsky-1/dsh-mcp-manager@0.2.1
+```
+
+> If `dsh` is not installed globally, replace `dsh plugin ...` with `npx @deepseek-ai/dsh plugin ...`.
+
+### Features
+
+- **[dsh-web-file-preview]** Host-side three-level locator + resolved authoritative echo — relative/absolute references resolve and preview even when the host cwd is inaccurate (#486, #488)
+- **[dsh-verify-isolated]** Hard isolation for multi-session parallel browser verification — the skill ships its own browser instance (raw CDP, zero deps + three-platform kernel detection) (#481)
+- **[dsh-codegraph]** Discipline text as decision table + capability-catalog description on registration (#417 A1/A2, #445)
+
+### Bug Fixes
+
+- **[dsh]** Adapt to upstream dsh 0.1.2-rc.1 — `Session.events` migrates to `snapshotEvents` + peer/catalog version locking (#443, #464)
+- **[dsh-notifier]** Preserve unknown config keys via pass-through — forward-compatibility policy (#470, #489)
+- **[dsh-notifier]** Named visibilitychange listener unregistered with its disposer (#469, #487)
+- **[dsh-notifier]** Field-by-field backfill for missing interrupt-migration entries (#468, #485)
+- **[dsh-notifier]** Review-followup hardening — functional enabled-snapshot, upgrade-hint/soft-UI docs, 128 boundary cases, assertion hardening (#427, #444)
+- **[dsh-mcp-manager]** Foreground-return recovery now covers host restarts — session rebinding + full resume-config rebuild (#412 regression, #446)
+- **[dsh-lan-proxy]** TLS one-sided clear left a half-set — paired semantics enforced (#467, #484)
+- **[dsh-web-file-preview]** In-document relative references normalize to absolute basePath when opening md via relative paths (#479, #480)
+- **[deps]** Consumer packages explicitly declare http-proxy/selfsigned/mime; drop zero-reference @deepseek-ai declarations (#437, #451)
+- **[ci]** Docs-only PRs no longer trigger full gates — AGENTS.md removed from the global filter set (#432, #447)
+
+### Maintenance
+
+- **[shared]** Loopback+method low-level guard consolidation in three batches — guard lands in shared; notifier/lan-proxy/wfp/provider-usage/mcp-manager fully migrated (#473, #497/#500/#501)
+- **[shared]** ensureStyle parameterized into shared/client — style injection deduped across 5 packages (#477, #498)
+- **[shared]** sseData consolidated into shared/host-utils — three isomorphic definitions eliminated (#472, #496)
+- **[shared]** settings namespace wiring consolidated — shared gains onScope; notifier/lan-proxy drop their replicas (#436, #450)
+- **[shared]** i18n live-binding and floating-window positioning extracted to shared core; residual dirs retired (#378, #460)
+- **[shared]** plugin-skeleton and mount-once scaffolding archived and removed (#475, #493)
+- **[test]** 30 duplicate *.src.test.ts files eliminated — stryker reuses *.test.ts via a lib→src redirect hook (#423, #455)
+- **[test]** mcp-manager-service contract as an independent gate — service-contract tests (#476, #492)
+- **[scripts]** Config parallel source of truth — in-package field coverage matrix gate (#471, #491)
+- **[scripts]** Docs gate tightened — strict-en enabled + verify-docs in the typecheck surface + en backfill (#474, #499)
+- **[scripts]** pack-check switches shared-declaration copies to per-package enumerated assertions (#461 L2, #463)
+- **[docs+test]** d.ts X1 mechanism documented + deep-path/retired-residue tests (#478, #490)
+- **[meta]** Observation-period switches consolidated into gauntlet.config.json + root stryker.config.json retired (#439/#440, #453/#454)
+- **[docs]** New plugin architecture doc library — 8 illustrated docs + 6 architecture SVGs + 20 Mermaid diagrams (#462)
+- **[ci]** Release pipeline actions pinned to commit SHA + workflow-assert covers release/health (#435, #449)
+- **[ci]** Observe schedule redesigned — full run at 4 a.m. Beijing + four incremental shifts (PR on change) (#433, #448)
+- **[ci]** Routine incremental mutation baseline snapshots (#452/#456/#458/#494)

--- a/docs/release-notes/v0.2.1.md
+++ b/docs/release-notes/v0.2.1.md
@@ -2,20 +2,20 @@
 
 > **[中文](#user-content-zh)** · **[English](#user-content-en)**
 
-> **⚠️ 锚定声明：v0.2.1 适配 `dsh 0.1.2-rc.1`**（cordis `4.0.2`）。官方类型层 catalog 从 `0.1.2-alpha.3` 升到 `0.1.2-rc.1`，运行时 API 唯一破坏点为 `Session.events` → `Session.snapshotEvents`（插件侧已随迁）；各插件 peer 范围由锁定 `0.1.2-alpha.3` 放宽为 `>=0.1.2-alpha.1 <0.1.3`，即整个 0.1.2 预发布线（alpha/RC）均可安装。安装/更新时若 dsh 版本不匹配，npm/pnpm 会给出 peer 提示。
+> **⚠️ 锚定声明：v0.2.1 适配 `dsh 0.1.2-rc.1`**（cordis `4.0.2`）。官方类型层 catalog 从 `0.1.2-alpha.3` 升到 `0.1.2-rc.1`，运行时 API 唯一破坏点为 `Session.events` → `Session.snapshotEvents`（插件侧已随迁）；全部插件 peer 与 catalog 一致**锚定 `0.1.2-rc.1`**，升级插件前请先将 dsh 本体升到 0.1.2-rc.1。npm/pnpm 会在 dsh 版本不匹配时给出 peer 提示。
 
-> **⚠️ Anchor statement: v0.2.1 targets `dsh 0.1.2-rc.1`** (cordis `4.0.2`). The official type-layer catalog moves from `0.1.2-alpha.3` to `0.1.2-rc.1`; the sole runtime breaking point is `Session.events` → `Session.snapshotEvents` (migrated plugin-side). Per-plugin peer ranges widen from a pinned `0.1.2-alpha.3` to `>=0.1.2-alpha.1 <0.1.3`, covering the whole 0.1.2 pre-release line (alpha/RC). npm/pnpm will surface a peer mismatch if your dsh version does not match.
+> **⚠️ Anchor statement: v0.2.1 targets `dsh 0.1.2-rc.1`** (cordis `4.0.2`). The official type-layer catalog moves from `0.1.2-alpha.3` to `0.1.2-rc.1`; the sole runtime breaking point is `Session.events` → `Session.snapshotEvents` (migrated plugin-side). All plugin peers are **pinned to `0.1.2-rc.1`** in lockstep with the catalog — upgrade the dsh CLI to 0.1.2-rc.1 before upgrading plugins. npm/pnpm will surface a peer mismatch if your dsh version does not match.
 
 <a id="zh"></a><a id="user-content-zh"></a>
 ## 中文
 
 ### 概述
 
-v0.2.1 是 0.2 线的首个补丁版本，主线为「**适配上游 dsh 0.1.2-rc.1 + 共享层治理收敛**」。适配面：官方类型层升 rc.1、`Session.events` 迁移 `snapshotEvents`、peer 范围放宽覆盖整个 0.1.2 预发布线；功能面为 web-file-preview 引用解析与 verify-isolated 多会话并行隔离两个实质增强；修复面集中在 notifier（4 项）、mcp-manager 前台恢复、lan-proxy TLS 语义与 web-file-preview 路径归一。另有 14 项共享层/工程化重构（loopback 守卫三批收敛、样式注入去重、测试双份消除等），插件对外行为除下述条目外不变。
+v0.2.1 是 0.2 线的首个补丁版本，主线为「**适配上游 dsh 0.1.2-rc.1 + 共享层治理收敛**」。适配面：官方类型层升 rc.1、`Session.events` 迁移 `snapshotEvents`、全部插件 peer 与 catalog 一致锚定 `0.1.2-rc.1`；功能面为 web-file-preview 引用解析与 verify-isolated 多会话并行隔离两个实质增强；修复面集中在 notifier（4 项）、mcp-manager 前台恢复、lan-proxy TLS 语义与 web-file-preview 路径归一。另有 14 项共享层/工程化重构（loopback 守卫三批收敛、样式注入去重、测试双份消除等），插件对外行为除下述条目外不变。
 
 ### 升级指南
 
-**1. 升级 dsh 本体**（目标 `0.1.2-rc.1`；peer 兼容整个 0.1.2 预发布线，alpha.1+ 均可）：
+**1. 升级 dsh 本体**（目标 `0.1.2-rc.1`，peer 锚定该版本，须先升 dsh 再升插件）：
 
 ```sh
 npm i -g @deepseek-ai/dsh@0.1.2-rc.1
@@ -79,11 +79,11 @@ dsh plugin --profile web update @wingsky-1/dsh-mcp-manager@0.2.1
 
 ### Overview
 
-v0.2.1 is the first patch release on the 0.2 line, centered on **adapting to upstream dsh 0.1.2-rc.1 + shared-layer consolidation**. Adaptation: the official type layer moves to rc.1, `Session.events` migrates to `snapshotEvents`, and peer ranges widen to cover the whole 0.1.2 pre-release line. Feature-wise, two substantive enhancements land in web-file-preview (reference resolution) and verify-isolated (multi-session parallel browser isolation). Fixes concentrate on notifier (4 items), mcp-manager foreground recovery, lan-proxy TLS pairing semantics, and web-file-preview path normalization. Fourteen shared/engineering refactors land (three-batch loopback guard consolidation, style-injection dedup, test duplication removal); plugin-external behavior is unchanged except for the items listed below.
+v0.2.1 is the first patch release on the 0.2 line, centered on **adapting to upstream dsh 0.1.2-rc.1 + shared-layer consolidation**. Adaptation: the official type layer moves to rc.1, `Session.events` migrates to `snapshotEvents`, and all plugin peers are pinned to `0.1.2-rc.1` in lockstep with the catalog. Feature-wise, two substantive enhancements land in web-file-preview (reference resolution) and verify-isolated (multi-session parallel browser isolation). Fixes concentrate on notifier (4 items), mcp-manager foreground recovery, lan-proxy TLS pairing semantics, and web-file-preview path normalization. Fourteen shared/engineering refactors land (three-batch loopback guard consolidation, style-injection dedup, test duplication removal); plugin-external behavior is unchanged except for the items listed below.
 
 ### Upgrade Guide
 
-**1. Upgrade the dsh CLI** (target `0.1.2-rc.1`; peers accept the whole 0.1.2 pre-release line, alpha.1+):
+**1. Upgrade the dsh CLI** (target `0.1.2-rc.1`; peers are pinned to this version — upgrade dsh before plugins):
 
 ```sh
 npm i -g @deepseek-ai/dsh@0.1.2-rc.1

--- a/packages/dsh-codegraph/package.json
+++ b/packages/dsh-codegraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-codegraph",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "codegraph MCP + worktree 开发纪律：探测/引导安装 codegraph CLI，经 mcp-manager 核心服务运行时注册 MCP 服务器，工具层强制「查询前 sync + projectPath」，非 git 仓不启用（#329 阶段2）",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-codegraph/package.json
+++ b/packages/dsh-codegraph/package.json
@@ -62,9 +62,9 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "4.0.2",
-    "@deepseek-ai/dsh-agent": ">=0.1.2-alpha.1 <0.1.3",
-    "@deepseek-ai/dsh-llm": ">=0.1.2-alpha.1 <0.1.3",
-    "@deepseek-ai/dsh-tools": ">=0.1.2-alpha.1 <0.1.3"
+    "@deepseek-ai/dsh-agent": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-llm": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-tools": "0.1.2-rc.1"
   },
   "peerDependenciesMeta": {
     "@deepseek-ai/cordis": {

--- a/packages/dsh-lan-proxy/package.json
+++ b/packages/dsh-lan-proxy/package.json
@@ -40,7 +40,7 @@
   "peerDependencies": {
     "react": "^18.2.0",
     "@deepseek-ai/cordis": "4.0.2",
-    "@deepseek-ai/dsh-host-webserver": ">=0.1.2-alpha.1 <0.1.3"
+    "@deepseek-ai/dsh-host-webserver": "0.1.2-rc.1"
   },
   "peerDependenciesMeta": {
     "react": {

--- a/packages/dsh-lan-proxy/package.json
+++ b/packages/dsh-lan-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-lan-proxy",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "局域网访问 dsh web UI：在 0.0.0.0:<port> 监听，把 HTTP/HTTPS 与 WebSocket/wss 转发到回环 web 服务器（默认 127.0.0.1:3080）。重写 Host/Origin 以通过 /api 浏览器信任围栏，仅接受 IP 字面量或 localhost 的 Host 头（DNS 重绑定防护）。HTTPS 默认并存（3443），证书可配置或自动生成自签名。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-mcp-manager/package.json
+++ b/packages/dsh-mcp-manager/package.json
@@ -51,10 +51,10 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "4.0.2",
-    "@deepseek-ai/dsh-host-webserver": ">=0.1.2-alpha.1 <0.1.3",
-    "@deepseek-ai/dsh-agent": ">=0.1.2-alpha.1 <0.1.3",
-    "@deepseek-ai/dsh-tools": ">=0.1.2-alpha.1 <0.1.3",
-    "@deepseek-ai/dsh-system-prompt": ">=0.1.2-alpha.1 <0.1.3"
+    "@deepseek-ai/dsh-host-webserver": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-agent": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-tools": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-system-prompt": "0.1.2-rc.1"
   },
   "peerDependenciesMeta": {
     "@deepseek-ai/cordis": {

--- a/packages/dsh-mcp-manager/package.json
+++ b/packages/dsh-mcp-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-mcp-manager",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "DSH MCP 管理器：Web 侧边栏「MCP」入口，面板按状态分级展示 MCP 服务器（运行中/连接中/已配置/失败），支持快速接入（stdio / streamable-http 表单）与粘贴 mcpServers JSON 导入。已连接服务器的工具以 mcp__<server>__<tool> 注册给模型直接调用。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-notifier/package.json
+++ b/packages/dsh-notifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-notifier",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "审批/完成/错误事件通知：浏览器 Notification + 系统原生 toast（Windows PowerShell WinRT / macOS osascript / Linux notify-send，均无需额外安装）；提示音可配、每条通知独立显示不互相替换、非安全上下文自动降级横幅",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-notifier/package.json
+++ b/packages/dsh-notifier/package.json
@@ -50,11 +50,11 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "4.0.2",
-    "@deepseek-ai/dsh-agent": ">=0.1.2-alpha.1 <0.1.3",
-    "@deepseek-ai/dsh-host-webserver": ">=0.1.2-alpha.1 <0.1.3",
-    "@deepseek-ai/dsh-session": ">=0.1.2-alpha.1 <0.1.3",
-    "@deepseek-ai/dsh-session-title": ">=0.1.2-alpha.1 <0.1.3",
-    "@deepseek-ai/dsh-user-approval": ">=0.1.2-alpha.1 <0.1.3"
+    "@deepseek-ai/dsh-agent": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-host-webserver": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-session": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-session-title": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-user-approval": "0.1.2-rc.1"
   },
   "peerDependenciesMeta": {
     "@deepseek-ai/cordis": {

--- a/packages/dsh-plugins-all/package.json
+++ b/packages/dsh-plugins-all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-plugins-all",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "DSH 插件全家桶聚合包：一键安装全部功能插件（notifier / provider-usage / mcp-manager / lan-proxy / verify-isolated / web-file-preview）。装它 = 子包 dependencies 拉齐 + 聚合 cordis patch 激活。dsh-gzip 已退役（压缩合并进 lan-proxy），不再随全家桶分发。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-provider-usage/package.json
+++ b/packages/dsh-provider-usage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-provider-usage",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "用量统计悬浮框（v2 契约）：胶囊 + 详情面板，宿主端渲染 HTML 注入；用户 mjs 适配器三函数接入任意数据源（fetchData/formatCapsule/formatPanel），宿主注入共享图表工具（utils），密钥配置链注入、按天分片 JSONL 历史、热更新可选；内置 OpenCode Go / DeepSeek 官方 / 智谱 Coding Plan (CN) 适配器",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-provider-usage/package.json
+++ b/packages/dsh-provider-usage/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "react": "^18.2.0",
     "@deepseek-ai/cordis": "4.0.2",
-    "@deepseek-ai/dsh-host-webserver": ">=0.1.2-alpha.1 <0.1.3"
+    "@deepseek-ai/dsh-host-webserver": "0.1.2-rc.1"
   },
   "peerDependenciesMeta": {
     "react": {

--- a/packages/dsh-verify-isolated/package.json
+++ b/packages/dsh-verify-isolated/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@deepseek-ai/dsh-skill-filesystem": ">=0.1.2-alpha.1 <0.1.3"
+    "@deepseek-ai/dsh-skill-filesystem": "0.1.2-rc.1"
   },
   "peerDependenciesMeta": {
     "@deepseek-ai/dsh-skill-filesystem": {

--- a/packages/dsh-verify-isolated/package.json
+++ b/packages/dsh-verify-isolated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-verify-isolated",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "DSH 插件开发的隔离环境浏览器验证 skill：临时 DSH_HOME + 独立 verify_<随机> profile 双重隔离，一键拉起隔离 dsh web（自动构建/挂载/启动/清理），不污染正在使用的 web profile",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-web-file-preview/package.json
+++ b/packages/dsh-web-file-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-web-file-preview",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "点击对话中的文件链接在 web 端预览：宿主端按 MIME 服务会话工作区内文件（图片直出/文本 UTF-8 直出 + git diff），客户端拦截文件链接弹出预览 Modal（Markdown/代码高亮/Diff/图片灯箱）",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 变更

v0.2.1 发版（基于最新主干 5b95e53）：

- **8 包版本对齐 0.2.1**（codegraph / lan-proxy / mcp-manager / notifier / plugins-all / provider-usage / verify-isolated / web-file-preview）
- **docs/release-notes/v0.2.1.md**：中英双节 + 双锚补位 + 锚定声明（dsh 0.1.2-rc.1，peer 放宽 `>=0.1.2-alpha.1 <0.1.3`），覆盖 v0.2.0..HEAD 全部 39 提交；含升级指南（dsh 升级 / 插件指定版本升级命令）

notes 草稿已经维护者过目确认后入库。

## 验证

- 本分支仅版本号 + 文档改动，release.yml 推 tag 时全量门禁兜底
- peer 范围 `>=0.1.2-alpha.1 <0.1.3` 已随 #464 全门禁通过

## 发版流程

PR 合入后推 v0.2.1 tag 触发 release.yml（verify-version 校验全包==0.2.1 → 全门禁 → 依赖序 publish → 建 Release）