### PR TITLE
fix(dsh-codegraph): codegraph_status 位置参数形态，修复 --path unknown option（#465）

### DIFF
--- a/packages/dsh-codegraph/src/tool-definition.ts
+++ b/packages/dsh-codegraph/src/tool-definition.ts
@@ -99,11 +99,17 @@ export function buildExploreToolDefinition(): ToolDefinition {
  * @param description 工具描述（含「何时用此工具 / 何时用另一工具」互引，#363 验收 11）
  * @param params 参数 schema（与 CLI 实测对齐）
  * @param required 必填参数名
- * @param buildArgs 由工具参数构建 CLI 子命令参数（不含 -p/--path，guardedCodegraph 追加）
+ * @param buildArgs 由工具参数构建 CLI 子命令参数；projectPath 由 execute 追加——
+ *   flag 模式追加 `--path <p>`，positional 模式（status）追加位置参数 `<p>`
  * @param opts.toolLabel 提示语中的工具显示名（默认取 name）
  * @param opts.symbolParam 需要同名软消歧的符号参数名（#363）：execute 内先
  *   `codegraph query <symbol>` 列候选，跨文件同名 ≥2 → 返回「传完整限定名」提示
  *   （CLI 对同名符号合并输出不报错，不消歧模型会拿到无提示的混合结果）
+ * @param opts.pathStyle projectPath 追加形态：`"flag"`（默认）追加 `--path <p>`；
+ *   `"positional"` 追加位置参数 `<p>`（供 `codegraph status`——CLI 1.6.0 实测
+ *   status 只接受位置参数 [path]，传 `--path` 报 unknown option #465）。positional
+ *   模式下 projectPath 从 `args.path` 读取（显式传入即目标路径，否则缺省补全），
+ *   且 buildArgs 不得自行追加位置参数（避免双位置参数 → too many arguments）
  */
 function buildCliTool(
   name: string,
@@ -111,7 +117,7 @@ function buildCliTool(
   params: ToolDefinition["parameters"],
   required: string[],
   buildArgs: (args: Record<string, unknown>) => string[],
-  opts: { toolLabel?: string; symbolParam?: string } = {},
+  opts: { toolLabel?: string; symbolParam?: string; pathStyle?: "flag" | "positional" } = {},
 ): ToolDefinition {
   const label = opts.toolLabel ?? name;
   return {
@@ -130,7 +136,10 @@ function buildCliTool(
       exec: { agent?: { session?: { header?: { cwd?: string } } } },
     ) => {
       const cwd = sessionCwd(exec);
-      const projectPath = typeof args.projectPath === "string" ? args.projectPath : undefined;
+      // positional 模式（status）：projectPath 语义由 `path` 参数承担（CLI 位置
+      // 参数）；其余工具沿用 `projectPath` 参数。
+      const projectPathKey = opts.pathStyle === "positional" ? "path" : "projectPath";
+      const projectPath = typeof args[projectPathKey] === "string" ? args[projectPathKey] : undefined;
       // 同名歧义软消歧（#363）：符号参数有值 → 先 query 列候选。
       if (opts.symbolParam !== undefined) {
         const symbol = args[opts.symbolParam];
@@ -155,7 +164,13 @@ function buildCliTool(
       const text = await guardedCodegraph(
         { projectPath },
         cwd,
-        async (p) => runCodegraph([...buildArgs(args), "--path", p]),
+        async (p) => {
+          const cmd = buildArgs(args);
+          // #465：status 只接受位置参数 [path]；其余子命令用 --path。
+          if (opts.pathStyle === "positional") cmd.push(p);
+          else cmd.push("--path", p);
+          return runCodegraph(cmd);
+        },
         label,
       );
       return { text };
@@ -347,10 +362,9 @@ export function buildStatusToolDefinition(): ToolDefinition {
       path: { type: "string", description: "目标 worktree 路径（缺省补全为当前会话 worktree；位置参数）" },
     },
     [],
-    (args) => {
-      const cmd = ["status"];
-      if (typeof args.path === "string" && args.path !== "") cmd.push(args.path);
-      return cmd;
-    },
+    // 位置参数由 execute 按 pathStyle: "positional" 统一追加（#465：buildArgs 不再
+    // 自行 push path，避免与追加的 projectPath 构成双位置参数 → too many arguments）。
+    () => ["status"],
+    { pathStyle: "positional" },
   );
 }

--- a/packages/dsh-codegraph/test/smoke.ts
+++ b/packages/dsh-codegraph/test/smoke.ts
@@ -643,6 +643,17 @@ check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpMa
             { agent: { session: { header: { cwd: repo } } } },
           );
           assert.ok(uniqText.includes("Impact of changing"), `唯一符号实际: ${uniqText.slice(0, 80)}`);
+
+          // #465：codegraph_status 经封装 execute 不抛 unknown option（CLI status
+          // 只接受位置参数 [path]）——不传 path（缺省补全）与显式 path 两种形态。
+          const defStatus = buildStatusToolDefinition();
+          const { text: stText } = await defStatus.execute({}, { agent: { session: { header: { cwd: repo } } } });
+          assert.ok(stText.includes("CodeGraph Status"), `status 实际: ${stText.slice(0, 80)}`);
+          const { text: stText2 } = await defStatus.execute(
+            { path: repo },
+            { agent: { session: { header: { cwd: repo } } } },
+          );
+          assert.ok(stText2.includes("CodeGraph Status"), `status 显式 path 实际: ${stText2.slice(0, 80)}`);
         });
       } finally {
         rmSync(dir, { recursive: true, force: true });
@@ -762,6 +773,50 @@ check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpMa
       assert.ok(text.includes("执行失败"), `实际: ${text.slice(0, 60)}`);
       assert.ok(!text.includes("查询无结果"), "命令失败不应误判为空结果");
     });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // #465：codegraph_status 的命令形态修复——CLI 1.6.0 只接受位置参数 [path]，
+  // execute 不得追加 --path（unknown option），也不得产生双位置参数
+  // （too many arguments）。fake CLI 记录全部 argv 验证命令形态。
+  registerAsync("封装 execute: codegraph_status 位置参数形态（无 --path、无双位置参数）", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cg-status-"));
+    const repoA = join(dir, "repoA");
+    const repoB = join(dir, "repoB");
+    for (const repo of [repoA, repoB]) {
+      mkdirSync(join(repo, ".git"), { recursive: true });
+      mkdirSync(join(repo, ".codegraph"), { recursive: true });
+    }
+    // fake codegraph：sync 与查询都把 argv 追加到 argv.log；查询输出固定 ok
+    writeFileSync(
+      join(dir, "codegraph"),
+      [
+        "#!/bin/sh",
+        `echo "$@" >> ${dir}/argv.log`,
+        `if [ "$1" = sync ]; then exit 0; fi`,
+        "echo ok",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    const def = buildStatusToolDefinition();
+    resetSyncCache();
+    await withGlobalPath(`${dir}:${process.env.PATH ?? ""}`, async () => {
+      // 不传 path → projectPath 缺省补全为会话 cwd 的 git 根
+      const { text: t1 } = await def.execute({}, { agent: { session: { header: { cwd: repoA } } } });
+      assert.equal(t1.trim(), "ok", "status 查询正常返回");
+      // 显式 path → projectPath 取该路径（sync 目标跟随），单一位置参数
+      const { text: t2 } = await def.execute({ path: repoB }, { agent: { session: { header: { cwd: repoA } } } });
+      assert.equal(t2.trim(), "ok", "status 显式 path 正常返回");
+    });
+    const lines = String(readFileSync(join(dir, "argv.log"))).trim().split("\n").filter(Boolean);
+    assert.deepEqual(
+      lines,
+      [`sync ${repoA}`, `status ${repoA}`, `sync ${repoB}`, `status ${repoB}`],
+      "命令形态：status 单一位置参数、无 --path、sync 目标跟随显式 path",
+    );
+    for (const l of lines) {
+      assert.ok(!l.includes("--path"), `不应出现 --path：${l}`);
+    }
     rmSync(dir, { recursive: true, force: true });
   });
 }


### PR DESCRIPTION
## 概述

修复 `codegraph_status` 工具调用失败：`error: unknown option '--path'`（CLI 1.6.0 实测 `codegraph status [path]` 只接受**位置参数**，不接受 `--path`）。

Closes #465

## 根因

`buildCliTool` 通用 execute 无条件追加 `--path <projectPath>`，而 `buildStatusToolDefinition` 的 buildArgs 已按位置参数构造 `["status", path]`，被 execute 层追加破坏 → 最终命令 `codegraph status [path] --path <p>` → CLI 报 unknown option。

## 修复（采纳 issue 方案 A）

`buildCliTool` 增加 `opts.pathStyle: "flag" | "positional"`（默认 `"flag"`，其余 7 个工具形态不变）：

- **positional 模式**（`codegraph_status` 启用）：
  - projectPath 语义由 `args.path` 承担（显式传入即目标路径，否则缺省补全为当前会话 worktree）——顺带修正原实现「显式传 path 时 sync 目标错位为 cwd 补全路径」的潜在问题；
  - CLI 参数按**位置参数**追加 `<p>`，不追加 `--path`；
  - buildArgs 不再自行 push path（避免双位置参数 → CLI 实测 `too many arguments`）。

## 验证

| # | 验收条目 | 断言位置 | 结果 |
|---|---|---|---|
| 1 | `codegraph_status` 经封装 execute 不抛 `unknown option`（不传 path，缺省补全） | smoke：fake CLI argv 形态 + 真实 CLI 分支 | ✅ 通过 |
| 2 | 显式传 path 正常：单一位置参数，无 `--path`、无双位置参数 | smoke：`封装 execute: codegraph_status 位置参数形态（无 --path、无双位置参数）` | ✅ 通过 |
| 3 | 其余 7 个工具 `--path` 追加形态不变 | smoke 既有断言全量（含真实 CLI 6 子命令） | ✅ 通过 |
| 4 | 真实 codegraph CLI 1.6.0 上 status execute 两种形态均返回状态输出 | smoke：真实 CLI 分支新增 status 断言 | ✅ 通过（本机 1.6.0 实测） |

五连门禁：`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 全绿（worktree 内实测）。

## 改动文件

- `packages/dsh-codegraph/src/tool-definition.ts`：`buildCliTool` 增加 `pathStyle` 选项；`buildStatusToolDefinition` 改传 `pathStyle: "positional"` 且 buildArgs 精简
- `packages/dsh-codegraph/test/smoke.ts`：新增 fake CLI argv 形态断言 + 真实 CLI status 断言
