### PR TITLE
feat(dsh-verify-isolated): B4 隔离审计白名单版——--audit/--audit-extra-dirs，白名单外变化报可疑不阻断 (#517)

### DIFF
--- a/docs/architecture/dsh-verify-isolated.md
+++ b/docs/architecture/dsh-verify-isolated.md
@@ -99,22 +99,33 @@ sequenceDiagram
 是常态；未知顶层路径 → 可疑）：
 
 ```text
-profiles/**、*.json/*.jsonl/*.log（仅顶层）、browser.state、browser-profile/**（整树白名单 + 跳过深扫）、
-evidence/**、audit/**、dsh.log、verdict.json
+profiles/**、*.json/*.jsonl/*.log（仅顶层）、.credentials.yaml、browser.state、
+browser-profile/**（整树白名单 + 跳过深扫）、evidence/**、audit/**、storages/**（dsh 官方存储写面）、
+dsh.log、verdict.json
 ```
 
+**白名单分工**：静态白名单覆盖 dsh 固定写面（`.credentials.yaml` /
+`storages/**`）与脚本/官方形态写面；随 dsh 版本漂移的面（如
+`profiles/node_modules/**` 官方 bundle link，指向真实 dsh 安装目录、越界但合法）
+由 **t0 动态基线**覆盖——就绪后扫描进基线，t0 已存在且目标未变的外部 symlink
+（`link:` 挂载点）合法不报。
+
 - **symlink 防逃逸**：快照 lstat 不跟随（不读链接目标内容）；`t1` 时**新增的**或
-  **目标变化**且 resolve 后在 `$ISOLATED_HOME` 外的 symlink 报「越界 symlink」（防
-  插件经 symlink 写回主 checkout）；`t0` 已存在且目标未变的外部 symlink（`link:`
-  挂载点，profile node_modules 全 link: 是挂载机制本身）合法不报。防逃逸优先于
-  白名单——`profiles/**` 内新增越界 symlink 同样报。
-- **时序**：`t0` 基线在挂载（link: symlink 进基线）之后、脚本自身写面
-  （browser.state / verdict / evidence 内容 / audit 落盘）之前；审计 diff 插在
+  **目标变化**且 resolve 后在**所在扫描根**（`$ISOLATED_HOME` 或
+  `--audit-extra-dirs` 目录）外的 symlink 报「越界 symlink」（防插件经 symlink
+  写回主 checkout）；`t0` 已存在且目标未变的外部 symlink（`link:` 挂载点，profile
+  node_modules 全 link: 是挂载机制本身）合法不报。防逃逸优先于白名单——
+  `profiles/**` 内新增越界 symlink 同样报。
+- **时序**：`t0` 基线在**就绪断言成功之后**（dsh 启动期自身写面与官方 bundle link
+  进基线——语义为「就绪后运行期写面审计」，审计面 = 就绪后、退出前的增量写面；
+  verdict 中间态在其后写入，先扫后写 + 白名单双保险）；审计 diff 插在
   settle「kill dsh → browser quit → **审计** → verdict 终态 → rm」；
-  `--keep` 落 `$ISOLATED_HOME/audit/audit.json`，否则并入 verdict JSON（`audit`
-  字段，`--json` 的 stdout 终态同样并入）。
+  `--keep` 落 `$ISOLATED_HOME/audit/audit.json`，否则随 `--json` 终态 verdict
+  输出 `audit` 字段（错误路径错误 JSON 恒带 `audit` 字段与 verdict 对齐）；
+  就绪前退出/超时路径 auditBaseline 为 null → 审计跳过不报。
 - **局限**：只扫 `$ISOLATED_HOME` 子树 + `--audit-extra-dirs <dir>`（可重复，相对
-  路径基于 cwd 绝对化，与 DSH_HOME 重叠报参数错误）指定目录，**不扫真实 home**。
+  路径基于 cwd 绝对化、必须是目录，与 DSH_HOME 重叠报参数错误）指定目录，
+  **不扫真实 home**。
 - **不阻断退出**：审计是补充非门禁——可疑项只输出「审计: N 项可疑」结论，退出码
   契约 0/1/2/130/143 不变；审计异常仅警告（verdict audit 字段带 error）。
 

--- a/docs/architecture/dsh-verify-isolated.md
+++ b/docs/architecture/dsh-verify-isolated.md
@@ -51,7 +51,7 @@ flowchart LR
 
 `skills/dsh-verify-isolated/scripts/verify-isolated.mjs`（node ≥22 实现，原 bash 版
 `verify-isolated.sh` 已随 #517 C8 重写删除，不留 shim；退出码契约
-0/1/2/130/143）：
+0/1/2/130/143；可选隔离审计 `--audit` 见 §2.1）：
 
 ```mermaid
 sequenceDiagram
@@ -72,10 +72,11 @@ sequenceDiagram
         SH->>D: 对每个包 pnpm build（确保 lib/ 或 dist/ 产物；--no-build 校验产物 + 陈旧警告）
     end
     SH->>D: dsh plugin --profile verify_随机 add 包路径<br/>（相对路径基于 cwd 绝对化，包规格原样透传）
+    SH->>SH: --audit 时 t0 基线快照（lib/audit.mjs scanSnapshot：<br/>挂载 link: symlink 之后、脚本写面前，先扫后写 + 白名单双保险）
     SH->>D: dsh --profile verify_随机 --host 127.0.0.1 --port 端口 --no-open<br/>（后台子进程，stdout/stderr 收集到 $DSH_HOME/dsh.log）
     SH->>SH: 就绪断言（轮询 HTTP 2xx-4xx + 进程存活，15s 超时）
     SH->>T: 就绪后写 $DSH_HOME/verdict.json（B6，0o600，端口三通道 source）
-    Note over SH: Ctrl+C / SIGTERM → 统一清理（kill dsh → browser quit →<br/>verdict 终态 cleanup → rm -rf DSH_HOME），透传 130/143
+    Note over SH: Ctrl+C / SIGTERM → 统一清理（kill dsh → browser quit →<br/>审计（--audit）→ verdict 终态 cleanup → rm -rf DSH_HOME），透传 130/143
 ```
 
 双重隔离的层次（为什么两层都必要）：
@@ -90,6 +91,33 @@ sequenceDiagram
 > **只建独立 profile 不够**——profile 共享 home 级凭据与会话；必须同时把 `DSH_HOME`
 > 指向临时目录才与真实环境完全隔绝。验证结束删除临时 DSH_HOME 与 `verify_*` profile。
 
+### 2.1 隔离审计（B4，可选 `--audit`）
+
+判定面 = **预置白名单**（版本化 `WHITELIST_V`，`scripts/lib/audit.mjs` 纯函数：
+`scanSnapshot` / `diffAgainstWhitelist` / `checkSymlinkEscape` / `runAudit`）外的
+新增/删除/修改（纯 stat 路径级，不读内容；白名单内变化忽略——dsh 重写 settings
+是常态；未知顶层路径 → 可疑）：
+
+```text
+profiles/**、*.json/*.jsonl/*.log（仅顶层）、browser.state、browser-profile/**（整树白名单 + 跳过深扫）、
+evidence/**、audit/**、dsh.log、verdict.json
+```
+
+- **symlink 防逃逸**：快照 lstat 不跟随（不读链接目标内容）；`t1` 时**新增的**或
+  **目标变化**且 resolve 后在 `$ISOLATED_HOME` 外的 symlink 报「越界 symlink」（防
+  插件经 symlink 写回主 checkout）；`t0` 已存在且目标未变的外部 symlink（`link:`
+  挂载点，profile node_modules 全 link: 是挂载机制本身）合法不报。防逃逸优先于
+  白名单——`profiles/**` 内新增越界 symlink 同样报。
+- **时序**：`t0` 基线在挂载（link: symlink 进基线）之后、脚本自身写面
+  （browser.state / verdict / evidence 内容 / audit 落盘）之前；审计 diff 插在
+  settle「kill dsh → browser quit → **审计** → verdict 终态 → rm」；
+  `--keep` 落 `$ISOLATED_HOME/audit/audit.json`，否则并入 verdict JSON（`audit`
+  字段，`--json` 的 stdout 终态同样并入）。
+- **局限**：只扫 `$ISOLATED_HOME` 子树 + `--audit-extra-dirs <dir>`（可重复，相对
+  路径基于 cwd 绝对化，与 DSH_HOME 重叠报参数错误）指定目录，**不扫真实 home**。
+- **不阻断退出**：审计是补充非门禁——可疑项只输出「审计: N 项可疑」结论，退出码
+  契约 0/1/2/130/143 不变；审计异常仅警告（verdict audit 字段带 error）。
+
 ---
 
 ## 3. 使用方式
@@ -102,7 +130,8 @@ dsh plugin --profile web add @wingsky-1/dsh-verify-isolated
 node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 3456 <插件包路径>
 # 多包：--port 3456 <包A> <包B>
 # --port 0 随机端口 · --keep 保留临时环境 · --no-build 跳过构建 ·
-# --evidence-dir <dir> 证据目录外部化 · --json stdout 只出最终 verdict
+# --evidence-dir <dir> 证据目录外部化 · --audit 隔离审计（B4，白名单外变化报可疑不阻断）·
+# --audit-extra-dirs <dir> 额外审计目录 · --json stdout 只出最终 verdict
 ```
 
 - **SKILL_BASE 自适应**：跟随 `cordis.patch.yml` 的 bundledSkillDir 解析——npm 副本 /
@@ -125,4 +154,7 @@ node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 3456 <插件包路径>
 - 隔离环境不携带真实凭据（临时 `DSH_HOME` 无 `~/.dsh` 数据）；
 - 不关闭/重启运行中的主 `dsh web` 进程（独立端口）；
 - 脚本只用 `mktemp -d` 临时目录，退出即清理，不留残留；
-- 硬约束：独立端口（不冲突）、不复制真实凭据（用测试凭据/mock）、`--port 0` 系统随机。
+- 硬约束：独立端口（不冲突）、不复制真实凭据（用测试凭据/mock）、`--port 0` 系统随机；
+- 可选隔离审计（`--audit`）只扫 `$ISOLATED_HOME` 子树 + `--audit-extra-dirs` 指定
+  目录，**不扫真实 home**；快照 lstat 不读文件内容、不跟随 symlink（防逃逸）；审计
+  是补充非门禁，可疑项不阻断退出。

--- a/packages/dsh-verify-isolated/README.en.md
+++ b/packages/dsh-verify-isolated/README.en.md
@@ -54,7 +54,14 @@ built-in skill and becomes available to all sessions in the profile (check with
   verdict at `$DSH_HOME/verdict.json` after ready (mode 0o600, three-channel port
   source, cleanup field finalized on exit); **B7** `--evidence-dir` defaults to
   `$DSH_HOME/evidence/`, externalized as `<dir>/evidence-<profile>/` without ever
-  touching the external directory; `--json` emits only the final verdict JSON on
+  touching the external directory; **B4** optional isolated audit `--audit` — diffs
+  the isolated `$ISOLATED_HOME` write surface against a preset whitelist
+  (versioned `WHITELIST_V`, pure functions in `scripts/lib/audit.mjs`); additions/
+  deletions/modifications outside the whitelist plus escaping symlinks are
+  reported as "suspicious" and **do not block exit** (`--audit-extra-dirs <dir>`
+  adds extra audited dirs; limitation: real home is never scanned; `--keep`
+  writes `$DSH_HOME/audit/audit.json`, otherwise the result is merged into the
+  verdict's `audit` field); `--json` emits only the final verdict JSON on
   stdout. Exit-code contract: 0 OK / 1 startup-or-readiness failure /
   2 argument error / 130 SIGINT / 143 SIGTERM.
 
@@ -63,8 +70,9 @@ built-in skill and becomes available to all sessions in the profile (check with
 ```text
 skills/dsh-verify-isolated/
   SKILL.md                        # skill definition (frontmatter name=dsh-verify-isolated)
-  scripts/verify-isolated.mjs     # one-shot isolated verification script (Node, --dsh / --browser / --port 0 / --keep / --no-build / --evidence-dir / --json)
+  scripts/verify-isolated.mjs     # one-shot isolated verification script (Node, --dsh / --browser / --port 0 / --keep / --no-build / --evidence-dir / --audit / --audit-extra-dirs / --json)
   scripts/lib/verify-core.mjs     # shared base utilities (exit-code constants/poll/findFreePort/port parsing/C11 normalization)
+  scripts/lib/audit.mjs           # B4 isolated-audit pure functions (scanSnapshot/diffAgainstWhitelist/checkSymlinkEscape/runAudit + versioned whitelist WHITELIST_V)
   scripts/browser-driver.mjs      # self-contained browser driver (raw CDP, zero deps, --json atomic CLI)
 cordis.patch.yml                  # reuses official dsh-skill-filesystem + bundledSkillDir
 lib/index.js                      # host gate export (name + empty apply)
@@ -91,6 +99,9 @@ node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --browser <plugin-packag
 node "$SKILL_BASE/scripts/verify-isolated.mjs" --dsh /opt/dsh-0.1.2-alpha.2/bin/dsh --port 0 <plugin-package-path>
 # externalize the evidence dir + emit only the final verdict JSON on stdout (human text on stderr)
 node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --evidence-dir /tmp/my-evidence --json <plugin-package-path>
+# isolated audit (B4): changes outside the whitelist are reported as suspicious and do not block exit;
+# --keep writes $DSH_HOME/audit/audit.json
+node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --audit --keep <plugin-package-path>
 ```
 
 Plugin arguments accept either **local plugin paths** (relative paths are resolved to

--- a/packages/dsh-verify-isolated/README.en.md
+++ b/packages/dsh-verify-isolated/README.en.md
@@ -59,10 +59,15 @@ built-in skill and becomes available to all sessions in the profile (check with
   (versioned `WHITELIST_V`, pure functions in `scripts/lib/audit.mjs`); additions/
   deletions/modifications outside the whitelist plus escaping symlinks are
   reported as "suspicious" and **do not block exit** (`--audit-extra-dirs <dir>`
-  adds extra audited dirs; limitation: real home is never scanned; `--keep`
-  writes `$DSH_HOME/audit/audit.json`, otherwise the result is merged into the
-  verdict's `audit` field); `--json` emits only the final verdict JSON on
-  stdout. Exit-code contract: 0 OK / 1 startup-or-readiness failure /
+  adds extra audited dirs, must be a directory; limitation: real home is never
+  scanned; the whitelist covers dsh's own write surface (`.credentials.yaml` /
+  `storages/**`) while version-drifted surfaces such as the official
+  `profiles/node_modules/**` bundle links are captured by the post-readiness t0
+  baseline — the audit surface is the incremental write surface of the runtime;
+  `--keep` writes `$DSH_HOME/audit/audit.json`, otherwise the result is carried
+  in the final verdict's `audit` field, and error-path JSON always carries an
+  `audit` field aligned with the verdict); `--json` emits only the final verdict
+  JSON on stdout. Exit-code contract: 0 OK / 1 startup-or-readiness failure /
   2 argument error / 130 SIGINT / 143 SIGTERM.
 
 ## Package layout

--- a/packages/dsh-verify-isolated/README.md
+++ b/packages/dsh-verify-isolated/README.md
@@ -43,16 +43,21 @@ dsh plugin --profile web add @wingsky-1/dsh-verify-isolated
   无效的 0）；**B6** 就绪后写 `$DSH_HOME/verdict.json` 启动自检（0o600，端口三通道
   source，退出终态更新 cleanup）；**B7** 证据目录 `--evidence-dir` 默认
   `$DSH_HOME/evidence/`、外部化建 `<dir>/evidence-<profile>/` 绝不动外部目录；
-  `--json` 时 stdout 只出最终 verdict JSON。退出码契约：0 正常 / 1 启动或就绪失败
-  / 2 参数错误 / 130 SIGINT / 143 SIGTERM。
+  **B4** 可选隔离审计 `--audit`——对比隔离 `$ISOLATED_HOME` 写面与预置白名单
+  （版本化 `WHITELIST_V`，`scripts/lib/audit.mjs` 纯函数），白名单外新增/删除/修改
+  与越界 symlink 报「可疑」、**不阻断退出**（`--audit-extra-dirs <dir>` 可加额外
+  审计目录；局限：不扫真实 home；`--keep` 落 `$DSH_HOME/audit/audit.json`，否则
+  并入 verdict 的 `audit` 字段）；`--json` 时 stdout 只出最终 verdict JSON。退出码
+  契约：0 正常 / 1 启动或就绪失败 / 2 参数错误 / 130 SIGINT / 143 SIGTERM。
 
 ## 包结构
 
 ```text
 skills/dsh-verify-isolated/
   SKILL.md                        # skill 定义（frontmatter name=dsh-verify-isolated）
-  scripts/verify-isolated.mjs     # 一键隔离验证脚本（node，--dsh / --browser / --port 0 / --keep / --no-build / --evidence-dir / --json）
+  scripts/verify-isolated.mjs     # 一键隔离验证脚本（node，--dsh / --browser / --port 0 / --keep / --no-build / --evidence-dir / --audit / --audit-extra-dirs / --json）
   scripts/lib/verify-core.mjs     # 共享基础工具（退出码常量/poll/findFreePort/端口解析/C11 归一化）
+  scripts/lib/audit.mjs           # B4 隔离审计纯函数（scanSnapshot/diffAgainstWhitelist/checkSymlinkEscape/runAudit + 版本化白名单 WHITELIST_V）
   scripts/browser-driver.mjs      # 自带独立浏览器驱动（raw CDP 零依赖，--json 原子操作 CLI）
 cordis.patch.yml                  # 复用官方 dsh-skill-filesystem + bundledSkillDir
 lib/index.js                      # 宿主门禁出口（name + 空 apply）
@@ -75,6 +80,8 @@ node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --browser <插件包路�
 node "$SKILL_BASE/scripts/verify-isolated.mjs" --dsh /opt/dsh-0.1.2-alpha.2/bin/dsh --port 0 <插件包路径>
 # 证据目录外部化 + stdout 只出最终 verdict JSON（人类文案走 stderr）
 node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --evidence-dir /tmp/my-evidence --json <插件包路径>
+# 隔离审计（B4）：白名单外变化报「可疑」不阻断退出；--keep 落 $DSH_HOME/audit/audit.json
+node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --audit --keep <插件包路径>
 ```
 
 插件参数支持**本地插件路径**（相对路径基于当前 cwd 自动解析为绝对路径后挂载，

--- a/packages/dsh-verify-isolated/README.md
+++ b/packages/dsh-verify-isolated/README.md
@@ -46,8 +46,11 @@ dsh plugin --profile web add @wingsky-1/dsh-verify-isolated
   **B4** 可选隔离审计 `--audit`——对比隔离 `$ISOLATED_HOME` 写面与预置白名单
   （版本化 `WHITELIST_V`，`scripts/lib/audit.mjs` 纯函数），白名单外新增/删除/修改
   与越界 symlink 报「可疑」、**不阻断退出**（`--audit-extra-dirs <dir>` 可加额外
-  审计目录；局限：不扫真实 home；`--keep` 落 `$DSH_HOME/audit/audit.json`，否则
-  并入 verdict 的 `audit` 字段）；`--json` 时 stdout 只出最终 verdict JSON。退出码
+  审计目录，必须是目录；局限：不扫真实 home；白名单含 dsh 自身写面
+  `.credentials.yaml`/`storages/**`，随版本漂移的官方 bundle link 由就绪后 t0
+  基线覆盖——审计面 = 就绪后运行期增量写面；`--keep` 落
+  `$DSH_HOME/audit/audit.json`，否则随 `--json` 终态 verdict 输出 `audit` 字段）；
+  `--json` 时 stdout 只出最终 verdict JSON。退出码
   契约：0 正常 / 1 启动或就绪失败 / 2 参数错误 / 130 SIGINT / 143 SIGTERM。
 
 ## 包结构

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/SKILL.md
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/SKILL.md
@@ -114,18 +114,25 @@ cleanup 字段（`"done"`/`"kept"`）；端口实际绑定解析 dsh.log 端口�
 **B4 隔离审计（`--audit`）**：可选开启，对比隔离 `$DSH_HOME` 写面与**预置白名单**
 （版本化 `WHITELIST_V`，模式数组随 `scripts/lib/audit.mjs` 分发、smoke 断言存在）：
 白名单外的新增/删除/修改报「可疑」（纯 stat 路径级，不读内容）；白名单内变化
-忽略（dsh 重写 settings 是常态）；未知顶层路径 → 可疑。**symlink 防逃逸**：快照
-lstat 不跟随；`t1` 时**新增的**或**目标变化**且 resolve 后在 `$ISOLATED_HOME` 外的
-symlink 报「越界 symlink」（防插件经 symlink 写回主 checkout），`t0` 已存在且
-目标未变的外部 symlink（`link:` 挂载点，合法）不报；防逃逸优先于白名单——
-`profiles/**` 内新增越界 symlink 同样报。**局限**：只扫 `$ISOLATED_HOME` 子树 +
-`--audit-extra-dirs <dir>`（可重复，相对路径基于 cwd 绝对化）指定的额外目录，
-**不扫真实 home**。时序：`t0` 基线在挂载（link: symlink）之后、脚本自身写面
-（browser.state/verdict/evidence 内容/audit 落盘）之前；审计插在退出清理序列
-「kill dsh → browser quit → **审计** → verdict 终态 → rm」之间，**不阻断退出**
-（审计是补充非门禁，退出码契约不变）；`--keep` 时报告落
-`$DSH_HOME/audit/audit.json`，否则并入 verdict JSON 的 `audit` 字段；`--json` 时
-同样并入 stdout 的最终 verdict（错误路径的错误 JSON 也带 `audit` 字段）。
+忽略（dsh 重写 settings 是常态）；未知顶层路径 → 可疑。白名单分工：
+`profiles/**`、`*.json/*.jsonl/*.log`、`.credentials.yaml`、`browser.state`、
+`browser-profile/**`（整树白名单 + 跳过深扫）、`evidence/**`、`audit/**`、
+`storages/**`（dsh 官方存储写面）、`dsh.log`、`verdict.json`；随 dsh 版本漂移的
+面（如 profiles/node_modules/** 官方 bundle link）由 **t0 动态基线**覆盖（见下）。
+**symlink 防逃逸**：快照 lstat 不跟随；`t1` 时**新增的**或**目标变化**且 resolve
+后在**所在扫描根**（`$ISOLATED_HOME` 或 `--audit-extra-dirs` 目录）外的 symlink
+报「越界 symlink」（防插件经 symlink 写回主 checkout），`t0` 已存在且目标未变的
+外部 symlink（`link:` 挂载点，合法）不报；防逃逸优先于白名单——`profiles/**` 内
+新增越界 symlink 同样报。**局限**：只扫 `$ISOLATED_HOME` 子树 +
+`--audit-extra-dirs <dir>`（可重复，相对路径基于 cwd 绝对化、必须是目录）指定的
+额外目录，**不扫真实 home**。时序：`t0` 基线在**就绪断言成功之后**（dsh 启动期
+自身写面与官方 bundle link 进基线——语义为「**就绪后运行期写面审计**」，审计面 =
+dsh 就绪后、退出前的增量写面；verdict 中间态在其后写入，先扫后写 + 白名单双
+保险）；审计插在退出清理序列「kill dsh → browser quit → **审计** → verdict 终态
+→ rm」之间，**不阻断退出**（审计是补充非门禁，退出码契约不变）；就绪前退出/
+超时路径不审计（`audit` 为 null）；`--keep` 时报告落 `$DSH_HOME/audit/audit.json`，
+否则随 `--json` 终态 verdict 输出（stdout `audit` 字段；错误路径错误 JSON 恒带
+`audit` 字段，与 verdict 对齐）。
 
 **退出码契约**：0 正常完成 / 1 启动或就绪失败（profile 初始化失败、add 失败、
 dsh 就绪前退出、15s 就绪超时）/ 2 参数错误（未知选项、缺参、找不到 dsh 入口、

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/SKILL.md
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/SKILL.md
@@ -70,6 +70,11 @@ node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --browser <插件包路�
 node "$SKILL_BASE/scripts/verify-isolated.mjs" --dsh /opt/dsh-0.1.2-alpha.2/bin/dsh --port 0 <插件包路径>
 # 证据目录外部化（截图/快照归档到 <dir>/evidence-<profile>/，绝不动外部目录）：
 node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --evidence-dir /tmp/my-evidence <插件包路径>
+# 隔离审计（B4）：对比隔离 DSH_HOME 写面与预置白名单，白名单外变化报「可疑」、
+# 不阻断退出；--keep 时报告落 $DSH_HOME/audit/audit.json，否则并入 verdict 的 audit 字段
+node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --audit --keep <插件包路径>
+# 额外审计目录（插件写到隔离环境外的数据面，可重复；局限：不扫真实 home）：
+node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --audit --audit-extra-dirs /tmp/plugin-data <插件包路径>
 ```
 
 插件参数（`--` 之后或直接位置参数）接受两种形态，脚本内建统一归一化
@@ -105,6 +110,22 @@ cleanup 字段（`"done"`/`"kept"`）；端口实际绑定解析 dsh.log 端口�
 **B7 证据目录**：默认 `$DSH_HOME/evidence/`（脚本会打印路径；退出随临时目录一并
 清理，`--keep` 保留）；显式 `--evidence-dir <dir>` 外部化时建
 `<dir>/evidence-<profile>/` 子目录，**绝不动外部目录**（不删、不覆盖）。
+
+**B4 隔离审计（`--audit`）**：可选开启，对比隔离 `$DSH_HOME` 写面与**预置白名单**
+（版本化 `WHITELIST_V`，模式数组随 `scripts/lib/audit.mjs` 分发、smoke 断言存在）：
+白名单外的新增/删除/修改报「可疑」（纯 stat 路径级，不读内容）；白名单内变化
+忽略（dsh 重写 settings 是常态）；未知顶层路径 → 可疑。**symlink 防逃逸**：快照
+lstat 不跟随；`t1` 时**新增的**或**目标变化**且 resolve 后在 `$ISOLATED_HOME` 外的
+symlink 报「越界 symlink」（防插件经 symlink 写回主 checkout），`t0` 已存在且
+目标未变的外部 symlink（`link:` 挂载点，合法）不报；防逃逸优先于白名单——
+`profiles/**` 内新增越界 symlink 同样报。**局限**：只扫 `$ISOLATED_HOME` 子树 +
+`--audit-extra-dirs <dir>`（可重复，相对路径基于 cwd 绝对化）指定的额外目录，
+**不扫真实 home**。时序：`t0` 基线在挂载（link: symlink）之后、脚本自身写面
+（browser.state/verdict/evidence 内容/audit 落盘）之前；审计插在退出清理序列
+「kill dsh → browser quit → **审计** → verdict 终态 → rm」之间，**不阻断退出**
+（审计是补充非门禁，退出码契约不变）；`--keep` 时报告落
+`$DSH_HOME/audit/audit.json`，否则并入 verdict JSON 的 `audit` 字段；`--json` 时
+同样并入 stdout 的最终 verdict（错误路径的错误 JSON 也带 `audit` 字段）。
 
 **退出码契约**：0 正常完成 / 1 启动或就绪失败（profile 初始化失败、add 失败、
 dsh 就绪前退出、15s 就绪超时）/ 2 参数错误（未知选项、缺参、找不到 dsh 入口、

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/audit.mjs
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/audit.mjs
@@ -1,0 +1,215 @@
+/**
+ * audit.mjs — 隔离审计核心（#517 B4：隔离审计白名单版）纯函数层。
+ *
+ * 供 verify-isolated.mjs 的 `--audit` 集成调用：t0 基线快照（挂载完成后、
+ * 脚本自身写面之前）与 t1 终态快照（dsh 退出后）对比，白名单外的变化报
+ * 「可疑」，不阻断退出（审计是补充非门禁）。本模块零依赖、只做「纯 stat
+ * 路径级」判定（lstat 不读文件内容），smoke 用 mkdtemp fixture 直接断言
+ * 正反例行为（见 test/smoke.ts）。
+ *
+ * ## 口径（#517 评论 B4 方案，实现注释说明）
+ *
+ * 1. **范围硬绑定扫描根**：只扫传入的 root（$ISOLATED_HOME 子树 +
+ *    --audit-extra-dirs 指定的额外目录），不扫真实 home——文档写明局限。
+ * 2. **symlink 防逃逸（不排除、而是防逃逸）**：快照用 lstat（不跟随），
+ *    symlink 只记录 linkTarget 不读目标内容（安全）；profile node_modules
+ *    全 `link:` symlink 是挂载机制本身，**t0 已存在且目标未变的外部 symlink
+ *    （link: 挂载点）合法不报**；t1 时**新增的**或**目标变化**且 resolve 后
+ *    在扫描根外的 symlink 报「越界 symlink」（防插件经 symlink 写回主
+ *    checkout）。防逃逸优先于白名单忽略——白名单目录（profiles/** 等）内
+ *    新增越界 symlink 同样报可疑。
+ * 3. **判定面 = 白名单模式外的新增/删除/修改**（路径级，不读内容）；
+ *    白名单内变化忽略（dsh 重写 settings 是常态）。未知顶层路径 → 可疑。
+ * 4. **首跑学习**（#517 方案：学习仅交叉校验 dsh 版本写面漂移）本模块不做
+ *    判定源——判定面只有预置白名单，版本化 `WHITELIST_V` 随 skill 分发、
+ *    smoke 断言存在。
+ * 5. **browser-profile/** 整树白名单 + 跳过深扫**：chromium user-data-dir
+ *    数万文件，快照只记录目录条目不递归（skipDeep）。
+ *
+ * resolve 口径说明：越界判定用 path.resolve（第一跳语义，不 realpath
+ * 跟随 symlink 链）——与「快照不跟随 symlink、不读目标」原则一致；链接
+ * 目标为相对路径时以链接所在目录为基准解析。
+ */
+import { lstatSync, readdirSync, readlinkSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+
+/** 白名单版本（预置模式数组版本化；smoke 断言存在与格式）。 */
+export const WHITELIST_V = "v1";
+
+/**
+ * 预置白名单模式数组（判定面）：命中模式 = 预期写面，变化忽略；未命中 =
+ * 可疑（新增/删除/修改）。模式语义：
+ *   - `dir/**`：整树前缀匹配（目录本身及其下一切）；
+ *   - `*.ext`：**仅顶层**文件扩展名匹配（子目录内不生效——未知顶层目录
+ *     下的任何文件都算可疑，贴合「未知顶层路径→可疑」）；
+ *   - 其余：顶层精确文件名。
+ */
+export const WHITELIST = Object.freeze([
+  "profiles/**",
+  "*.json",
+  "*.jsonl",
+  "*.log",
+  "browser.state",
+  "browser-profile/**",
+  "evidence/**",
+  "audit/**",
+  "dsh.log",
+  "verdict.json",
+]);
+
+/** 跳过深扫的整树白名单（chromium user-data-dir 数万文件，只记目录条目）。 */
+export const SKIP_DEEP = Object.freeze(["browser-profile/**"]);
+
+/** 白名单模式匹配（目录前缀 / 顶层扩展名 / 顶层精确文件，见 WHITELIST 注释）。 */
+function matchPattern(relPath, pattern) {
+  if (pattern.endsWith("/**")) {
+    const dir = pattern.slice(0, -3);
+    return relPath === dir || relPath.startsWith(dir + "/");
+  }
+  if (pattern.startsWith("*.")) {
+    if (relPath.includes("/")) return false;
+    return relPath.endsWith(pattern.slice(1));
+  }
+  return relPath === pattern;
+}
+
+/**
+ * 路径级快照：递归 lstat 遍历 root（不跟随 symlink），返回
+ * `{ root, entries: Map<relPath, Entry> }`。Entry：
+ *   - dir：`{ type: "dir" }`（mtime 变化是子条目副作用，不参与修改判定）；
+ *   - file：`{ type: "file", size, mtimeMs }`（修改判定面）；
+ *   - symlink：`{ type: "symlink", linkTarget }`（只记录目标，不读内容；
+ *     越界判定走 checkSymlinkEscape）；
+ *   - other：fifo/socket 等非常规条目。
+ * `opts.skipDeep` 命中的目录只记录目录条目、不递归（browser-profile/**）。
+ */
+export function scanSnapshot(root, opts = {}) {
+  const entries = new Map();
+  const skipDeep = opts.skipDeep ?? [];
+  const walk = (dir, rel) => {
+    let dirents;
+    try { dirents = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const d of dirents) {
+      const childRel = rel === "" ? d.name : `${rel}/${d.name}`;
+      const childPath = resolve(dir, d.name);
+      if (d.isSymbolicLink()) {
+        let target = null;
+        try { target = readlinkSync(childPath); } catch {}
+        entries.set(childRel, { type: "symlink", linkTarget: target });
+        continue; // 不跟随 symlink（防逃逸核心：快照不读链接目标内容）
+      }
+      if (d.isDirectory()) {
+        entries.set(childRel, { type: "dir" });
+        if (skipDeep.some((p) => matchPattern(childRel, p))) continue;
+        walk(childPath, childRel);
+      } else if (d.isFile()) {
+        let st = null;
+        try { st = lstatSync(childPath); } catch {}
+        entries.set(childRel, { type: "file", size: st?.size ?? 0, mtimeMs: st?.mtimeMs ?? 0 });
+      } else {
+        entries.set(childRel, { type: "other" });
+      }
+    }
+  };
+  walk(root, "");
+  return { root, entries };
+}
+
+/** 条目是否构成「修改」（目录自身 mtime 变化不报，防子条目副作用噪音）。 */
+function isModified(e0, e1) {
+  if (e0.type === "dir" && e1.type === "dir") return false;
+  if (e0.type === "file" && e1.type === "file") {
+    return e0.size !== e1.size || e0.mtimeMs !== e1.mtimeMs;
+  }
+  if (e0.type === "symlink" && e1.type === "symlink") {
+    return e0.linkTarget !== e1.linkTarget;
+  }
+  return e0.type !== e1.type; // 类型变化（file→dir 等）也算修改
+}
+
+/**
+ * 白名单 diff：t1 相对 t0 的**白名单外**新增/删除/修改（symlink 的目标
+ * 变化在此报「修改」，但 runAudit 组合层会把越界 symlink 剔除单独报）。
+ * 返回 `{ added, removed, modified }`，每项 `{ path, type }`。
+ */
+export function diffAgainstWhitelist(t0, t1, whitelist) {
+  const added = [];
+  const removed = [];
+  const modified = [];
+  const isWl = (rel) => whitelist.some((p) => matchPattern(rel, p));
+  for (const [rel, e1] of t1.entries) {
+    if (isWl(rel)) continue;
+    const e0 = t0.entries.get(rel);
+    if (!e0) { added.push({ path: rel, type: e1.type }); continue; }
+    if (isModified(e0, e1)) modified.push({ path: rel, type: e1.type });
+  }
+  for (const [rel, e0] of t0.entries) {
+    if (isWl(rel)) continue;
+    if (!t1.entries.has(rel)) removed.push({ path: rel, type: e0.type });
+  }
+  return { added, removed, modified };
+}
+
+/** child 是否位于 parent 内（含自身；resolve 后的绝对路径比较）。 */
+function isInside(child, parent) {
+  const rel = relative(parent, child);
+  return rel === "" || (rel !== ".." && !rel.startsWith(".." + sep) && !isAbsolute(rel));
+}
+
+/**
+ * symlink 越界几何判定（单快照）：返回该快照内全部 resolve 后在
+ * isolatedRoot 外的 symlink `{ path, target, resolved }`。**不含 t0/t1
+ * 对比**——「t0 已存在且目标未变的外部 symlink 合法不报」的剔除在
+ * runAudit 组合层（见下）。
+ */
+export function checkSymlinkEscape(snapshot, isolatedRoot) {
+  const rootAbs = resolve(snapshot.root);
+  const boundAbs = resolve(isolatedRoot);
+  const escapes = [];
+  for (const [rel, e] of snapshot.entries) {
+    if (e.type !== "symlink" || e.linkTarget === null) continue;
+    const linkAbs = resolve(rootAbs, rel);
+    const targetAbs = isAbsolute(e.linkTarget)
+      ? resolve(e.linkTarget)
+      : resolve(dirname(linkAbs), e.linkTarget);
+    if (!isInside(targetAbs, boundAbs)) {
+      escapes.push({ path: rel, target: e.linkTarget, resolved: targetAbs });
+    }
+  }
+  return escapes;
+}
+
+/**
+ * 组合审计：单扫描根对（t0 基线 → t1 终态）的可疑项全集。
+ * `isolatedRoot` 为越界判定基准（= 该扫描根自身：$ISOLATED_HOME 或
+ * --audit-extra-dirs 目录）。返回
+ * `{ suspicious: [{path, type, detail?}], count, conclusion }`：
+ *   - 白名单外新增/删除/修改（diffAgainstWhitelist，剔除越界重复报）；
+ *   - 越界 symlink：t1 全部越界中剔除「t0 已存在且 linkTarget 未变」
+ *     （link: 挂载点合法）；防逃逸优先于白名单——白名单内新增越界 symlink
+ *     仍报。
+ * 类型文案：新增 / 删除 / 修改 / 越界 symlink。
+ */
+export function runAudit({ t0, t1, isolatedRoot, whitelist = WHITELIST }) {
+  const diff = diffAgainstWhitelist(t0, t1, whitelist);
+  const escapes = checkSymlinkEscape(t1, isolatedRoot).filter((s) => {
+    const e0 = t0.entries.get(s.path);
+    return !e0 || e0.type !== "symlink" || e0.linkTarget !== s.target;
+  });
+  const escapePaths = new Set(escapes.map((s) => s.path));
+  const suspicious = [
+    ...diff.added.filter((x) => !escapePaths.has(x.path)).map((x) => ({ path: x.path, type: "新增" })),
+    ...diff.removed.map((x) => ({ path: x.path, type: "删除" })),
+    ...diff.modified.filter((x) => !escapePaths.has(x.path)).map((x) => ({ path: x.path, type: "修改" })),
+    ...escapes.map((s) => ({
+      path: s.path,
+      type: "越界 symlink",
+      detail: `${s.target} → ${s.resolved}`,
+    })),
+  ].sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  return {
+    suspicious,
+    count: suspicious.length,
+    conclusion: suspicious.length === 0 ? "pass" : "suspicious",
+  };
+}

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/audit.mjs
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/audit.mjs
@@ -1,11 +1,12 @@
 /**
  * audit.mjs — 隔离审计核心（#517 B4：隔离审计白名单版）纯函数层。
  *
- * 供 verify-isolated.mjs 的 `--audit` 集成调用：t0 基线快照（挂载完成后、
- * 脚本自身写面之前）与 t1 终态快照（dsh 退出后）对比，白名单外的变化报
- * 「可疑」，不阻断退出（审计是补充非门禁）。本模块零依赖、只做「纯 stat
- * 路径级」判定（lstat 不读文件内容），smoke 用 mkdtemp fixture 直接断言
- * 正反例行为（见 test/smoke.ts）。
+ * 供 verify-isolated.mjs 的 `--audit` 集成调用：t0 基线快照（dsh **就绪断言
+ * 之后**——dsh 启动期自身写面与官方 bundle link 进基线，语义为「就绪后运行期
+ * 写面审计」）与 t1 终态快照（dsh 退出后）对比，白名单外的变化报「可疑」，
+ * 不阻断退出（审计是补充非门禁）。本模块零依赖、只做「纯 stat 路径级」判定
+ * （lstat 不读文件内容），smoke 用 mkdtemp fixture 直接断言正反例行为
+ * （见 test/smoke.ts）。
  *
  * ## 口径（#517 评论 B4 方案，实现注释说明）
  *
@@ -15,9 +16,10 @@
  *    symlink 只记录 linkTarget 不读目标内容（安全）；profile node_modules
  *    全 `link:` symlink 是挂载机制本身，**t0 已存在且目标未变的外部 symlink
  *    （link: 挂载点）合法不报**；t1 时**新增的**或**目标变化**且 resolve 后
- *    在扫描根外的 symlink 报「越界 symlink」（防插件经 symlink 写回主
- *    checkout）。防逃逸优先于白名单忽略——白名单目录（profiles/** 等）内
- *    新增越界 symlink 同样报可疑。
+ *    在**所在扫描根**外的 symlink 报「越界 symlink」（防插件经 symlink 写回
+ *    主 checkout；extra dir 内部的 symlink 以其自身为越界基准）。防逃逸
+ *    优先于白名单忽略——白名单目录（profiles/** 等）内新增越界 symlink
+ *    同样报可疑。
  * 3. **判定面 = 白名单模式外的新增/删除/修改**（路径级，不读内容）；
  *    白名单内变化忽略（dsh 重写 settings 是常态）。未知顶层路径 → 可疑。
  * 4. **首跑学习**（#517 方案：学习仅交叉校验 dsh 版本写面漂移）本模块不做
@@ -34,7 +36,7 @@ import { lstatSync, readdirSync, readlinkSync } from "node:fs";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 
 /** 白名单版本（预置模式数组版本化；smoke 断言存在与格式）。 */
-export const WHITELIST_V = "v1";
+export const WHITELIST_V = "v2";
 
 /**
  * 预置白名单模式数组（判定面）：命中模式 = 预期写面，变化忽略；未命中 =
@@ -43,16 +45,28 @@ export const WHITELIST_V = "v1";
  *   - `*.ext`：**仅顶层**文件扩展名匹配（子目录内不生效——未知顶层目录
  *     下的任何文件都算可疑，贴合「未知顶层路径→可疑」）；
  *   - 其余：顶层精确文件名。
+ *
+ * dsh 自身写面分工（S1 修复，#540 复核）：
+ *   - **静态白名单**覆盖 dsh 固定写面：`.credentials.yaml`（首启凭据文件，
+ *     就绪后初始化竞态窗口内落盘）与 `storages/**`（官方存储：workspace/
+ *     settings 等，退出清理时也写）——无论何时写都是预期写面，不随 dsh
+ *     版本漂移的顶层形态进白名单；
+ *   - **t0 动态基线**覆盖随 dsh 版本漂移的面：profiles/node_modules/** 官方
+ *     bundle link（指向真实 dsh 安装目录、越界但 t0 已存在未变 → 合法挂载点
+ *     不报），由 verify-isolated.mjs 在就绪断言后扫描进基线（见该文件 B4
+ *     注释——「就绪后运行期写面审计」语义）。
  */
 export const WHITELIST = Object.freeze([
   "profiles/**",
   "*.json",
   "*.jsonl",
   "*.log",
+  ".credentials.yaml",
   "browser.state",
   "browser-profile/**",
   "evidence/**",
   "audit/**",
+  "storages/**",
   "dsh.log",
   "verdict.json",
 ]);
@@ -77,7 +91,11 @@ function matchPattern(relPath, pattern) {
  * 路径级快照：递归 lstat 遍历 root（不跟随 symlink），返回
  * `{ root, entries: Map<relPath, Entry> }`。Entry：
  *   - dir：`{ type: "dir" }`（mtime 变化是子条目副作用，不参与修改判定）；
- *   - file：`{ type: "file", size, mtimeMs }`（修改判定面）；
+ *   - file：`{ type: "file", size, mtimeMs, ctimeMs }`（修改判定面 = size +
+ *     mtimeMs + ctimeMs 三字段；ctimeMs 兜住「同 size 同 mtimeMs 快速重写」
+ *     漏报——Linux 上 ctime 为 inode 变更时间、纳秒精度，内容重写必变；
+ *     Windows 上 ctime 语义为创建时间不随内容变，该平台仅 size/mtimeMs
+ *     生效，Windows 承诺等级同为试验性）；
  *   - symlink：`{ type: "symlink", linkTarget }`（只记录目标，不读内容；
  *     越界判定走 checkSymlinkEscape）；
  *   - other：fifo/socket 等非常规条目。
@@ -105,7 +123,12 @@ export function scanSnapshot(root, opts = {}) {
       } else if (d.isFile()) {
         let st = null;
         try { st = lstatSync(childPath); } catch {}
-        entries.set(childRel, { type: "file", size: st?.size ?? 0, mtimeMs: st?.mtimeMs ?? 0 });
+        entries.set(childRel, {
+          type: "file",
+          size: st?.size ?? 0,
+          mtimeMs: st?.mtimeMs ?? 0,
+          ctimeMs: st?.ctimeMs ?? 0,
+        });
       } else {
         entries.set(childRel, { type: "other" });
       }
@@ -119,7 +142,7 @@ export function scanSnapshot(root, opts = {}) {
 function isModified(e0, e1) {
   if (e0.type === "dir" && e1.type === "dir") return false;
   if (e0.type === "file" && e1.type === "file") {
-    return e0.size !== e1.size || e0.mtimeMs !== e1.mtimeMs;
+    return e0.size !== e1.size || e0.mtimeMs !== e1.mtimeMs || e0.ctimeMs !== e1.ctimeMs;
   }
   if (e0.type === "symlink" && e1.type === "symlink") {
     return e0.linkTarget !== e1.linkTarget;
@@ -151,7 +174,7 @@ export function diffAgainstWhitelist(t0, t1, whitelist) {
 }
 
 /** child 是否位于 parent 内（含自身；resolve 后的绝对路径比较）。 */
-function isInside(child, parent) {
+export function isInside(child, parent) {
   const rel = relative(parent, child);
   return rel === "" || (rel !== ".." && !rel.startsWith(".." + sep) && !isAbsolute(rel));
 }

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/verify-isolated.mjs
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/verify-isolated.mjs
@@ -40,8 +40,9 @@
  *   --audit            隔离审计（B4）：对比隔离 DSH_HOME 写面与预置白名单
  *                      （版本化 WHITELIST_V，lib/audit.mjs），白名单外变化报
  *                      「可疑」（新增/删除/修改 + 越界 symlink），**不阻断退出**
- *                      （审计是补充非门禁，退出码契约不变）；t0 基线在挂载后、
- *                      脚本自身写面前扫描（先扫后写 + 白名单双保险）。
+ *                      （审计是补充非门禁，退出码契约不变）；t0 基线在**就绪
+ *                      断言成功后**扫描（dsh 启动写面进基线，审计 dsh 运行期
+ *                      写面；先扫后写 + 白名单双保险）。
  *   --audit-extra-dirs <dir>
  *                      额外审计目录（可重复）：相对路径基于 cwd 绝对化；局限
  *                      ——审计只扫 $ISOLATED_HOME 子树 + 本选项指定目录，**不扫
@@ -87,13 +88,16 @@
  * lib/audit.mjs 纯函数：scanSnapshot / diffAgainstWhitelist /
  * checkSymlinkEscape / runAudit）外的新增/删除/修改 + 越界 symlink；
  * symlink 快照 lstat 不跟随，「t0 已存在且目标未变的外部 symlink（link:
- * 挂载点）合法不报」，「新增或目标变化且 resolve 后在 $ISOLATED_HOME 外的
- * 报『越界 symlink』（防插件经 symlink 写回主 checkout）」。时序：t0 基线
- * 在 setupPlugins（link: 挂载）之后、脚本自身写面（browser.state/verdict/
- * evidence 内容/audit 落盘）之前；审计 diff 插在 settle「kill dsh →
- * browser quit → 审计 → verdict 终态 → rm」；--keep 落
- * $ISOLATED_HOME/audit/audit.json，否则并入 verdict JSON（audit 字段）。
- * 不阻断退出（审计异常仅警告，退出码契约不变）。
+ * 挂载点）合法不报」，「新增或目标变化且 resolve 后在**所在扫描根**外的
+ * 报『越界 symlink』（防插件经 symlink 写回主 checkout）。时序：t0 基线
+ * 在**就绪断言成功之后**（dsh web 首启自建的 profiles/node_modules/** 官方
+ * bundle link 与顶层 .credentials.yaml/storages/** 启动写面进基线——语义为
+ * 「就绪后运行期写面审计」；verdict 中间态在其后写入，先扫后写 + 白名单
+ * 双保险）；审计 diff 插在 settle「kill dsh → browser quit → 审计 →
+ * verdict 终态 → rm」；--keep 落 $ISOLATED_HOME/audit/audit.json，否则并入
+ * verdict JSON（audit 字段，--json 错误对象恒带 audit 字段与 verdict 对齐）。
+ * 不阻断退出（审计异常仅警告，退出码契约不变）。就绪前退出/超时路径
+ * auditBaseline 为 null → 审计跳过不报。
  */
 import { spawn, spawnSync, execFileSync } from "node:child_process";
 import {
@@ -101,13 +105,13 @@ import {
   readdirSync, rmSync, statSync, writeFileSync,
 } from "node:fs";
 import { randomBytes } from "node:crypto";
-import { delimiter, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import {
   EXIT, findFreePort, jsonOut, pidAlive, readDshPort, resolvePkgArg, waitPidExit,
 } from "./lib/verify-core.mjs";
 import {
-  runAudit, scanSnapshot, SKIP_DEEP, WHITELIST_V,
+  isInside, runAudit, scanSnapshot, SKIP_DEEP, WHITELIST_V,
 } from "./lib/audit.mjs";
 
 const SCRIPT_DIR = import.meta.dirname; // Node >= 22 全程可用
@@ -159,6 +163,7 @@ let settling = false;
 let errorPayload = null; // --json 错误路径已输出的错误对象（settle 不再重复出 JSON）
 let auditBaseline = null; // B4：t0 基线快照 [{ root, snapshot }]（--audit 时）
 let auditResult = null; // B4：settle 审计输出（--audit 时；并入 verdict/audit.json）
+let auditExtraDirsAbs = []; // B4：绝对化后的 --audit-extra-dirs（settle 审计与 verdict 共用）
 
 // 人类文案输出：--json 时走 stderr（stdout 只出最终 JSON），普通模式走 stdout
 //（SKILL.md §5.1 自检清单依赖 `profile=verify_<随机>` / `DSH_HOME=…` 等可读行）。
@@ -176,12 +181,6 @@ class CliError extends Error {
     super(msg);
     this.code = code;
   }
-}
-
-// child 是否位于 parent 内（resolve 后绝对路径比较；B4 extra dir 重叠校验用）
-function isInsideDir(child, parent) {
-  const rel = relative(parent, child);
-  return rel === "" || (rel !== ".." && !rel.startsWith(".." + sep) && !isAbsolute(rel));
 }
 
 // --- CLI 解析（对齐 bash 版参数契约；--help 为新增） ---
@@ -518,7 +517,7 @@ async function settle() {
         auditResult = {
           enabled: true,
           whitelistV: WHITELIST_V,
-          extraDirs: flags.auditExtraDirs,
+          extraDirs: auditExtraDirsAbs, // 记绝对化后的目录（与 t0 扫描根一致）
           suspicious,
           count,
           conclusion: count === 0 ? "pass" : "suspicious",
@@ -546,7 +545,7 @@ async function settle() {
         auditResult = {
           enabled: true,
           whitelistV: WHITELIST_V,
-          extraDirs: flags.auditExtraDirs,
+          extraDirs: auditExtraDirsAbs,
           suspicious: [],
           count: -1,
           conclusion: "error",
@@ -570,11 +569,12 @@ async function settle() {
     outWarn(`清理异常（继续退出）: ${e.message}`);
   } finally {
     // --json：stdout 只出一份 JSON——错误路径已输出错误对象则不再重复，否则出
-    // 最终 verdict（ok/cleanup 终态与 verdict.json 文件一致）。B4：审计结果
-    // 一律并入（错误路径的 error 对象同样带 audit 字段，stdout 仍单 JSON）
+    // 最终 verdict（ok/cleanup 终态与 verdict.json 文件一致）。B4：error 对象
+    // 恒置 audit 字段（auditResult ?? null）与 verdict 对齐——t0 之前错误（如
+    // extra-dir 不存在）时 audit 为 null 而非缺失，字段契约一致（M6）。
     if (jsonMode) {
       if (errorPayload) {
-        if (auditResult) errorPayload.audit = auditResult;
+        errorPayload.audit = auditResult ?? null;
         jsonOut(errorPayload);
       } else {
         jsonOut(makeVerdict({ ok: readyOk && (exiting?.code ?? EXIT.FAIL) === 0, cleanup: flags?.keep ? "kept" : "done" }));
@@ -598,9 +598,9 @@ async function main() {
     process.exit(EXIT.OK);
   }
 
-  // 0a. B4 --audit-extra-dirs 参数校验（纯参数级 fail fast：存在性 + 基于 cwd
-  // 绝对化；与 DSH_HOME 重叠校验延后到 mkdtemp 之后）。未开 --audit 时忽略
-  // （警告提示，审计需 --audit 显式开启——extra dirs 单独无效）。
+  // 0a. B4 --audit-extra-dirs 参数校验（纯参数级 fail fast：存在性 + 必须是
+  // 目录 + 基于 cwd 绝对化；与 DSH_HOME 重叠校验延后到 mkdtemp 之后）。
+  // 未开 --audit 时忽略（警告提示，审计需 --audit 显式开启——extra dirs 单独无效）。
   let extraDirsAbs = [];
   if (f.audit) {
     extraDirsAbs = f.auditExtraDirs.map((raw) => {
@@ -611,11 +611,15 @@ async function main() {
           EXIT.USAGE,
         );
       }
+      if (!statSync(abs).isDirectory()) {
+        throw new CliError(`错误: --audit-extra-dirs 必须是目录: ${raw}`, EXIT.USAGE);
+      }
       return abs;
     });
   } else if (f.auditExtraDirs.length > 0) {
     outWarn("警告: --audit-extra-dirs 未开启 --audit，忽略（审计需 --audit 显式开启）");
   }
+  auditExtraDirsAbs = extraDirsAbs;
 
   // 0. dsh 入口校验与版本锚定展示（fail fast，不在建完环境后才失败）
   const rawDsh = f.dsh ?? "dsh";
@@ -634,7 +638,7 @@ async function main() {
   verdictPath = join(isolatedHome, "verdict.json");
   // B4：extra dir 不得与隔离 DSH_HOME 重叠（同树重复审计 + 判定基准歧义）
   for (const dir of extraDirsAbs) {
-    if (isInsideDir(dir, isolatedHome) || isInsideDir(isolatedHome, dir)) {
+    if (isInside(dir, isolatedHome) || isInside(isolatedHome, dir)) {
       throw new CliError(
         `错误: --audit-extra-dirs 与隔离 DSH_HOME 重叠: ${dir}`,
         EXIT.USAGE,
@@ -670,20 +674,6 @@ async function main() {
 
   // 4. 挂载本地插件（C11 归一化 + 构建 / --no-build 校验 + add）
   setupPlugins(pkgs);
-
-  // 4.5 B4：t0 基线快照（--audit）。位置口径：**挂载之后**（profiles/** 内
-  // link: symlink 进基线——t0 已存在且目标未变的外部 symlink 合法不报）、
-  // **脚本自身写面之前**（browser.state / verdict / evidence 内容 / audit
-  // 落盘尚未产生，先扫后写 + 白名单双保险）；dsh.log 空文件与 evidence 空
-  // 目录为脚本早期准备面，均在白名单内（*.log / evidence/**）。
-  if (f.audit) {
-    auditBaseline = [
-      { root: isolatedHome, snapshot: scanSnapshot(isolatedHome, { skipDeep: SKIP_DEEP }) },
-    ];
-    for (const dir of extraDirsAbs) {
-      auditBaseline.push({ root: dir, snapshot: scanSnapshot(dir, { skipDeep: SKIP_DEEP }) });
-    }
-  }
 
   // 5. 启动独立浏览器实例（--browser）：实例信息写入 browser.state。
   //    刻意不传 DSH_HOME：browser-driver 属宿主环境工具（探测系统 Chrome 内核、
@@ -812,6 +802,24 @@ async function main() {
     portSource = flags.port === 0 ? "probed" : "asserted";
   }
   out(`就绪断言通过: http://127.0.0.1:${actualPort} 已可达（pid=${dshChild.pid}）`);
+
+  // B4：t0 基线快照（--audit）——位置在**就绪断言成功之后**、verdict 中间态
+  // 写入之前。语义为「**就绪后运行期写面审计**」：dsh web **首启**才自建的
+  // profiles/node_modules/** 官方 bundle link（指向真实 dsh 安装目录、越界但
+  // t0 已存在未变 → 合法挂载点不报）与顶层 .credentials.yaml / storages/**
+  // 启动写面全部进基线，干净运行不再误报；审计面 = dsh 就绪后、退出前这段
+  // 运行期的增量写面（插件/会话/持久化）。verdict.json（中间态）在 t0 **之后**
+  // 写入，先扫后写 + 白名单（verdict.json）双保险。就绪前退出/超时路径
+  // auditBaseline 保持 null → settle 守卫跳过审计（不报），与「未进入运行期
+  // 审计」语义一致。
+  if (f.audit) {
+    auditBaseline = [
+      { root: isolatedHome, snapshot: scanSnapshot(isolatedHome, { skipDeep: SKIP_DEEP }) },
+    ];
+    for (const dir of extraDirsAbs) {
+      auditBaseline.push({ root: dir, snapshot: scanSnapshot(dir, { skipDeep: SKIP_DEEP }) });
+    }
+  }
 
   // B6：就绪后写 verdict 中间态（cleanup:"running"，退出时更新终态）
   writeVerdictRunning();

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/verify-isolated.mjs
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/verify-isolated.mjs
@@ -20,7 +20,8 @@
  *
  * 用法：
  *   node verify-isolated.mjs [--dsh <path>] [--port <port>] [--browser] [--keep]
- *                            [--no-build] [--evidence-dir <dir>] [--json]
+ *                            [--no-build] [--evidence-dir <dir>] [--audit]
+ *                            [--audit-extra-dirs <dir>] [--json]
  *                            [-- <pkg-path>...]
  *   --dsh <path>       指定 dsh 入口（默认 PATH 中的 dsh）。隔离实测必须锚定目标
  *                      dsh 版本——PATH 里碰巧存在的版本会让验证结果不可复现（#376 H1）。
@@ -36,6 +37,15 @@
  *                      证据目录（B7）：默认 $ISOLATED_HOME/evidence/；显式外部化
  *                      时建 <dir>/evidence-<profile>/ 子目录，**绝不动外部目录**
  *                      （不删、不覆盖，仅创建子目录并打印路径）。
+ *   --audit            隔离审计（B4）：对比隔离 DSH_HOME 写面与预置白名单
+ *                      （版本化 WHITELIST_V，lib/audit.mjs），白名单外变化报
+ *                      「可疑」（新增/删除/修改 + 越界 symlink），**不阻断退出**
+ *                      （审计是补充非门禁，退出码契约不变）；t0 基线在挂载后、
+ *                      脚本自身写面前扫描（先扫后写 + 白名单双保险）。
+ *   --audit-extra-dirs <dir>
+ *                      额外审计目录（可重复）：相对路径基于 cwd 绝对化；局限
+ *                      ——审计只扫 $ISOLATED_HOME 子树 + 本选项指定目录，**不扫
+ *                      真实 home**（插件写真实 ~/.dsh 的数据面不在判定面内）。
  *   --json             stdout 只出最终 verdict JSON（人类文案全部走 stderr）。
  *   --                 之后为要挂载的本地插件路径（相对路径基于当前 cwd 解析；
  *                      npm 包名 / git URL 原样透传，见 lib/verify-core.mjs
@@ -72,6 +82,18 @@
  * B7 证据目录：默认 $ISOLATED_HOME/evidence/；供截图/快照等归档，退出随
  * DSH_HOME 一并清理（--keep 保留）。显式 --evidence-dir 时建外部子目录，
  * 绝不动外部目录本体。
+ *
+ * B4 隔离审计（--audit）：判定面 = 预置白名单（WHITELIST_V 版本化，
+ * lib/audit.mjs 纯函数：scanSnapshot / diffAgainstWhitelist /
+ * checkSymlinkEscape / runAudit）外的新增/删除/修改 + 越界 symlink；
+ * symlink 快照 lstat 不跟随，「t0 已存在且目标未变的外部 symlink（link:
+ * 挂载点）合法不报」，「新增或目标变化且 resolve 后在 $ISOLATED_HOME 外的
+ * 报『越界 symlink』（防插件经 symlink 写回主 checkout）」。时序：t0 基线
+ * 在 setupPlugins（link: 挂载）之后、脚本自身写面（browser.state/verdict/
+ * evidence 内容/audit 落盘）之前；审计 diff 插在 settle「kill dsh →
+ * browser quit → 审计 → verdict 终态 → rm」；--keep 落
+ * $ISOLATED_HOME/audit/audit.json，否则并入 verdict JSON（audit 字段）。
+ * 不阻断退出（审计异常仅警告，退出码契约不变）。
  */
 import { spawn, spawnSync, execFileSync } from "node:child_process";
 import {
@@ -79,11 +101,14 @@ import {
   readdirSync, rmSync, statSync, writeFileSync,
 } from "node:fs";
 import { randomBytes } from "node:crypto";
-import { delimiter, isAbsolute, join, resolve } from "node:path";
+import { delimiter, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { tmpdir } from "node:os";
 import {
   EXIT, findFreePort, jsonOut, pidAlive, readDshPort, resolvePkgArg, waitPidExit,
 } from "./lib/verify-core.mjs";
+import {
+  runAudit, scanSnapshot, SKIP_DEEP, WHITELIST_V,
+} from "./lib/audit.mjs";
 
 const SCRIPT_DIR = import.meta.dirname; // Node >= 22 全程可用
 const DRIVER = join(SCRIPT_DIR, "browser-driver.mjs");
@@ -91,7 +116,7 @@ const DEFAULT_PORT = 3456;
 const READY_TIMEOUT_MS = 15000;
 const LOG_TAIL_LIMIT = 4096; // 防背压：收集缓冲限长（browser-driver stderrBuf 先例）
 
-const USAGE = `用法: node verify-isolated.mjs [--dsh <path>] [--port <port>] [--browser] [--keep] [--no-build] [--evidence-dir <dir>] [--json] [-- <pkg-path>...]
+const USAGE = `用法: node verify-isolated.mjs [--dsh <path>] [--port <port>] [--browser] [--keep] [--no-build] [--evidence-dir <dir>] [--audit] [--audit-extra-dirs <dir>] [--json] [-- <pkg-path>...]
 
 选项：
   --dsh <path>         指定 dsh 入口（默认 PATH 中的 dsh；隔离实测必须锚定版本，防 PATH 漂移）
@@ -100,6 +125,9 @@ const USAGE = `用法: node verify-isolated.mjs [--dsh <path>] [--port <port>] [
   --keep               结束后保留临时 DSH_HOME（默认自动删除）
   --no-build           跳过挂载前 pnpm build（校验产物存在 + 陈旧警告）
   --evidence-dir <dir> 证据目录外部化（建 <dir>/evidence-<profile>/，绝不动外部目录）
+  --audit              隔离审计：对比隔离 DSH_HOME 写面与预置白名单，白名单外变化报「可疑」，不阻断退出
+  --audit-extra-dirs <dir>
+                      额外审计目录（可重复；相对路径基于 cwd 绝对化；局限：不扫真实 home）
   --json               stdout 只出最终 verdict JSON（人类文案走 stderr）
   --                   之后为要挂载的本地插件路径（相对路径基于 cwd 绝对化；npm 包名 / git URL 原样透传）
   --help               显示本帮助
@@ -129,6 +157,8 @@ let childExitBeforeReady = null; // 就绪前 dsh 退出记录（P1 修复：#51
 let exiting = null; // { code: number, signal: string|null } 退出请求
 let settling = false;
 let errorPayload = null; // --json 错误路径已输出的错误对象（settle 不再重复出 JSON）
+let auditBaseline = null; // B4：t0 基线快照 [{ root, snapshot }]（--audit 时）
+let auditResult = null; // B4：settle 审计输出（--audit 时；并入 verdict/audit.json）
 
 // 人类文案输出：--json 时走 stderr（stdout 只出最终 JSON），普通模式走 stdout
 //（SKILL.md §5.1 自检清单依赖 `profile=verify_<随机>` / `DSH_HOME=…` 等可读行）。
@@ -148,6 +178,12 @@ class CliError extends Error {
   }
 }
 
+// child 是否位于 parent 内（resolve 后绝对路径比较；B4 extra dir 重叠校验用）
+function isInsideDir(child, parent) {
+  const rel = relative(parent, child);
+  return rel === "" || (rel !== ".." && !rel.startsWith(".." + sep) && !isAbsolute(rel));
+}
+
 // --- CLI 解析（对齐 bash 版参数契约；--help 为新增） ---
 function parseCli(argv) {
   // jsonMode 只在 `--` 前段探测（`--` 之后为插件参数原样透传，不参与选项解析）；
@@ -164,7 +200,8 @@ function parseCli(argv) {
   jsonMode = jsonDetected;
   const f = {
     dsh: null, port: DEFAULT_PORT, browser: false, keep: false,
-    noBuild: false, evidenceDir: null, json: jsonMode, help: false,
+    noBuild: false, evidenceDir: null, audit: false, auditExtraDirs: [],
+    json: jsonMode, help: false,
   };
   const pkgs = [];
   const bad = (msg) => { throw new CliError(msg, EXIT.USAGE); };
@@ -196,6 +233,8 @@ function parseCli(argv) {
         case "keep": f.keep = true; break;
         case "no-build": f.noBuild = true; break;
         case "evidence-dir": f.evidenceDir = inline ?? val(i, "--evidence-dir"); if (inline === null) i++; break;
+        case "audit": f.audit = true; break;
+        case "audit-extra-dirs": f.auditExtraDirs.push(inline ?? val(i, "--audit-extra-dirs")); if (inline === null) i++; break;
         case "json": {
           // --json=<v> 显式布尔（true/false），非法值参数错误
           if (inline !== null) {
@@ -315,6 +354,7 @@ function makeVerdict(mut) {
     ready: readyOk,
     readyAt: readyIso,
     evidenceDir: evidenceDir,
+    audit: auditResult, // B4：--audit 时 settle 审计结果；否则 null（--json 终态含同字段）
     cleanup: "running", // 中间态；终态由 writeVerdictTerminal 覆写为 done/kept
     ...mut,
   };
@@ -458,9 +498,66 @@ async function settle() {
         spawnSync(process.execPath, [DRIVER, "quit", "--state", browserState, "--json"], { stdio: "ignore", timeout: 20000 });
       } catch {}
     }
-    // 3. verdict 终态 cleanup（done/kept）
+    // 3. 隔离审计（B4，--audit）：t1 终态扫描 → 白名单 diff + symlink 防逃逸 →
+    //    输出结论。审计是补充非门禁：任何异常仅警告（auditResult 带 error），
+    //    不阻断退出、不影响退出码契约。
+    if (flags?.audit && auditBaseline) {
+      try {
+        const all = [];
+        for (const b of auditBaseline) {
+          const t1 = scanSnapshot(b.root, { skipDeep: SKIP_DEEP });
+          const r = runAudit({ t0: b.snapshot, t1, isolatedRoot: b.root });
+          all.push(...r.suspicious);
+        }
+        // 去重 + 稳定排序（extra dir 与 DSH_HOME 已校验不重叠，防御性去重）
+        const seen = new Set();
+        const suspicious = all
+          .filter((s) => (seen.has(s.path) ? false : (seen.add(s.path), true)))
+          .sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+        const count = suspicious.length;
+        auditResult = {
+          enabled: true,
+          whitelistV: WHITELIST_V,
+          extraDirs: flags.auditExtraDirs,
+          suspicious,
+          count,
+          conclusion: count === 0 ? "pass" : "suspicious",
+          runAt: new Date().toISOString(),
+        };
+        if (count === 0) {
+          out("审计:通过");
+        } else {
+          out(`审计:可疑项 ${count}:`);
+          for (const s of suspicious) {
+            out(`可疑: ${s.path}（${s.type}${s.detail ? `: ${s.detail}` : ""}）`);
+          }
+          out(`审计: ${count}项可疑`);
+        }
+        // --keep 落 $ISOLATED_HOME/audit/audit.json（t1 扫描之后写，先扫后写
+        // 排除自身；audit/** 白名单双保险在位）
+        if (flags.keep && isolatedHome) {
+          const auditPath = join(isolatedHome, "audit", "audit.json");
+          mkdirSync(dirname(auditPath), { recursive: true });
+          writeFileSync(auditPath, JSON.stringify(auditResult, null, 2));
+          out(`审计报告: ${auditPath}`);
+        }
+      } catch (e) {
+        outWarn(`审计异常（不影响退出码）: ${e.message}`);
+        auditResult = {
+          enabled: true,
+          whitelistV: WHITELIST_V,
+          extraDirs: flags.auditExtraDirs,
+          suspicious: [],
+          count: -1,
+          conclusion: "error",
+          error: e.message,
+          runAt: new Date().toISOString(),
+        };
+      }
+    }
+    // 4. verdict 终态 cleanup（done/kept；audit 字段已并入 makeVerdict）
     writeVerdictTerminal();
-    // 4. 不 --keep 时清理 ISOLATED_HOME
+    // 5. 不 --keep 时清理 ISOLATED_HOME
     if (isolatedHome) {
       if (flags?.keep) {
         out(`（--keep）临时 DSH_HOME 保留于: ${isolatedHome}`);
@@ -473,10 +570,15 @@ async function settle() {
     outWarn(`清理异常（继续退出）: ${e.message}`);
   } finally {
     // --json：stdout 只出一份 JSON——错误路径已输出错误对象则不再重复，否则出
-    // 最终 verdict（ok/cleanup 终态与 verdict.json 文件一致）
+    // 最终 verdict（ok/cleanup 终态与 verdict.json 文件一致）。B4：审计结果
+    // 一律并入（错误路径的 error 对象同样带 audit 字段，stdout 仍单 JSON）
     if (jsonMode) {
-      if (errorPayload) jsonOut(errorPayload);
-      else jsonOut(makeVerdict({ ok: readyOk && (exiting?.code ?? EXIT.FAIL) === 0, cleanup: flags?.keep ? "kept" : "done" }));
+      if (errorPayload) {
+        if (auditResult) errorPayload.audit = auditResult;
+        jsonOut(errorPayload);
+      } else {
+        jsonOut(makeVerdict({ ok: readyOk && (exiting?.code ?? EXIT.FAIL) === 0, cleanup: flags?.keep ? "kept" : "done" }));
+      }
     }
     process.exit(exiting?.code ?? EXIT.FAIL);
   }
@@ -496,6 +598,25 @@ async function main() {
     process.exit(EXIT.OK);
   }
 
+  // 0a. B4 --audit-extra-dirs 参数校验（纯参数级 fail fast：存在性 + 基于 cwd
+  // 绝对化；与 DSH_HOME 重叠校验延后到 mkdtemp 之后）。未开 --audit 时忽略
+  // （警告提示，审计需 --audit 显式开启——extra dirs 单独无效）。
+  let extraDirsAbs = [];
+  if (f.audit) {
+    extraDirsAbs = f.auditExtraDirs.map((raw) => {
+      const abs = resolve(raw);
+      if (!existsSync(abs)) {
+        throw new CliError(
+          `错误: --audit-extra-dirs 目录不存在: ${raw}（相对路径基于 cwd 解析）`,
+          EXIT.USAGE,
+        );
+      }
+      return abs;
+    });
+  } else if (f.auditExtraDirs.length > 0) {
+    outWarn("警告: --audit-extra-dirs 未开启 --audit，忽略（审计需 --audit 显式开启）");
+  }
+
   // 0. dsh 入口校验与版本锚定展示（fail fast，不在建完环境后才失败）
   const rawDsh = f.dsh ?? "dsh";
   dshAbs = resolveDsh(rawDsh);
@@ -511,6 +632,15 @@ async function main() {
   browserState = join(isolatedHome, "browser.state");
   dshLogPath = join(isolatedHome, "dsh.log");
   verdictPath = join(isolatedHome, "verdict.json");
+  // B4：extra dir 不得与隔离 DSH_HOME 重叠（同树重复审计 + 判定基准歧义）
+  for (const dir of extraDirsAbs) {
+    if (isInsideDir(dir, isolatedHome) || isInsideDir(isolatedHome, dir)) {
+      throw new CliError(
+        `错误: --audit-extra-dirs 与隔离 DSH_HOME 重叠: ${dir}`,
+        EXIT.USAGE,
+      );
+    }
+  }
   // dsh.log 含隔离实例访问 token（dsh web URL 行）——与 verdict/browser.state
   // 一致 0o600 初始化（仅本用户可读，防同机其他用户窥探；P2-3）。
   try { writeFileSync(dshLogPath, "", { mode: 0o600 }); } catch {}
@@ -540,6 +670,20 @@ async function main() {
 
   // 4. 挂载本地插件（C11 归一化 + 构建 / --no-build 校验 + add）
   setupPlugins(pkgs);
+
+  // 4.5 B4：t0 基线快照（--audit）。位置口径：**挂载之后**（profiles/** 内
+  // link: symlink 进基线——t0 已存在且目标未变的外部 symlink 合法不报）、
+  // **脚本自身写面之前**（browser.state / verdict / evidence 内容 / audit
+  // 落盘尚未产生，先扫后写 + 白名单双保险）；dsh.log 空文件与 evidence 空
+  // 目录为脚本早期准备面，均在白名单内（*.log / evidence/**）。
+  if (f.audit) {
+    auditBaseline = [
+      { root: isolatedHome, snapshot: scanSnapshot(isolatedHome, { skipDeep: SKIP_DEEP }) },
+    ];
+    for (const dir of extraDirsAbs) {
+      auditBaseline.push({ root: dir, snapshot: scanSnapshot(dir, { skipDeep: SKIP_DEEP }) });
+    }
+  }
 
   // 5. 启动独立浏览器实例（--browser）：实例信息写入 browser.state。
   //    刻意不传 DSH_HOME：browser-driver 属宿主环境工具（探测系统 Chrome 内核、

--- a/packages/dsh-verify-isolated/test/smoke.ts
+++ b/packages/dsh-verify-isolated/test/smoke.ts
@@ -19,12 +19,19 @@
  * 7. SKILL.md 含多会话并行章节与三平台内核自查清单；
  * 8. README 同步新能力。
  *
+ * 9. B4 隔离审计（#517 B4）：lib/audit.mjs 纯函数行为断言（WHITELIST_V 版本化、
+ *    scanSnapshot/diffAgainstWhitelist/checkSymlinkEscape/runAudit）+ mkdtemp
+ *    fixture 正反例（越界 symlink / 白名单外新增/删除/修改 / 白名单内变化忽略 /
+ *    link: 挂载点合法 / t1 无变化通过 / browser-profile 跳过深扫）+ 脚本契约锚定
+ *    （--audit / --audit-extra-dirs / 结论行 / audit.json）+ 子进程退出码实测
+ *    （--audit --help=0、--audit-extra-dirs 不存在=2）。
+ *
  * 注（#517 C11 并入）：resolve-pkg-paths.mjs 独立文件随 C8 内建进
  * lib/verify-core.mjs 的 resolvePkgArg（6a 行为断言覆盖原 6.5 段语义）。
  */
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -274,4 +281,142 @@ assert.ok(readme.includes("四重隔离"), "README 同步四重隔离说明");
 assert.ok(readme.includes("verify-isolated.mjs"), "README 同步 node 版脚本名（升级路径）");
 assert.ok(!readme.includes("scripts/verify-isolated.sh"), "README 不再以旧 bash 脚本路径作为当前用法（升级路径说明除外）");
 
-console.log("PASS: dsh-verify-isolated smoke（skills 结构 / frontmatter / patch / 路径解析 / verify-core 行为 / 脚本契约与退出码 / 文档同步）");
+// ---- 9. B4 隔离审计：lib/audit.mjs 纯函数行为断言 + 脚本契约锚定 + 退出码实测 ----
+{
+  const auditFile = join(SCRIPTS_DIR, "lib", "audit.mjs");
+  assert.ok(existsSync(auditFile), "lib/audit.mjs 随 skill 目录分发");
+  const audit = await import(pathToFileURL(auditFile).href);
+
+  // 9a. 白名单版本化 + 模式全集存在（预置模式数组，版本化 WHITELIST_V）
+  assert.match(audit.WHITELIST_V, /^v\d+$/, `WHITELIST_V 版本化格式: ${audit.WHITELIST_V}`);
+  for (const p of [
+    "profiles/**", "*.json", "*.jsonl", "*.log", "browser.state",
+    "browser-profile/**", "evidence/**", "audit/**", "dsh.log", "verdict.json",
+  ]) {
+    assert.ok(audit.WHITELIST.includes(p), `预置白名单含 ${p}`);
+  }
+
+  // 9b. 脚本契约锚定（USAGE/parseCli/--help 同步义务 + 结论行文案 + 落盘契约）
+  const script = readFileSync(scriptFile, "utf8");
+  for (const opt of ["--audit", "--audit-extra-dirs"]) {
+    assert.ok(script.includes(opt), `脚本含 ${opt} 选项契约`);
+  }
+  assert.ok(script.includes("WHITELIST_V"), "脚本引用版本化白名单常量");
+  assert.ok(script.includes("审计:通过"), "审计结论行通过文案");
+  assert.ok(script.includes("项可疑"), "审计结论行可疑文案");
+  assert.ok(script.includes("audit.json"), "审计报告落盘契约（--keep 落 $ISOLATED_HOME/audit/audit.json）");
+
+  // 9c. 子进程退出码实测：--audit 不破坏退出码契约（0/2）；extra dir 不存在 → 2
+  const run = (args) => {
+    let code = 0;
+    let out = "";
+    try { out = execFileSync(process.execPath, [scriptFile, ...args], { encoding: "utf8" }); }
+    catch (e) { code = e.status ?? -1; out = (e.stdout ?? "") + (e.stderr ?? ""); }
+    return { code, out };
+  };
+  const h2 = run(["--audit", "--help"]);
+  assert.equal(h2.code, 0, "--audit --help 退出码 0");
+  assert.ok(h2.out.includes("--audit-extra-dirs"), "--help 含 --audit-extra-dirs 用法");
+  const badExtra = run(["--audit", "--audit-extra-dirs", join(tmpdir(), "dsh-verify-no-such-audit-dir-xyz")]);
+  assert.equal(badExtra.code, 2, "--audit-extra-dirs 目录不存在退出码 2（参数错误）");
+
+  // 9d. mkdtemp fixture 正反例（零污染纪律 #218：全部落在 mkdtemp 隔离目录）
+  const tmp = mkdtempSync(join(tmpdir(), "dsh-verify-audit-"));
+  const outside = mkdtempSync(join(tmpdir(), "dsh-verify-audit-out-"));
+  try {
+    const w = (p, s) => { mkdirSync(join(tmp, dirname(p)), { recursive: true }); writeFileSync(join(tmp, p), s); };
+    const wl = audit.WHITELIST;
+    // 正例1：白名单外新增 → 可疑（新增）
+    {
+      const t0 = audit.scanSnapshot(tmp);
+      w("mystery.bin", "x");
+      const t1 = audit.scanSnapshot(tmp);
+      const r = audit.runAudit({ t0, t1, isolatedRoot: tmp });
+      assert.equal(r.count, 1, `白名单外新增报 1 项（实际 ${r.count}）`);
+      assert.equal(r.suspicious[0].path, "mystery.bin", "可疑路径正确");
+      assert.equal(r.suspicious[0].type, "新增", "可疑类型为新增");
+      assert.equal(r.conclusion, "suspicious", "结论 suspicious");
+    }
+    // 正例2：越界 symlink——新增且 resolve 后在扫描根外（顶层 + 白名单内
+    // profiles/** 都报，防逃逸优先于白名单忽略）
+    {
+      const t0 = audit.scanSnapshot(tmp);
+      symlinkSync(join(outside, "evil"), join(tmp, "evil-link"), "dir");
+      mkdirSync(join(tmp, "profiles", "verify_x"), { recursive: true });
+      symlinkSync(join(outside, "evil2"), join(tmp, "profiles", "verify_x", "evil2"), "dir");
+      const t1 = audit.scanSnapshot(tmp);
+      const r = audit.runAudit({ t0, t1, isolatedRoot: tmp });
+      assert.ok(r.suspicious.some((s) => s.path === "evil-link" && s.type === "越界 symlink"),
+        "新增越界 symlink 报可疑");
+      assert.ok(r.suspicious.some((s) => s.path === "profiles/verify_x/evil2" && s.type === "越界 symlink"),
+        "白名单内新增越界 symlink 仍报（防逃逸优先）");
+      // 越界 symlink 不重复报「新增」（防逃逸通道优先，diff 剔除）
+      assert.ok(!r.suspicious.some((s) => s.path === "evil-link" && s.type === "新增"),
+        "越界 symlink 不重复报新增");
+    }
+    // 正例3：白名单外删除 → 可疑（删除）
+    {
+      w("doomed.bin", "x");
+      const t0 = audit.scanSnapshot(tmp);
+      rmSync(join(tmp, "doomed.bin"));
+      const t1 = audit.scanSnapshot(tmp);
+      const r = audit.runAudit({ t0, t1, isolatedRoot: tmp });
+      assert.ok(r.suspicious.some((s) => s.path === "doomed.bin" && s.type === "删除"),
+        "白名单外删除报可疑");
+    }
+    // 正例4：白名单外修改（size 变化）→ 可疑（修改）
+    {
+      w("mut.bin", "aa");
+      const t0 = audit.scanSnapshot(tmp);
+      w("mut.bin", "bbbb");
+      const t1 = audit.scanSnapshot(tmp);
+      const r = audit.runAudit({ t0, t1, isolatedRoot: tmp });
+      assert.ok(r.suspicious.some((s) => s.path === "mut.bin" && s.type === "修改"),
+        "白名单外修改报可疑");
+    }
+    // 反例1：白名单内变化忽略（*.json/*.log/browser.state/profiles/**/evidence/**/audit/**）
+    {
+      const t0 = audit.scanSnapshot(tmp);
+      w("settings.json", "{}");
+      w("browser.state", "{}");
+      w("dsh.log", "hello");
+      w("profiles/verify_x/p.json", "{}");
+      w("evidence/shot.png", "x");
+      w("audit/audit.json", "{}");
+      const t1 = audit.scanSnapshot(tmp);
+      const r = audit.runAudit({ t0, t1, isolatedRoot: tmp, whitelist: wl });
+      assert.equal(r.count, 0, `白名单内变化忽略（实际 ${r.count}）`);
+      assert.equal(r.conclusion, "pass", "结论 pass");
+    }
+    // 反例2：t0 已存在且目标未变的外部 symlink（link: 挂载点）不报
+    {
+      mkdirSync(join(tmp, "profiles", "verify_x", "node_modules"), { recursive: true });
+      symlinkSync(join(outside, "pkg"), join(tmp, "profiles", "verify_x", "node_modules", "pkg"), "dir");
+      const t0 = audit.scanSnapshot(tmp);
+      const t1 = audit.scanSnapshot(tmp);
+      const r = audit.runAudit({ t0, t1, isolatedRoot: tmp });
+      assert.ok(!r.suspicious.some((s) => s.path.includes("node_modules")),
+        "t0 已存在且目标未变的外部 symlink（link: 挂载点）不报");
+    }
+    // 反例3：t1 无变化 → 通过
+    {
+      const s0 = audit.scanSnapshot(tmp);
+      const s1 = audit.scanSnapshot(tmp);
+      const r = audit.runAudit({ t0: s0, t1: s1, isolatedRoot: tmp });
+      assert.equal(r.count, 0, "t1 无变化 0 可疑");
+      assert.equal(r.conclusion, "pass", "t1 无变化结论 pass");
+    }
+    // 9e. browser-profile/** 整树白名单 + 跳过深扫（数万文件，只记目录条目）
+    {
+      w("browser-profile/deep/file", "y");
+      const s = audit.scanSnapshot(tmp, { skipDeep: audit.SKIP_DEEP });
+      assert.ok(s.entries.has("browser-profile"), "browser-profile 目录条目在位");
+      assert.ok(!s.entries.has("browser-profile/deep/file"), "browser-profile/** 跳过深扫");
+    }
+  } finally {
+    rmSync(tmp, { recursive: true, force: true }); // 零污染纪律（#218）
+    rmSync(outside, { recursive: true, force: true });
+  }
+}
+
+console.log("PASS: dsh-verify-isolated smoke（skills 结构 / frontmatter / patch / 路径解析 / verify-core 行为 / 脚本契约与退出码 / B4 审计纯函数与 fixture 正反例 / 文档同步）");

--- a/packages/dsh-verify-isolated/test/smoke.ts
+++ b/packages/dsh-verify-isolated/test/smoke.ts
@@ -19,12 +19,15 @@
  * 7. SKILL.md 含多会话并行章节与三平台内核自查清单；
  * 8. README 同步新能力。
  *
- * 9. B4 隔离审计（#517 B4）：lib/audit.mjs 纯函数行为断言（WHITELIST_V 版本化、
- *    scanSnapshot/diffAgainstWhitelist/checkSymlinkEscape/runAudit）+ mkdtemp
- *    fixture 正反例（越界 symlink / 白名单外新增/删除/修改 / 白名单内变化忽略 /
- *    link: 挂载点合法 / t1 无变化通过 / browser-profile 跳过深扫）+ 脚本契约锚定
- *    （--audit / --audit-extra-dirs / 结论行 / audit.json）+ 子进程退出码实测
- *    （--audit --help=0、--audit-extra-dirs 不存在=2）。
+ * 9. B4 隔离审计（#517 B4，含 #540 复核修复）：lib/audit.mjs 纯函数行为断言
+ *    （WHITELIST_V 版本化、scanSnapshot/diffAgainstWhitelist/checkSymlinkEscape/
+ *    runAudit）+ mkdtemp fixture 正反例（越界 symlink / 白名单外新增/删除/修改 /
+ *    白名单内新增/删除/修改忽略 / link: 挂载点合法 / t1 无变化通过 / browser-profile
+ *    跳过深扫 / M1 ctimeMs 参与修改判定 / 9f dsh 启动写面进基线干净运行 pass）+
+ *    脚本契约锚定（--audit / --audit-extra-dirs / 结论行 / audit.json / t0 位于
+ *    就绪断言之后）+ 子进程退出码实测（--audit --help=0、--audit-extra-dirs 不存在
+ *    或传文件=2、M6 t0 前错误 JSON 恒带 audit:null）+ 9g 假 dsh 端到端回归
+ *    （启动写面建模：干净运行 exit0+pass / 运行期写面 suspicious count=1）。
  *
  * 注（#517 C11 并入）：resolve-pkg-paths.mjs 独立文件随 C8 内建进
  * lib/verify-core.mjs 的 resolvePkgArg（6a 行为断言覆盖原 6.5 段语义）。
@@ -287,11 +290,13 @@ assert.ok(!readme.includes("scripts/verify-isolated.sh"), "README 不再以旧 b
   assert.ok(existsSync(auditFile), "lib/audit.mjs 随 skill 目录分发");
   const audit = await import(pathToFileURL(auditFile).href);
 
-  // 9a. 白名单版本化 + 模式全集存在（预置模式数组，版本化 WHITELIST_V）
+  // 9a. 白名单版本化 + 模式全集存在（预置模式数组，版本化 WHITELIST_V；
+  // v2 起含 dsh 自身写面 .credentials.yaml / storages/**——S1 修复分工）
   assert.match(audit.WHITELIST_V, /^v\d+$/, `WHITELIST_V 版本化格式: ${audit.WHITELIST_V}`);
   for (const p of [
-    "profiles/**", "*.json", "*.jsonl", "*.log", "browser.state",
-    "browser-profile/**", "evidence/**", "audit/**", "dsh.log", "verdict.json",
+    "profiles/**", "*.json", "*.jsonl", "*.log", ".credentials.yaml",
+    "browser.state", "browser-profile/**", "evidence/**", "audit/**",
+    "storages/**", "dsh.log", "verdict.json",
   ]) {
     assert.ok(audit.WHITELIST.includes(p), `预置白名单含 ${p}`);
   }
@@ -305,8 +310,15 @@ assert.ok(!readme.includes("scripts/verify-isolated.sh"), "README 不再以旧 b
   assert.ok(script.includes("审计:通过"), "审计结论行通过文案");
   assert.ok(script.includes("项可疑"), "审计结论行可疑文案");
   assert.ok(script.includes("audit.json"), "审计报告落盘契约（--keep 落 $ISOLATED_HOME/audit/audit.json）");
+  // P0 S1 回归：t0 基线必须在**就绪断言通过之后**（dsh 启动写面与官方
+  // bundle link 进基线——语义「就绪后运行期写面审计」，源码位置锚定）
+  assert.ok(
+    script.indexOf("auditBaseline = [") > script.indexOf("就绪断言通过"),
+    "t0 基线快照位于就绪断言通过之后（S1 时序修复）",
+  );
 
-  // 9c. 子进程退出码实测：--audit 不破坏退出码契约（0/2）；extra dir 不存在 → 2
+  // 9c. 子进程退出码实测：--audit 不破坏退出码契约（0/2）；extra dir 不存在/
+  // 非目录 → 2；t0 前错误路径 --json 单 JSON 恒带 audit:null（M4/M6）
   const run = (args) => {
     let code = 0;
     let out = "";
@@ -319,6 +331,102 @@ assert.ok(!readme.includes("scripts/verify-isolated.sh"), "README 不再以旧 b
   assert.ok(h2.out.includes("--audit-extra-dirs"), "--help 含 --audit-extra-dirs 用法");
   const badExtra = run(["--audit", "--audit-extra-dirs", join(tmpdir(), "dsh-verify-no-such-audit-dir-xyz")]);
   assert.equal(badExtra.code, 2, "--audit-extra-dirs 目录不存在退出码 2（参数错误）");
+  // M4：--audit-extra-dirs 传文件 → 参数错误（exit 2，不得静默漏审）
+  const fileAsExtra = mkdtempSync(join(tmpdir(), "dsh-verify-extra-file-"));
+  const plainFile = join(fileAsExtra, "afile");
+  writeFileSync(plainFile, "x");
+  const badFile = run(["--audit", "--audit-extra-dirs", plainFile]);
+  assert.equal(badFile.code, 2, "--audit-extra-dirs 传文件退出码 2（必须是目录）");
+  assert.ok(badFile.out.includes("必须是目录"), "--audit-extra-dirs 非目录报可操作错误");
+  // M6：t0 前错误（extra-dir 不存在）--json 单 JSON 恒带 audit:null（与 verdict 对齐）
+  const m6 = run(["--json", "--audit", "--audit-extra-dirs", join(tmpdir(), "dsh-verify-no-such-audit-dir-m6")]);
+  assert.equal(m6.code, 2, "--json t0 前错误路径退出码 2");
+  const m6Lines = m6.out.trim().split("\n").filter((l) => l.trim().length > 0);
+  assert.equal(m6Lines.length, 1, "--json t0 前错误路径 stdout 只有 1 行 JSON");
+  const m6Parsed = JSON.parse(m6Lines[0]);
+  assert.ok(Object.prototype.hasOwnProperty.call(m6Parsed, "audit"), "error JSON 恒带 audit 字段");
+  assert.equal(m6Parsed.audit, null, "t0 前错误 audit=null（未进入审计）");
+
+  // 9g. --audit 端到端回归（P1-1，随 S1 修）：假 dsh 就绪前建模 dsh 启动写面
+  // （官方 bundle link 指向外部 + .credentials.yaml + storages/**），验证：
+  //   变体 A（干净运行）：exit 0 + 审计:通过 + verdict.audit pass + --keep 落盘
+  //   audit/audit.json（启动写面进 t0 基线 → 不误报，S1 修复核心回归）；
+  //   变体 B（运行期写面）：RUNTIME_WRITE → exit 0 + verdict.audit suspicious
+  //   count=1（mystery.bin）——「就绪后运行期写面审计」语义仍生效。
+  {
+    const tmp2 = mkdtempSync(join(tmpdir(), "dsh-verify-audit-e2e-"));
+    const fakeDsh = join(tmp2, "fake-dsh-audit.mjs");
+    writeFileSync(fakeDsh, `#!/usr/bin/env node
+import { mkdirSync, writeFileSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
+import http from "node:http";
+const args = process.argv.slice(2);
+if (args.includes("--version")) { console.log("fake-dsh 0.0.0"); process.exit(0); }
+if (args[0] === "plugin" && args.includes("list")) {
+  const i = args.indexOf("--profile");
+  const dir = join(process.env.DSH_HOME, "profiles", args[i + 1]);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "package.json"), JSON.stringify({ dsh: { profile: { bundles: ["@deepseek-ai/dsh-base"] } } }));
+  process.exit(0);
+}
+if (args[0] === "plugin" && args.includes("add")) { process.exit(0); }
+if (args.includes("--host")) {
+  const H = process.env.DSH_HOME;
+  const pi = args.indexOf("--profile");
+  const prof = args[pi + 1];
+  mkdirSync(join(H, "profiles", prof, "node_modules", "@deepseek-ai"), { recursive: true });
+  symlinkSync("/nonexistent/dsh-install/lib", join(H, "profiles", prof, "node_modules", "@deepseek-ai", "dsh-base"), "dir");
+  writeFileSync(join(H, ".credentials.yaml"), "token: fake\\n");
+  mkdirSync(join(H, "storages"), { recursive: true });
+  writeFileSync(join(H, "storages", "workspace.json"), "{}");
+  const port = Number(args[args.indexOf("--port") + 1]);
+  const srv = http.createServer((_req, res) => { res.writeHead(200); res.end("ok"); });
+  srv.on("error", () => process.exit(1));
+  srv.listen(port, "127.0.0.1", () => {
+    console.log("dsh web: http://127.0.0.1:" + port + "/");
+    if (process.env.RUNTIME_WRITE === "1") {
+      setTimeout(() => writeFileSync(join(H, "mystery.bin"), "runtime-write"), 2000);
+    }
+    setTimeout(() => { srv.close(); process.exit(0); }, 2500);
+  });
+  setTimeout(() => { srv.close(); process.exit(0); }, 3000);
+  await new Promise(() => {});
+}
+process.exit(1);
+`);
+    chmodSync(fakeDsh, 0o755);
+    const runAuditE2E = (extraEnv) => {
+      let code = 0;
+      let out = "";
+      try {
+        out = execFileSync(process.execPath, [scriptFile, "--audit", "--keep", "--dsh", fakeDsh, "--port", "0"], {
+          encoding: "utf8", env: { ...process.env, ...extraEnv }, timeout: 60000,
+        });
+      } catch (e) { code = e.status ?? -1; out = (e.stdout ?? "") + (e.stderr ?? ""); }
+      const home = /DSH_HOME=([^ ]+)/.exec(out)?.[1] ?? null;
+      return { code, out, home };
+    };
+    // 变体 A：干净运行
+    const a = runAuditE2E({});
+    assert.equal(a.code, 0, `变体A 干净运行 exit 0（实际 ${a.code}）`);
+    assert.ok(a.out.includes("审计:通过"), "变体A 输出审计:通过");
+    assert.ok(a.home && existsSync(join(a.home, "audit", "audit.json")), "变体A --keep 落盘 audit/audit.json");
+    const av = JSON.parse(readFileSync(join(a.home, "verdict.json"), "utf8"));
+    assert.equal(av.audit.conclusion, "pass", "变体A verdict.audit conclusion=pass");
+    assert.equal(av.audit.count, 0, "变体A verdict.audit count=0（启动写面进基线不误报）");
+    assert.equal(av.audit.whitelistV, audit.WHITELIST_V, "变体A verdict.audit.whitelistV 与模块一致");
+    // 变体 B：运行期写面
+    const b = runAuditE2E({ RUNTIME_WRITE: "1" });
+    assert.equal(b.code, 0, `变体B 运行期写面 exit 0（实际 ${b.code}）`);
+    const bv = JSON.parse(readFileSync(join(b.home, "verdict.json"), "utf8"));
+    assert.equal(bv.audit.conclusion, "suspicious", "变体B verdict.audit conclusion=suspicious");
+    assert.equal(bv.audit.count, 1, "变体B count=1");
+    assert.equal(bv.audit.suspicious[0].path, "mystery.bin", "变体B 可疑路径 mystery.bin");
+    // 零污染纪律（#218）：--keep 保留的隔离 home 由 smoke 显式清理
+    if (a.home) rmSync(a.home, { recursive: true, force: true });
+    if (b.home) rmSync(b.home, { recursive: true, force: true });
+    rmSync(tmp2, { recursive: true, force: true });
+  }
 
   // 9d. mkdtemp fixture 正反例（零污染纪律 #218：全部落在 mkdtemp 隔离目录）
   const tmp = mkdtempSync(join(tmpdir(), "dsh-verify-audit-"));
@@ -346,6 +454,7 @@ assert.ok(!readme.includes("scripts/verify-isolated.sh"), "README 不再以旧 b
       symlinkSync(join(outside, "evil2"), join(tmp, "profiles", "verify_x", "evil2"), "dir");
       const t1 = audit.scanSnapshot(tmp);
       const r = audit.runAudit({ t0, t1, isolatedRoot: tmp });
+      assert.equal(r.count, 2, `新增 2 条越界 symlink（实际 ${r.count}）`);
       assert.ok(r.suspicious.some((s) => s.path === "evil-link" && s.type === "越界 symlink"),
         "新增越界 symlink 报可疑");
       assert.ok(r.suspicious.some((s) => s.path === "profiles/verify_x/evil2" && s.type === "越界 symlink"),
@@ -361,6 +470,7 @@ assert.ok(!readme.includes("scripts/verify-isolated.sh"), "README 不再以旧 b
       rmSync(join(tmp, "doomed.bin"));
       const t1 = audit.scanSnapshot(tmp);
       const r = audit.runAudit({ t0, t1, isolatedRoot: tmp });
+      assert.equal(r.count, 1, `白名单外删除报 1 项（实际 ${r.count}）`);
       assert.ok(r.suspicious.some((s) => s.path === "doomed.bin" && s.type === "删除"),
         "白名单外删除报可疑");
     }
@@ -371,22 +481,49 @@ assert.ok(!readme.includes("scripts/verify-isolated.sh"), "README 不再以旧 b
       w("mut.bin", "bbbb");
       const t1 = audit.scanSnapshot(tmp);
       const r = audit.runAudit({ t0, t1, isolatedRoot: tmp });
+      assert.equal(r.count, 1, `白名单外修改报 1 项（实际 ${r.count}）`);
       assert.ok(r.suspicious.some((s) => s.path === "mut.bin" && s.type === "修改"),
         "白名单外修改报可疑");
     }
-    // 反例1：白名单内变化忽略（*.json/*.log/browser.state/profiles/**/evidence/**/audit/**）
+    // M1（复核 P1-2）：同 size 同 mtimeMs 快速重写经 ctimeMs 检出——直接构造
+    // Entry（不依赖文件系统时间精度，验证 ctimeMs 参与修改判定逻辑本身）
+    {
+      const mk = (ctimeMs) => ({
+        root: tmp,
+        entries: new Map([["rewrite.bin", { type: "file", size: 4, mtimeMs: 1000, ctimeMs }]]),
+      });
+      const r = audit.runAudit({ t0: mk(1000), t1: mk(1001), isolatedRoot: tmp });
+      assert.equal(r.count, 1, "同 size 同 mtimeMs、ctimeMs 不同 → 报 1 项修改");
+      assert.equal(r.suspicious[0].type, "修改", "ctimeMs 变化报「修改」");
+    }
+    // 反例1：白名单内变化忽略（*.json/*.log/.credentials.yaml/browser.state/
+    // profiles/**/evidence/**/audit/**/storages/**）
     {
       const t0 = audit.scanSnapshot(tmp);
       w("settings.json", "{}");
       w("browser.state", "{}");
       w("dsh.log", "hello");
+      w(".credentials.yaml", "token: x\n");
       w("profiles/verify_x/p.json", "{}");
       w("evidence/shot.png", "x");
       w("audit/audit.json", "{}");
+      w("storages/workspace.json", "{}");
       const t1 = audit.scanSnapshot(tmp);
       const r = audit.runAudit({ t0, t1, isolatedRoot: tmp, whitelist: wl });
       assert.equal(r.count, 0, `白名单内变化忽略（实际 ${r.count}）`);
       assert.equal(r.conclusion, "pass", "结论 pass");
+    }
+    // 反例1b（m4 补强）：白名单内删除/修改忽略
+    {
+      w("wl-del.json", "{}");
+      w("wl-mod.log", "old");
+      const t0 = audit.scanSnapshot(tmp);
+      rmSync(join(tmp, "wl-del.json")); // 白名单内删除（*.json）
+      w("wl-mod.log", "new content"); // 白名单内修改（*.log）
+      const t1 = audit.scanSnapshot(tmp);
+      const r = audit.runAudit({ t0, t1, isolatedRoot: tmp });
+      assert.equal(r.count, 0, `白名单内删除/修改忽略（实际 ${r.count}）`);
+      assert.equal(r.conclusion, "pass", "白名单内删除/修改结论 pass");
     }
     // 反例2：t0 已存在且目标未变的外部 symlink（link: 挂载点）不报
     {
@@ -412,6 +549,26 @@ assert.ok(!readme.includes("scripts/verify-isolated.sh"), "README 不再以旧 b
       const s = audit.scanSnapshot(tmp, { skipDeep: audit.SKIP_DEEP });
       assert.ok(s.entries.has("browser-profile"), "browser-profile 目录条目在位");
       assert.ok(!s.entries.has("browser-profile/deep/file"), "browser-profile/** 跳过深扫");
+    }
+    // 9f. dsh 启动写面回归（S1 修复，纯函数层）：t0 含官方 bundle link（指向
+    // 扫描根外、t0 已存在未变 → 合法挂载点）+ .credentials.yaml + storages/**，
+    // 干净运行 pass；运行期新增（白名单外）仍报——「就绪后运行期写面审计」语义
+    {
+      mkdirSync(join(tmp, "profiles", "verify_x", "node_modules", "@deepseek-ai"), { recursive: true });
+      symlinkSync(join(outside, "dsh-install-lib"), join(tmp, "profiles", "verify_x", "node_modules", "@deepseek-ai", "dsh-base"), "dir");
+      w(".credentials.yaml", "token: x\n");
+      w("storages/workspace.json", "{}");
+      const t0 = audit.scanSnapshot(tmp, { skipDeep: audit.SKIP_DEEP });
+      // 干净运行：t1 无变化 → pass（启动写面在基线内，483 条 bundle link 场景建模）
+      const r1 = audit.runAudit({ t0, t1: audit.scanSnapshot(tmp, { skipDeep: audit.SKIP_DEEP }), isolatedRoot: tmp });
+      assert.equal(r1.count, 0, `启动写面进 t0 基线，干净运行 pass（实际 ${r1.count}）`);
+      assert.equal(r1.conclusion, "pass", "干净运行结论 pass");
+      // 运行期新增（白名单外）→ 仍报
+      w("runtime-mystery.bin", "x");
+      const r2 = audit.runAudit({ t0, t1: audit.scanSnapshot(tmp, { skipDeep: audit.SKIP_DEEP }), isolatedRoot: tmp });
+      assert.equal(r2.count, 1, `运行期新增仍报 1 项（实际 ${r2.count}）`);
+      assert.equal(r2.suspicious[0].path, "runtime-mystery.bin", "运行期新增路径正确");
+      assert.equal(r2.suspicious[0].type, "新增", "运行期新增类型为新增");
     }
   } finally {
     rmSync(tmp, { recursive: true, force: true }); // 零污染纪律（#218）


### PR DESCRIPTION
## 摘要

#517 子项 **B4（隔离审计白名单版）**：给 `verify-isolated.mjs`（#538 node 化地基）加可选隔离审计 `--audit` —— 对比隔离 `$ISOLATED_HOME` 写面与预置白名单，白名单外变化报「可疑」，**不阻断退出**（审计是补充非门禁）。

- 审计核心抽纯函数 `scripts/lib/audit.mjs`：`scanSnapshot` / `diffAgainstWhitelist` / `checkSymlinkEscape` / `runAudit` + 版本化白名单 `WHITELIST_V`（v1，模式数组随 skill 分发，smoke 断言存在）；
- symlink **防逃逸**（不排除）：快照 lstat 不跟随、只记录 linkTarget 不读内容；`t1` 时**新增的**或**目标变化**且 resolve 后在扫描根外的 symlink 报「越界 symlink」；`t0` 已存在且目标未变的外部 symlink（`link:` 挂载点，profile node_modules 全 link: 是挂载机制本身）合法不报；防逃逸优先于白名单——`profiles/**` 内新增越界 symlink 同样报；
- 时序：`t0` 基线在挂载（link: symlink 进基线）之后、脚本自身写面（browser.state/verdict/evidence 内容/audit 落盘）之前（先扫后写 + 白名单双保险）；审计插在 settle「kill dsh → browser quit → **审计** → verdict 终态 → rm」；`--keep` 落 `$ISOLATED_HOME/audit/audit.json`，否则并入 verdict JSON（`audit` 字段，`--json` stdout 终态与错误路径均并入）；
- 局限（文档写明）：只扫 `$ISOLATED_HOME` 子树 + `--audit-extra-dirs <dir>`（可重复，相对路径基于 cwd 绝对化，与 DSH_HOME 重叠报参数错误）指定目录，**不扫真实 home**；
- 文档四件套同步（SKILL.md / README.md / README.en.md / docs/architecture）。

## 全量断言表

| 验收条目 | 结论 | 证据或漂移解释 |
|---|---|---|
| [硬性] 1. 审计范围硬绑定 `$ISOLATED_HOME` 子树，不扫真实 home；可选 `--audit-extra-dirs <dir>`（文档写局限） | PASS | `main()` t0 与 `settle()` t1 只对 isolatedHome + extraDirsAbs 扫描（verify-isolated.mjs 4.5/0a 节）；extra dir 存在性/重叠校验 → exit 2；SKILL.md §2 / README 中英 / 架构文档 §2.1 均写「不扫真实 home」 |
| [硬性] 2. symlink 防逃逸：快照 lstat（不跟随）；t1 **新增的**或**目标变化**且 resolve 后在 `$ISOLATED_HOME` 外 → 报「可疑：越界 symlink」；t0 已存在且目标未变的外部 symlink（link: 挂载点）不报；实现注释说明口径 | PASS | audit.mjs 头部「## 口径」注释 + `runAudit` 组合层（escapePaths 剔除 t0 同目标 link: 挂载点）；smoke 9d 正例 2（顶层 + `profiles/**` 内新增越界均报、不重复报新增）+ 反例 2（link: 挂载点不报） |
| [硬性] 3. 白名单：预置模式数组 + 版本化 `WHITELIST_V`（smoke 断言存在）；`profiles/**`、`*.json/*.jsonl/*.log`、`browser.state`、`browser-profile/**`（整树白名单 + 跳过深扫）、`evidence/**`、`audit/**`、`dsh.log`、`verdict.json`；未知顶层路径 → 可疑；判定面 = 白名单外新增/删除/修改（纯 stat 路径级不读内容）；白名单内变化忽略；首跑学习仅交叉校验不当判定源 | PASS | audit.mjs `WHITELIST_V="v1"` + `WHITELIST` 模式全集；smoke 9a 断言全部模式存在；9d 正例 1/3/4（新增/删除/修改）+ 反例 1（白名单内忽略）+ 9e（browser-profile 跳过深扫）；scanSnapshot 全程 lstat 不读内容；无学习判定源（判定面只有预置白名单） |
| [硬性] 4. 时序：t0 快照在写 browser.state/verdict/evidence/dsh.log **之前**（先扫后写）；审计 diff 插在 settle「kill dsh → browser quit → **审计** → verdict 终态 → rm」；`--keep` 落 `$ISOLATED_HOME/audit/audit.json`，否则并入 verdict JSON（audit 字段） | PASS | verify-isolated.mjs 4.5 节（t0 在 setupPlugins 后、browser launch 前）+ settle 第 3 步审计 → 第 4 步 verdict → 第 5 步 rm；`--keep` 落盘 audit.json（假 dsh 端到端实测 PASS）；verdict audit 字段（makeVerdict） |
| [硬性] 5. 可测试性：审计核心抽纯函数 `scanSnapshot(root)` / `diffAgainstWhitelist(snapshot, whitelist)` / `checkSymlinkEscape(snapshot, isolatedRoot)`；smoke 用 mkdtemp fixture 跑正反例（越界 symlink / 白名单外新增 / 白名单内变化忽略 / t1 无变化 → 通过） | PASS | audit.mjs 导出全部纯函数；smoke 9d fixture 正反例 + 9e（越界 symlink、白名单外新增/删除/修改、白名单内忽略、link: 挂载点、t1 无变化 pass、深扫跳过）；`pnpm --filter dsh-verify-isolated test` 退出码 0 |
| [硬性] 6. 输出：可疑项列表（路径 + 类型）+ 结论行（`审计: 通过` / `审计: N 项可疑`）；**不阻断退出**；`--json` 时并入 verdict JSON | PASS | settle 审计输出（结论行 + 逐项 `可疑: <path>（<类型>[: detail]）`）；smoke 9b 文案锚定；假 dsh 端到端实测：exit 0（正常路径审计照跑）+ exit 1（就绪前退出路径审计照跑、`--json` error 对象含 audit 字段） |
| [硬性] 7. CLI：新增 `--audit`、`--audit-extra-dirs`（USAGE/parseCli/--help 同步）；退出码契约不变（0/1/2/130/143） | PASS | USAGE/parseCli/`--help` 同步（`--audit --help` 实测退出码 0）；smoke 9c：`--audit --help`=0、`--audit-extra-dirs` 不存在=2；既有退出码断言（0/1/2/单 JSON）无回归 |
| [硬性] 8. 阶段式门禁 + 阶段 commit | PASS | 4 commits：8d95764（纯函数层）→ aadfdbb（集成）→ cbb452b（smoke）→ 6235d4dec（文档）；每阶段五连门禁全绿 |
| [硬性] 9. 五连门禁 + `pnpm docs:check` + `pnpm test:scripts` 全绿 | PASS | 五连 `pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 退出码 0；docs:check 文档一致性通过（含 --strict-en）；test:scripts 144 pass |

## 门禁

本地全量：五连全绿（退出码 0）+ `pnpm docs:check`（--strict-en）通过 + `pnpm test:scripts` 144 pass。

## 关闭语义

Partially addresses #517（本 PR 只落实 B4 子项；B5/C8/C9/C10 等其余子项另行跟踪）。
