### PR TITLE
feat(dsh-notifier): 频道域保存 + 基线按域推进 + 409 冲突双动作恢复（#405 PR2）

### DIFF
--- a/packages/dsh-notifier/src/client/index.ts
+++ b/packages/dsh-notifier/src/client/index.ts
@@ -67,6 +67,20 @@ function diffSettingsPayload(settings: Record<string, any>, baseLine: Record<str
 }
 
 /**
+ * 409 冲突「保留我的修改并覆盖」的 rebase 纯函数（issue #405 PR2b）：
+ * 以服务端最新 effective 为基底，把本地变更键的值覆盖上去（键级 last-write-wins，
+ * 与 JSON Merge Patch / Firebase per-key merge 同语义）——本地变更键集合由调用方
+ * 在用户触发「覆盖」动作时实时重算（非 409 时刻快照，横幅期间的新编辑不丢）。
+ * 顶层浅拷贝即可（settings 不可变更新模式，patch 不原位改对象）。
+ * @param localChanges 本地相对旧基线的变更键集合（域/全量均适用）。
+ * @param remoteEffective 服务端最新 effective（GET /config 拉取）。
+ * @returns rebase 后的新草稿（作为 setSettings 输入）。
+ */
+function rebaseSettings(localChanges: Record<string, any>, remoteEffective: Record<string, any>): Record<string, any> {
+  return Object.assign({}, remoteEffective, localChanges);
+}
+
+/**
  * 按保存入口从全量 diff 中取子集（issue #405 PR2 域保存）：
  * - entry "all"：原样返回（foot 全量保存）；
  * - entry "channels"：仅保留 channels 键（频道域保存——事件/参数半成品草稿不
@@ -144,7 +158,7 @@ function createSaveGuard(): { tryBegin(entry: string): boolean; isBusy(): boolea
   };
   var STYLE_ID = "dsh-notifier-style";
   // 合并 #418/#421/#426/#508 后统一 bump（保证新样式重注入；508-1 > 426-1）
-  var CSS_VERSION = "405-1";
+  var CSS_VERSION = "405-2";
   // 浏览器通知图标（内联 SVG data URL，零外部资源；铃铛造型）。
   var NOTIFY_ICON =
     "data:image/svg+xml;utf8," +
@@ -718,6 +732,12 @@ function createSaveGuard(): { tryBegin(entry: string): boolean; isBusy(): boolea
     var savingDraft = useState(false);
     var saving = savingDraft[0];
     var setSaving = savingDraft[1];
+    // #405 PR2b：409 冲突横幅态。null=无冲突；非 null={ entry, latest }——
+    // latest 为冲突时拉取的服务端最新 {effective, revision}（「加载最新/覆盖」动作
+    // 的数据源）。横幅期间用户可继续编辑（非模态），动作触发时实时重算本地变更。
+    var conflictDraft = useState(null as null | { entry: string; latest: any });
+    var conflict = conflictDraft[0];
+    var setConflict = conflictDraft[1];
 
     function loadHistory(alive: { value: boolean }) {
       fetchHistory().then(function (records) {
@@ -744,7 +764,7 @@ function createSaveGuard(): { tryBegin(entry: string): boolean; isBusy(): boolea
         .then(function (v: any) {
           if (!alive.value) return;
           var effective = (v && v.effective) || {};
-          patch(Object.assign({}, effective));
+          commitSettings(Object.assign({}, effective));
           baselineRef.current = Object.assign({}, effective);
           var nextMeta = { user: v.user || {}, revision: v.revision, effective: effective, writable: v.writable !== false };
           metaRef.current = nextMeta;
@@ -789,6 +809,16 @@ function createSaveGuard(): { tryBegin(entry: string): boolean; isBusy(): boolea
       setSaved("");
     }
 
+    /** 整体替换 settings（#405 PR2b）：已知完整 next 时同步写 settingsRef 再
+     *  setState——调用方（loadCard / 冲突恢复 rebase / 静默刷新）随后可能立即
+     *  读 ref（如覆盖重提 saveFor），不能等 updater 异步执行。事件级增量编辑
+     *  仍走 patch（updater 内写 ref，天然与 state 计算同步）。 */
+    function commitSettings(next: Record<string, any>) {
+      settingsRef.current = next;
+      setSettings(next);
+      setSaved("");
+    }
+
     /** 基线 diff：只提交与加载基线不同的键（A4，防组合层 base 被默认值回写覆盖）。
      *  逻辑收敛在模块级纯函数 diffSettingsPayload（#470 复核 P1-2，供测试直测）。
      *  #405：读 settingsRef（非渲染闭包 settings）——trailing 补发在 .then 回调里
@@ -797,8 +827,42 @@ function createSaveGuard(): { tryBegin(entry: string): boolean; isBusy(): boolea
       return diffSettingsPayload(settingsRef.current || settings, baselineRef.current);
     }
 
-    /** 提交 PUT 并处理响应（save 的内核；guard 占用与释放由 save 负责）。 */
-    function putAndCommit(payload: Record<string, any>) {
+    /** 409 冲突恢复（#405 PR2b）：拉最新 → 无脏静默刷新 / 有脏弹双动作横幅。 */
+    function handleConflict(entry: string) {
+      fetchConfig()
+        .then(function (v: any) {
+          if (!v) return;
+          var latest = { effective: (v && v.effective) || {}, revision: v && v.revision, user: (v && v.user) || {} };
+          // 本地已无该入口脏（用户在 409 往返间撤销/放弃）→ 静默切到最新（兑现
+          // issue 要点 4「自动重拉重新渲染」的安全路径，不打扰）。
+          if (Object.keys(diffPayloadFor(entry)).length === 0) {
+            applyLatestQuiet(latest);
+            return;
+          }
+          setConflict({ entry: entry, latest: latest });
+          setSaved(""); // 冲突横幅自带标题（conflictTitle/conflictChannels），foot 提示区清空防重复
+        })
+        .catch(function () {
+          // 拉最新失败：保留原错误提示（saveFailConflict），不弹横幅
+          setSaved(t("saveFailConflict", { msg: "" }), true);
+        });
+    }
+
+    /** 无脏静默刷新：settings/baseline/meta 全部切到服务端最新（不丢任何草稿——
+     *  调用前已确认本地无脏）。 */
+    function applyLatestQuiet(latest: any) {
+      commitSettings(Object.assign({}, latest.effective));
+      baselineRef.current = Object.assign({}, latest.effective);
+      var nextMeta = { user: latest.user || {}, revision: latest.revision, effective: Object.assign({}, latest.effective), writable: true };
+      metaRef.current = nextMeta;
+      setMeta(nextMeta);
+      runtimeConfig = latest.effective;
+      setSaved("");
+    }
+
+    /** 提交 PUT 并处理响应（save 的内核；guard 占用与释放由 saveFor 负责）。
+     *  #405 PR2b：409 不再只提示文案——转 handleConflict 进入双动作恢复流程。 */
+    function putAndCommit(payload: Record<string, any>, entry: string) {
       var expectedRevision = metaRef.current && typeof metaRef.current.revision === "number" ? metaRef.current.revision : undefined;
       return fetch(ROUTES.config, {
         method: "PUT",
@@ -825,13 +889,17 @@ function createSaveGuard(): { tryBegin(entry: string): boolean; isBusy(): boolea
         };
         metaRef.current = nextMeta; // 同步写 ref：补发立即读新 revision，不再 409
         setMeta(nextMeta);
+        setConflict(null); // 覆盖保存成功：横幅关闭（若曾因再 409 重现）
         setSaved(t("savedOk"));
         setTimeout(function () { setSaved(""); }, 2200);
       }).catch(function (e: any) {
         var msg = (e && e.message) || e;
-        setSaved(String(msg).indexOf("版本冲突") >= 0
-          ? t("saveFailConflict", { msg: msg })
-          : t("saveFail", { msg: msg }), true);
+        if (String(msg).indexOf("版本冲突") >= 0) {
+          // 版本冲突：进入双动作恢复（不再仅提示手动关闭重开）
+          handleConflict(entry);
+          return;
+        }
+        setSaved(t("saveFail", { msg: msg }), true);
       });
     }
 
@@ -859,11 +927,42 @@ function createSaveGuard(): { tryBegin(entry: string): boolean; isBusy(): boolea
         return;
       }
       setSaving(true);
-      putAndCommit(payload).finally(function () {
+      putAndCommit(payload, entry).finally(function () {
         setSaving(false);
         var nextEntry = saveGuard.end();
         if (nextEntry !== null) saveFor(nextEntry, true); // trailing 补发（同入口，天然不循环）
       });
+    }
+
+    /** 冲突横幅「加载最新」：丢弃本地草稿，切到服务端最新（等价旧「关闭重开」
+     *  的手动重拉，无需用户手动操作）。 */
+    function resolveConflictLoadLatest() {
+      if (!conflict) return;
+      applyLatestQuiet(conflict.latest);
+      setConflict(null);
+      toast(t("conflictLoadedLatest"));
+    }
+
+    /** 冲突横幅「保留我的修改并覆盖」：rebase-then-retry——
+     *  以最新 effective 为新基线，把本地变更键（动作触发时实时重算，非 409 快照，
+     *  横幅期间新编辑不丢）覆盖上去，用新 revision 重提；再 409 会回到横幅
+     *  （每次覆盖消费一次用户动作，天然收敛、无自动风暴）。 */
+    function resolveConflictOverwrite() {
+      if (!conflict) return;
+      var entry = conflict.entry;
+      var latest = conflict.latest;
+      var localChanges = diffPayloadFor(entry); // 实时重算（相对旧基线的当前脏）
+      var merged = rebaseSettings(localChanges, latest.effective || {});
+      commitSettings(merged); // 同步写 ref：随后 saveFor 立即以 merged 计算 diff
+      baselineRef.current = Object.assign({}, latest.effective || {});
+      var nextMeta = { user: latest.user || {}, revision: latest.revision, effective: Object.assign({}, latest.effective || {}), writable: true };
+      metaRef.current = nextMeta;
+      setMeta(nextMeta);
+      runtimeConfig = latest.effective;
+      setConflict(null);
+      setSaved("");
+      // 用最新 revision 重提（quiet 补发语义：diff 由合并后的 settings 计算）
+      saveFor(entry, true);
     }
 
     /** #508 M1：放弃更改——草稿回写加载基线（编辑态/运行时镜像同步还原）。
@@ -871,7 +970,7 @@ function createSaveGuard(): { tryBegin(entry: string): boolean; isBusy(): boolea
      *  （foot 渲染处），消除「在途成功回调覆盖放弃后基线」的竞态。 */
     function discardChanges() {
       if (baselineRef.current) {
-        patch(function () { return Object.assign({}, baselineRef.current); });
+        commitSettings(Object.assign({}, baselineRef.current));
         runtimeConfig = baselineRef.current;
       }
       setSaved("");
@@ -1913,6 +2012,19 @@ function createSaveGuard(): { tryBegin(entry: string): boolean; isBusy(): boolea
       React.createElement("div", { className: "dn-set-body" },
         activeTab === "events" ? eventsPane : activeTab === "channels" ? channelsPane : historyPane,
         React.createElement("div", { className: "dn-set-notes" }, degradation),
+        // #405 PR2b：409 冲突双动作横幅（非模态：横幅期间可继续编辑；动作触发时
+        // 实时重算本地变更）。「忽略」= 关闭横幅、草稿保留原样。
+        conflict
+          ? React.createElement("div", { className: "dn-conflict", role: "alert" },
+              React.createElement("span", { className: "dn-conflictText" },
+                t(conflict.entry === "channels" ? "conflictChannels" : "conflictTitle")),
+              React.createElement("span", { className: "dn-conflictActions" },
+                React.createElement("button", { type: "button", className: "dn-set-btn dn-set-btnSmall", onClick: resolveConflictLoadLatest }, t("conflictLoadLatest")),
+                React.createElement("button", { type: "button", className: "dn-set-btn dn-set-btnSmall dn-set-save", disabled: saving, onClick: resolveConflictOverwrite }, t("conflictOverwrite")),
+                React.createElement("button", { type: "button", className: "dn-set-btn dn-set-btnSmall", onClick: function () { setConflict(null); } }, t("conflictIgnore")),
+              ),
+            )
+          : null,
         React.createElement("div", { className: "dn-set-foot" },
           saved
             ? React.createElement("span", { className: saved.err ? "dn-set-error" : "dn-set-saved" }, saved.msg)
@@ -1938,6 +2050,7 @@ export function apply(ctx: any) {
     (apply as any).diffSettingsPayload = diffSettingsPayload;
     (apply as any).createSaveGuard = createSaveGuard;
     (apply as any).domainPayload = domainPayload;
+    (apply as any).rebaseSettings = rebaseSettings;
     try {
       ensureStyle({ id: STYLE_ID, cssText: STYLE, version: CSS_VERSION });
 

--- a/packages/dsh-notifier/src/client/index.ts
+++ b/packages/dsh-notifier/src/client/index.ts
@@ -67,26 +67,49 @@ function diffSettingsPayload(settings: Record<string, any>, baseLine: Record<str
 }
 
 /**
+ * 按保存入口从全量 diff 中取子集（issue #405 PR2 域保存）：
+ * - entry "all"：原样返回（foot 全量保存）；
+ * - entry "channels"：仅保留 channels 键（频道域保存——事件/参数半成品草稿不
+ *   随频道域保存提交）；
+ * - 未知入口：返回空对象（保守不提交）。
+ * 模块级纯函数（apply 挂载 + vm 直测），对齐 diffSettingsPayload 先例。
+ */
+function domainPayload(diff: Record<string, any>, entry: string): Record<string, any> {
+  if (entry === "all") return diff;
+  if (entry === "channels") {
+    if (!Object.prototype.hasOwnProperty.call(diff, "channels")) return {};
+    return { channels: diff.channels };
+  }
+  return {};
+}
+
+/**
  * 保存串行 guard（issue #405 要素 2）：同一时刻仅一个在途保存请求。
- * exhaustMap + trailing 语义——在途期间再点保存不丢弃意图：记 pending，
- * 由调用方在本次在途结束（end）后补发一次（补发是完整保存，是否仍有脏由
- * 调用方 save() 的 diff 空检查兜底，天然不循环）。
+ * exhaustMap + trailing 语义——在途期间再点保存不丢弃意图：记 pending（含
+ * 入口标识），由调用方在本次在途结束（end）后按同一入口补发一次（补发是完整
+ * 保存，是否仍有脏由调用方 saveFor() 的 diff 空检查兜底，天然不循环）。
+ *
+ * 为什么 pending 记入口而非布尔：#405 PR2 有两个保存入口——foot 全量（"all"）
+ * 与频道 tab 域保存（"channels"），语义不同。在途期间被拒的入口必须原样补发：
+ * 若「保存频道」被拒却补发全量，会把事件 tab 的半成品草稿一并提交。同一次在途
+ * 多次点击不同入口时记最后一次意图（end 只返回一个入口，天然不风暴）。
  *
  * 模块级纯工厂（无 React 依赖），对齐 diffSettingsPayload 先例：
  * apply 挂载 + vm materialize 直测，「测试即产品实现」。
  *
- * @returns {{ tryBegin(): boolean; isBusy(): boolean; end(): boolean }}
- * - tryBegin(): 空闲则占用并返回 true；在途则记 pending 返回 false（不占用）。
- * - end(): 释放占用；返回「在途期间是否积累过补发意图」（调用方据此补发一次）。
- *   必须与 tryBegin 成功一一配对（放 finally），任何路径都释放，防永久卡死。
+ * @returns {{ tryBegin(entry: string): boolean; isBusy(): boolean; end(): string | null }}
+ * - tryBegin(entry): 空闲则占用并返回 true；在途则记 pending=entry 返回 false。
+ * - end(): 释放占用；返回「在途期间最后一次被拒的入口」（调用方据此同入口补发
+ *   一次）；无 pending 返回 null。必须与 tryBegin 成功一一配对（放 finally），
+ *   任何路径都释放，防永久卡死。
  */
-function createSaveGuard(): { tryBegin(): boolean; isBusy(): boolean; end(): boolean } {
+function createSaveGuard(): { tryBegin(entry: string): boolean; isBusy(): boolean; end(): string | null } {
   var busy = false;
-  var pending = false;
+  var pending: string | null = null;
   return {
-    tryBegin(): boolean {
+    tryBegin(entry: string): boolean {
       if (busy) {
-        pending = true;
+        pending = entry;
         return false;
       }
       busy = true;
@@ -95,13 +118,11 @@ function createSaveGuard(): { tryBegin(): boolean; isBusy(): boolean; end(): boo
     isBusy(): boolean {
       return busy;
     },
-    end(): boolean {
+    end(): string | null {
       busy = false;
-      if (pending) {
-        pending = false;
-        return true;
-      }
-      return false;
+      var p = pending;
+      pending = null;
+      return p;
     },
   };
 }
@@ -814,16 +835,24 @@ function createSaveGuard(): { tryBegin(): boolean; isBusy(): boolean; end(): boo
       });
     }
 
-    /** 保存（#405 串行 guard 接入）：同一时刻仅一个在途 PUT——
-     *  - 在途期间再次点击：guard 记 pending 并立即返回（不重复发 PUT）；
-     *    本次在途结束（finally 释放 guard）后若积累过点击，自动补发一次（trailing），
-     *    补发读 settingsRef 最新草稿 + metaRef 最新 revision，无丢失、无误 409；
+    /** 从全量 diff 中按入口过滤出本次要提交的键（#405 PR2 域保存；
+     *  纯逻辑收敛在模块级 domainPayload，供测试直测）。 */
+    function diffPayloadFor(entry: string): Record<string, any> {
+      return domainPayload(diffPayload(), entry);
+    }
+
+    /** 保存（#405 串行 guard 接入，入口参数化）：同一时刻仅一个在途 PUT——
+     *  - entry："all"（foot 全量）/ "channels"（频道 tab 域保存，只提 channels 键）；
+     *  - 在途期间再次点击（任意入口）：guard 记 pending=该入口并立即返回；
+     *    本次在途结束（finally 释放 guard）后按被拒入口原样补发（trailing）——
+     *    补发读 settingsRef 最新草稿 + metaRef 最新 revision，无丢失、无误 409，
+     *    域保存被拒不会升级成全量提交（事件 tab 半成品不被误提交）；
      *  - 空 diff：初次点击提示「未修改」；补发路径（quietIfEmpty=true）静默返回，
      *    不覆盖刚显示的「已保存」；
      *  - guard.end() 放 finally：成功/失败/异常任何路径都释放，防按钮永久卡死。 */
-    function save(quietIfEmpty?: boolean) {
-      if (!saveGuard.tryBegin()) return; // 在途：记 pending，由在途 finally 补发
-      var payload = diffPayload();
+    function saveFor(entry: string, quietIfEmpty?: boolean) {
+      if (!saveGuard.tryBegin(entry)) return; // 在途：记 pending=entry，由在途 finally 补发
+      var payload = diffPayloadFor(entry);
       if (Object.keys(payload).length === 0) {
         saveGuard.end();
         if (!quietIfEmpty) setSaved(t("unchanged"));
@@ -832,7 +861,8 @@ function createSaveGuard(): { tryBegin(): boolean; isBusy(): boolean; end(): boo
       setSaving(true);
       putAndCommit(payload).finally(function () {
         setSaving(false);
-        if (saveGuard.end()) save(true); // trailing 补发（完整保存，天然不循环）
+        var nextEntry = saveGuard.end();
+        if (nextEntry !== null) saveFor(nextEntry, true); // trailing 补发（同入口，天然不循环）
       });
     }
 
@@ -1854,15 +1884,30 @@ function createSaveGuard(): { tryBegin(): boolean; isBusy(): boolean; end(): boo
       dedupFold,
       dndCard,
     ];
-    // 频道 tab 内容：频道卡组（内置 + Bark + Webhook）+ 添加按钮（#418：无就近保存——
-    // 与 foot 保存同一份全量草稿，双保存按钮视觉重复；域级拆分属 #405 跟踪）
+    // 频道 tab 内容：频道卡组（内置 + Bark + Webhook）+ 添加按钮 + 域保存行。
+    // #405 PR2 域保存（方案定稿形态 B）：频道 tab 底部「保存频道」只提交 channels
+    // 键——与 foot 全量保存语义不同（域 vs 全量），不构成 #418 移除的「双份全量
+    // 保存」视觉重复；#418 原文预留「域级拆分后按域重排按钮位置」，本行兑现。
+    var channelsDomainSave = React.createElement("div", { className: "dn-ch-domainSave", key: "ch-domain-save" },
+      React.createElement("span", { className: "dn-ch-domainSaveHint" }, t("channelsDomainHint")),
+      React.createElement("button", {
+        type: "button",
+        className: "dn-set-btn dn-set-btnPrimary dn-set-save",
+        disabled: saving,
+        onClick: function () { saveFor("channels"); },
+      }, saving ? t("saving") : t("saveChannels")),
+    );
     var channelsPane = [
       channelsChildren,
+      channelsDomainSave,
     ];
 
     // #402 第 4 条：去掉设置卡 title/副标题；顶部直接是 tab 栏。
     // #508 M1：底部保存栏 = 脏状态指示（diffSettingsPayload 键数）+ 放弃更改 + 保存。
     var dirtyCount = Object.keys(diffPayload()).length;
+    // #405 PR2 域保存：频道域脏态（channels 单键）。脏计数分域——foot 显示总数，
+    // 频道 tab 域按钮依据本域脏态使能/禁用（域保存语义 ≠ 全量，两入口并存不重复）。
+    var channelsDirty = Object.prototype.hasOwnProperty.call(diffPayload(), "channels");
     return React.createElement("li", { className: "dn-set-card" },
       tabbar,
       React.createElement("div", { className: "dn-set-body" },
@@ -1878,7 +1923,7 @@ function createSaveGuard(): { tryBegin(): boolean; isBusy(): boolean; end(): boo
           // #405：保存中（guard 在途）禁用「放弃更改」与「保存」——防提交窗口内矛盾操作
           // （放弃被在途成功回调覆盖基线）与连点重复 PUT；按钮文案切换「保存中…」。
           React.createElement("button", { type: "button", className: "dn-set-btn dn-set-btnSmall", disabled: saving, onClick: discardChanges }, t("discardChanges")),
-          React.createElement("button", { type: "button", className: "dn-set-save", disabled: saving, onClick: function () { save(); } }, saving ? t("saving") : t("save")),
+          React.createElement("button", { type: "button", className: "dn-set-save", disabled: saving, onClick: function () { saveFor("all"); } }, saving ? t("saving") : t("save")),
         ),
       ),
     );
@@ -1892,6 +1937,7 @@ export function apply(ctx: any) {
     // 保证「测试即产品实现」而非手写近似。
     (apply as any).diffSettingsPayload = diffSettingsPayload;
     (apply as any).createSaveGuard = createSaveGuard;
+    (apply as any).domainPayload = domainPayload;
     try {
       ensureStyle({ id: STYLE_ID, cssText: STYLE, version: CSS_VERSION });
 

--- a/packages/dsh-notifier/src/client/locales.ts
+++ b/packages/dsh-notifier/src/client/locales.ts
@@ -85,6 +85,8 @@ export const zh = {
   tabLabel: "通知中心",
   save: "保存",
   saving: "保存中…",
+  saveChannels: "保存频道",
+  channelsDomainHint: "仅保存频道改动，不影响事件/参数等未保存修改",
   // ===== M2 频道卡（issue #366）=====
   chEnabled: "启用",
   chDisabled: "未启用",
@@ -260,6 +262,8 @@ export const en: Record<NotifierLocaleKey, string> = {
   tabLabel: "Notification center",
   save: "Save",
   saving: "Saving…",
+  saveChannels: "Save channels",
+  channelsDomainHint: "Saves channel changes only; other unsaved edits stay untouched",
   chEnabled: "Enabled",
   chDisabled: "Disabled",
   chTest: "Send test",

--- a/packages/dsh-notifier/src/client/locales.ts
+++ b/packages/dsh-notifier/src/client/locales.ts
@@ -39,6 +39,13 @@ export const zh = {
   savedOk: "已保存",
   saveFailConflict: "保存失败：{msg}（请关闭本卡片重新打开后重试）",
   saveFail: "保存失败：{msg}",
+  // #405 PR2b：409 冲突双动作横幅
+  conflictTitle: "配置已在其他窗口被修改：",
+  conflictChannels: "频道配置已在其他窗口被修改：",
+  conflictLoadLatest: "加载最新（放弃我的修改）",
+  conflictOverwrite: "保留我的修改并覆盖",
+  conflictIgnore: "忽略",
+  conflictLoadedLatest: "已加载最新配置",
   // 测试/清理动作
   testSent: "测试通知已发送（服务端未释放句柄 {n} 条）",
   testFail: "发送测试通知失败：{msg}{hint}",
@@ -224,6 +231,13 @@ export const en: Record<NotifierLocaleKey, string> = {
   savedOk: "Saved",
   saveFailConflict: "Save failed: {msg} (close and reopen this card, then retry)",
   saveFail: "Save failed: {msg}",
+  // #405 PR2b：409 conflict resolution banner
+  conflictTitle: "Configuration was changed in another window:",
+  conflictChannels: "Channel configuration was changed in another window:",
+  conflictLoadLatest: "Load latest (discard my changes)",
+  conflictOverwrite: "Keep my changes and overwrite",
+  conflictIgnore: "Ignore",
+  conflictLoadedLatest: "Loaded latest configuration",
   testSent: "Test notification sent ({n} unreleased server handles)",
   testFail: "Failed to send test notification: {msg}{hint}",
   cleared: "Cleared {n} history entries",

--- a/packages/dsh-notifier/src/client/style.css
+++ b/packages/dsh-notifier/src/client/style.css
@@ -317,6 +317,24 @@
   .dn-set-card .dn-set-save:disabled:hover { opacity: 0.45; }
 }
 
+/* #405 PR2：频道 tab 域保存行（仅提交 channels 键，与 foot 全量语义不同） */
+.dn-set-card .dn-ch-domainSave {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px dashed var(--dsw-alias-border-l1, #e2e5ea);
+}
+.dn-set-card .dn-ch-domainSaveHint {
+  flex: 1;
+  color: var(--dsw-alias-label-tertiary, #6d7480);
+  font-size: 11px;
+  line-height: 1.6;
+}
+.dn-set-card .dn-ch-domainSave .dn-set-save { min-height: 32px; }
+
 /* --- 免打扰 --- */
 .dn-set-card .dn-dnd {
   border: 1px solid var(--dsw-alias-border-l1, #e2e5ea);

--- a/packages/dsh-notifier/src/client/style.css
+++ b/packages/dsh-notifier/src/client/style.css
@@ -335,6 +335,36 @@
 }
 .dn-set-card .dn-ch-domainSave .dn-set-save { min-height: 32px; }
 
+/* #405 PR2b：409 冲突双动作横幅（非模态，foot 上方） */
+.dn-set-card .dn-conflict {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--dsw-alias-state-warning-soft, rgba(240, 151, 9, 0.35));
+  background: var(--dsw-alias-state-warning-soft, rgba(240, 151, 9, 0.12));
+  border-radius: 8px;
+}
+.dn-set-card .dn-conflictText {
+  flex: 1;
+  color: var(--dsw-alias-label-primary, #1f2329);
+  font-size: 12px;
+  line-height: 1.6;
+}
+.dn-set-card .dn-conflictActions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+/* 窄屏：横幅换行堆叠（动作行不溢出） */
+@media (max-width: 480px) {
+  .dn-set-card .dn-conflict { flex-direction: column; align-items: stretch; }
+  .dn-set-card .dn-conflictActions { justify-content: flex-start; }
+}
+
 /* --- 免打扰 --- */
 .dn-set-card .dn-dnd {
   border: 1px solid var(--dsw-alias-border-l1, #e2e5ea);

--- a/packages/dsh-notifier/test/client-contract.test.ts
+++ b/packages/dsh-notifier/test/client-contract.test.ts
@@ -93,9 +93,12 @@ const pkgDir = fileURLToPath(new URL("..", import.meta.url));
   const client = readFileSync(new URL("../lib/client.js", import.meta.url), "utf8");
 
   // 1. 频道 tab 去就近保存：单一保存入口（foot），且源码/产物/样式三处无 dn-ch-saveRow
-  assert.ok(!src.includes("dn-ch-saveRow"), "#418：频道 tab 就近保存行已移除");
-  assert.ok(!client.includes("dn-ch-saveRow"), "#418：产物无就近保存 class");
-  assert.ok(!src.includes("tabSave"), "#418：tabSave 变量已移除");
+  //    ——#418 移除的是「双份全量保存」的旧行（dn-ch-saveRow）；#405 后按方案定稿
+  //    引入的域保存行 class 为 dn-ch-domainSave（仅提交 channels 键，语义 ≠ 全量），
+  //    属 #418 原文预留的「域级拆分后按域重排按钮位置」兑现，不构成该回归。
+  assert.ok(!src.includes("dn-ch-saveRow"), "#418：旧就近保存行 class 未回归");
+  assert.ok(!client.includes("dn-ch-saveRow"), "#418：产物无旧就近保存 class");
+  assert.ok(!src.includes("tabSave"), "#418：tabSave 变量未回归");
   // 2. 浏览器通知权限状态行移入浏览器频道卡（browserPermLine 只挂在 browser 卡）
   assert.ok(src.includes("browserPermLine"), "#418：浏览器权限状态行归入频道卡");
   assert.ok(src.includes('channelId === "browser" ? browserPermLine()'), "#418：权限行只渲染于浏览器卡");
@@ -507,32 +510,64 @@ const pkgDir = fileURLToPath(new URL("..", import.meta.url));
     effect(fn) { const d = fn(); disposers3.push(d); return d; },
   });
   const guardFactory = mod.apply.createSaveGuard;
+  const domainFn = mod.apply.domainPayload;
   assert.equal(typeof guardFactory, "function", "#405：apply 挂载 createSaveGuard 纯工厂");
+  assert.equal(typeof domainFn, "function", "#405：apply 挂载 domainPayload 纯函数");
   for (const d of disposers3.splice(0)) d();
+
+  // domainPayload：域过滤语义（#405 PR2）——channels 域只提 channels 键；
+  // all 原样；未知入口空对象
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(domainFn({ channels: [1], notifyAsk: false, quietHours: {} }, "channels"))),
+    { channels: [1] },
+    "#405：channels 域只提交 channels 键（事件/参数草稿不随域保存提交）"
+  );
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(domainFn({ notifyAsk: false }, "channels"))),
+    {},
+    "#405：无 channels 变更时 channels 域提交为空"
+  );
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(domainFn({ channels: [1], notifyAsk: false }, "all"))),
+    { channels: [1], notifyAsk: false },
+    "#405：all 入口原样全量提交"
+  );
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(domainFn({ channels: [1] }, "unknown"))),
+    {},
+    "#405：未知入口保守返回空（不提交）"
+  );
 
   // 1. 单飞行：首次占用成功；在途期间再 tryBegin 返回 false（记 pending），不占用
   const g1 = guardFactory();
   assert.equal(g1.isBusy(), false, "#405：初始空闲");
-  assert.equal(g1.tryBegin(), true, "#405：首次 tryBegin 占用成功");
+  assert.equal(g1.tryBegin("all"), true, "#405：首次 tryBegin 占用成功");
   assert.equal(g1.isBusy(), true, "#405：占用后在途");
-  assert.equal(g1.tryBegin(), false, "#405：在途期间 tryBegin 被拒（单飞行）");
+  assert.equal(g1.tryBegin("all"), false, "#405：在途期间 tryBegin 被拒（单飞行）");
   assert.equal(g1.isBusy(), true, "#405：被拒不改变在途态");
 
-  // 2. trailing 补发意图：在途期间积累过点击 → end() 返回 true（应补发一次）
-  assert.equal(g1.end(), true, "#405：在途期间有 pending → end 返回补发意图");
+  // 2. trailing 补发入口：在途期间积累过点击 → end() 返回该入口（应同入口补发一次）
+  assert.equal(g1.end(), "all", "#405：在途期间有 pending → end 返回补发入口");
   assert.equal(g1.isBusy(), false, "#405：end 后释放空闲");
 
-  // 3. 无 pending：end 返回 false（不产生补发/风暴）
+  // 3. 无 pending：end 返回 null（不产生补发/风暴）
   const g2 = guardFactory();
-  assert.equal(g2.tryBegin(), true, "#405：g2 占用成功");
-  assert.equal(g2.end(), false, "#405：无 pending → end 返回 false（不补发）");
+  assert.equal(g2.tryBegin("all"), true, "#405：g2 占用成功");
+  assert.equal(g2.end(), null, "#405：无 pending → end 返回 null（不补发）");
 
-  // 4. 多次在途点击只记一次 pending（补发一次即清）；end 幂等释放
+  // 4. 域入口保真：被拒的是 "channels" → end 返回 "channels"（域保存不被升级成全量）
   const g3 = guardFactory();
-  g3.tryBegin();
-  g3.tryBegin();
-  g3.tryBegin();
-  assert.equal(g3.end(), true, "#405：多次 pending 合并为一次补发意图");
-  assert.equal(g3.end(), false, "#405：再次 end（无 pending）返回 false");
+  g3.tryBegin("all");
+  assert.equal(g3.tryBegin("channels"), false, "#405：在途期间域保存被拒");
+  assert.equal(g3.end(), "channels", "#405：end 返回最后一次被拒入口 channels");
+  assert.equal(g3.end(), null, "#405：再次 end（无 pending）返回 null");
   assert.equal(g3.isBusy(), false, "#405：重复 end 幂等释放");
+
+  // 5. 多次不同入口点击：记最后一次意图
+  const g4 = guardFactory();
+  g4.tryBegin("all");
+  g4.tryBegin("channels");
+  g4.tryBegin("all");
+  assert.equal(g4.end(), "all", "#405：多次被拒记最后一次入口");
+  assert.equal(g4.end(), null, "#405：清空后再 end 返回 null");
 }

--- a/packages/dsh-notifier/test/client-contract.test.ts
+++ b/packages/dsh-notifier/test/client-contract.test.ts
@@ -511,9 +511,27 @@ const pkgDir = fileURLToPath(new URL("..", import.meta.url));
   });
   const guardFactory = mod.apply.createSaveGuard;
   const domainFn = mod.apply.domainPayload;
+  const rebaseFn = mod.apply.rebaseSettings;
   assert.equal(typeof guardFactory, "function", "#405：apply 挂载 createSaveGuard 纯工厂");
   assert.equal(typeof domainFn, "function", "#405：apply 挂载 domainPayload 纯函数");
+  assert.equal(typeof rebaseFn, "function", "#405：apply 挂载 rebaseSettings 纯函数");
   for (const d of disposers3.splice(0)) d();
+
+  // rebaseSettings：键级 last-write-wins——最新 effective 为基底，本地变更键覆盖；
+  // 远端新键保留、本地未改键取远端值
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(rebaseFn(
+      { notifyAsk: false, channels: [1] },
+      { notifyAsk: true, notifySound: true, channels: [9], kindRoutes: { ask: ["browser"] } },
+    ))),
+    { notifyAsk: false, notifySound: true, channels: [1], kindRoutes: { ask: ["browser"] } },
+    "#405：rebase 键级合并——本地变更覆盖、远端未冲突键保留"
+  );
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(rebaseFn({}, { notifyAsk: true }))),
+    { notifyAsk: true },
+    "#405：无本地变更 → rebase 结果即远端最新"
+  );
 
   // domainPayload：域过滤语义（#405 PR2）——channels 域只提 channels 键；
   // all 原样；未知入口空对象

--- a/packages/dsh-notifier/test/client-style.test.ts
+++ b/packages/dsh-notifier/test/client-style.test.ts
@@ -101,7 +101,7 @@ import { assert } from "./helpers.ts";
   // 首次 apply：按 id 注入 1 个 <style>，dataset.version 承载 CSS_VERSION
   mod.apply(ctx);
   assert.equal(styleNodes(), 1, "#477：首次 apply 注入 1 个 dsh-notifier-style");
-  assert.equal(headNodes[0].dataset.version, "405-1", "#477：dataset.version 承载 CSS_VERSION");
+  assert.equal(headNodes[0].dataset.version, "405-2", "#477：dataset.version 承载 CSS_VERSION");
 
   // 重复 apply（宿主热更/重挂载）：幂等，仍 1 个，不重建
   mod.apply(ctx);


### PR DESCRIPTION
## 概要

issue #405（保存模型演进）PR2：**频道域保存按钮 + 基线按域推进 + 409 冲突双动作恢复**（客户端，方案定稿形态 B）。基于 #405 PR1（串行 guard 层），依赖其先合并。

## 改动

**PR2a — 频道域保存（客户端提交层按域解耦，HTTP 接口不拆）**
- guard pending 升级为入口标记（all/channels）：在途被拒的域保存**原样同入口补发**，不被升级成全量提交（防事件 tab 半成品误提交）；
- 频道 tab 底部「保存频道」行（`dn-ch-domainSave`，新 class——#418 移除的是双份全量保存的 `dn-ch-saveRow`，域语义不同，兑现 #418 原文预留的「域级拆分后按域重排按钮位置」）；
- `domainPayload()` 模块级纯函数（channels 域只提 channels 键）；**基线按域推进**：域保存成功后只并入本域键，事件 tab 草稿不被固化；
- 脏计数分域（foot 总数 + 域按钮语义）。

**PR2b — 409 冲突恢复（双动作横幅，不做静默丢草稿）**
- PUT 409 不再仅提示「手动关闭重开」：`handleConflict` 拉最新 → 本地已无脏则静默刷新（自动重拉的安全路径）/ 有脏弹非模态横幅（三动作：加载最新 / 保留我的修改并覆盖 / 忽略）；
- `rebaseSettings()` 模块级纯函数（键级 last-write-wins）：覆盖 = rebase-then-retry——本地变更键**动作触发时实时重算**（横幅期间新编辑不丢），用新 revision 重提，再 409 收敛回横幅（无自动风暴）；
- `commitSettings()` 整体替换写入口（同步写 settingsRef）——rebase 后立即 saveFor 读到最新草稿；
- i18n 6 key + alias-token 样式 + 窄屏堆叠适配。

## 测试与实测

- client-contract：domainPayload / rebaseSettings 纯函数直测、guard 入口保真（channels 被拒不升级 all）、源码契约（域保存 class / saveFor 入口 / 横幅 class）；
- 浏览器隔离实测（dsh-verify-isolated）：
  - 域保存成功（Saved）后事件草稿保留（回 Events 可见、foot Save 提交）——**基线按域推进实证**；
  - 409 冲突横幅出现（"Channel configuration was changed in another window"）→ **Keep my changes and overwrite**：本地改动保留并提交成功；**Load latest**：丢本地同步最新、无脏；Ignore 渲染；
  - 窄屏 400px 无横向溢出；
  - 截图归档：`packages/dsh-notifier/docs/archive/405-conflict-banner.png`、`405-channels-tab-full.png`；
- 全量门禁绿。

## 契约影响

无（纯客户端；PUT /config 契约不变，无新依赖，无安全语义变化）。

关联 issue #405。依赖 #405 PR1；后续 PR3（kinds 闭环）基于本 PR。
