### PR TITLE
feat(gate): B5 homedir 门禁——forbid-homedir-src.mjs AST 扫描 src 禁直连 HOME 来源 API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,5 +624,8 @@ jobs:
       - name: Forbid legacy src tests（#423：变异测试单份维护，*.src.test.ts 全仓禁现）
         run: node scripts/gate/forbid-src-tests.mjs
 
+      - name: Forbid homedir in src（#517 B5：src 禁直连 HOME 来源 API，AST 扫描 fail-closed）
+        run: node scripts/gate/forbid-homedir-src.mjs
+
       - name: Docs check（README/链接/占位符）
         run: pnpm docs:check

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -213,8 +213,9 @@ SessionHeader.origin / Agent.session），并同步根 README「版本适配」�
   以证明写面）。
 - **门禁（已落地）**：`scripts/gate/forbid-homedir-src.mjs`（B5，#517）以 AST 扫描
   禁止插件 src 直连 HOME 来源 API（`os.homedir` / `os.userInfo` / `process.env.HOME` /
-  `untildify`，含 import 别名与 `os["homedir"]` 中括号混淆形态；`.ts/.mts/.mjs` 全覆盖，
-  解析失败一律 fail-closed 判红）。合法例外须**双源豁免**：调用点紧邻注释
+  `untildify`，含 import 别名、`os["homedir"]` 中括号混淆形态与动态 import
+  命名空间形态；`.ts/.mts/.mjs` 全覆盖，解析失败一律 fail-closed 判红）。合法例外
+  须**双源豁免**：调用点紧邻真实注释（`//` 后在字符串字面量之外）
   `// dsh-gate:allow-homedir <理由含 #NNN>` + 脚本内 WHITELIST 文件级清单，缺一判红。
   本地运行 `pnpm gate:homedir`；CI 在 repo-gate 段执行。解析器说明：typescript 7 已移除
   经典 JS AST API，扫描链为 esbuild 剥类型 + acorn estree 解析 + node:module

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -211,8 +211,14 @@ SessionHeader.origin / Agent.session），并同步根 README「版本适配」�
   （无 `DSH_HOME`）路径逐字节不变 + 设 `DSH_HOME` 后路径随隔离 home（finally
   恢复 env，防污染同进程其他用例）；写面用 e2e 落盘断言锁定（读函数返回值不足
   以证明写面）。
-- **门禁演进**：B5（#517）计划在门禁加静态扫描（禁 `packages/*/src` 直连
-  `os.homedir`，带豁免机制）之前，依赖本条自觉遵守。
+- **门禁（已落地）**：`scripts/gate/forbid-homedir-src.mjs`（B5，#517）以 AST 扫描
+  禁止插件 src 直连 HOME 来源 API（`os.homedir` / `os.userInfo` / `process.env.HOME` /
+  `untildify`，含 import 别名与 `os["homedir"]` 中括号混淆形态；`.ts/.mts/.mjs` 全覆盖，
+  解析失败一律 fail-closed 判红）。合法例外须**双源豁免**：调用点紧邻注释
+  `// dsh-gate:allow-homedir <理由含 #NNN>` + 脚本内 WHITELIST 文件级清单，缺一判红。
+  本地运行 `pnpm gate:homedir`；CI 在 repo-gate 段执行。解析器说明：typescript 7 已移除
+  经典 JS AST API，扫描链为 esbuild 剥类型 + acorn estree 解析 + node:module
+  SourceMap 行映射回 TS 原文（豁免注释匹配原文，transform 会剥离注释）。
 
 ### 事件订阅与 scope 语义（cordis dispatch 过滤）
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "aggregate:check": "node scripts/gate/aggregate.ts --check",
     "test:scripts": "node --test scripts/test/*.test.ts",
     "test:src-tests": "node scripts/gate/forbid-src-tests.mjs",
+    "gate:homedir": "node scripts/gate/forbid-homedir-src.mjs",
     "docs:check": "node scripts/gate/verify-docs.ts --strict-en",
     "typecheck": "pnpm -r --if-present run typecheck",
     "cov": "c8 --reporter=json --reporter=json-summary --reporter=text pnpm -r --if-present test",

--- a/packages/dsh-provider-usage/src/apply.ts
+++ b/packages/dsh-provider-usage/src/apply.ts
@@ -85,6 +85,7 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
   if (rawConfig.enabled === false) return; // 显式禁用：不注册任何路由
   const config = normalizeConfig(rawConfig);
   const sanitizeDiagnostic = (s: string): string =>
+    // dsh-gate:allow-homedir #517 展示层脱敏：把诊断文本中的 home 前缀折叠为 ~，不产生读写面
     s.split(dshHome()).join("~/.dsh").split(homedir()).join("~");
   const registry = makeAdapterRegistry({
     sanitizePath: sanitizeDiagnostic,

--- a/packages/dsh-provider-usage/src/path-resolve.ts
+++ b/packages/dsh-provider-usage/src/path-resolve.ts
@@ -32,6 +32,7 @@ export function pluginHome(base = dshHomeBase()): string {
  * 保证「UI 承诺支持 ~ 路径」与校验行为一致）。
  */
 export function expandHomePath(p: string): string {
+  // dsh-gate:allow-homedir #87 用户路径 ~ 前缀展开（untildify 业界标准实现，目标由用户指定）
   return untildify(p);
 }
 

--- a/packages/dsh-provider-usage/src/provider-config.ts
+++ b/packages/dsh-provider-usage/src/provider-config.ts
@@ -74,6 +74,7 @@ export function credentialsFile(dshHome?: string): string {
 
 /** auth.json 文件路径。 */
 export function opencodeAuthFile(): string {
+  // dsh-gate:allow-homedir #525 opencode 外部凭据：DSH_HOME 域之外的第三方工具自身写面
   return join(homedir(), ".local", "share", "opencode", "auth.json");
 }
 

--- a/packages/dsh-web-file-preview/src/git.ts
+++ b/packages/dsh-web-file-preview/src/git.ts
@@ -79,6 +79,7 @@ async function runGit(args: string[], timeoutMs = 8000, opts: { numericExitIsErr
  * @returns diff 探测结果（async，不阻塞事件循环）。
  */
 export async function computeGitDiff(cwd: string, path: string): Promise<GitDiffResult> {
+  // dsh-gate:allow-homedir #87 用户路径 ~ 前缀展开（untildify 业界标准实现，目标由用户指定）
   const resolved = resolve(cwd, untildify(path));
   const dir = dirname(resolved);
 

--- a/packages/dsh-web-file-preview/src/routes.ts
+++ b/packages/dsh-web-file-preview/src/routes.ts
@@ -128,6 +128,7 @@ export async function resolveFile(
   path: string,
 ): Promise<ResolveFileOutcome | null> {
   if (path === undefined || path === "") return null;
+  // dsh-gate:allow-homedir #87 用户路径 ~ 前缀展开（untildify 业界标准实现，目标由用户指定）
   const expandedPath = untildify(path);
   // ① 绝对 / ② 相对：统一 resolve 一次（绝对路径的 cwd 参数本就不参与 resolve）。
   let resolved: string | null = null;
@@ -195,6 +196,7 @@ export async function serveFileRoute(
   }
   // cwd 仅在 path 为相对路径时必需（评审 C5）：绝对路径无需 cwd 即可定位；
   // 相对路径缺 cwd 直接 400，避免误导性提示。
+  // dsh-gate:allow-homedir #87 用户路径 ~ 前缀展开（untildify 业界标准实现，目标由用户指定）
   if (!isAbsolute(untildify(path)) && (cwd === undefined || cwd === "")) {
     writeJson(res, 400, { error: "missing cwd (relative path requires cwd)" });
     return;
@@ -338,6 +340,7 @@ async function resolveAllocTarget(cwd: string | undefined, path: string): Promis
   if (path === undefined || path === "") {
     return { ok: false, status: 400, error: "missing path" };
   }
+  // dsh-gate:allow-homedir #87 用户路径 ~ 前缀展开（untildify 业界标准实现，目标由用户指定）
   if (!isAbsolute(untildify(path)) && (cwd === undefined || cwd === "")) {
     return { ok: false, status: 400, error: "missing cwd (relative path requires cwd)" };
   }

--- a/scripts/gate/forbid-homedir-src.mjs
+++ b/scripts/gate/forbid-homedir-src.mjs
@@ -13,9 +13,15 @@
  *   - `os.homedir` / `os["homedir"]`（命名空间 import，含中括号混淆形态与值引用）；
  *   - `os.userInfo()`（homedir 的别名通道：`.homedir` 字段同为 HOME 来源）；
  *   - `process.env.HOME` / `process.env["HOME"]`；
- *   - `untildify(...)`（default import，含别名）。
- * 已知局限（不为此增加复杂度，本仓无此形态）：`const { HOME } = process.env`
- * 解构形态、`const f = untildify` 值传递别名。新增豁免机制兜底。
+ *   - `untildify(...)`（default import，含别名）；
+ *   - 动态 import 命名空间形态：`const os = await import("node:os")` → `os.homedir()`
+ *     （F3，含 `(await import("node:os")).homedir()` 直接形态）。
+ * 已知局限（不为此增加复杂度，本仓无此形态；新增豁免机制兜底）：named 解构
+ * `const { homedir } = await import("node:os")`、`const { HOME } = process.env`
+ * 解构形态、`const f = untildify` 值传递别名。
+ * 遮蔽免疫依赖 esbuild transform 对遮蔽绑定的自动重命名（同名 import 的参数/
+ * 局部 const 会被改为 homedir2/os2 等，名称级检测不误报）——由自测中
+ * 遮蔽回归用例锁定，若 esbuild 升级改变此行为，自测会先行暴露（F4）。
  *
  * 豁免双源（缺一判红，三态输出）：
  *   1. 调用点紧邻注释：命中行行尾或上一行 `// dsh-gate:allow-homedir <理由含 #NNN>`；
@@ -53,7 +59,37 @@ const WHITELIST = new Map([
 ]);
 
 const EXEMPT_MARK = "dsh-gate:allow-homedir";
-const EXEMPT_RE = new RegExp(`//\\s*${EXEMPT_MARK}\\s+([^\\n]*#\\d+[^\\n]*)`);
+const EXEMPT_RE = new RegExp(`\\s*${EXEMPT_MARK}\\s+([^\\n]*#\\d+[^\\n]*)`);
+
+/**
+ * 提取行内的「真实」行注释文本——跳过字符串字面量中的 `//`（F1：纯文本正则
+ * 会把 `const msg = "// dsh-gate:allow-homedir #999 伪造"` 误判为豁免标记，
+ * 使白名单文件内“逐调用点”粒度失效）。轻量词法：跟踪单/双引号与反引号
+ * （含转义；模板字符串内不做嵌套插值解析，本仓豁免注释行不依赖该场景）。
+ * 行内无字符串外的 `//` 注释 → 返回 null。
+ */
+function lineCommentText(line) {
+  let i = 0;
+  const n = line.length;
+  while (i < n) {
+    const ch = line[i];
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const q = ch;
+      i++;
+      while (i < n) {
+        if (line[i] === "\\") { i += 2; continue; }
+        if (line[i] === q) { i++; break; }
+        i++;
+      }
+      continue;
+    }
+    if (ch === "/" && line[i + 1] === "/") {
+      return line.slice(i + 2);
+    }
+    i++;
+  }
+  return null;
+}
 
 /** 递归收集各包 src 目录下全部 .ts/.mts/.mjs（含未跟踪；跳过 d.mts 与 test 文件）。 */
 function collectSrcFiles(root) {
@@ -68,7 +104,7 @@ function collectSrcFiles(root) {
     for (const e of entries) {
       const p = join(dir, e.name);
       if (e.isDirectory()) walk(p);
-      else if (e.isFile() && /\.(ts|mts|mjs)$/.test(e.name) && !/\.d\.mts$/.test(e.name) && !/\.test\./.test(e.name)) {
+      else if (e.isFile() && /\.(ts|mts|mjs)$/.test(e.name) && !/\.d\.(ts|mts)$/.test(e.name) && !/\.test\./.test(e.name)) {
         hits.push(p);
       }
     }
@@ -133,14 +169,30 @@ function staticProp(member) {
  */
 function detectInAst(ast) {
   const { homedirNamed, userInfoNamed, untildifyNamed, osNamespaces } = collectImports(ast);
+  const dynOsNamespaces = new Set(); // F3：const os = await import("node:os") 动态绑定
   const hits = [];
   const push = (node, api) => hits.push({ generatedLine: node.loc.start.line - 1, generatedColumn: node.loc.start.column, api, text: "" });
+  /** 提取动态 import 的模块源（import("x") / await import("x")），非动态形态返回 null。 */
+  const dynSource = (node) => {
+    let inner = node;
+    if (inner?.type === "AwaitExpression") inner = inner.argument;
+    if (inner?.type === "ImportExpression") return inner.source?.value ?? null;
+    if (inner?.type === "CallExpression" && inner.callee?.type === "Import") return inner.arguments[0]?.value ?? null;
+    return null;
+  };
   (function walk(node) {
     if (!node || typeof node.type !== "string") return;
+    if (node.type === "VariableDeclarator" && node.id.type === "Identifier" && node.init) {
+      const src = dynSource(node.init);
+      if (src === "node:os" || src === "os") dynOsNamespaces.add(node.id.name);
+    }
     if (node.type === "MemberExpression") {
       const prop = staticProp(node);
+      // 动态 import 直接形态：os.homedir()（F3）
+      const dynSrc = dynSource(node.object);
+      if (dynSrc !== null && (prop === "homedir" || prop === "userInfo")) push(node, `os.${prop}`);
       // os.homedir / os["homedir"] / os.userInfo / os["userInfo"]（值引用与调用同罪）
-      if (node.object.type === "Identifier" && osNamespaces.has(node.object.name) && (prop === "homedir" || prop === "userInfo")) {
+      if (node.object.type === "Identifier" && (osNamespaces.has(node.object.name) || dynOsNamespaces.has(node.object.name)) && (prop === "homedir" || prop === "userInfo")) {
         push(node, `os.${prop}`);
       }
       // process.env.HOME / process.env["HOME"]
@@ -171,11 +223,13 @@ function detectInAst(ast) {
   return hits;
 }
 
-/** 命中行的豁免注释匹配：命中 TS 行行尾或上一行含合法豁免标记（理由含 #NNN）。 */
+/** 命中行的豁免注释匹配：命中 TS 行行尾或上一行的**真实**注释含合法豁免标记。 */
 function hasExemption(tsLines, lineIdx) {
   const near = [tsLines[lineIdx], tsLines[lineIdx - 1]].filter((l) => l !== undefined);
   for (const line of near) {
-    const m = line.match(EXEMPT_RE);
+    const comment = lineCommentText(line);
+    if (comment === null) continue;
+    const m = comment.match(EXEMPT_RE);
     if (m) return m[1].trim();
   }
   return null;
@@ -196,10 +250,10 @@ async function scanFile(file) {
   }
   const ast = acorn.parse(js, { ecmaVersion: "latest", sourceType: "module", locations: true });
   const rawHits = detectInAst(ast);
-  if (rawHits.length === 0) return [];
+  if (rawHits.length === 0) return { hits: [], tsLines };
   // 映射回 TS 原文行号（.mjs 本身即原文）
   const map = mapJson ? new SourceMap(JSON.parse(mapJson)) : null;
-  return rawHits.map((h) => {
+  const hits = rawHits.map((h) => {
     let lineIdx = h.generatedLine;
     if (map) {
       const entry = map.findEntry(h.generatedLine, h.generatedColumn);
@@ -208,11 +262,18 @@ async function scanFile(file) {
     const text = (tsLines[lineIdx] ?? "").trim().slice(0, 90);
     return { line: lineIdx + 1, api: h.api, text };
   });
+  return { hits, tsLines };
 }
 
 async function main() {
-  const rootArgIdx = process.argv.indexOf("--root");
-  const root = rootArgIdx !== -1 ? process.argv[rootArgIdx + 1] : ROOT;
+  const argv = process.argv;
+  const eq = argv.find((a) => a.startsWith("--root="));
+  const spacedIdx = argv.indexOf("--root");
+  const root = eq
+    ? eq.slice("--root=".length)
+    : spacedIdx !== -1
+      ? argv[spacedIdx + 1]
+      : ROOT;
   const files = collectSrcFiles(root);
   if (files.length === 0) {
     console.error("forbid-homedir-src: 未发现任何扫描目标（packages/*/src 空，fail-closed）");
@@ -222,18 +283,21 @@ async function main() {
   const badExemptions = [];
   const legitExemptions = [];
   const parseFailures = [];
+  const hitRels = new Set(); // 本次确有命中的 WHITELIST 文件（F2：反向校验判定面）
   for (const file of files) {
     const rel = relative(root, file).split(sep).join("/");
-    let hits;
+    let result;
     try {
-      hits = await scanFile(file);
+      result = await scanFile(file);
     } catch (e) {
       parseFailures.push(`${rel}: ${String(e.message).slice(0, 120)}`);
       continue;
     }
+    const { hits, tsLines } = result;
+    if (hits.length > 0 && WHITELIST.has(rel)) hitRels.add(rel);
     const whitelisted = WHITELIST.has(rel);
     for (const h of hits) {
-      const reason = hasExemption(readFileSync(file, "utf8").split("\n"), h.line - 1);
+      const reason = hasExemption(tsLines, h.line - 1);
       if (reason && whitelisted) {
         legitExemptions.push(`${rel}:${h.line} [${h.api}] 豁免理由：${reason}`);
       } else if (reason && !whitelisted) {
@@ -245,14 +309,9 @@ async function main() {
       }
     }
   }
-  // WHITELIST 反向校验（防清单腐烂）：磁盘上存在、且本次确有命中记录的文件
-  // 才算「活的」豁免条目——文件不存在（--root fixture / 包已整体移除）不判腐烂，
-  // 由其包目录存在与否决定；文件存在但全文件零命中 = 条目已失效，报非法豁免。
-  const hitRels = new Set();
-  for (const f of files) {
-    const rel = relative(root, f).split(sep).join("/");
-    if (WHITELIST.has(rel)) hitRels.add(rel);
-  }
+  // WHITELIST 反向校验（防清单腐烂，F2）：磁盘上存在、且本次**确有命中**的文件
+  // 才算「活的」豁免条目——文件不存在（--root fixture / 包已整体移除）不判腐烂；
+  // 文件存在但本次零命中 = 条目已失效（豁免调用点已删/重构而清单未清），报非法豁免。
   for (const k of WHITELIST.keys()) {
     const onDisk = existsSync(join(root, k));
     if (onDisk && !hitRels.has(k)) badExemptions.push(`${k}: WHITELIST 条目指向的文件本次零命中（已腐烂，应删除条目）`);

--- a/scripts/gate/forbid-homedir-src.mjs
+++ b/scripts/gate/forbid-homedir-src.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+/**
+ * B5 门禁（#517）：packages 各插件 src 禁直连 HOME 来源 API（AST 扫描，fail-closed）。
+ *
+ * 背景：DSH_HOME 语义收敛（#525 接缝 shared/dsh-home）后，插件 src 直连
+ * `os.homedir()` / `process.env.HOME` / `untildify()` 会绕过 DSH_HOME 隔离语义，
+ * 导致隔离验证（dsh-verify-isolated）与真实写面审计（B4）出现盲区。src 需要
+ * home 路径时应走 `shared/dsh-home.js` 的 `dshHome()`；确属「DSH_HOME 域之外」
+ * 的合法场景（外部工具凭据、用户输入 `~` 展开、展示层脱敏）须逐调用点豁免。
+ *
+ * 检测语义（AST 级，防 text 扫描绕过）：
+ *   - `homedir()` / `import { homedir as hd }` 别名调用（来自 node:os / os）；
+ *   - `os.homedir` / `os["homedir"]`（命名空间 import，含中括号混淆形态与值引用）；
+ *   - `os.userInfo()`（homedir 的别名通道：`.homedir` 字段同为 HOME 来源）；
+ *   - `process.env.HOME` / `process.env["HOME"]`；
+ *   - `untildify(...)`（default import，含别名）。
+ * 已知局限（不为此增加复杂度，本仓无此形态）：`const { HOME } = process.env`
+ * 解构形态、`const f = untildify` 值传递别名。新增豁免机制兜底。
+ *
+ * 豁免双源（缺一判红，三态输出）：
+ *   1. 调用点紧邻注释：命中行行尾或上一行 `// dsh-gate:allow-homedir <理由含 #NNN>`；
+ *   2. 本文件 WHITELIST 清单（文件级，版本化）。
+ *   三态：无命中（OK）/ 双源齐备豁免（OK，汇总输出）/ 违规或不合法豁免（FAIL）。
+ *
+ * 解析器：typescript 7 已移除经典 JS AST API（createSourceFile 等），故用
+ * esbuild（既有 devDep）剥类型 + acorn（既有 devDep）estree 解析 + node:module
+ * SourceMap 行映射回 TS 原文行号。豁免注释匹配 TS 原文（transform 会剥离注释）。
+ *
+ * 扫描范围：packages 下各 dsh-* 包 src 目录的 .ts/.mts/.mjs（含未跟踪文件；
+ * .d.mts 类型声明、*.test.* 跳过——§1 测试义务用 homedir 锁默认路径契约是合法的）。
+ * fail-closed：任何文件解析失败直接判红。
+ * 用法：node scripts/gate/forbid-homedir-src.mjs [--root <dir>]
+ */
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { transform } from "esbuild";
+import * as acorn from "acorn";
+import { SourceMap } from "node:module";
+
+const ROOT = join(import.meta.dirname, "../..");
+
+/** 豁免清单（文件级，双源之二）。值 = 豁免理由（须含 issue 号）。 */
+const WHITELIST_V = 1;
+const WHITELIST = new Map([
+  // #525/#517：opencode 外部凭据路径——DSH_HOME 域之外的第三方工具自身写面
+  ["packages/dsh-provider-usage/src/provider-config.ts", "#525 opencode 外部凭据"],
+  // #517：展示层脱敏（诊断文本把 home 前缀折叠为 ~），不产生读写面
+  ["packages/dsh-provider-usage/src/apply.ts", "#517 展示层脱敏"],
+  // #87：用户输入 `~` 前缀展开（untildify 业界标准实现），目标由用户指定
+  ["packages/dsh-provider-usage/src/path-resolve.ts", "#87 用户路径 ~ 展开"],
+  ["packages/dsh-web-file-preview/src/git.ts", "#87 用户路径 ~ 展开"],
+  ["packages/dsh-web-file-preview/src/routes.ts", "#87 用户路径 ~ 展开"],
+]);
+
+const EXEMPT_MARK = "dsh-gate:allow-homedir";
+const EXEMPT_RE = new RegExp(`//\\s*${EXEMPT_MARK}\\s+([^\\n]*#\\d+[^\\n]*)`);
+
+/** 递归收集各包 src 目录下全部 .ts/.mts/.mjs（含未跟踪；跳过 d.mts 与 test 文件）。 */
+function collectSrcFiles(root) {
+  const hits = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return; // 目录不存在：packages/*/src 命名约定下静默跳过，命中计数兜底
+    }
+    for (const e of entries) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (e.isFile() && /\.(ts|mts|mjs)$/.test(e.name) && !/\.d\.mts$/.test(e.name) && !/\.test\./.test(e.name)) {
+        hits.push(p);
+      }
+    }
+  };
+  const packagesDir = join(root, "packages");
+  let pkgEntries;
+  try {
+    pkgEntries = readdirSync(packagesDir, { withFileTypes: true });
+  } catch {
+    console.error(`forbid-homedir-src: 无法读取 ${packagesDir}（fail-closed）`);
+    process.exit(1);
+  }
+  for (const e of pkgEntries) {
+    if (e.isDirectory() && e.name.startsWith("dsh-")) walk(join(packagesDir, e.name, "src"));
+  }
+  return hits;
+}
+
+/**
+ * 从 estree AST 收集 HOME 来源 API 的本地绑定名。
+ * 返回 { homedirNamed, userInfoNamed, untildifyNamed, osNamespaces }。
+ */
+function collectImports(ast) {
+  const homedirNamed = new Set();
+  const userInfoNamed = new Set();
+  const untildifyNamed = new Set();
+  const osNamespaces = new Set();
+  for (const node of ast.body) {
+    if (node.type !== "ImportDeclaration") continue;
+    const src = node.source.value;
+    const isOs = src === "node:os" || src === "os";
+    const isUntildify = src === "untildify";
+    if (!isOs && !isUntildify) continue;
+    for (const spec of node.specifiers) {
+      if (spec.type === "ImportNamespaceSpecifier" && isOs) {
+        osNamespaces.add(spec.local.name);
+      } else if (spec.type === "ImportDefaultSpecifier" && isUntildify) {
+        untildifyNamed.add(spec.local.name);
+      } else if (spec.type === "ImportSpecifier") {
+        const imported = spec.imported.name ?? spec.imported.value;
+        if (isOs && imported === "homedir") homedirNamed.add(spec.local.name);
+        if (isOs && imported === "userInfo") userInfoNamed.add(spec.local.name);
+        if (isUntildify && imported === "untildify") untildifyNamed.add(spec.local.name);
+      }
+    }
+  }
+  return { homedirNamed, userInfoNamed, untildifyNamed, osNamespaces };
+}
+
+/** 成员访问的静态属性名（`a.b` → "b"；`a["b"]` → "b"；动态 → null）。 */
+function staticProp(member) {
+  if (!member.computed) return member.property.name ?? null;
+  if (member.property.type === "Literal" && typeof member.property.value === "string") {
+    return member.property.value;
+  }
+  return null;
+}
+
+/**
+ * 在单个 estree AST 上检测 HOME 来源 API 使用。
+ * 返回 [{ generatedLine, generatedColumn, api, text }]（0-based 生成码坐标）。
+ */
+function detectInAst(ast) {
+  const { homedirNamed, userInfoNamed, untildifyNamed, osNamespaces } = collectImports(ast);
+  const hits = [];
+  const push = (node, api) => hits.push({ generatedLine: node.loc.start.line - 1, generatedColumn: node.loc.start.column, api, text: "" });
+  (function walk(node) {
+    if (!node || typeof node.type !== "string") return;
+    if (node.type === "MemberExpression") {
+      const prop = staticProp(node);
+      // os.homedir / os["homedir"] / os.userInfo / os["userInfo"]（值引用与调用同罪）
+      if (node.object.type === "Identifier" && osNamespaces.has(node.object.name) && (prop === "homedir" || prop === "userInfo")) {
+        push(node, `os.${prop}`);
+      }
+      // process.env.HOME / process.env["HOME"]
+      if (
+        prop === "HOME" &&
+        node.object.type === "MemberExpression" &&
+        staticProp(node.object) === "env" &&
+        node.object.object.type === "Identifier" &&
+        node.object.object.name === "process"
+      ) {
+        push(node, "process.env.HOME");
+      }
+    } else if (node.type === "CallExpression" && node.callee.type === "Identifier") {
+      const name = node.callee.name;
+      if (homedirNamed.has(name)) push(node, `${name}()（node:os homedir 别名调用）`);
+      else if (userInfoNamed.has(name)) push(node, `${name}()（node:os userInfo 别名调用）`);
+      else if (untildifyNamed.has(name)) push(node, `${name}()（untildify 别名调用）`);
+    }
+    for (const key of Object.keys(node)) {
+      const child = node[key];
+      if (Array.isArray(child)) {
+        for (const c of child) if (c && typeof c.type === "string") walk(c);
+      } else if (child && typeof child.type === "string") {
+        walk(child);
+      }
+    }
+  })(ast);
+  return hits;
+}
+
+/** 命中行的豁免注释匹配：命中 TS 行行尾或上一行含合法豁免标记（理由含 #NNN）。 */
+function hasExemption(tsLines, lineIdx) {
+  const near = [tsLines[lineIdx], tsLines[lineIdx - 1]].filter((l) => l !== undefined);
+  for (const line of near) {
+    const m = line.match(EXEMPT_RE);
+    if (m) return m[1].trim();
+  }
+  return null;
+}
+
+/** 解析单个文件并检测。fail-closed：解析异常直接抛给调用方判红。 */
+async function scanFile(file) {
+  const content = readFileSync(file, "utf8");
+  const tsLines = content.split("\n");
+  const isMjs = file.endsWith(".mjs");
+  // 单次 transform 同时取 code 与 sourcemap（sourcemap 仅在有命中时才解析）
+  let js = content;
+  let mapJson = null;
+  if (!isMjs) {
+    const t = await transform(content, { loader: "ts", sourcemap: true, sourcefile: file });
+    js = t.code;
+    mapJson = t.map;
+  }
+  const ast = acorn.parse(js, { ecmaVersion: "latest", sourceType: "module", locations: true });
+  const rawHits = detectInAst(ast);
+  if (rawHits.length === 0) return [];
+  // 映射回 TS 原文行号（.mjs 本身即原文）
+  const map = mapJson ? new SourceMap(JSON.parse(mapJson)) : null;
+  return rawHits.map((h) => {
+    let lineIdx = h.generatedLine;
+    if (map) {
+      const entry = map.findEntry(h.generatedLine, h.generatedColumn);
+      if (entry?.originalLine !== undefined) lineIdx = entry.originalLine;
+    }
+    const text = (tsLines[lineIdx] ?? "").trim().slice(0, 90);
+    return { line: lineIdx + 1, api: h.api, text };
+  });
+}
+
+async function main() {
+  const rootArgIdx = process.argv.indexOf("--root");
+  const root = rootArgIdx !== -1 ? process.argv[rootArgIdx + 1] : ROOT;
+  const files = collectSrcFiles(root);
+  if (files.length === 0) {
+    console.error("forbid-homedir-src: 未发现任何扫描目标（packages/*/src 空，fail-closed）");
+    process.exit(1);
+  }
+  const violations = [];
+  const badExemptions = [];
+  const legitExemptions = [];
+  const parseFailures = [];
+  for (const file of files) {
+    const rel = relative(root, file).split(sep).join("/");
+    let hits;
+    try {
+      hits = await scanFile(file);
+    } catch (e) {
+      parseFailures.push(`${rel}: ${String(e.message).slice(0, 120)}`);
+      continue;
+    }
+    const whitelisted = WHITELIST.has(rel);
+    for (const h of hits) {
+      const reason = hasExemption(readFileSync(file, "utf8").split("\n"), h.line - 1);
+      if (reason && whitelisted) {
+        legitExemptions.push(`${rel}:${h.line} [${h.api}] 豁免理由：${reason}`);
+      } else if (reason && !whitelisted) {
+        badExemptions.push(`${rel}:${h.line} [${h.api}] 有豁免注释但文件不在 WHITELIST（v${WHITELIST_V}）`);
+      } else if (!reason && whitelisted) {
+        violations.push(`${rel}:${h.line} [${h.api}] 在 WHITELIST 但该调用点缺紧邻豁免注释 ${EXEMPT_MARK}`);
+      } else {
+        violations.push(`${rel}:${h.line} [${h.api}] ${h.text}`);
+      }
+    }
+  }
+  // WHITELIST 反向校验（防清单腐烂）：磁盘上存在、且本次确有命中记录的文件
+  // 才算「活的」豁免条目——文件不存在（--root fixture / 包已整体移除）不判腐烂，
+  // 由其包目录存在与否决定；文件存在但全文件零命中 = 条目已失效，报非法豁免。
+  const hitRels = new Set();
+  for (const f of files) {
+    const rel = relative(root, f).split(sep).join("/");
+    if (WHITELIST.has(rel)) hitRels.add(rel);
+  }
+  for (const k of WHITELIST.keys()) {
+    const onDisk = existsSync(join(root, k));
+    if (onDisk && !hitRels.has(k)) badExemptions.push(`${k}: WHITELIST 条目指向的文件本次零命中（已腐烂，应删除条目）`);
+  }
+
+  const fail = violations.length > 0 || badExemptions.length > 0 || parseFailures.length > 0;
+  if (parseFailures.length > 0) {
+    console.error("forbid-homedir-src: 解析失败（fail-closed，一律判红）：");
+    for (const p of parseFailures) console.error(`  - ${p}`);
+  }
+  if (badExemptions.length > 0) {
+    console.error("forbid-homedir-src: 存在豁免但不合法（三态之 FAIL）：");
+    for (const b of badExemptions) console.error(`  - ${b}`);
+  }
+  if (violations.length > 0) {
+    console.error(`forbid-homedir-src: 发现 ${violations.length} 处 HOME 来源 API 直连（应走 shared/dsh-home 或逐点豁免）：`);
+    for (const v of violations) console.error(`  - ${v}`);
+  }
+  if (fail) {
+    console.error(`forbid-homedir-src: FAIL（扫描 ${files.length} 文件，违规 ${violations.length} / 非法豁免 ${badExemptions.length} / 解析失败 ${parseFailures.length}）`);
+    process.exit(1);
+  }
+  if (legitExemptions.length > 0) {
+    console.log(`forbid-homedir-src: OK（扫描 ${files.length} 文件，合法豁免 ${legitExemptions.length} 处，WHITELIST v${WHITELIST_V}）：`);
+    for (const l of legitExemptions) console.log(`  - ${l}`);
+  } else {
+    console.log(`forbid-homedir-src: OK（扫描 ${files.length} 文件，无 HOME 来源 API 直连）`);
+  }
+}
+
+main().catch((e) => {
+  console.error(`forbid-homedir-src: 运行异常（fail-closed）：${e?.stack ?? e}`);
+  process.exit(1);
+});

--- a/scripts/test/forbid-homedir-src.test.ts
+++ b/scripts/test/forbid-homedir-src.test.ts
@@ -140,6 +140,65 @@ test('豁免三态：豁免注释缺 issue 号 → 不算合法豁免，按违�
   assert.match(r.stderr, /违规 1 /)
 })
 
+test('F1：字符串字面量里的伪豁免注释不生效（真实注释词法识别）→ 判违规', () => {
+  const dir = fixture([{
+    rel: 'a.ts',
+    content: 'import { homedir } from "node:os"\nconst msg = "// dsh-gate:allow-homedir #999 字符串伪造"\nexport const p = homedir()\n',
+  }])
+  const r = run(dir)
+  assert.equal(r.status, 1, r.stderr)
+  assert.match(r.stderr, /违规 1 /)
+  assert.ok(!r.stderr.includes('字符串伪造'), '字符串内容不得被当作豁免理由')
+})
+
+test('F2：WHITELIST 条目文件存在但本次零命中 → 报已腐烂（非死代码）', () => {
+  // 构造与真实 WHITELIST 相对路径同形的文件，但内容无任何 HOME API 命中
+  const dir = mkdtempSync(join(tmpdir(), 'forbid-homedir-rot-'))
+  mkdirSync(join(dir, 'packages/dsh-provider-usage/src'), { recursive: true })
+  writeFileSync(join(dir, 'packages/dsh-provider-usage/src/apply.ts'),
+    'export const clean = 1\n') // WHITELIST 含此文件，但零命中
+  try {
+    const r = spawnSync(process.execPath, [SCRIPT, '--root', dir], { encoding: 'utf8' })
+    assert.equal(r.status, 1, r.stderr)
+    assert.match(r.stderr, /已腐烂，应删除条目/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('F3：dynamic import 命名空间形态（await import("node:os")）→ 判违规', () => {
+  const dir = fixture([{
+    rel: 'a.ts',
+    content: 'export async function g() {\n  const os = await import("node:os")\n  return os.homedir()\n}\n',
+  }])
+  const r = run(dir)
+  assert.equal(r.status, 1, r.stderr)
+  assert.match(r.stderr, /os\.homedir/)
+})
+
+test('F4：参数/局部同名遮蔽不误报（esbuild 自动重命名，锁定行为）', () => {
+  const dir = fixture([{
+    rel: 'a.ts',
+    content: 'import { homedir } from "node:os"\nimport * as os from "node:os"\n'
+      + 'export function g(homedir: () => string) { return homedir() }\n'
+      + 'export const x = () => { const os = { homedir: () => "x" }; return os.homedir() }\n',
+  }])
+  const r = run(dir)
+  assert.equal(r.status, 0, r.stderr)
+  assert.match(r.stdout, /无 HOME 来源 API 直连/)
+})
+
+test('P3：--root=<path> 等号形态可用', () => {
+  const dir = fixture([{ rel: 'a.ts', content: 'export const a = 1\n' }])
+  try {
+    const r = spawnSync(process.execPath, [SCRIPT, `--root=${dir}`], { encoding: 'utf8' })
+    assert.equal(r.status, 0, r.stderr)
+    assert.match(r.stdout, /OK（扫描 1 文件/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('fail-closed：语法损坏文件（TS 不可解析）→ exit 1 且指明解析失败', () => {
   const dir = fixture([{
     rel: 'broken.ts',

--- a/scripts/test/forbid-homedir-src.test.ts
+++ b/scripts/test/forbid-homedir-src.test.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// @ts-nocheck
+/** forbid-homedir-src.mjs 自测（#517 B5）：正反例 + 三态 + fail-closed 全组合。 */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const ROOT = join(import.meta.dirname, '../..')
+const SCRIPT = join(ROOT, 'scripts/gate/forbid-homedir-src.mjs')
+
+/** 构造最小 fixture 仓库（--root 注入）。pkgFiles: [{ rel, content }] */
+function fixture(pkgFiles) {
+  const dir = mkdtempSync(join(tmpdir(), 'forbid-homedir-src-test-'))
+  mkdirSync(join(dir, 'packages/dsh-fake/src'), { recursive: true })
+  for (const { rel, content } of pkgFiles) {
+    const p = join(dir, 'packages/dsh-fake/src', rel)
+    mkdirSync(join(p, '..'), { recursive: true })
+    writeFileSync(p, content)
+  }
+  return dir
+}
+
+function run(root) {
+  try {
+    return spawnSync(process.execPath, [SCRIPT, '--root', root], { encoding: 'utf8' })
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+test('正例：干净 src（无任何 HOME 来源 API）→ exit 0', () => {
+  const dir = fixture([{ rel: 'a.ts', content: 'export const a = 1\n' }])
+  const r = run(dir)
+  assert.equal(r.status, 0, r.stderr)
+  assert.match(r.stdout, /OK（扫描 1 文件，无 HOME 来源 API 直连）/)
+})
+
+test('正例：shared/dsh-home 式合法接缝不受影响（dshHome 内部实现在 packages 外）', () => {
+  const dir = fixture([{
+    rel: 'a.ts',
+    // 插件 src 调 dshHome()（从 shared 导入）而非 homedir——门禁不命中
+    content: 'import { dshHome } from "../../shared/dsh-home.js"\nexport const p = dshHome()\n',
+  }])
+  const r = run(dir)
+  assert.equal(r.status, 0, r.stderr)
+})
+
+test('反例：os.homedir 直连（named import）→ exit 1', () => {
+  const dir = fixture([{
+    rel: 'a.ts',
+    content: 'import { homedir } from "node:os"\nexport const p = join(homedir(), ".dsh")\n',
+  }])
+  const r = run(dir)
+  assert.equal(r.status, 1)
+  assert.match(r.stderr, /homedir\(\)（node:os homedir 别名调用）/)
+  assert.match(r.stderr, /FAIL（扫描 1 文件，违规 1 /)
+})
+
+test('反例：别名 import { homedir as hd } 逃逸 → exit 1', () => {
+  const dir = fixture([{
+    rel: 'a.ts',
+    content: 'import { homedir as hd } from "os"\nexport const p = hd()\n',
+  }])
+  const r = run(dir)
+  assert.equal(r.status, 1)
+  assert.match(r.stderr, /hd\(\)（node:os homedir 别名调用）/)
+})
+
+test('反例：os["homedir"] 中括号混淆形态 → exit 1', () => {
+  const dir = fixture([{
+    rel: 'a.ts',
+    content: 'import * as os from "node:os"\nexport const p = os["homedir"]()\n',
+  }])
+  const r = run(dir)
+  assert.equal(r.status, 1)
+  assert.match(r.stderr, /os\.homedir/)
+})
+
+test('反例：process.env.HOME 直连（含中括号形态）→ exit 1', () => {
+  const dir = fixture([{
+    rel: 'a.ts',
+    content: 'export const h = process.env["HOME"]\n',
+  }])
+  const r = run(dir)
+  assert.equal(r.status, 1)
+  assert.match(r.stderr, /process\.env\.HOME/)
+})
+
+test('反例：os.userInfo()（homedir 别名通道）→ exit 1', () => {
+  const dir = fixture([{
+    rel: 'a.ts',
+    content: 'import * as os from "node:os"\nexport const u = os.userInfo().homedir\n',
+  }])
+  const r = run(dir)
+  assert.equal(r.status, 1)
+  assert.match(r.stderr, /os\.userInfo/)
+})
+
+test('反例：untildify 直连 → exit 1', () => {
+  const dir = fixture([{
+    rel: 'a.ts',
+    content: 'import untildify from "untildify"\nexport const p = untildify("~/x")\n',
+  }])
+  const r = run(dir)
+  assert.equal(r.status, 1)
+  assert.match(r.stderr, /untildify\(\)（untildify 别名调用）/)
+})
+
+test('反例：.mjs 文件同样受扫（adapters 旁路防护）→ exit 1', () => {
+  const dir = fixture([{
+    rel: 'a.mjs',
+    content: 'import { homedir } from "node:os"\nexport const p = homedir()\n',
+  }])
+  const r = run(dir)
+  assert.equal(r.status, 1)
+  assert.match(r.stderr, /homedir\(\)（node:os homedir 别名调用）/)
+})
+
+test('豁免三态：有注释但不在 WHITELIST → FAIL（不合法豁免）', () => {
+  const dir = fixture([{
+    rel: 'a.ts',
+    content: 'import { homedir } from "node:os"\n// dsh-gate:allow-homedir #999 测试理由\nexport const p = homedir()\n',
+  }])
+  const r = run(dir)
+  assert.equal(r.status, 1)
+  assert.match(r.stderr, /有豁免注释但文件不在 WHITELIST/)
+})
+
+test('豁免三态：豁免注释缺 issue 号 → 不算合法豁免，按违规报', () => {
+  const dir = fixture([{
+    rel: 'a.ts',
+    content: 'import { homedir } from "node:os"\n// dsh-gate:allow-homedir 随手一豁\nexport const p = homedir()\n',
+  }])
+  const r = run(dir)
+  assert.equal(r.status, 1)
+  // 无 #NNN → hasExemption 返回 null → 该命中不在 WHITELIST → 违规
+  assert.match(r.stderr, /违规 1 /)
+})
+
+test('fail-closed：语法损坏文件（TS 不可解析）→ exit 1 且指明解析失败', () => {
+  const dir = fixture([{
+    rel: 'broken.ts',
+    content: 'export const a = (((\n',
+  }])
+  const r = run(dir)
+  assert.equal(r.status, 1)
+  assert.match(r.stderr, /解析失败（fail-closed，一律判红）/)
+})
+
+test('本仓真实快照：7 处合法豁免全部识别 → exit 0 且台账一致', () => {
+  const r = spawnSync(process.execPath, [SCRIPT], { cwd: ROOT, encoding: 'utf8' })
+  assert.equal(r.status, 0, r.stderr)
+  assert.match(r.stdout, /合法豁免 7 处/)
+  for (const f of [
+    'packages/dsh-provider-usage/src/apply.ts',
+    'packages/dsh-provider-usage/src/path-resolve.ts',
+    'packages/dsh-provider-usage/src/provider-config.ts',
+    'packages/dsh-web-file-preview/src/git.ts',
+    'packages/dsh-web-file-preview/src/routes.ts',
+  ]) assert.ok(r.stdout.includes(f), `${f} 应在合法豁免台账中`)
+})

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -426,7 +426,7 @@ test('#423: 变异测试单份维护——禁 *.src.test.ts 回潮 + lib→src h
   }
 })
 
-test('#517 B5: ci.yml homedir 门禁——forbid-homedir-src 步骤在 repo-gate 段 + 根 scripts 入口', () => {
+test('#517 B5: ci.yml homedir 门禁——Forbid homedir 步骤存在并调 forbid-homedir-src.mjs + 根 scripts 入口', () => {
   assert.ok(CI.includes('Forbid homedir in src'),
     'ci.yml repo-gate 必须含 Forbid homedir in src 步骤（#517 B5 防回归）')
   assert.ok(CI.includes('run: node scripts/gate/forbid-homedir-src.mjs'),

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -426,6 +426,18 @@ test('#423: 变异测试单份维护——禁 *.src.test.ts 回潮 + lib→src h
   }
 })
 
+test('#517 B5: ci.yml homedir 门禁——forbid-homedir-src 步骤在 repo-gate 段 + 根 scripts 入口', () => {
+  assert.ok(CI.includes('Forbid homedir in src'),
+    'ci.yml repo-gate 必须含 Forbid homedir in src 步骤（#517 B5 防回归）')
+  assert.ok(CI.includes('run: node scripts/gate/forbid-homedir-src.mjs'),
+    'Forbid homedir in src 必须调用 scripts/gate/forbid-homedir-src.mjs')
+  assert.ok(existsSync(join(ROOT, 'scripts/gate/forbid-homedir-src.mjs')),
+    'forbid-homedir-src.mjs 脚本必须存在')
+  const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'))
+  assert.equal(pkg.scripts['gate:homedir'], 'node scripts/gate/forbid-homedir-src.mjs',
+    '根 package.json 必须含 gate:homedir 本地入口（与 ci.yml 同一命令）')
+})
+
 test('#178+#204: ci.yml PR 增量门禁——读仓库基线文件 + 按命中包切片 + 并入 repo-gate', () => {
   // #204：直接读 scripts/gate/baseline/ 仓库内文件，替代 actions/cache restore（跨 ref 失效）
   assert.ok(CI.includes('Restore repo incremental baseline'), 'mutation-gate 基线读取步骤在位（读仓库内文件）')


### PR DESCRIPTION
Partially addresses #517（Meta 子项 B5，红线获批实施：维护者 2026-09-05 会话批复「方案没问题就实施」，留痕见 issue 评论 issuecomment-5548884978）

## 方案相对原批的实测修正（材料级，语义不变）

- **解析器路线**：handoff 预研「typescript 7.0.2 createSourceFile 可用」已被实测证伪——TS7（Go 原生重写）主入口仅导出 version，经典 JS AST API 全数移除。改用 **esbuild（既有 devDep）剥类型 + acorn（既有 devDep）estree 解析 + node:module SourceMap 行映射回 TS 原文行号**，零新增依赖。AST 防混淆语义完整保留（已实测 `os["homedir"]`、别名 import、`process.env["HOME"]` 均命中）。
- **豁免台账勘误**：扫描面实测命中 **5 文件 7 调用点**（批次计划评论记录的 2 处仅为 os.homedir 部分）——untildify 分布在 provider-usage/path-resolve.ts 与 web-file-preview/git.ts、routes.ts（×3），均属方案既有豁免口径（#87 用户路径 ~ 展开）。
- **扫描面补全**：`os.userInfo()` 纳入 API 名单（`.homedir` 字段是 HOME 来源别名通道）；`.mjs` 纳入扫描（dsh-provider-usage/src/adapters/ 有 3 个 .mjs，防旁路）。

## 实现

- `scripts/gate/forbid-homedir-src.mjs`（~280 行）：
  - 检测面：`os.homedir` / `os.userInfo`（命名空间成员访问含中括号混淆、named import 别名调用、值引用同罪）、`process.env.HOME`（含中括号）、`untildify`（default import 含别名）；
  - fail-closed：任何文件 esbuild/acorn 解析失败 → exit 1；
  - 豁免双源（缺一判红，三态输出）：① 调用点紧邻注释 `// dsh-gate:allow-homedir <理由含 #NNN>`（匹配 TS 原文，transform 剥离注释）② 脚本内 WHITELIST v1 文件级清单（版本化）+ 反向防腐烂校验（磁盘存在但零命中 → 报非法豁免）；
  - 已知局限显式声明（脚本头注释）：`const { HOME } = process.env` 解构、值传递别名不覆盖（本仓无此形态，豁免机制兜底）。
- 豁免正例 ×7：provider-config.ts:78（#525 opencode 外部凭据）/ apply.ts:89（#517 展示层脱敏）/ path-resolve.ts:36 + git.ts:83 + routes.ts:132,200,344（#87 用户路径 ~ 展开）。
- 接入四件：ci.yml repo-gate 段新步骤、根 package.json `gate:homedir`、`scripts/test/workflow-assert.test.ts` 结构断言（仿 #423 forbid-src-tests 模式）、`scripts/test/forbid-homedir-src.test.ts` 自测 13 例（干净正例 ×2 / 直连反例 ×7 / 豁免三态 ×2 / fail-closed ×1 / 本仓真实快照 ×1，mkdtemp 隔离 #218）。
- `docs/DEVELOPMENT.md` §1「门禁演进」段落地改写为「门禁（已落地）」。

## 门禁证据

- 五连全绿：`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck`
- `pnpm test:scripts`：158 pass（144 + B5 13 + workflow-assert 1）
- `pnpm docs:check`（--strict-en）通过
- `pnpm gate:homedir`：OK（扫描 148 文件，合法豁免 7 处，WHITELIST v1）

## 断言表（qa 复核锚点）

| # | 断言 | 类型 |
|---|---|---|
| 1 | 本仓现状扫描 exit 0，台账 7 处合法豁免与 WHITELIST 一致 | [硬性] gate 实测 |
| 2 | 新增 `homedir()` 直连（不带豁免）→ exit 1 | [硬性] fixture 实测 |
| 3 | 别名 `import { homedir as hd }` → exit 1 | [硬性] fixture 实测 |
| 4 | `os["homedir"]()` 混淆形态 → exit 1 | [硬性] fixture 实测 |
| 5 | `process.env["HOME"]` → exit 1 | [硬性] fixture 实测 |
| 6 | `os.userInfo().homedir` → exit 1 | [硬性] fixture 实测 |
| 7 | `.mjs` 文件命中 → exit 1 | [硬性] fixture 实测 |
| 8 | 豁免注释缺 #NNN → 判违规 | [硬性] fixture 实测 |
| 9 | 有注释无 WHITELIST → 判非法豁免 | [硬性] fixture 实测 |
| 10 | WHITELIST 文件零命中 → 报腐烂 | [硬性] 代码路径+语义 |
| 11 | 语法损坏文件 → exit 1 fail-closed | [硬性] fixture 实测 |
| 12 | ci.yml 步骤 + package.json 入口 + 脚本存在 | [硬性] workflow-assert |
| 13 | dshHome()（shared 接缝）不命中 | [硬性] fixture 实测 |
