### PR TITLE
fix(dsh-provider-usage): 通知类型注入改 cordis 官方可选姿势 + notifier 重载补注册（#534）

### DIFF
--- a/packages/dsh-provider-usage/src/apply.ts
+++ b/packages/dsh-provider-usage/src/apply.ts
@@ -548,24 +548,29 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
   const reportMutex = new Mutex();
 
   /**
-   * 可选服务探测：ctx["wingsky.notifier"] 不在本插件 inject 声明面——cordis 的
+   * 可选服务探测：'wingsky.notifier' 不在本插件 inject 声明面——cordis 的
    * inject 为硬依赖（声明而服务缺失会令插件整体 INACTIVE，见 Fiber._refresh），
-   * 故推送能力必须经 try-catch 动态探测：服务在 →返回服务；不在 →get trap 同步
-   * 抛错就地吞掉、返回 null（静默跳过推送，主流程零影响）。
+   * 故推送能力必须经 get(name, false) 非严格探测（cordis 官方可选注入姿势，
+   * 与 dsh-notifier 自身 getNotifierService 同形；service.d.ts 第 12 行写明）：
+   * 服务在 →返回服务；不在 →返回 undefined → 返回 null（静默跳过推送，主流程
+   * 零影响）。不能用 ctx["wingsky.notifier"] 属性访问——未声明 inject 时 cordis
+   * get trap 无论服务是否已提供都抛 "cannot get property without inject"。
    * 每次发送/注册前现取、不缓存引用：与 notifier 插件的加载/热重载时序无关。
+   * try/catch 保留：防御 ctx.get 在其 mixin accessor 链路理论抛错，静默降级
+   * 而不是让 apply 整体启动失败（与 getNotifierService 逐字同形）。
    */
   function optionalNotifier(): {
     send: (req: { source: string; kind: string; severity: string; title: string; body: string }) => Promise<unknown>;
     registerKind?: (reg: { id: string; label: string }) => unknown;
   } | null {
     try {
-      const n = (ctx as { "wingsky.notifier"?: unknown })["wingsky.notifier"];
+      const n = (ctx as { get?: (name: string, strict?: boolean) => unknown }).get?.("wingsky.notifier", false);
       if (n !== null && typeof n === "object" && typeof (n as { send?: unknown }).send === "function") {
         return n as { send: (req: { source: string; kind: string; severity: string; title: string; body: string }) => Promise<unknown>; registerKind?: (reg: { id: string; label: string }) => unknown };
       }
       return null;
     } catch {
-      return null; // cordis get trap：服务未提供（未声明 inject 的必需服务访问被拒）
+      return null; // ctx.get 异常：服务不可达时静默降级（不阻断挂载/主流程）
     }
   }
 
@@ -623,8 +628,14 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
     warn: (msg) => console.warn(`[dsh-provider-usage] report: ${sanitizeDiagnostic(msg)}`),
   });
 
-  // 可选推送 kind 动态注册（挂载时一次性；中心不在/异常静默——注册失败不阻断挂载）。
-  {
+  // 可选推送 kind 动态注册（挂载直调 + internal/service 事件补注册）：
+  // registerKind 幂等（notifier 侧 kindRegistry.set），重复调用无害。
+  // - 挂载直调：notifier 已加载（profile 顺序在其后）时立即注册；
+  // - internal/service 订阅：notifier 后加载/HMR 重建 kindRegistry（新建空表）
+  //   时补注册（事件在服务 provide/unprovide/fiber 生命周期迁移时派发，
+  //   { global: true } 与 dsh-notifier 对 userQuestions 的订阅先例一致）；
+  // - 两者任一路成功即保证 kind 在清单中；中心不在/异常静默——不阻断挂载。
+  function ensureReportKind(): void {
     const notifier = optionalNotifier();
     if (notifier !== null && typeof notifier.registerKind === "function") {
       try {
@@ -632,6 +643,10 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
       } catch { /* 注册失败静默：推送为可选功能 */ }
     }
   }
+  ensureReportKind();
+  trendDisposers.push(ctx.on("internal/service", (name) => {
+    if (name === "wingsky.notifier") ensureReportKind();
+  }, { global: true }));
 
   // 7. 路由注册
   // #308 断连感知统一形态（stats/history 共用）：请求级 AbortController——客户端

--- a/packages/dsh-provider-usage/test/unit-apply.test.ts
+++ b/packages/dsh-provider-usage/test/unit-apply.test.ts
@@ -361,16 +361,28 @@ export function formatPanel() { return "<p>p</p>"; }
 import fs, { existsSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
 import { syncBuiltinESMExports } from "node:module";
 
-/** 构造标准 fake ctx：收集路由与 disposer。 */
+/** 构造标准 fake ctx：收集路由与 disposer。
+ *  - over.get：可选注入的假 wingsky.notifier 服务（get 桩命中 "wingsky.notifier" 时返回）；
+ *  - over.recordOn：为 true 时记录 ctx.on 监听器到 listeners（供 internal/service 补注册测试手动触发）。 */
 function makeCtx(over: {
   llm?: unknown;
+  get?: unknown;
+  recordOn?: boolean;
 } = {}) {
   const routes: Array<Record<string, unknown>> = [];
   const disposers: Array<() => void> = [];
+  const listeners: Map<string, Array<(...args: unknown[]) => unknown>> = new Map();
   const ctx = {
     logger: { warn: () => {} },
     webServer: { register(route: Record<string, unknown>) { routes.push(route); return () => {}; } },
-    on: onStub,
+    on: over.recordOn
+      ? (name: string, cb: (...args: unknown[]) => unknown) => {
+          const list = listeners.get(name) ?? [];
+          list.push(cb);
+          listeners.set(name, list);
+          return () => {};
+        }
+      : onStub,
     llm: over.llm !== undefined ? over.llm : { listProviders() { return []; } },
     fiber: { state: "active" },
     inject: (deps: unknown, cb: (s: unknown) => void) => { cb({ settings: {} }); },
@@ -380,7 +392,10 @@ function makeCtx(over: {
       return typeof d === "function" ? d : () => {};
     },
   };
-  return { ctx, routes, disposers };
+  if (over.get !== undefined) {
+    (ctx as Record<string, unknown>).get = (name: string) => (name === "wingsky.notifier" ? over.get : undefined);
+  }
+  return { ctx, routes, disposers, listeners };
 }
 
 // ---------------------------------------------------------------- #301：apply 内部恢复隔离坏状态且诊断单次可见
@@ -848,4 +863,68 @@ export function formatPanel() { return "<p>f</p>"; }
     await fetchWithTimeout("https://gw.test/def");
     assert.ok(defCalls >= 1, "默认参数下仍走 fetch 至少一次");
   });
+}
+
+// ---------------------------------------------------------------- #534：通知类型注入（可选 notifier 探测 + 动态 kind 注册/补注册）
+
+{
+  /** 假 notifier 服务：send 恒可调，registerKind 记录调用（不真正落盘）。 */
+  function fakeNotifier(kinds: Array<{ id: string; label: string }>) {
+    return {
+      send: async () => ({ ok: true }),
+      registerKind(reg: { id: string; label: string }) {
+        kinds.push({ id: reg.id, label: reg.label });
+      },
+    };
+  }
+
+  // 落盘隔离（#218 零污染纪律）：DSH_HOME 指向临时目录，不碰真实环境与仓库
+  const dir = mkdtempSync(join(tmpdir(), "dou-kind-534-"));
+  const historyDir = join(dir, "history");
+  const savedDshHome = process.env.DSH_HOME;
+  process.env.DSH_HOME = join(dir, "dshhome");
+  mkdirSync(process.env.DSH_HOME, { recursive: true });
+  try {
+    const baseCfg = { autoReload: false, apiKey: "sk-test", apiEndpoint: "http://127.0.0.1:9", historyDir };
+
+    // 1) ctx 无 get（fake ctx 未提供探测面）：降级不注册、apply 正常挂载不抛
+    {
+      const { ctx, routes, disposers } = makeCtx();
+      await apply(ctx, baseCfg);
+      assert.ok(routes.some((r) => r.path === ROUTES.health), "无 notifier 探测面时 apply 正常挂载");
+      for (const dispose of [...disposers].reverse()) { try { dispose(); } catch {} }
+    }
+
+    // 2) ctx.get 命中 wingsky.notifier（notifier 已加载）：挂载即注册 provider-usage:report
+    {
+      const kinds: Array<{ id: string; label: string }> = [];
+      const { ctx, routes, disposers } = makeCtx({ get: fakeNotifier(kinds) });
+      await apply(ctx, baseCfg);
+      assert.equal(kinds.length, 1, "挂载直调注册一次");
+      assert.equal(kinds[0].id, "provider-usage:report", "注册 kind id 正确");
+      assert.equal(kinds[0].label, "用量报告", "注册 kind label 正确");
+      for (const dispose of [...disposers].reverse()) { try { dispose(); } catch {} }
+    }
+
+    // 3) internal/service 事件补注册：notifier 后加载/HMR 重建后 kindRegistry 为空，
+    //    事件触发 → 重新注册（挂载 1 次 + 事件触发 1 次 = 2 次，幂等无害）
+    {
+      const kinds: Array<{ id: string; label: string }> = [];
+      const { ctx, disposers, listeners } = makeCtx({ get: fakeNotifier(kinds), recordOn: true });
+      await apply(ctx, baseCfg);
+      assert.equal(kinds.length, 1, "挂载直调已注册一次");
+      const svcListeners = listeners.get("internal/service") ?? [];
+      assert.ok(svcListeners.length >= 1, "internal/service 监听已注册");
+      // 手动触发 notifier 服务事件（模拟 notifier 提供/重载完成广播）
+      for (const cb of svcListeners) {
+        cb("wingsky.notifier");
+      }
+      assert.equal(kinds.length, 2, "事件触发补注册一次（幂等追加）");
+      assert.equal(kinds[1].id, "provider-usage:report", "补注册 kind id 一致");
+      for (const dispose of [...disposers].reverse()) { try { dispose(); } catch {} }
+    }
+  } finally {
+    if (savedDshHome === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = savedDshHome;
+  }
 }


### PR DESCRIPTION
## 关联 issue
Closes #534

## 背景
dsh-provider-usage 本应向 dsh-notifier 注册动态通知类型「用量报告」（kind `provider-usage:report`），但运行中 `GET /api/dsh-notifier/kinds` 恒空、历史从未出现该事件。

## 根因
`optionalNotifier()` 用无 inject 声明的属性访问 `ctx["wingsky.notifier"]` 探测服务。@deepseek-ai/cordis@4.0.2 的 Context Proxy get trap 对未声明 inject 的属性访问**无论服务是否已提供都抛** `cannot get property without inject`，被 try/catch 吞掉后恒返 null → `registerKind` 从未执行。已用 cordis 4.0.2 最小复现实证；dsh-notifier `getNotifierService` 与 `service.d.ts` 第 12 行均写明官方姿势 `ctx.get(name, false)`。

## 改动
1. **主修复**：`optionalNotifier()` 改 `ctx.get?.("wingsky.notifier", false)`，与 `getNotifierService` 逐字同形（保留 try/catch 静默降级，防 apply 启动失败）；同步改写注释。
2. **加固**：抽 `ensureReportKind()`（幂等 registerKind）；挂载直调一次 + `ctx.on("internal/service", ...)`（global:true，disposer 入 trendDisposers）——覆盖 notifier 后加载 / HMR 重建 kindRegistry 后动态 kind 丢失。
3. **测试**：`unit-apply.test.ts` makeCtx 加可选 get 桩与监听器记录；三条断言：无 get 降级不注册、挂载即注册、事件触发补注册。落盘走 mkdtemp 隔离（#218 零污染纪律）。

## 门禁
- [x] pnpm build
- [x] pnpm test（全仓 exit 0）
- [x] pnpm contract
- [x] pnpm pack:check
- [x] pnpm typecheck

## 验证（需用户本人重启 dsh web 后执行）
重启后 `GET /api/dsh-notifier/kinds` 应含 `provider-usage:report`；通知中心设置页「通知类型」区出现「用量报告」（agent 不代操作重启，红线）。