### PR TITLE
fix(dsh-verify-isolated): 插件参数相对路径绝对化——规避 dsh 当 git URL 解析（#517 C11）

### DIFF
--- a/docs/architecture/dsh-verify-isolated.md
+++ b/docs/architecture/dsh-verify-isolated.md
@@ -47,9 +47,9 @@ flowchart LR
 
 ---
 
-## 2. 一键脚本：双重隔离的六步
+## 2. 一键脚本：四重隔离的流程
 
-`skills/dsh-verify-isolated/scripts/verify-isolated.sh`（102 行，`set -euo pipefail`）：
+`skills/dsh-verify-isolated/scripts/verify-isolated.sh`（bash + 内嵌 node，`set -euo pipefail`）：
 
 ```mermaid
 sequenceDiagram
@@ -63,14 +63,15 @@ sequenceDiagram
     U->>SH: bash verify-isolated.sh --port 3456 插件包路径
     SH->>T: DSH_HOME=$(mktemp -d)（隔离凭据/会话/home 级 patch）
     SH->>SH: trap cleanup EXIT（--keep 保留 / 默认 rm -rf）
-    SH->>P: dsh plugin --profile verify_随机 add --help<br/>（以 add --help 副作用初始化 profile）
+    SH->>P: dsh plugin --profile verify_随机 list<br/>（显式初始化 profile，#376 M1）
     SH->>P: node 注入 dsh.profile.bundles：<br/>@deepseek-ai/dsh-base + @deepseek-ai/dsh-web-app<br/>（按名从 dsh 安装目录解析，不走 npm）
+    SH->>SH: resolve-pkg-paths.mjs 归一化插件参数<br/>（相对路径按 cwd 绝对化，规避 dsh 当 git URL，#517 C11）
     alt 默认（BUILD=1）
-        SH->>D: 对每个包 pnpm build（确保 lib/ 或 dist/ 产物）
+        SH->>D: 对每个本地包 pnpm build（确保 lib/ 或 dist/ 产物）
     end
-    SH->>D: dsh plugin --profile verify_随机 add 包路径（link 挂载）
-    SH->>D: dsh --profile verify_随机 --port 端口 --no-open<br/>（前台阻塞）
-    Note over D: Ctrl+C → EXIT trap 自动清理临时 DSH_HOME 与 profile
+    SH->>D: dsh plugin --profile verify_随机 add 绝对路径数组（link 挂载）
+    SH->>D: dsh --profile verify_随机 --host 127.0.0.1 --port 端口 --no-open<br/>（显式回环 + DSH_TELEMETRY_DISABLED=1，前台阻塞）
+    Note over D: Ctrl+C → EXIT trap 自动清理 dsh 进程、浏览器实例、临时 DSH_HOME 与 profile
 ```
 
 双重隔离的层次（为什么两层都必要）：
@@ -79,6 +80,8 @@ sequenceDiagram
 |---|---|---|
 | 第一层：临时 `DSH_HOME` | `DSH_HOME=$(mktemp -d)` | 凭据、会话、全部用户数据、home 级 `cordis.patch.yml` |
 | 第二层：独立 profile | `verify_<8位随机>`（非 `web`） | 插件组合栈（bundles）、profile 级 patch、插件依赖 |
+| 第三层：独立端口 | `--port` 自选/探测空闲端口 | 与主 `dsh web` 及其它验证实例互不冲突 |
+| 第四层：独立浏览器实例 | `--browser`（自带 browser-driver.mjs，raw CDP） | 页面/tab/console 完全独立，多会话并行互不可见 |
 
 > **只建独立 profile 不够**——profile 共享 home 级凭据与会话；必须同时把 `DSH_HOME`
 > 指向临时目录才与真实环境完全隔绝。验证结束删除临时 DSH_HOME 与 `verify_*` profile。
@@ -101,12 +104,12 @@ bash "$SKILL_BASE/scripts/verify-isolated.sh" --port 3456 <插件包路径>
   `link:` 开发态 / 仓库 checkout 均返回真实 skill 目录（脚本相对它定位）；
 - 脚本自包含、从任意 cwd 以绝对路径调用；不确定时先 `ls "$SKILL_BASE/scripts/
   verify-isolated.sh"` 自证；
-- **浏览器验证**（SKILL.md §5）：Playwright 或 chrome-devtools MCP 访问
-  `http://localhost:<port>`；核验 UI 呈现 / Console（挂载失败只应 warn 不应 throw）/
-  双主题 / 窄屏（768×1024 pad、375×667 phone）；**防 flake**：轮询
-  （`waitForSelector`/`wait_for`）禁固定 sleep；截图只截插件 UI 本身（element
-  screenshot，不带整窗防泄露本机信息），dsh-plugin-hub 归档至
-  `packages/dsh-<name>/docs/archive/`；
+- **浏览器验证**（SKILL.md §5/§6）：`--browser` 拉起 skill 自带独立浏览器实例
+  （browser-driver.mjs，独立 user-data-dir + 调试端口，多会话并行硬隔离）；核验 UI
+  呈现 / Console（挂载失败只应 warn 不应 throw）/ 双主题 / 窄屏（768×1024 pad、
+  375×667 phone）；**防 flake**：轮询（`wait --selector`）禁固定 sleep；截图只截
+  插件 UI 本身（element screenshot，不带整窗防泄露本机信息），dsh-plugin-hub
+  归档至 `packages/dsh-<name>/docs/archive/`；
 - **完成检查**：隔离实例已启动且端口不冲突 → UI 渲染正常 → Console 无未处理错误 →
   截图已归档 → 实例已停止、临时 DSH_HOME 与 `verify_*` profile 已清理。
 

--- a/packages/dsh-verify-isolated/README.en.md
+++ b/packages/dsh-verify-isolated/README.en.md
@@ -41,12 +41,13 @@ built-in skill and becomes available to all sessions in the profile (check with
 - **One-shot script** `skills/dsh-verify-isolated/scripts/verify-isolated.sh`: validate the
   dsh entry and print its version (`--dsh` pins the target dsh version) → create temp
   DSH_HOME → create profile (explicit `plugin list` init) → inject web-app bundle →
-  build and link local plugins (`--no-build` validates artifact presence + staleness
-  warning) → (optionally `--browser`) launch a dedicated browser instance → start
-  (explicit `--host 127.0.0.1` loopback + `DSH_TELEMETRY_DISABLED=1` telemetry off) →
-  readiness probe → unified trap cleanup on exit (dsh process + browser process +
-  user-data-dir + DSH_HOME, no leftovers); `--port 0` auto-detects the real free port
-  (no longer prints an invalid 0).
+  normalize plugin args via `resolve-pkg-paths.mjs` (relative paths → absolute against
+  cwd; package specs pass through; #517 C11) → build and link local plugins (`--no-build`
+  validates artifact presence + staleness warning) → (optionally `--browser`) launch a
+  dedicated browser instance → start (explicit `--host 127.0.0.1` loopback +
+  `DSH_TELEMETRY_DISABLED=1` telemetry off) → readiness probe → unified trap cleanup on
+  exit (dsh process + browser process + user-data-dir + DSH_HOME, no leftovers);
+  `--port 0` auto-detects the real free port (no longer prints an invalid 0).
 
 ## Package layout
 
@@ -54,6 +55,7 @@ built-in skill and becomes available to all sessions in the profile (check with
 skills/dsh-verify-isolated/
   SKILL.md                        # skill definition (frontmatter name=dsh-verify-isolated)
   scripts/verify-isolated.sh      # one-shot isolated verification script (--dsh / --browser / --port 0 / --keep / --no-build)
+  scripts/resolve-pkg-paths.mjs   # plugin arg normalizer (relative path → absolute; package spec passthrough; #517 C11)
   scripts/browser-driver.mjs      # self-contained browser driver (raw CDP, zero deps, --json atomic CLI)
 cordis.patch.yml                  # reuses official dsh-skill-filesystem + bundledSkillDir
 lib/index.js                      # host gate export (name + empty apply)
@@ -77,6 +79,11 @@ bash "$SKILL_BASE/scripts/verify-isolated.sh" --port 0 --browser <plugin-package
 # prevents PATH drift)
 bash "$SKILL_BASE/scripts/verify-isolated.sh" --dsh /opt/dsh-0.1.2-alpha.2/bin/dsh --port 0 <plugin-package-path>
 ```
+
+Plugin arguments accept either **local plugin paths** (relative paths are resolved to
+absolute paths against the current cwd before mounting — dsh otherwise parses a
+non-absolute path as a git URL; #517 C11) or **package specs** (npm package names /
+git URLs pass through unchanged).
 
 Browser instance operations (instance info in `$DSH_HOME/browser.state`; the command
 contract is in `browser-driver.mjs --help`. **Page-operation commands need Node ≥22** —

--- a/packages/dsh-verify-isolated/README.md
+++ b/packages/dsh-verify-isolated/README.md
@@ -47,6 +47,7 @@ dsh plugin --profile web add @wingsky-1/dsh-verify-isolated
 skills/dsh-verify-isolated/
   SKILL.md                        # skill 定义（frontmatter name=dsh-verify-isolated）
   scripts/verify-isolated.sh      # 一键隔离验证脚本（--dsh / --browser / --port 0 / --keep / --no-build）
+  scripts/resolve-pkg-paths.mjs   # 插件参数归一化（相对路径→绝对 / 包规格透传，#517 C11）
   scripts/browser-driver.mjs      # 自带独立浏览器驱动（raw CDP 零依赖，--json 原子操作 CLI）
 cordis.patch.yml                  # 复用官方 dsh-skill-filesystem + bundledSkillDir
 lib/index.js                      # 宿主门禁出口（name + 空 apply）
@@ -67,6 +68,10 @@ bash "$SKILL_BASE/scripts/verify-isolated.sh" --port 0 --browser <插件包路�
 # 锚定 dsh 版本（验证特定 dsh 版本生态时必带，防 PATH 漂移）
 bash "$SKILL_BASE/scripts/verify-isolated.sh" --dsh /opt/dsh-0.1.2-alpha.2/bin/dsh --port 0 <插件包路径>
 ```
+
+插件参数支持**本地插件路径**（相对路径基于当前 cwd 自动解析为绝对路径后挂载，
+规避 dsh 把非绝对路径当 git URL 解析——#517 C11）或**包规格**（npm 包名/git URL
+原样透传）。
 
 浏览器实例操作（实例信息在 `$DSH_HOME/browser.state`；命令契约见
 `browser-driver.mjs --help`。**页面操作命令需 Node ≥22**——依赖内置全局

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/SKILL.md
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/SKILL.md
@@ -67,6 +67,15 @@ bash "$SKILL_BASE/scripts/verify-isolated.sh" --port 0 --browser <插件包路�
 bash "$SKILL_BASE/scripts/verify-isolated.sh" --dsh /opt/dsh-0.1.2-alpha.2/bin/dsh --port 0 <插件包路径>
 ```
 
+插件参数（`--` 之后或直接位置参数）接受两种形态，脚本经
+`resolve-pkg-paths.mjs` 统一归一化（#517 C11）：
+
+- **本地插件路径**（推荐，worktree 根执行时写相对路径即可）：相对路径基于当前
+  cwd 解析为**绝对路径**后挂载——dsh 会把非绝对路径当 git URL 解析、报
+  `Repository not found` 迷惑错误，脚本已自动规避；绝对路径原样使用。
+- **包规格**（npm 包名 / git URL）：原样透传（仅适用 registry 可解析的包；
+  内置 bundle 如 `@deepseek-ai/dsh-web-app` 仍需按 §3 手动注入，不走 add）。
+
 若注入的 base 不可用或不确信，先自证脚本位置再执行
 （`ls "$SKILL_BASE/scripts/verify-isolated.sh"`），或直接用 glob 全局搜索
 `verify-isolated.sh` 取其真实绝对路径——脚本从任意 cwd 以绝对路径调用

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/resolve-pkg-paths.mjs
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/resolve-pkg-paths.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * resolve-pkg-paths.mjs — 插件参数归一化：本地路径绝对化 / 包规格透传（零依赖）。
+ *
+ * 背景（#517 C11）：`dsh plugin add` 同时接受本地路径、npm 包名、git URL 三种
+ * 形态。verify-isolated.sh 挂载本地插件时若把**相对路径**原样传给 dsh，dsh
+ * 会把它当 git URL 解析（`https://github.com/<相对路径>.git`）→ ls-remote
+ * Repository not found → 脚本报迷惑错误。本模块统一做「路径 vs 包规格」判定：
+ * 类路径参数绝对化（相对路径基于当前 cwd），包规格原样透传。单一事实源，
+ * verify-isolated.sh 与未来 node 化版本共用；smoke 以本模块输出做行为断言
+ * （不文本 grep 脚本）。
+ *
+ * 判定规则（顺序敏感）：
+ *   1. 形态类路径（`.` `..` `/` `~` 开头）→ 绝对化；
+ *   2. cwd 下存在该路径（目录或文件）→ 绝对化（如 `packages/dsh-notifier`）；
+ *   3. 其余 → 视为包规格（`@scope/name`、`name@version`、git URL），原样透传。
+ * 绝对化用 `path.resolve`（不展开 `~`——展开留给 shell/调用方，脚本已有先例；
+ * node 版 C8 补 expandHomePath 时一并处理）。
+ *
+ * 用法：
+ *   node resolve-pkg-paths.mjs [--json] [--] <arg>...
+ *   --json    输出 JSON 数组 [{input, resolved, kind: "path"|"spec", abs?}]
+ *   默认      每行一个归一化结果（path → 绝对路径；spec → 原样）
+ */
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, resolve } from "node:path";
+
+const PATH_LIKE = /^(\.{1,2}\/|\.{1,2}$|\/|~)/;
+
+/** `~`/`~/x` 展开为 home 前缀（`path.resolve` 不做 `~` 展开，C8 前就地处理）。 */
+function expand(input) {
+  if (input === "~") return homedir();
+  if (input.startsWith("~/")) return resolve(homedir(), input.slice(2));
+  return input;
+}
+
+function classify(input) {
+  const expanded = expand(input);
+  if (PATH_LIKE.test(expanded)) return { input, kind: "path", abs: resolve(expanded) };
+  if (existsSync(expanded)) return { input, kind: "path", abs: resolve(expanded) };
+  return { input, kind: "spec", abs: null };
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  let json = false;
+  let args = argv;
+  if (argv[0] === "--json") { json = true; args = argv.slice(1); }
+  if (args[0] === "--") args = args.slice(1);
+  if (args.length === 0) {
+    process.stderr.write("resolve-pkg-paths: 至少需要一个参数\n");
+    process.exit(2);
+  }
+  const items = args.map(classify);
+  if (json) {
+    process.stdout.write(JSON.stringify(items) + "\n");
+  } else {
+    for (const it of items) process.stdout.write((it.kind === "path" ? it.abs : it.input) + "\n");
+  }
+  process.exit(0);
+}
+
+main();

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/verify-isolated.sh
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/verify-isolated.sh
@@ -36,7 +36,9 @@
 #   --no-build 跳过挂载前的 pnpm build（默认会构建每个插件，保证 lib/ 或 dist/
 #              产物存在）；此时校验产物存在（缺失即报可操作错误），并对比 src/
 #              与产物的 mtime，源码更新即给陈旧警告（防「存在但陈旧」锚定旧版本）
-#   --         之后的位置参数为要挂载的本地插件路径（相对路径基于当前 cwd 解析）
+#   --         之后的位置参数为要挂载的插件：本地插件路径（相对/绝对；相对路径
+#              基于当前 cwd 解析为绝对路径，规避 dsh 把非绝对路径当 git URL
+#              解析——#517 C11）或包规格（npm 包名/git URL 原样透传）
 #
 # 示例（在插件仓库根执行）：
 #   verify-isolated.sh packages/dsh-mcp-manager
@@ -133,14 +135,24 @@ node -e '
   fs.writeFileSync(p, JSON.stringify(j, null, 2));
 ' "$DSH_HOME/profiles/$PROFILE/package.json"
 
-# 4. 挂载本地插件（相对路径基于当前 cwd，dsh 官方会锚定到调用目录；绝对路径原样使用）
+# 4. 挂载本地插件：先经 resolve-pkg-paths.mjs 归一化全部参数——**相对路径基于
+#    当前 cwd 取绝对路径**（dsh 会把非绝对路径当 git URL 解析、报 `Repository
+#    not found` 迷惑错误，#517 C11）；npm 包名/git URL 等包规格原样透传。
 if [[ ${#PKGS[@]} -gt 0 ]]; then
+  # 单次调用解析全部参数（替代逐包 node -e 子进程），输出每行一个归一化结果
+  PKGS_ABS=()
+  while IFS= read -r p; do PKGS_ABS+=("$p"); done < <(
+    node "$SCRIPT_DIR/resolve-pkg-paths.mjs" -- "${PKGS[@]}"
+  )
   # dsh 直读构建产物（hub 的 lib/、xiaozhuge 的 dist/），不 build 则 link 到的
   # 源码目录缺产物、启动即 ERR_MODULE_NOT_FOUND
-  for pkg in "${PKGS[@]}"; do
-    # 相对路径基于当前 cwd 取绝对路径：node path.resolve 替代 GNU realpath -m
-    # （BSD/macOS 的 realpath 无 -m）
-    pkg_abs="$(node -e 'console.log(require("node:path").resolve(process.argv[1]))' "$pkg")"
+  for pkg_abs in "${PKGS_ABS[@]}"; do
+    # 插件目录须存在且为合法包（目录不存在/非插件目录给可操作错误，不等
+    # dsh 的迷惑报错；包规格（npm 名/git URL）跳过本校验原样传给 dsh）
+    if [[ ! -f "$pkg_abs/package.json" ]]; then
+      echo "跳过: 非本地插件目录（无 package.json）: $pkg_abs（若为包名/git URL 将原样传给 dsh）"
+      continue
+    fi
     if [[ "$BUILD" -eq 1 ]]; then
       if [[ -f "$pkg_abs/package.json" ]] && grep -q '"build"' "$pkg_abs/package.json"; then
         echo "构建插件: $pkg_abs"
@@ -182,7 +194,13 @@ if [[ ${#PKGS[@]} -gt 0 ]]; then
       ' "$pkg_abs"
     fi
   done
-  "$DSH_ABS" plugin --profile "$PROFILE" add "${PKGS[@]}" >/dev/null
+  # add 统一用归一化后的绝对路径数组（相对路径在 dsh 侧会被当 git URL）
+  if ! "$DSH_ABS" plugin --profile "$PROFILE" add "${PKGS_ABS[@]}" >/dev/null; then
+    echo "错误: dsh plugin add 失败（已传入归一化路径）:" >&2
+    for p in "${PKGS_ABS[@]}"; do echo "  - $p" >&2; done
+    echo "       相对路径已按当前 cwd 解析为绝对路径（#517 C11）；请核对插件路径/包名" >&2
+    exit 1
+  fi
 fi
 
 # 5. 启动独立浏览器实例（--browser）：独立 user-data-dir + 自选空闲调试端口，

--- a/packages/dsh-verify-isolated/test/smoke.ts
+++ b/packages/dsh-verify-isolated/test/smoke.ts
@@ -119,6 +119,50 @@ assert.ok(noArgExitsNonZero, "browser-driver 无参数应非零退出（用法�
   // 启动生命周期：后台 + 就绪断言 + wait（EXIT trap 兜底 kill）
   assert.ok(script.includes('DSH_PID=$!'), "dsh 后台启动记录 pid");
   assert.ok(script.includes('wait "$DSH_PID"'), "前台 wait 保持阻塞体感");
+  // #517 C11：插件参数归一化——脚本调用 resolve-pkg-paths.mjs，add 用绝对路径数组
+  assert.ok(script.includes("resolve-pkg-paths.mjs"), "脚本调用 resolve-pkg-paths.mjs（#517 C11 单点归一化）");
+  assert.ok(script.includes("PKGS_ABS=()"), "脚本累积 PKGS_ABS 绝对路径数组");
+  assert.ok(script.includes('add "${PKGS_ABS[@]}"'), "plugin add 用归一化后的绝对路径数组（非原始相对路径）");
+  assert.ok(script.includes("dsh 会把非绝对路径当 git URL 解析"), "脚本注释声明相对路径 git URL 陷阱（#517 C11）");
+  assert.ok(!script.includes('plugin add "${PKGS[@]}"'), "plugin add 不再直接传原始 ${PKGS[@]}（相对路径会当 git URL）");
+}
+
+// ---- 6.5 resolve-pkg-paths.mjs 行为断言（#517 C11：路径 vs 包规格归一化） ----
+{
+  const resolver = join(SKILL_DIR, "scripts", "resolve-pkg-paths.mjs");
+  assert.ok(existsSync(resolver), "resolve-pkg-paths.mjs 随 skill 目录分发");
+  const absBase = runResolver(resolver, ["--json", "--", "./rel", "@scope/name", "@wingsky-1/dsh-notifier"]);
+  // 相对路径（./ 形态）→ path（resolve）
+  const rel = absBase.find((i) => i.input === "./rel");
+  assert.equal(rel.kind, "path", "./rel 判为 path");
+  assert.ok(rel.abs.endsWith("/rel") && rel.abs.startsWith("/"), "./rel 解析为绝对路径");
+  // 包规格 → spec 原样透传
+  assert.equal(absBase.find((i) => i.input === "@scope/name").kind, "spec", "@scope/name 判为 spec");
+  assert.equal(absBase.find((i) => i.input === "@scope/name").abs, null, "spec 无 abs");
+  assert.equal(absBase.find((i) => i.input === "@wingsky-1/dsh-notifier").kind, "spec", "scoped 包名判为 spec");
+  // cwd 存在路径 → path（仓库根踩点：packages/dsh-notifier，与脚本真实调用场景一致）
+  const REPO_ROOT = join(PKG_ROOT, "..", "..");
+  const exist1 = runResolver(resolver, ["--json", "--", "packages/dsh-notifier"], REPO_ROOT);
+  assert.equal(exist1[0].kind, "path", "cwd 存在的相对目录判为 path");
+  assert.ok(exist1[0].abs.includes("/packages/dsh-notifier") && exist1[0].abs.startsWith("/"), "cwd 存在目录解析为绝对路径");
+  // 绝对路径 → path 原样
+  const abs1 = runResolver(resolver, ["--json", "--", "/tmp/x"]);
+  assert.equal(abs1[0].kind, "path", "绝对路径判为 path");
+  assert.equal(abs1[0].abs, "/tmp/x", "绝对路径逐字节保留");
+  // ~ 开头 → 展开 home
+  const tilde = runResolver(resolver, ["--json", "--", "~"]);
+  assert.equal(tilde[0].kind, "path", "~ 判为 path");
+  assert.ok(tilde[0].abs.startsWith("/") && !tilde[0].abs.includes("~"), "~ 展开为 home 绝对路径");
+  // 不含空格外的边界：无参数非零退出
+  let noArgFails = false;
+  try { runResolver(resolver, []); } catch (e) { noArgFails = e.status === 2; }
+  assert.ok(noArgFails, "resolver 无参数非零退出（exit 2）");
+}
+
+/** 跑 resolve-pkg-paths.mjs --json 并解析输出。 */
+function runResolver(resolver, args, cwd) {
+  const out = execFileSync(process.execPath, [resolver, ...args], { encoding: "utf8", ...(cwd ? { cwd } : {}) });
+  return JSON.parse(out.trim());
 }
 
 // ---- 7. SKILL.md 含多会话并行章节与三平台内核自查 ----


### PR DESCRIPTION
## 概要

#517 C11：verify-isolated.sh 把相对路径原样传给 `dsh plugin add` 时，dsh 0.1.2-rc.1 会将其解析为 git URL（`Repository not found` 迷惑错误）。抽零依赖 `resolve-pkg-paths.mjs` 统一归一化：相对路径基于 cwd 绝对化、包规格（npm 名/git URL）原样透传，add 统一用绝对路径数组，失败提示可操作。

## 改动清单

| 文件 | 改动 |
|---|---|
| scripts/resolve-pkg-paths.mjs（新） | 路径 vs 包规格归一化（`--json` 供 smoke/未来 node 版；`~` 展开；cwd 存在判定） |
| scripts/verify-isolated.sh | PKGS_ABS 累积 + add 用绝对数组 + 注释纠错（原「dsh 锚定调用目录」声明与实测不符）+ 非插件目录前置校验 + add 失败可操作提示 |
| test/smoke.ts | resolver 行为断言（相对/绝对/包规格/`~`/空参，仓库根 cwd 踩点）+ 脚本契约锁定（弃纯文本 grep） |
| SKILL.md / README.md / README.en.md | §2 路径语义说明 + 包结构树补 resolver |
| docs/architecture/dsh-verify-isolated.md | 陈旧修正：102 行 → 现状、add --help 初始化 → plugin list（#376 M1）、Playwright MCP → 自带 browser-driver（#481）、隔离层表补全四层、sequence 补 resolver 步骤 |

## 门禁

五连门禁全绿（build/test/contract/pack:check/typecheck）+ docs:check --strict-en 通过 + test:scripts 144 pass。

## 断言表

- [硬性] resolver：相对路径（./ 与 cwd 存在目录）→ 绝对路径；绝对路径逐字节保留；`~` 展开 home；包规格原样透传；空参 exit 2
- [硬性] 脚本：add 用 `${PKGS_ABS[@]}`（非原始 ${PKGS[@]}）；注释声明 git URL 陷阱
- [硬性] bash -n 语法通过
- [软性] 文档四件套（SKILL/README 中英/架构）同步

Closes: 关联 #517（Meta 子项 C11，Meta 全部子项完成后统一关闭）