### PR TITLE
fix(dsh-mcp-manager): ws_mcp_call 失败错误去除重复 detail 建议（#529）

### DIFF
--- a/packages/dsh-mcp-manager/src/middleware.ts
+++ b/packages/dsh-mcp-manager/src/middleware.ts
@@ -609,7 +609,7 @@ export class McpMiddleware {
       return projected;
     } catch (error) {
       if (signal?.aborted === true) throw signal.reason;
-      throw new Error(this.hostRedact(`ws_mcp_call: ${JSON.stringify(`${parsed.server}/${tool}`)} 调用失败：${msgOf(error)}；可先用 ws_mcp_detail 核对参数 schema，或确认服务器已连接后重试`));
+      throw new Error(this.hostRedact(`ws_mcp_call: ${JSON.stringify(`${parsed.server}/${tool}`)} 调用失败：${msgOf(error)}`));
     }
   }
 

--- a/packages/dsh-mcp-manager/test/unit-middleware.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.test.ts
@@ -762,6 +762,14 @@ function makeHost(serversByRoot = new Map()) {
       /远端工具返回错误：.*boom.*ws_mcp_detail/,
       "isError:true 抛错且文案可归因",
     );
+    // #529：外层 catch 不再追加 detail 建议，同一条错误里「ws_mcp_detail」只出现一次。
+    const dupErr = await mw.callTool(fullServerName(ROOT, "py"), "echo", {}, undefined).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    assert.ok(dupErr instanceof Error, "isError:true 应抛错");
+    const detailCount = (dupErr.message.match(/ws_mcp_detail/g) ?? []).length;
+    assert.equal(detailCount, 1, `detail 建议只出现一次（实际 ${detailCount} 次：${dupErr.message}）`);
     await dispose();
   }
 
@@ -819,7 +827,8 @@ function makeHost(serversByRoot = new Map()) {
   // 复核闸 F1：isError:true 且 content 非数组（协议违规形态）→ 走兜底分支时
   // fallbackText 保留远端原文（msgOf，与旧文案行为等价），不丢成 "(no output)"。
   // 注：no-content isError 分支不经 errorText handler（其入参契约为 content
-  // 数组），文案经外层 catch 统一包装为「调用失败：<原文>；可先用 …」。
+  // 数组），文案经外层 catch 统一包装为「调用失败：<原文>」（#529：外层不再
+  // 追加 detail 建议，建议由内层按场景给一次）。
   {
     const { mw, dispose } = await withFakeClient({ isError: true, content: "boom-msg" });
     await assert.rejects(


### PR DESCRIPTION
## 背景

issue #529：ws_mcp_call 失败时错误信息里「用 ws_mcp_detail 核对参数」的提示出现两次（超时 / 远端 isError 场景），`ws_mcp_call:` 前缀也重复。

## 根因

`src/middleware.ts` `callTool` 外层 catch（L612）对错误做「定位前缀 + 原文 + 追加 detail 建议」的二次包装，而内层错误已自带按场景分化的建议：

- L584 withTimeout 超时消息已带「请用 ws_mcp_detail 核对参数或检查服务器状态」；
- L595 errorText（isError:true + content 数组）已带「可先用 ws_mcp_detail 核对参数 schema 后重试」；
- L612 再追加「可先用 ws_mcp_detail 核对参数 schema，或确认服务器已连接后重试」→ 叠加重复。

实际形态：

```
ws_mcp_call: <server>/<tool> 调用失败：ws_mcp_call: 调用超时（30000ms）…请用 ws_mcp_detail 核对参数或检查服务器状态；可先用 ws_mcp_detail 核对参数 schema，或确认服务器已连接后重试
```

## 改动（方案 A）

- `middleware.ts`：外层 catch 只保留定位前缀 + 原文 + 脱敏，删掉追加的 detail 建议（建议由内层按场景给一次）；
- `unit-middleware.test.ts`：同步注释，新增防回归断言——isError:true 场景同一条错误中 `ws_mcp_detail` 只出现一次。

## 验证

- `pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 全绿；
- 包级 smoke 全过（含既有断言：远端错误可归因 / 调用失败原文保留）。