### PR TITLE
refactor(shared): 抽 shared/dsh-home 单一事实源——4 包 9 处 DSH_HOME 解析收敛（#517）

### DIFF
--- a/packages/dsh-lan-proxy/src/apply.ts
+++ b/packages/dsh-lan-proxy/src/apply.ts
@@ -6,11 +6,12 @@
  * randomUUID polyfill 同处装配。路由表归 config-routes.ts，settings 接线归
  * settings.ts，存量迁移归 migrate.ts；本模块不 import index.ts（防循环）。
  */
-import { homedir, networkInterfaces } from "node:os";
+import { networkInterfaces } from "node:os";
 import { join } from "node:path";
 import { mkdirSync } from "node:fs";
 import type { Context } from "@deepseek-ai/cordis";
 import { writeJson, errorMessage, guardLoopbackMethod } from "../../../shared/host-utils.js";
+import { dshHome } from "../../../shared/dsh-home.js";
 import { createLanProxy, DEFAULT_OPTIONS, DEFAULT_DEFLATE_POLICY } from "./proxy.ts";
 import type { TlsMaterials, LanProxy } from "./proxy.ts";
 import { ensureSelfSignedTls, loadTlsFromFiles } from "./cert.ts";
@@ -50,7 +51,7 @@ function lanIpv4Addresses(): string[] {
 
 /** 插件目录（<DSH_HOME>/lan-proxy）：自签名证书缓存 + 存量迁移备份所在。 */
 export function pluginDir(): string {
-  return join(process.env.DSH_HOME ?? join(homedir(), ".dsh"), "lan-proxy");
+  return join(dshHome(), "lan-proxy");
 }
 
 /**

--- a/packages/dsh-mcp-manager/src/catalog.ts
+++ b/packages/dsh-mcp-manager/src/catalog.ts
@@ -9,7 +9,7 @@
 
 import { createHash, randomUUID } from "node:crypto";
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { dshHome } from "../../../shared/dsh-home.js";
 import type { ServerConfig } from "./types.ts";
 
 /** 目录条目。 */
@@ -69,7 +69,7 @@ export const DEFAULT_CATALOG_MAX_ENTRIES = 6;
 
 /** 目录缓存文件（连接成功时把工具描述摘要持久化于此；目录 digest 的稳定数据源）。 */
 export function catalogCacheFile() {
-  return join(process.env.DSH_HOME ?? join(homedir(), ".dsh"), "dsh-mcp-catalog.json");
+  return join(dshHome(), "dsh-mcp-catalog.json");
 }
 
 /**

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -11,9 +11,9 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { homedir } from "node:os";
 import type { ServerResponse } from "node:http";
 import type { SseHub } from "../../../shared/sse-hub.js";
+import { dshHome } from "../../../shared/dsh-home.js";
 import type { Context, LoggerService } from "@deepseek-ai/cordis";
 import type { ServerConfig, ClientUiConfig } from "./types.ts";
 import type { ToolDefinition } from "@deepseek-ai/dsh-tools";
@@ -39,10 +39,11 @@ import type { MiddlewareMode, ProjectUnit, DisabledToolsMap } from "./middleware
 /** 中间层 all 模式的全局虚拟 root（全局服务器经中间层访问时的路由 key）。 */
 export const MIDDLEWARE_GLOBAL_ROOT = "@global";
 
-/** DSH 全局家目录（与官方 dsh-home-paths 同语义：DSH_HOME ?? ~/.dsh）。 */
+/** DSH 全局家目录（与官方 dsh-home-paths 同语义：DSH_HOME ?? ~/.dsh）。
+ *  resolve 为本处 .dsh 标记排除的对比用途服务；归一语义（空串回落）由
+ *  shared/dsh-home.js 单一事实源承载（#517 收敛）。 */
 function dshHomePath() {
-  const envHome = process.env.DSH_HOME;
-  return resolve(envHome !== undefined && envHome !== "" ? envHome : join(homedir(), ".dsh"));
+  return resolve(dshHome());
 }
 
 /**

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -39,9 +39,9 @@ import type { MiddlewareMode, ProjectUnit, DisabledToolsMap } from "./middleware
 /** 中间层 all 模式的全局虚拟 root（全局服务器经中间层访问时的路由 key）。 */
 export const MIDDLEWARE_GLOBAL_ROOT = "@global";
 
-/** DSH 全局家目录（与官方 dsh-home-paths 同语义：DSH_HOME ?? ~/.dsh）。
- *  resolve 为本处 .dsh 标记排除的对比用途服务；归一语义（空串回落）由
- *  shared/dsh-home.js 单一事实源承载（#517 收敛）。 */
+/** DSH 全局家目录（shared/dsh-home.js 语义：DSH_HOME 非空白原样采用、空白
+ *  视同未设置回落 ~/.dsh；#517 收敛）。resolve 为本处 .dsh 标记排除的对比
+ *  用途服务。 */
 function dshHomePath() {
   return resolve(dshHome());
 }

--- a/packages/dsh-mcp-manager/src/middleware-state.ts
+++ b/packages/dsh-mcp-manager/src/middleware-state.ts
@@ -6,13 +6,13 @@ import { createHash } from "node:crypto";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { homedir } from "node:os";
 import type { ProjectUnit, DisabledToolsMap } from "./middleware-types.ts";
 import { parseDisabledTools } from "./middleware-utils.ts";
+import { dshHome } from "../../../shared/dsh-home.js";
 
 /** userDisabled 持久化文件路径。 */
 export function userStateFile() {
-  return join(process.env.DSH_HOME ?? join(homedir(), ".dsh"), "dsh-mcp-user-state.json");
+  return join(dshHome(), "dsh-mcp-user-state.json");
 }
 
 /** 加载 userDisabled（损坏/缺失 → 空）。 */
@@ -59,7 +59,7 @@ export async function saveUserState(file: string, units: Map<string, ProjectUnit
 /** 目录缓存文件路径（每工作空间一份；root 哈希防路径注入）。 */
 export function catalogCacheFileFor(root: string) {
   const hash = createHash("sha256").update(root).digest("hex").slice(0, 16);
-  return join(process.env.DSH_HOME ?? join(homedir(), ".dsh"), "dsh-mcp-catalog", `${hash}.json`);
+  return join(dshHome(), "dsh-mcp-catalog", `${hash}.json`);
 }
 
 /** 加载工具级禁用（disabledTools 三段：root → server → tool[]；损坏/缺失 → 空）。 */

--- a/packages/dsh-mcp-manager/src/store.ts
+++ b/packages/dsh-mcp-manager/src/store.ts
@@ -8,14 +8,14 @@
 import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { homedir } from "node:os";
+import { dshHome } from "../../../shared/dsh-home.js";
 import type { ServerConfig } from "./types.ts";
 
 // ------------------------------------------------------------------ 存储
 
 /** 默认配置存储路径。 */
 export function defaultStorePath() {
-  return join(process.env.DSH_HOME ?? join(homedir(), ".dsh"), "dsh-mcp.json");
+  return join(dshHome(), "dsh-mcp.json");
 }
 
 /**

--- a/packages/dsh-notifier/src/config.ts
+++ b/packages/dsh-notifier/src/config.ts
@@ -10,6 +10,7 @@
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { dshHome as sharedDshHome } from "../../../shared/dsh-home.js";
 import { parseHHMM } from "./quiet-hours.ts";
 import type { QuietHoursConfig } from "./quiet-hours.ts";
 
@@ -231,14 +232,14 @@ export const CONFIG_KEYS: readonly BooleanKeys[] = ["notifyAsk", "notifyQuestion
 const PROTOTYPE_POLLUTION_KEYS: readonly string[] = ["__proto__", "constructor", "prototype", "toString", "hasOwnProperty", "valueOf", "isPrototypeOf", "propertyIsEnumerable", "toLocaleString"];
 
 /**
- * DSH home 基目录（#510）：插件落盘路径统一感知 `DSH_HOME`——官方 dsh 在隔离
- * 环境（多实例 / 测试沙箱 / dsh-verify-isolated 临时 home）下运行时，官方
- * settings 存储已随 DSH_HOME 隔离，插件 history/status 落盘也必须随隔离 home
- * 走，否则读写两面都串到真实 `~/.dsh`（#510 根因）。未设置时回落 `~/.dsh`，
- * 默认形态路径逐字节不变。写法对齐 dsh-provider-usage/src/path-resolve.ts 先例。
+ * DSH home 基目录（#510 → #517 收敛）：薄 facade，语义由 shared/dsh-home.js
+ * 单一事实源承载（非空 env 原样采用、未设置或空串回落 ~/.dsh）。插件落盘
+ * 路径（configFile/historyFile/statusFile）统一经此解析——官方 settings 存储
+ * 已随 DSH_HOME 隔离，插件 history/status 落盘也必须随隔离 home 走，否则
+ * 读写两面都串到真实 ~/.dsh（#510 根因）。
  */
 function dshHome(): string {
-  return process.env.DSH_HOME ?? join(homedir(), ".dsh");
+  return sharedDshHome();
 }
 
 /**

--- a/packages/dsh-notifier/src/config.ts
+++ b/packages/dsh-notifier/src/config.ts
@@ -7,7 +7,6 @@
  * validateSettings / sanitizeSettings 校验——非法值 400 拒绝 + hint，
  * 不再静默丢弃回默认（H6）。
  */
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { dshHome as sharedDshHome } from "../../../shared/dsh-home.js";

--- a/packages/dsh-provider-usage/src/apply.ts
+++ b/packages/dsh-provider-usage/src/apply.ts
@@ -27,6 +27,7 @@ import { basename, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { guardLoopbackMethod, writeJson, readJsonBody, errorMessage, sseData } from "../../../shared/host-utils.js";
 import { installSettingsNamespace } from "../../../shared/settings-namespace.js";
+import { dshHome } from "../../../shared/dsh-home.js";
 import { Mutex } from "async-mutex";
 import type { Context } from "@deepseek-ai/cordis";
 import type { WebRoute } from "@deepseek-ai/dsh-host-webserver";
@@ -82,7 +83,7 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
   if (rawConfig.enabled === false) return; // 显式禁用：不注册任何路由
   const config = normalizeConfig(rawConfig);
   const sanitizeDiagnostic = (s: string): string =>
-    s.split(process.env.DSH_HOME ?? join(homedir(), ".dsh")).join("~/.dsh").split(homedir()).join("~");
+    s.split(dshHome()).join("~/.dsh").split(homedir()).join("~");
   const registry = makeAdapterRegistry({
     sanitizePath: sanitizeDiagnostic,
   });
@@ -92,7 +93,7 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
   };
 
   // -------------------------------------------------------- 历史存储与持久化根
-  const historyRoot = config.historyDir || join(process.env.DSH_HOME ?? join(homedir(), ".dsh"), "dsh-provider-usage");
+  const historyRoot = config.historyDir || join(dshHome(), "dsh-provider-usage");
   const history = new HistoryStore({
     root: historyRoot,
     maxAgeMs: config.maxAgeDays * 86400000,

--- a/packages/dsh-provider-usage/src/path-resolve.ts
+++ b/packages/dsh-provider-usage/src/path-resolve.ts
@@ -9,8 +9,8 @@
  * 4. 解析后做 `existsSync` / 可读校验；失败 → 记诊断 + 该条目跳过。
  */
 import { existsSync, statSync } from "node:fs";
-import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
+import { dshHome as dshHomeBase } from "../../../shared/dsh-home.js";
 // issue #87：~ 展开复用成熟开源实现 untildify（与 dsh-web-file-preview 同源同版，
 // devDependency + 构建期 esbuild 内联，发布物零运行时依赖）。
 // 行为边界：仅展开开头的 `~`；`~user/...` 形态不展开、原样返回（旧手写实现把
@@ -19,10 +19,11 @@ import untildify from "untildify";
 
 /**
  * 插件 home 目录（host 文件逻辑归属区 ~/.dsh/plugins/provider-usage）。
- * @param base - DSH_HOME 根（缺省读 env，回落 ~/.dsh）；参数化供调用方在非全局
- *   env 场景（如路由入参校验）复用同一拼装规则。
+ * 渐进退役 facade：base 缺省语义由 shared/dsh-home.js 单一事实源承载（#517），
+ * 公开签名不变——参数化供调用方在非全局 env 场景（如路由入参校验）复用。
+ * @param base - DSH_HOME 根（缺省读 env，空串视同未设置，回落 ~/.dsh）。
  */
-export function pluginHome(base = process.env.DSH_HOME ?? join(homedir(), ".dsh")): string {
+export function pluginHome(base = dshHomeBase()): string {
   return join(base, "plugins", "provider-usage");
 }
 
@@ -52,7 +53,7 @@ export function resolvePath(p: string): string | undefined {
     expanded = trimmed;
   } else {
     // 相对路径：尝试 DSH_HOME → 插件 home
-    const dshHome = process.env.DSH_HOME ?? join(homedir(), ".dsh");
+    const dshHome = dshHomeBase();
     const candidates = [join(dshHome, trimmed), join(pluginHome(), trimmed)];
     for (const candidate of candidates) {
       if (existsSync(candidate)) {

--- a/packages/dsh-provider-usage/src/provider-config.ts
+++ b/packages/dsh-provider-usage/src/provider-config.ts
@@ -20,6 +20,7 @@ import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { dshHome as dshHomeShared } from "../../../shared/dsh-home.js";
 
 /** 插件配置提供的 apiEndpoint/apiKey（可选）。 */
 export interface ProviderConfigInput {
@@ -65,9 +66,10 @@ function opencodeKeyFromAuth(text: string | undefined): string | undefined {
   return undefined;
 }
 
-/** .credentials.yaml 文件路径。 */
+/** .credentials.yaml 文件路径（DSH 官方凭据文档，dsh-credentials-local 同源：
+ *  base 语义由 shared/dsh-home.js 承载，#517 收敛）。 */
 export function credentialsFile(dshHome?: string): string {
-  return join(dshHome ?? process.env.DSH_HOME ?? join(homedir(), ".dsh"), ".credentials.yaml");
+  return join(dshHome ?? dshHomeShared(), ".credentials.yaml");
 }
 
 /** auth.json 文件路径。 */

--- a/packages/dsh-provider-usage/src/user-adapters.ts
+++ b/packages/dsh-provider-usage/src/user-adapters.ts
@@ -8,9 +8,9 @@
 import { copyFile, link, mkdir, open, readFile, readdir, rename, unlink } from "node:fs/promises";
 import { constants, existsSync } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { expandHomePath, pluginHome, resolvePath } from "./path-resolve.ts";
+import { dshHome as dshHomeDefault } from "../../../shared/dsh-home.js";
 
 /** 损坏启用状态的取证备份上限；新隔离的现场始终保留，其余按文件名时间戳轮转。 */
 export const ADAPTER_STATE_BACKUP_LIMIT = 5;
@@ -361,7 +361,7 @@ export async function writeAdapterState(
 /** 校验 add 入参 file 字段：文件存在可读 + 路径规整禁穿越。 */
 export function resolveAddAdapterFile(
   input: unknown,
-  dshHome = process.env.DSH_HOME ?? join(homedir(), ".dsh"),
+  dshHome = dshHomeDefault(),
 ): string | undefined {
   if (typeof input !== "string") return undefined;
   const trimmed = input.trim();

--- a/scripts/test/shared-dsh-home.test.ts
+++ b/scripts/test/shared-dsh-home.test.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * shared/dsh-home.js 行为契约单测（#517 C10 接缝）。
+ *
+ * 锚定 DSH home 解析的统一语义：非空 env 原样采用 / 未设置回落 ~/.dsh /
+ * **空串视同未设置**（P2-2 评审结论——收敛前 `??` 形态空串解析为 cwd 相对
+ * 路径，mcp-manager manager.ts 形态则回落默认，行为分裂由本模块统一）。
+ * 默认形态路径与历史实现逐字节一致（join(homedir(), ".dsh")，不 resolve）。
+ *
+ * 运行：node --test scripts/test/shared-dsh-home.test.ts（或 pnpm test:scripts）
+ * 零落盘：纯内存行为测试（homedir 断言基于当前用户 home 计算，无文件写入）。
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { homedir } from 'node:os'
+import { join, isAbsolute } from 'node:path'
+import { dshHome } from '../../shared/dsh-home.js'
+
+test('dshHome：未设置 DSH_HOME 时回落 ~/.dsh（默认形态逐字节不变）', () => {
+  const prev = process.env.DSH_HOME
+  delete process.env.DSH_HOME
+  try {
+    assert.equal(dshHome(), join(homedir(), '.dsh'))
+  } finally {
+    if (prev !== undefined) process.env.DSH_HOME = prev
+  }
+})
+
+test('dshHome：非空 DSH_HOME 原样采用（不 resolve、不规范化）', () => {
+  const prev = process.env.DSH_HOME
+  try {
+    process.env.DSH_HOME = '/tmp/dsh-home-contract'
+    assert.equal(dshHome(), '/tmp/dsh-home-contract')
+    // 带冗余分隔符/点段的值原样保留——本模块不做路径规范化
+    process.env.DSH_HOME = '/tmp/dsh-home//x/.'
+    assert.equal(dshHome(), '/tmp/dsh-home//x/.')
+  } finally {
+    if (prev !== undefined) process.env.DSH_HOME = prev
+    else delete process.env.DSH_HOME
+  }
+})
+
+test('dshHome：空串与纯空白视同未设置（对齐官方 resolveDshHome，回落 ~/.dsh）', () => {
+  const prev = process.env.DSH_HOME
+  try {
+    process.env.DSH_HOME = ''
+    assert.equal(dshHome(), join(homedir(), '.dsh'))
+    assert.ok(isAbsolute(dshHome()), '结果为绝对路径（非 cwd 相对）')
+    process.env.DSH_HOME = '   '
+    assert.equal(dshHome(), join(homedir(), '.dsh'), '纯空白同样视同未设置')
+  } finally {
+    if (prev !== undefined) process.env.DSH_HOME = prev
+    else delete process.env.DSH_HOME
+  }
+})
+
+test('dshHome：env 恢复纪律（finally 后还原测试前状态）', () => {
+  // 前面用例各自 finally 恢复；此处锚定恢复语义本身
+  const prev = process.env.DSH_HOME
+  try {
+    process.env.DSH_HOME = '/tmp/probe'
+    assert.equal(dshHome(), '/tmp/probe')
+  } finally {
+    if (prev !== undefined) process.env.DSH_HOME = prev
+    else delete process.env.DSH_HOME
+  }
+  assert.equal(dshHome() === prev || (prev === undefined && dshHome() === join(homedir(), '.dsh')), true)
+})

--- a/scripts/test/shared-dsh-home.test.ts
+++ b/scripts/test/shared-dsh-home.test.ts
@@ -29,7 +29,7 @@ test('dshHome：未设置 DSH_HOME 时回落 ~/.dsh（默认形态逐字节不�
   }
 })
 
-test('dshHome：非空 DSH_HOME 原样采用（不 resolve、不规范化）', () => {
+test('dshHome：非空 DSH_HOME 原样采用（不 resolve、不规范化、不展开 ~）', () => {
   const prev = process.env.DSH_HOME
   try {
     process.env.DSH_HOME = '/tmp/dsh-home-contract'
@@ -37,6 +37,10 @@ test('dshHome：非空 DSH_HOME 原样采用（不 resolve、不规范化）', (
     // 带冗余分隔符/点段的值原样保留——本模块不做路径规范化
     process.env.DSH_HOME = '/tmp/dsh-home//x/.'
     assert.equal(dshHome(), '/tmp/dsh-home//x/.')
+    // ~ 前缀原样返回（不展开——官方在 resolve 层做 expandHomePath，插件拼 base 不展开；
+    // 锁定防后续「顺手对齐官方」加展开时无回归锁）
+    process.env.DSH_HOME = '~/x'
+    assert.equal(dshHome(), '~/x')
   } finally {
     if (prev !== undefined) process.env.DSH_HOME = prev
     else delete process.env.DSH_HOME
@@ -58,7 +62,9 @@ test('dshHome：空串与纯空白视同未设置（对齐官方 resolveDshHome�
 })
 
 test('dshHome：env 恢复纪律（finally 后还原测试前状态）', () => {
-  // 前面用例各自 finally 恢复；此处锚定恢复语义本身
+  // 前面用例各自 finally 恢复；此处锚定恢复语义本身：恢复后 dshHome() 必须与
+  // 「prev 按本模块语义解析的结果」一致（prev 为空白串时视同未设置，故不能
+  // 断言 dshHome() === prev——那会与空白语义自相矛盾，评审 P1-1 实证假失败）。
   const prev = process.env.DSH_HOME
   try {
     process.env.DSH_HOME = '/tmp/probe'
@@ -67,5 +73,6 @@ test('dshHome：env 恢复纪律（finally 后还原测试前状态）', () => {
     if (prev !== undefined) process.env.DSH_HOME = prev
     else delete process.env.DSH_HOME
   }
-  assert.equal(dshHome() === prev || (prev === undefined && dshHome() === join(homedir(), '.dsh')), true)
+  const expected = prev !== undefined && prev.trim().length > 0 ? prev : join(homedir(), '.dsh')
+  assert.equal(dshHome(), expected)
 })

--- a/shared/README.md
+++ b/shared/README.md
@@ -15,7 +15,7 @@ DSH 插件家族共用的模块（构建期 esbuild 内联进各插件包，不�
 | `host-utils.js` | 宿主 | `writeJson` / `errorMessage` / `readBody`（限长显式化）/ `readJsonBody`（宽松版）/ `sseData`（SSE data 帧序列化 `data: <json>\n\n`；undefined / 含 `\n` payload 行为对齐三包历史、非承诺契约；`sseData` 消费方：mcp-manager / notifier / provider-usage）/ `guardLoopbackMethod`（loopback+方法白名单守卫；403 先于 405 为守卫自身执行顺序，仅适用于套守卫端点） | lan-proxy / mcp-manager / notifier / provider-usage / web-file-preview |
 | `frontmatter.js` | 宿主 | `parseFrontmatter` / `parseFrontmatterAll` / `setFrontmatterField` / `parseYamlBool` | 历史：commands-files / skill-explorer 同源复制统一；现生产消费已退役（verify-isolated 测试仍引用） |
 | `settings-namespace.js` | 宿主 | `installSettingsNamespace`（settings 服务面注入） | lan-proxy / mcp-manager / notifier / provider-usage |
-| `dsh-home.js` | 宿主 | `dshHome`（DSH home 解析单一事实源，#517：`DSH_HOME` 非空白原样采用、未设置或空白回落 `~/.dsh`——空白视同未设置对齐官方 `dsh-home-paths#resolveDshHome`；不 resolve/不展开 `~`，默认形态路径逐字节不变。豁免口径见 DEVELOPMENT.md §1：非 dsh 生态凭据不跟随） | lan-proxy / mcp-manager / notifier / provider-usage |
+| `dsh-home.js` | 宿主 | `dshHome`（DSH home 解析单一事实源，#517：`DSH_HOME` 非空白原样采用、未设置或空白回落 `~/.dsh`——空白视同未设置对齐官方 `dsh-home-paths#resolveDshHome`；不 resolve/不展开 `~`，默认形态路径逐字节不变。豁免口径（非 dsh 生态凭据不跟随）与落盘纪律条款见 DEVELOPMENT.md §1，由 PR #523 承载） | lan-proxy / mcp-manager / notifier / provider-usage |
 | `mcp-manager-service.d.ts` | 宿主 | MCP 管理器服务契约类型面（消费方只走公开入口） | mcp-manager / codegraph |
 | `placement-math.js` | 双端 | 浮窗/胶囊定位/层级/断点纯函数（#128 → #378 抽取，含 `panelTopForAnchor` 与参数化 `panelZIndexFor(base, dflt)`） | mcp-manager / provider-usage |
 | `client/i18n.js` | 客户 | 共享 `t` 活绑定 + `bindLocale`（#348 → #378 抽取；未装配回落 key 本体） | mcp-manager / provider-usage / web-file-preview |

--- a/shared/README.md
+++ b/shared/README.md
@@ -15,6 +15,7 @@ DSH 插件家族共用的模块（构建期 esbuild 内联进各插件包，不�
 | `host-utils.js` | 宿主 | `writeJson` / `errorMessage` / `readBody`（限长显式化）/ `readJsonBody`（宽松版）/ `sseData`（SSE data 帧序列化 `data: <json>\n\n`；undefined / 含 `\n` payload 行为对齐三包历史、非承诺契约；`sseData` 消费方：mcp-manager / notifier / provider-usage）/ `guardLoopbackMethod`（loopback+方法白名单守卫；403 先于 405 为守卫自身执行顺序，仅适用于套守卫端点） | lan-proxy / mcp-manager / notifier / provider-usage / web-file-preview |
 | `frontmatter.js` | 宿主 | `parseFrontmatter` / `parseFrontmatterAll` / `setFrontmatterField` / `parseYamlBool` | 历史：commands-files / skill-explorer 同源复制统一；现生产消费已退役（verify-isolated 测试仍引用） |
 | `settings-namespace.js` | 宿主 | `installSettingsNamespace`（settings 服务面注入） | lan-proxy / mcp-manager / notifier / provider-usage |
+| `dsh-home.js` | 宿主 | `dshHome`（DSH home 解析单一事实源，#517：`DSH_HOME` 非空白原样采用、未设置或空白回落 `~/.dsh`——空白视同未设置对齐官方 `dsh-home-paths#resolveDshHome`；不 resolve/不展开 `~`，默认形态路径逐字节不变。豁免口径见 DEVELOPMENT.md §1：非 dsh 生态凭据不跟随） | lan-proxy / mcp-manager / notifier / provider-usage |
 | `mcp-manager-service.d.ts` | 宿主 | MCP 管理器服务契约类型面（消费方只走公开入口） | mcp-manager / codegraph |
 | `placement-math.js` | 双端 | 浮窗/胶囊定位/层级/断点纯函数（#128 → #378 抽取，含 `panelTopForAnchor` 与参数化 `panelZIndexFor(base, dflt)`） | mcp-manager / provider-usage |
 | `client/i18n.js` | 客户 | 共享 `t` 活绑定 + `bindLocale`（#348 → #378 抽取；未装配回落 key 本体） | mcp-manager / provider-usage / web-file-preview |

--- a/shared/dsh-home.d.ts
+++ b/shared/dsh-home.d.ts
@@ -1,0 +1,6 @@
+/**
+ * DSH home 解析（单一事实源）：`DSH_HOME` 非空白原样采用；未设置或空白回落
+ * `~/.dsh`（默认形态路径逐字节不变）。语义对齐官方
+ * `@deepseek-ai/dsh-home-paths#resolveDshHome`（空白 env 视同未设置）。
+ */
+export declare function dshHome(): string;

--- a/shared/dsh-home.js
+++ b/shared/dsh-home.js
@@ -1,0 +1,31 @@
+// dsh 插件家族共享层 — DSH home 解析（单一事实源）。
+//
+// 历史：`process.env.DSH_HOME ?? join(homedir(), ".dsh")` 在 4 包 9 处逐字复制
+// （#517 全仓扫描），且与 mcp-manager manager.ts 的空串防御形态并存——
+// `DSH_HOME=""` 在两种形态下分别解析为 cwd 相对路径（随进程 cwd 漂移）与
+// 默认 home，行为分裂。统一由本模块承载：**空白（空串/纯空白）视同未设置**
+// ——与官方 `@deepseek-ai/dsh-home-paths` `resolveDshHome` 权威语义对齐
+// （"An empty or whitespace-only `$DSH_HOME` is treated as unset"），非空 env
+// 原样采用（不 resolve、不展开 `~`——官方在 resolve 层做，插件落盘拼 base
+// 不需要），保证默认形态路径逐字节不变。
+//
+// 消费方：dsh-notifier / dsh-lan-proxy / dsh-mcp-manager / dsh-provider-usage
+// （provider-usage 的 path-resolve.ts pluginHome 为渐进退役 facade，内部改调
+// 本模块，公开签名不变）。
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * DSH home 基目录：`DSH_HOME` 非空白原样采用；未设置**或空白**回落
+ * `~/.dsh`（默认形态路径逐字节不变）。语义对齐官方
+ * `@deepseek-ai/dsh-home-paths#resolveDshHome`（空白 env 视同未设置）。
+ * 落盘/读取持久化文件一律以本函数为 base
+ * （docs/DEVELOPMENT.md §1「落盘路径必须感知 DSH_HOME」）。
+ *
+ * @returns {string} DSH home 目录路径。
+ */
+export function dshHome() {
+  const env = process.env.DSH_HOME;
+  return env !== undefined && env.trim().length > 0 ? env : join(homedir(), ".dsh");
+}

--- a/shared/dsh-home.js
+++ b/shared/dsh-home.js
@@ -20,8 +20,8 @@ import { join } from "node:path";
  * DSH home 基目录：`DSH_HOME` 非空白原样采用；未设置**或空白**回落
  * `~/.dsh`（默认形态路径逐字节不变）。语义对齐官方
  * `@deepseek-ai/dsh-home-paths#resolveDshHome`（空白 env 视同未设置）。
- * 落盘/读取持久化文件一律以本函数为 base
- * （docs/DEVELOPMENT.md §1「落盘路径必须感知 DSH_HOME」）。
+ * 落盘/读取持久化文件一律以本函数为 base——仓库纪律「落盘路径必须感知
+ * DSH_HOME」及其豁免口径由 docs/DEVELOPMENT.md §1 承载（PR #523）。
  *
  * @returns {string} DSH home 目录路径。
  */


### PR DESCRIPTION
## 概要

#517 C10 接缝落地：抽 `shared/dsh-home.js/.d.ts` 单一事实源，4 包 **13 处** DSH_HOME 解析表达式（12 处 `??` 逐字复制 + 1 处 mcp-manager manager 空白防御特殊形态）收敛为一处。基于 #522（#510）与 #523（docs 条款）合入后的 main。

## 语义（关键决策）

- **空白视同未设置**：`DSH_HOME` 为空串/纯空白时回落 `~/.dsh`——对齐官方 `@deepseek-ai/dsh-home-paths#resolveDshHome` 权威实现（"An empty or whitespace-only `$DSH_HOME` is treated as unset"），非臆造口径；
- **修复评审 P2-2**（#522 对抗性评审发现）：收敛前 12 处 `??` 形态在 `DSH_HOME=""` 时解析为 cwd 相对路径、随进程 cwd 漂移，与 mcp-manager manager.ts 的空串防御形态行为分裂——本 PR 统一为「空白回落默认」；顺带修复 provider-usage `sanitizeDiagnostic` 在 `DSH_HOME=""` 时 `split("")` 逐字符插 `~/.dsh` 毁诊断文本且不脱敏的灾难行为；
- **默认形态路径逐字节不变**：非空 env 原样采用，不 resolve、不展开 `~`（官方在 resolve 层做，插件拼 base 不需要；`~` 展开缺口已留痕 #517 由 C10/B5 跟踪）；
- **manager.ts 行为说明**：与原空串防御实现仅在「纯空白 env」病态输入下有行为差（原 `resolve("   ")` → cwd 相对怪目录，现回落 `~/.dsh`）——方向与官方一致；
- **豁免口径**：`~/.local/share/opencode/auth.json` 直连 homedir 不收敛（非 dsh 生态凭据，DEVELOPMENT.md §1 豁免条款）；`provider-config.ts` 的 `.credentials.yaml` **予以收敛**——它是 DSH 官方凭据文档（`dsh-credentials-local` 以 `resolveDshHome()/.credentials.yaml` 同源解析），非 opencode 私有。

## 改动清单

| 包 | 文件 | 收敛点 |
|---|---|---|
| notifier | config.ts | #510 的 `dshHome()` 薄化为 shared facade（删零使用 homedir import） |
| lan-proxy | apply.ts | `pluginDir()` |
| mcp-manager | catalog.ts / middleware-state.ts ×2 / store.ts / manager.ts | 路径函数 ×4 + manager 归一版（`resolve(dshHome())`） |
| provider-usage | apply.ts ×2 / path-resolve.ts ×2 / provider-config.ts / user-adapters.ts | 落盘/校验链 + `pluginHome` 渐进退役 facade（公开签名不变） |

配套：`scripts/test/shared-dsh-home.test.ts` 独立单测 ×4（准入规则 6；含 `~/x` 原样返回回归锁）+ `shared/README.md` 登记消费方与行为契约（准入规则 5）。

## 评审留痕

合并前独立对抗性评审（VERDICT: request-changes → P1×3 已修）：
- P1-1 测试用例 4 复合断言在 prev 空白串时恒 false（已实证假失败）→ 改按语义解析期望值；
- P1-2 DEVELOPMENT.md §1 条款引用悬空 → **由 #523 先行合并解决**（本分支已 rebase 到含 #523 的 main，引用成立），jsdoc/README 引用处标注承载方；
- P1-3 notifier 死 import → 删除。
P2×4：`~` 展开缺口与计数口径留痕 #517；manager 注释已改准确；`~/x` 锁已补。

## 门禁

本地 `pnpm build / test / contract / pack:check / typecheck` 全绿；`test:scripts` 144 pass（含新 shared 单测，含 `DSH_HOME=""` 环境实跑）。

## 后续

- B5 门禁静态扫描（禁 `packages/*/src` 直连 `os.homedir`、落盘须经本模块，带豁免机制）以本模块为锚点立项；
- C10 官方 DSH_HOME 语义演进（XDG 等）时只改本模块（含补 expandHomePath 或内联官方包的取舍）。
