### PR TITLE
feat(dsh-verify-isolated): verify-isolated.sh 加固——--dsh 版本锚定/显式回环与遥测禁用/就绪断言/产物校验

### DIFF
--- a/packages/dsh-verify-isolated/README.en.md
+++ b/packages/dsh-verify-isolated/README.en.md
@@ -38,18 +38,22 @@ built-in skill and becomes available to all sessions in the profile (check with
 - **Minimal startup dependencies**: profile bundles contain `@deepseek-ai/dsh-base` +
   `@deepseek-ai/dsh-web-app` (built-in bundles are resolved by name from the dsh install
   directory, not via npm);
-- **One-shot script** `skills/dsh-verify-isolated/scripts/verify-isolated.sh`: create temp
-  DSH_HOME → create profile → inject web-app bundle → build and link local plugins →
-  (optionally `--browser`) launch a dedicated browser instance → start → unified trap
-  cleanup on exit (browser process + user-data-dir + DSH_HOME, no leftovers);
-  `--port 0` auto-detects the real free port (no longer prints an invalid 0).
+- **One-shot script** `skills/dsh-verify-isolated/scripts/verify-isolated.sh`: validate the
+  dsh entry and print its version (`--dsh` pins the target dsh version) → create temp
+  DSH_HOME → create profile (explicit `plugin list` init) → inject web-app bundle →
+  build and link local plugins (`--no-build` validates artifact presence + staleness
+  warning) → (optionally `--browser`) launch a dedicated browser instance → start
+  (explicit `--host 127.0.0.1` loopback + `DSH_TELEMETRY_DISABLED=1` telemetry off) →
+  readiness probe → unified trap cleanup on exit (dsh process + browser process +
+  user-data-dir + DSH_HOME, no leftovers); `--port 0` auto-detects the real free port
+  (no longer prints an invalid 0).
 
 ## Package layout
 
 ```text
 skills/dsh-verify-isolated/
   SKILL.md                        # skill definition (frontmatter name=dsh-verify-isolated)
-  scripts/verify-isolated.sh      # one-shot isolated verification script (--browser / --port 0 / --keep / --no-build)
+  scripts/verify-isolated.sh      # one-shot isolated verification script (--dsh / --browser / --port 0 / --keep / --no-build)
   scripts/browser-driver.mjs      # self-contained browser driver (raw CDP, zero deps, --json atomic CLI)
 cordis.patch.yml                  # reuses official dsh-skill-filesystem + bundledSkillDir
 lib/index.js                      # host gate export (name + empty apply)
@@ -69,6 +73,9 @@ bash "$SKILL_BASE/scripts/verify-isolated.sh" --port 3456 <plugin-package-path>
 # parallel sessions / browser verification: --port 0 auto-detects the port,
 # --browser launches a dedicated browser instance
 bash "$SKILL_BASE/scripts/verify-isolated.sh" --port 0 --browser <plugin-package-path>
+# pin the dsh version (required when verifying a specific dsh release's ecosystem,
+# prevents PATH drift)
+bash "$SKILL_BASE/scripts/verify-isolated.sh" --dsh /opt/dsh-0.1.2-alpha.2/bin/dsh --port 0 <plugin-package-path>
 ```
 
 Browser instance operations (instance info in `$DSH_HOME/browser.state`; the command
@@ -86,6 +93,9 @@ node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/brow
 
 - The isolated environment carries no real credentials (the temp `DSH_HOME` has no
   `~/.dsh` data);
+- The isolated `dsh web` binds explicitly to loopback (`--host 127.0.0.1`, reachable
+  from this machine only) and explicitly disables telemetry
+  (`DSH_TELEMETRY_DISABLED=1`, no test data leaves the machine);
 - It never stops/restarts the running main `dsh web` process (dedicated port);
 - The browser instance binds only to a loopback debug port
   (`--remote-debugging-address=127.0.0.1`), reachable from this machine only;

--- a/packages/dsh-verify-isolated/README.md
+++ b/packages/dsh-verify-isolated/README.md
@@ -32,18 +32,21 @@ dsh plugin --profile web add @wingsky-1/dsh-verify-isolated
   全缺失 fail-fast 打印安装指引；
 - **最小启动依赖**：profile bundles 含 `@deepseek-ai/dsh-base` +
   `@deepseek-ai/dsh-web-app`（内置 bundle 按名从 dsh 安装目录解析，不走 npm）；
-- **一键脚本** `skills/dsh-verify-isolated/scripts/verify-isolated.sh`：建临时
-  DSH_HOME → 建 profile → 注入 web-app bundle → 构建并 link 本地插件 →
-  （可选 `--browser`）启动独立浏览器实例 → 启动 → 退出 trap 统一清理
-  （浏览器进程 + user-data-dir + DSH_HOME 无残留）；`--port 0` 自动探测真实
-  空闲端口（不再打印无效的 0）。
+- **一键脚本** `skills/dsh-verify-isolated/scripts/verify-isolated.sh`：校验 dsh
+  入口并打印版本（`--dsh` 锚定目标 dsh 版本）→ 建临时 DSH_HOME → 建 profile
+  （`plugin list` 显式初始化）→ 注入 web-app bundle → 构建并 link 本地插件
+  （`--no-build` 时校验产物存在 + 陈旧警告）→ （可选 `--browser`）启动独立浏览器
+  实例 → 启动（显式 `--host 127.0.0.1` 回环 + `DSH_TELEMETRY_DISABLED=1` 遥测
+  禁用）→ 就绪断言 → 退出 trap 统一清理（dsh 进程 + 浏览器进程 +
+  user-data-dir + DSH_HOME 无残留）；`--port 0` 自动探测真实空闲端口（不再打印
+  无效的 0）。
 
 ## 包结构
 
 ```text
 skills/dsh-verify-isolated/
   SKILL.md                        # skill 定义（frontmatter name=dsh-verify-isolated）
-  scripts/verify-isolated.sh      # 一键隔离验证脚本（--browser / --port 0 / --keep / --no-build）
+  scripts/verify-isolated.sh      # 一键隔离验证脚本（--dsh / --browser / --port 0 / --keep / --no-build）
   scripts/browser-driver.mjs      # 自带独立浏览器驱动（raw CDP 零依赖，--json 原子操作 CLI）
 cordis.patch.yml                  # 复用官方 dsh-skill-filesystem + bundledSkillDir
 lib/index.js                      # 宿主门禁出口（name + 空 apply）
@@ -61,6 +64,8 @@ skill 加载后按清单执行；也可直接调包内一键脚本。脚本相�
 bash "$SKILL_BASE/scripts/verify-isolated.sh" --port 3456 <插件包路径>
 # 多会话并行/浏览器验证：--port 0 自动探测端口，--browser 拉起独立浏览器实例
 bash "$SKILL_BASE/scripts/verify-isolated.sh" --port 0 --browser <插件包路径>
+# 锚定 dsh 版本（验证特定 dsh 版本生态时必带，防 PATH 漂移）
+bash "$SKILL_BASE/scripts/verify-isolated.sh" --dsh /opt/dsh-0.1.2-alpha.2/bin/dsh --port 0 <插件包路径>
 ```
 
 浏览器实例操作（实例信息在 `$DSH_HOME/browser.state`；命令契约见
@@ -76,6 +81,8 @@ node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/brow
 ## 安全模型
 
 - 隔离环境不携带真实凭据（临时 `DSH_HOME` 无 `~/.dsh` 数据）；
+- 隔离 `dsh web` 显式回环绑定（`--host 127.0.0.1`，仅本机可连）并显式禁用遥测
+  （`DSH_TELEMETRY_DISABLED=1`，测试数据不外发）；
 - 不关闭/重启运行中的主 `dsh web` 进程（独立端口）；
 - 浏览器实例只绑定回环调试端口（`--remote-debugging-address=127.0.0.1`），
   仅本机可连；

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/SKILL.md
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/SKILL.md
@@ -58,9 +58,13 @@ SKILL_BASE="<Base directory for this skill 一行的绝对路径，见上方 ski
 bash "$SKILL_BASE/scripts/verify-isolated.sh" --port 3456 <插件包路径>
 # 多包：... --port 3456 <包A路径> <包B路径>
 # 端口冲突：--port 0 让脚本自动探测真实空闲端口；--keep 保留临时环境便于排查
-# 跳过构建：--no-build（默认会先 pnpm build 各插件，保证 lib/ 或 dist/ 产物存在）
+# 跳过构建：--no-build（默认会先 pnpm build 各插件，保证 lib/ 或 dist/ 产物存在；
+#           产物缺失会报可操作错误，源码比产物新会给陈旧警告）
 # 浏览器验证：加 --browser 自动拉起 skill 自带独立浏览器实例（见 §5 多会话并行）
 bash "$SKILL_BASE/scripts/verify-isolated.sh" --port 0 --browser <插件包路径>
+# 锚定 dsh 版本：验证特定 dsh 版本的生态时必须 --dsh 指定入口（默认用 PATH 中的
+# dsh——PATH 碰巧是什么版本就验什么，结果不可复现）
+bash "$SKILL_BASE/scripts/verify-isolated.sh" --dsh /opt/dsh-0.1.2-alpha.2/bin/dsh --port 0 <插件包路径>
 ```
 
 若注入的 base 不可用或不确信，先自证脚本位置再执行
@@ -68,11 +72,14 @@ bash "$SKILL_BASE/scripts/verify-isolated.sh" --port 0 --browser <插件包路�
 `verify-isolated.sh` 取其真实绝对路径——脚本从任意 cwd 以绝对路径调用
 （自包含、不依赖自身位置）；`SKILL_BASE` 里的尖括号是占位说明，不是可执行值。
 
-脚本自动完成：建临时 `DSH_HOME` → 建 `verify_<8位随机>` profile → 注入内置
-`@deepseek-ai/dsh-web-app` bundle → **构建并**把本地插件 link 进 profile →
-`--browser` 时启动独立浏览器实例（实例信息写入 `$DSH_HOME/browser.state`）→
-启动隔离 `dsh web`（前台阻塞）。`Ctrl+C` 退出时 `trap` 自动清理浏览器实例、
-临时 `DSH_HOME` 与 profile。
+脚本自动完成：建临时 `DSH_HOME` → 校验 dsh 入口并打印版本（`--dsh` 锚定）→ 建
+`verify_<8位随机>` profile（`dsh plugin --profile <p> list` 显式初始化，失败即报
+可操作错误）→ 注入内置 `@deepseek-ai/dsh-web-app` bundle → **构建并**把本地插件
+link 进 profile（`--no-build` 时校验产物存在 + 陈旧警告）→ `--browser` 时启动
+独立浏览器实例（实例信息写入 `$DSH_HOME/browser.state`）→ 启动隔离 `dsh web`
+（显式 `--host 127.0.0.1` 回环 + `DSH_TELEMETRY_DISABLED=1` 遥测禁用）→ **就绪
+断言**（轮询 HTTP 可达，15s 超时报可操作错误）→ 前台等待。`Ctrl+C` 退出时
+`trap` 自动清理 dsh 进程、浏览器实例、临时 `DSH_HOME` 与 profile。
 
 > **构建说明**：dsh 直读构建产物（dsh-plugin-hub 各包的 `lib/`、xiaozhuge 的 `dist/`），
 > 脚本默认在挂载前 `pnpm build` 各插件，保证产物存在；产物已就绪时可 `--no-build` 跳过。
@@ -86,8 +93,8 @@ DSH_HOME=$(mktemp -d)
 export DSH_HOME
 
 # 2. 第二层隔离：独立 profile（verify_<8位随机>，避免与真实环境冲突）
-PROFILE=verify_$(openssl rand -hex 4)
-dsh plugin --profile "$PROFILE" add --help >/dev/null   # 初始化 profile（含 dsh-base 模板）
+PROFILE="verify_$(node -e 'console.log(require("node:crypto").randomBytes(4).toString("hex"))')"
+dsh plugin --profile "$PROFILE" list >/dev/null   # 显式初始化 profile（含 dsh-base 模板；失败即停）
 
 # 3. 注入内置 web-app bundle：@deepseek-ai/dsh-base、@deepseek-ai/dsh-web-app 按名
 #    从 dsh 安装目录解析，不进 dependencies、不走 npm
@@ -105,8 +112,12 @@ node -e '
 # 4. 挂载本地插件（主 checkout 的 packages/*，link 进 profile）
 dsh plugin --profile "$PROFILE" add /path/to/main-checkout/packages/dsh-<name>
 
-# 5. 启动隔离 dsh web（指定不冲突端口；--port 0 让系统随机）
-dsh --profile "$PROFILE" --port 3456
+# 5. 启动隔离 dsh web（指定不冲突端口；--port 0 让系统随机；显式回环 + 遥测禁用）
+DSH_TELEMETRY_DISABLED=1 dsh --profile "$PROFILE" --host 127.0.0.1 --port 3456 --no-open
+
+# 6. 就绪断言（对齐脚本 M2 行为）：轮询 HTTP 可达再开始验证（GUI 带鉴权，2xx-4xx
+#    均算就绪；连接拒绝继续等，15s 超时报错）
+node -e 'const t=Date.now();(async()=>{for(;;){try{const r=await fetch("http://127.0.0.1:3456/",{signal:AbortSignal.timeout(1500)});if(r.status<500)break}catch{}if(Date.now()-t>15000)throw new Error("15s 未就绪");await new Promise(r=>setTimeout(r,250))}})()'
 ```
 
 需要浏览器实例时（第四层隔离，等价于脚本 `--browser`）：
@@ -133,6 +144,11 @@ node "$SKILL_BASE/scripts/browser-driver.mjs" quit --state "$DSH_HOME/browser.st
   `@deepseek-ai/dsh-frontend` 不在 registry，会 404）。
 - **独立端口**：`--port <n>` 选择与运行中主 `dsh web` 不冲突的端口（如 3456），
   `--port 0` 自动探测真实空闲端口，**不要关闭或重启运行中的主 dsh web 进程**。
+- **显式回环 + 遥测禁用**：隔离实例一律 `--host 127.0.0.1`（当前 dsh 默认即回环，
+  显式写死防上游默认变更）+ `DSH_TELEMETRY_DISABLED=1`（测试数据不外发遥测）；
+  一键脚本已内置，手动拉起时也必须带上。
+- **锚定 dsh 版本**：验证特定 dsh 版本的生态时用 `--dsh <path>` 指定入口，默认
+  PATH 中的 `dsh` 会让验证结果随环境漂移、不可复现。
 - **不复制真实凭据**：隔离环境使用临时 `DSH_HOME`，不携带 `~/.dsh` 下的真实凭据、
   令牌、API 密钥等。若验证需要凭据，使用测试专用凭据或 mock 数据。
 - **验证完成后清理**：停止隔离 `dsh web` 进程后，删除临时 `DSH_HOME` 目录
@@ -161,6 +177,7 @@ headless 内核，实例信息写入各任务自己的 `browser.state`（`--brow
 | 2 | profile | 脚本输出 `profile=verify_<8位随机>`；`dsh plugin --profile web list` 不受影响 |
 | 3 | 端口 | dsh web 端口与主实例及其它并行实例互不相同；`--port 0` 时脚本会打印探测到的真实端口 |
 | 4 | 浏览器实例 | `browser.state` 的 `port`/`pid`/`userDataDir` 为本任务独有；并行任务各自的 state 文件路径不同（各在各自 DSH_HOME 下） |
+| 5 | 插件持久化隔离感知 | 验证涉及**读写插件自己的持久化文件**（通知记录、用量数据等）时，先确认该插件落盘路径 DSH_HOME 感知（hub 内查是否有 `process.env.DSH_HOME ?? homedir()/.dsh` 契约）。**不感知时的处置**：在验证记录中标注「该插件隔离盲区」→ 验证中避免触发会写持久化文件的操作（清理/发送测试类按钮）→ 提报 issue（先例 #510）。读面串同样算盲区，截图含真实数据时须说明 |
 
 并行验证建议：每个任务**单独运行一个 `verify-isolated.sh --port 0 --browser` 进程**
 （各自独立临时 DSH_HOME / profile / 端口 / 浏览器实例），不要在同一隔离环境内
@@ -260,7 +277,11 @@ node "$SKILL_BASE/scripts/browser-driver.mjs" console   --state "$STATE" --url h
 
 ## 7. 完成检查
 
-- [ ] 隔离 `dsh web` 实例已启动且不冲突主实例端口（`--port 0` 时打印真实端口）
+- [ ] 隔离 `dsh web` 实例已启动且不冲突主实例端口（`--port 0` 时打印真实端口；
+      脚本会做就绪断言，超时未就绪会给出可操作错误）
+- [ ] 隔离实例为显式回环 + 遥测禁用（脚本内置；手动拉起时核对 `--host` 与
+      `DSH_TELEMETRY_DISABLED=1`）
+- [ ] 若验证涉及插件持久化文件：已核对插件 DSH_HOME 感知（不感知按 §5.1 第 5 项处置）
 - [ ] 若做并行验证：四重隔离自检清单（§5.1）逐项通过，各任务浏览器 state 独立
 - [ ] 插件 UI 在隔离环境渲染正常（双主题 + 窄屏如适用）
 - [ ] Console 无未处理错误（挂载失败仅 warn）

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/verify-isolated.sh
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/verify-isolated.sh
@@ -4,11 +4,17 @@
 # 用途：在不污染真实 ~/.dsh（含正在使用的 web profile）的前提下，拉起一个
 # 完全隔离的 dsh web 实例，用于客户端 UI 改动的浏览器实测。
 #
-# 双重隔离：
+# 四重隔离：
 #   1. DSH_HOME 指向全新临时目录 —— 隔离凭据 / 会话 / home 级 cordis.patch.yml；
-#   2. 独立 profile verify_<8位随机> —— 隔离插件组合栈，不触碰用户 web profile。
+#   2. 独立 profile verify_<8位随机> —— 隔离插件组合栈，不触碰用户 web profile；
+#   3. 独立端口 + 显式回环（--host 127.0.0.1）—— 当前 dsh 默认即回环，显式写死
+#      把隐式行为钉成结构性保证，防上游默认变更；
+#   4. --browser 时独立浏览器实例（browser-driver.mjs，raw CDP 零依赖）。
+# 隔离环境同时显式 DSH_TELEMETRY_DISABLED=1：测试数据不外发遥测。
 #
-# 最小依赖（实测验证）：
+# 依赖：
+#   - node（profile 初始化校验 / bundle 注入 / 端口探测 / 产物校验 / 就绪断言均走
+#     node，零新增系统依赖）；bash + coreutils 基础面。
 #   - dsh 安装目录自带 @deepseek-ai/dsh-base 与 @deepseek-ai/dsh-web-app，
 #     按名从安装目录解析，不写进 dependencies、不走 npm（dsh-web-app 的依赖
 #     @deepseek-ai/dsh-frontend 不在 registry，dsh plugin add 走 npm 会 404）。
@@ -16,8 +22,10 @@
 #     dsh.profile.bundles（紧跟 @deepseek-ai/dsh-base 之后），再添加用户插件。
 #
 # 用法：
-#   verify-isolated.sh [--port <port>] [--browser] [--keep] [--no-build] [-- <pkg-path>...]
+#   verify-isolated.sh [--dsh <path>] [--port <port>] [--browser] [--keep] [--no-build] [-- <pkg-path>...]
 #
+#   --dsh <path>  指定 dsh 入口（默认 PATH 中的 dsh）。隔离实测必须锚定目标 dsh
+#                 版本——PATH 里碰巧存在的版本会让验证结果不可复现（#376 H1）。
 #   默认：端口 3456（--port 0 自动探测真实空闲端口），结束后自动清理临时
 #   DSH_HOME 与 profile。
 #   --browser 额外启动独立浏览器实例（scripts/browser-driver.mjs，raw CDP 零依赖）：
@@ -25,12 +33,15 @@
 #     $ISOLATED_HOME/browser.state（与 DSH_HOME 同生命周期，退出随 trap 一并清理，
 #     多会话并行各自独立、互不串扰）。浏览器操作命令见 browser-driver.mjs --help。
 #   --keep     结束后保留临时 DSH_HOME（不删，方便排查；路径会打印）
-#   --no-build 跳过挂载前的 pnpm build（默认会构建每个插件，保证 lib/ 或 dist/ 产物存在）
+#   --no-build 跳过挂载前的 pnpm build（默认会构建每个插件，保证 lib/ 或 dist/
+#              产物存在）；此时校验产物存在（缺失即报可操作错误），并对比 src/
+#              与产物的 mtime，源码更新即给陈旧警告（防「存在但陈旧」锚定旧版本）
 #   --         之后的位置参数为要挂载的本地插件路径（相对路径基于当前 cwd 解析）
 #
 # 示例（在插件仓库根执行）：
 #   verify-isolated.sh packages/dsh-mcp-manager
 #   verify-isolated.sh --port 0 --browser packages/dsh-notifier packages/dsh-mcp-manager
+#   verify-isolated.sh --dsh /opt/dsh-0.1.2-alpha.2/bin/dsh --port 0 <插件路径>
 # 绝对路径亦可：
 #   verify-isolated.sh /path/to/repo/packages/dsh-mcp-manager
 set -euo pipefail
@@ -39,10 +50,12 @@ PORT=3456
 KEEP=0
 BUILD=1
 BROWSER=0
+DSH_BIN=dsh
 PKGS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --port) PORT="$2"; shift 2 ;;
+    --dsh) [[ $# -ge 2 ]] || { echo "错误: --dsh 需要一个路径参数" >&2; exit 2; }; DSH_BIN="$2"; shift 2 ;;
+    --port) [[ $# -ge 2 ]] || { echo "错误: --port 需要一个端口参数" >&2; exit 2; }; PORT="$2"; shift 2 ;;
     --browser) BROWSER=1; shift ;;
     --keep) KEEP=1; shift ;;
     --no-build) BUILD=0; shift ;;
@@ -52,18 +65,39 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# 0. dsh 入口校验与版本锚定展示：--dsh 指定独立 prefix 安装的 dsh 时，隔离实例
+#    必须确实用该版本拉起，否则验证结果无效（fail fast，不在建完环境后才失败）。
+#    解析为绝对路径后全程用 $DSH_ABS 调用——真正锚定版本，防 PATH 漂移。
+DSH_RAW="$(command -v "$DSH_BIN" 2>/dev/null || true)"
+if [[ -z "$DSH_RAW" ]]; then
+  echo "错误: 找不到 dsh 入口: $DSH_BIN（--dsh 需指向可执行的 dsh）" >&2
+  exit 2
+fi
+DSH_ABS="$(node -e 'console.log(require("node:path").resolve(process.argv[1]))' "$DSH_RAW")"
+if [[ ! -x "$DSH_ABS" ]]; then
+  echo "错误: dsh 入口不可执行: $DSH_ABS（--dsh 需指向可执行的 dsh）" >&2
+  exit 2
+fi
+echo "dsh 入口: $DSH_ABS ($("$DSH_ABS" --version 2>/dev/null | head -n 1))"
+
 # 本脚本目录（browser-driver.mjs 同目录随 skill 分发）
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # 1. 第一层隔离：全新临时 DSH_HOME（隔离全部用户数据）
 ISOLATED_HOME="$(mktemp -d)"
 export DSH_HOME="$ISOLATED_HOME"
-PROFILE="verify_$(openssl rand -hex 4)"
+# profile 随机后缀走 node crypto（替代 openssl CLI，最小环境也可用）
+PROFILE="verify_$(node -e 'console.log(require("node:crypto").randomBytes(4).toString("hex"))')"
 BROWSER_STATE="$ISOLATED_HOME/browser.state"
+DSH_PID=""
 cleanup() {
-  # --browser：先优雅关闭浏览器实例（CDP Browser.close + kill 兜底），
-  # 再清理 DSH_HOME——user-data-dir 在 ISOLATED_HOME 内，随 rm -rf 一并删除，
-  # 进程与临时目录双重保障无残留（Ctrl+C / 崩溃 / 正常退出均走 EXIT trap）。
+  # 先停隔离 dsh web（后台子进程），再优雅关闭浏览器实例（CDP Browser.close +
+  # kill 兜底），最后清理 DSH_HOME——user-data-dir 在 ISOLATED_HOME 内，随 rm -rf
+  # 一并删除，进程与临时目录双重保障无残留（Ctrl+C / 崩溃 / 正常退出均走 EXIT trap）。
+  if [[ -n "$DSH_PID" ]] && kill -0 "$DSH_PID" 2>/dev/null; then
+    kill "$DSH_PID" 2>/dev/null || true
+    wait "$DSH_PID" 2>/dev/null || true
+  fi
   if [[ "$BROWSER" -eq 1 && -f "$BROWSER_STATE" ]]; then
     echo "清理浏览器实例（browser-driver quit）..."
     node "$SCRIPT_DIR/browser-driver.mjs" quit --state "$BROWSER_STATE" --json >/dev/null 2>&1 || true
@@ -77,8 +111,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# 2. 初始化独立 profile（verify_<随机>，含 dsh-base 模板）
-dsh plugin --profile "$PROFILE" add --help >/dev/null
+# 2. 初始化独立 profile（verify_<随机>，含 dsh-base 模板）：显式用 plugin list
+#    初始化（0.1.2-rc.1 实证会创建 profile 骨架），替代依赖「add --help 会顺带
+#    初始化」的未文档化行为；失败 fail loudly 给可操作错误。
+if ! "$DSH_ABS" plugin --profile "$PROFILE" list >/dev/null 2>&1; then
+  echo "错误: profile 初始化失败（dsh plugin --profile $PROFILE list）——检查 dsh 入口与版本" >&2
+  exit 1
+fi
 
 # 3. 注入内置 web-app bundle（按名从 dsh 安装目录解析，不走 npm）
 node -e '
@@ -96,21 +135,54 @@ node -e '
 
 # 4. 挂载本地插件（相对路径基于当前 cwd，dsh 官方会锚定到调用目录；绝对路径原样使用）
 if [[ ${#PKGS[@]} -gt 0 ]]; then
-  # 4a. 先构建每个插件（默认）：dsh 直读构建产物（hub 的 lib/、xiaozhuge 的 dist/），
-  #     不 build 则 link 到的源码目录缺产物、启动即 ERR_MODULE_NOT_FOUND
-  if [[ "$BUILD" -eq 1 ]]; then
-    for pkg in "${PKGS[@]}"; do
-      # 支持相对路径（基于当前 cwd）与绝对路径；目录或仓库根均可
-      pkg_abs="$(cd "$(pwd)" && realpath -m "$pkg")"
+  # dsh 直读构建产物（hub 的 lib/、xiaozhuge 的 dist/），不 build 则 link 到的
+  # 源码目录缺产物、启动即 ERR_MODULE_NOT_FOUND
+  for pkg in "${PKGS[@]}"; do
+    # 相对路径基于当前 cwd 取绝对路径：node path.resolve 替代 GNU realpath -m
+    # （BSD/macOS 的 realpath 无 -m）
+    pkg_abs="$(node -e 'console.log(require("node:path").resolve(process.argv[1]))' "$pkg")"
+    if [[ "$BUILD" -eq 1 ]]; then
       if [[ -f "$pkg_abs/package.json" ]] && grep -q '"build"' "$pkg_abs/package.json"; then
         echo "构建插件: $pkg_abs"
         (cd "$pkg_abs" && pnpm build)
       else
         echo "跳过构建（无 build 脚本）: $pkg_abs"
       fi
-    done
-  fi
-  dsh plugin --profile "$PROFILE" add "${PKGS[@]}" >/dev/null
+    else
+      # --no-build：产物存在性校验（缺失即报可操作错误，不等启动时
+      # ERR_MODULE_NOT_FOUND）+ 产物 vs src mtime 陈旧警告（#376 L2）
+      if [[ ! -d "$pkg_abs/lib" && ! -d "$pkg_abs/dist" ]]; then
+        echo "错误: --no-build 但缺少构建产物（lib/ 或 dist/）: $pkg_abs" >&2
+        echo "       请先 pnpm build，或去掉 --no-build 让脚本自动构建" >&2
+        exit 2
+      fi
+      node -e '
+        const fs = require("node:fs"), path = require("node:path");
+        const root = process.argv[1];
+        const newest = (dir) => {
+          let m = 0;
+          const walk = (d) => {
+            let es;
+            try { es = fs.readdirSync(d, { withFileTypes: true }); } catch { return; }
+            for (const e of es) {
+              const p = path.join(d, e.name);
+              if (e.isDirectory()) walk(p);
+              else if (e.isFile()) { const t = fs.statSync(p).mtimeMs; if (t > m) m = t; }
+            }
+          };
+          walk(dir);
+          return m;
+        };
+        const prods = ["lib", "dist"].map((d) => path.join(root, d)).filter((d) => { try { return fs.statSync(d).isDirectory(); } catch { return false; } });
+        if (prods.length === 0) return;
+        const src = path.join(root, "src");
+        const s = fs.existsSync(src) ? newest(src) : 0;
+        const p = Math.max(...prods.map(newest));
+        if (s > p) console.warn("警告: 源码比构建产物新（--no-build 可能验证到旧版本）: " + root);
+      ' "$pkg_abs"
+    fi
+  done
+  "$DSH_ABS" plugin --profile "$PROFILE" add "${PKGS[@]}" >/dev/null
 fi
 
 # 5. 启动独立浏览器实例（--browser）：独立 user-data-dir + 自选空闲调试端口，
@@ -152,6 +224,50 @@ fi
 
 echo "隔离环境就绪: DSH_HOME=$ISOLATED_HOME  profile=$PROFILE"
 echo "启动 dsh web 于 http://127.0.0.1:$PORT （Ctrl+C 退出并自动清理）"
-# 8. 前台启动（阻塞）。不用 exec：exec 会替换 shell，dsh 被 Ctrl+C/SIGTERM 杀掉时
-#    EXIT trap 不触发、临时目录残留。前台子进程 + EXIT trap 保证任何退出都清理。
-dsh --profile "$PROFILE" --port "$PORT" --no-open
+# 8. 启动（后台子进程 + 显式回环 + 遥测禁用）。不用 exec：exec 会替换 shell，
+#    dsh 被杀时 EXIT trap 不触发、临时目录残留。后台 + wait 保持「前台阻塞」体感，
+#    且 EXIT trap 能兜底 kill 残留 dsh；SIGINT（Ctrl+C）会同时送达同进程组的
+#    dsh 子进程，wait 返回后 trap 统一清理。
+#    --host 127.0.0.1：显式回环（#376 H2）；DSH_TELEMETRY_DISABLED=1：隔离环境
+#    禁用遥测（0.1.2 线 profile-boot 消费的官方开关）。
+DSH_TELEMETRY_DISABLED=1 "$DSH_ABS" --profile "$PROFILE" --host 127.0.0.1 --port "$PORT" --no-open &
+DSH_PID=$!
+
+# 9. 就绪断言（#376 M2）：轮询 HTTP 可达（GUI 带鉴权，2xx-4xx 均算就绪；5xx 与
+#    连接失败继续等），每轮同时核对 dsh 进程存活——防「默认端口被其他服务占用、
+#    探测连到占用者」的假阳性，也防 dsh 启动即崩时空等满 15s；15s 超时给可操作
+#    错误而非裸崩溃。node 探测退出码：0=就绪、1=超时、2=进程已退出。
+probe_rc=0
+node -e '
+  const port = process.argv[1], pid = Number(process.argv[2]);
+  const deadline = Date.now() + 15000;
+  const alive = () => { try { process.kill(pid, 0); return true; } catch { return false; } };
+  const once = async () => {
+    try {
+      const r = await fetch("http://127.0.0.1:" + port + "/", { signal: AbortSignal.timeout(1500) });
+      return r.status < 500;
+    } catch { return false; }
+  };
+  (async () => {
+    for (;;) {
+      if (!alive()) process.exit(2);
+      if (await once()) process.exit(0);
+      if (Date.now() > deadline) process.exit(1);
+      await new Promise((r) => setTimeout(r, 250));
+    }
+  })();
+' "$PORT" "$DSH_PID" || probe_rc=$?
+if [[ "$probe_rc" -eq 0 ]]; then
+  echo "就绪断言通过: http://127.0.0.1:$PORT 已可达（pid=$DSH_PID）"
+elif [[ "$probe_rc" -eq 2 ]]; then
+  echo "错误: dsh web 进程在就绪前退出（可能端口被占/EADDRINUSE/插件加载失败）——按上方 dsh 输出排查；--keep 可保留现场" >&2
+  exit 1
+elif [[ "$probe_rc" -eq 130 || "$probe_rc" -eq 143 ]]; then
+  # 用户在探测期间 Ctrl+C（SIGINT/SIGTERM 同时送达探测进程与 dsh）：静默走清理
+  exit "$probe_rc"
+else
+  echo "错误: dsh web 15s 内未就绪（端口 $PORT）——按上方 dsh 输出排查；--keep 可保留现场" >&2
+  exit 1
+fi
+# 10. 前台等待：dsh 退出（含 Ctrl+C）后 EXIT trap 统一清理
+wait "$DSH_PID"

--- a/packages/dsh-verify-isolated/test/smoke.ts
+++ b/packages/dsh-verify-isolated/test/smoke.ts
@@ -43,8 +43,8 @@ assert.ok(!raw.includes("node_modules/@wingsky-1"),
 // ---- 2. 一键脚本随 skill 分发 ----
 const scriptFile = join(SKILL_DIR, "scripts", "verify-isolated.sh");
 assert.ok(existsSync(scriptFile), "一键脚本随 skill 目录分发");
-assert.ok(readFileSync(scriptFile, "utf8").includes("verify_$(openssl rand -hex 4)"),
-  "脚本含 verify_<随机> profile 逻辑");
+assert.ok(readFileSync(scriptFile, "utf8").includes('verify_$(node -e'),
+  "脚本含 verify_<随机> profile 逻辑（node crypto 生成，不依赖 openssl CLI）");
 
 // ---- 3. cordis.patch.yml 复用官方 provider + bundledSkillDir 配置 ----
 const patch = readFileSync(join(PKG_ROOT, "cordis.patch.yml"), "utf8");
@@ -78,7 +78,7 @@ try { execFileSync(process.execPath, [driverFile], { encoding: "utf8" }); }
 catch { noArgExitsNonZero = true; }
 assert.ok(noArgExitsNonZero, "browser-driver 无参数应非零退出（用法提示，不误启动浏览器）");
 
-// ---- 6. verify-isolated.sh 含 --browser 与 --port 0 修复逻辑 ----
+// ---- 6. verify-isolated.sh 参数契约：--browser/--port 0/#376 加固（--dsh/回环/遥测/初始化/就绪断言/L1/L2） ----
 {
   const script = readFileSync(scriptFile, "utf8");
   assert.ok(script.includes("--browser"), "脚本含 --browser 选项");
@@ -86,6 +86,39 @@ assert.ok(noArgExitsNonZero, "browser-driver 无参数应非零退出（用法�
   assert.ok(script.includes("browser.state"), "脚本管理 browser.state 实例文件");
   assert.ok(script.includes("--port 0"), "脚本含 --port 0 处理分支");
   assert.ok(script.includes("探测空闲端口"), "--port 0 自选真实空闲端口（修复打印 0 无效）");
+  // #376 H1：--dsh 参数化 dsh 入口（版本锚定），校验可执行 + 版本展示
+  assert.ok(script.includes("--dsh"), "脚本含 --dsh 选项（dsh 入口版本锚定）");
+  assert.ok(script.includes('DSH_BIN="$2"'), "--dsh 解析到 DSH_BIN");
+  assert.ok(script.includes('DSH_BIN=dsh'), "DSH_BIN 默认 dsh（无 --dsh 时行为兼容现状）");
+  assert.ok(script.includes('dsh 入口不可执行'), "--dsh 目标不可执行时 fail fast");
+  assert.ok(script.includes("--version"), "启动前展示 dsh 版本（锚定证据）");
+  // #376 H2：显式回环 + 遥测禁用（锚定启动行本体——注释里出现同串不算数）
+  assert.ok(script.includes('DSH_TELEMETRY_DISABLED=1 "$DSH_ABS"'), "隔离实例显式禁用遥测（锚定启动行）");
+  assert.ok(
+    script.includes('"$DSH_ABS" --profile "$PROFILE" --host 127.0.0.1 --port "$PORT" --no-open'),
+    "隔离实例显式回环绑定（锚定启动行）",
+  );
+  // #376 M1：profile 初始化走显式 plugin list（不再依赖 add --help 未文档化行为）
+  assert.ok(script.includes('plugin --profile "$PROFILE" list'), "profile 初始化用显式 plugin list");
+  assert.ok(!script.includes("add --help >/dev/null"), "不再依赖 add --help 隐式初始化（注释提及不受限）");
+  assert.ok(script.includes("profile 初始化失败"), "初始化失败 fail loudly");
+  // #376 M2：启动后就绪断言（轮询 HTTP 可达 + 进程存活核对，超时可操作错误）
+  assert.ok(script.includes("就绪断言通过"), "启动后就绪断言通过输出");
+  assert.ok(script.includes("15s 内未就绪"), "就绪超时给可操作错误");
+  assert.ok(script.includes("AbortSignal.timeout"), "就绪探测带超时（不裸连）");
+  assert.ok(script.includes("进程在就绪前退出"), "就绪探测核对 dsh 进程存活（防端口被占假阳性）");
+  assert.ok(script.includes("r.status < 500"), "就绪判定不接受 5xx");
+  // #376 L1：openssl/realpath 依赖替换为 node（脚本本已硬依赖 node）
+  assert.ok(script.includes("randomBytes(4)"), "随机后缀走 node crypto");
+  assert.ok(!script.includes("openssl rand"), "不再依赖 openssl CLI");
+  assert.ok(!script.includes('realpath -m "$pkg"'), "不再调用 GNU realpath -m（注释提及不受限）");
+  assert.ok(script.includes('require("node:path").resolve'), "路径解析走 node path.resolve");
+  // #376 L2：--no-build 产物存在性检查 + 陈旧产物警告
+  assert.ok(script.includes("--no-build 但缺少构建产物"), "--no-build 缺产物报可操作错误");
+  assert.ok(script.includes("源码比构建产物新"), "--no-build 陈旧产物 mtime 警告");
+  // 启动生命周期：后台 + 就绪断言 + wait（EXIT trap 兜底 kill）
+  assert.ok(script.includes('DSH_PID=$!'), "dsh 后台启动记录 pid");
+  assert.ok(script.includes('wait "$DSH_PID"'), "前台 wait 保持阻塞体感");
 }
 
 // ---- 7. SKILL.md 含多会话并行章节与三平台内核自查 ----
@@ -95,6 +128,11 @@ assert.ok(raw.includes("DSH_VERIFY_CHROME"), "SKILL.md 含 DSH_VERIFY_CHROME 内
 assert.ok(raw.includes("ms-playwright"), "SKILL.md 含 ms-playwright 缓存路径表");
 assert.ok(raw.includes("Google Chrome.app"), "SKILL.md 含 macOS 自查路径");
 assert.ok(raw.includes("ProgramFiles"), "SKILL.md 含 Windows 自查路径");
+// #376 配套：SKILL.md 含 --dsh 用法与隔离自检第 5 项（插件持久化 DSH_HOME 感知）
+assert.ok(raw.includes("--dsh"), "SKILL.md 含 --dsh 版本锚定用法");
+assert.ok(raw.includes("DSH_HOME 感知"), "SKILL.md 自检清单含插件 DSH_HOME 感知项（#510 盲区）");
+assert.ok(raw.includes("DSH_TELEMETRY_DISABLED=1"), "SKILL.md 含遥测禁用原则");
+assert.ok(raw.includes("--host 127.0.0.1"), "SKILL.md 含显式回环原则");
 
 // ---- 8. README 同步新能力 ----
 const readme = readFileSync(join(PKG_ROOT, "README.md"), "utf8");


### PR DESCRIPTION
## 概要

实施 #376 全项（整体演进 Meta 见 #517 第一批 A1+A3），改动集中在 `dsh-verify-isolated` 包：

- **H1 `--dsh <path>`**：参数化 dsh 入口（默认 `dsh` 兼容现状），`command -v` + node `path.resolve` 解析为绝对路径后全程以 `$DSH_ABS` 调用——真正锚定版本、防 PATH 漂移；启动前校验可执行并打印 `--version`。
- **H2 显式回环 + 遥测禁用**：启动行 `DSH_TELEMETRY_DISABLED=1 "$DSH_ABS" ... --host 127.0.0.1`（0.1.2-rc.1 实测裸 dsh 默认即回环，显式写死把隐式行为钉成保证）。
- **M1**：profile 初始化从 `add --help`（未文档化隐式行为）改为显式 `plugin list`（0.1.2-rc.1 实证会建骨架），失败 fail loudly。
- **M2 就绪断言**：dsh 改后台 + wait（EXIT trap 兜底 kill），node fetch 轮询可达（2xx-4xx 算就绪、5xx 继续等）+ 每轮 `process.kill(pid, 0)` 进程存活核对（防默认端口被其他服务占用、探测连到占用者的假阳性，也防空等崩溃进程）；15s 超时/进程早退/用户中断三分支，均给可操作信息。
- **L1**：`openssl rand` → node `crypto.randomBytes`；GNU `realpath -m` → node `path.resolve`（脚本本已多处硬依赖 node，零新增依赖）。
- **L2**：`--no-build` 校验 lib//dist/ 产物存在（缺失报可操作错误）+ 产物 vs src mtime 陈旧警告（防「存在但陈旧」锚定旧版本）。
- **SKILL.md**：`--dsh` 用法、手动步骤与脚本对齐（list 初始化 / 回环 + 遥测 / 就绪断言步骤 6）、关键原则补两条、四重隔离自检清单补**第 5 项**——验证涉及读写插件持久化文件时确认插件 DSH_HOME 感知，不感知给处置动作（#510 盲区，A3）。
- **smoke**：#376 契约面正负向断言；H2 断言锚定启动行本体（注释出现同串不算数）。
- **README / README.en**：工作原理 / 包结构 / 使用 / 安全模型同步。

## 关联 issue

- Closes #376
- Refs #517（Meta：本 PR = 第一批 A1+A3；A2 = #510 修复独立 PR 跟进）

## 评审留痕

- 合并前独立 subagent 复核（ISSUE-WORKFLOW §2.5，diff >100 行且触及回环/遥测安全语义）：无 P0；P1-1 就绪断言语义（`< 599` → `< 500` + 进程存活核对）、P1-2 smoke H2 断言锚定启动行——**均已在 bdd4294 修复**；P2-1（绝对路径解析）/P2-2（缺参用法提示）/P2-3（探测期 Ctrl+C 误报）/P2-5（手动流程补就绪断言）顺带修复。
- 已知边界（复核 P2-6）：`plugin list` 建骨架与 `--host` flag 均只实证 0.1.2-rc.1，锚定更旧版本（如 alpha.2）未实测——本机无旧版安装，建议 #376 关闭前按文档示例补一次锚定实测，或在 #376 留言确认。

## 验收对照（#376）

- [x] `--dsh <path>` 指定独立 prefix 安装的 dsh 时，隔离实例确实用该版本拉起（启动前打印解析绝对路径 + `--version`；`--dsh` 缺失/不可执行 fail fast）
- [x] 隔离实例仅回环监听（显式 `--host 127.0.0.1`）且无遥测外发（`DSH_TELEMETRY_DISABLED=1`）
- [x] 默认行为（无 `--dsh`）与现状兼容（`DSH_BIN` 默认 `dsh`，解析逻辑不变）
- [x] `--no-build` + 缺产物时给出可操作错误提示（含陈旧产物警告）
- [x] profile 初始化不再依赖 `add --help` 未文档化行为
- [x] 启动后就绪断言（超时/崩溃均给可操作错误）

## 门禁

`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 本地全绿；smoke 无网络无真实凭据、纯文本契约断言（防 flake）。
