### PR TITLE
docs(readme): 插件描述对齐各包当前功能面

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -20,9 +20,10 @@ install them all at once as a single bundle, or pick individual plugins as neede
   plaintext nor reach the browser; each plugin's threat model and hardening details live
   in its README security section
 - **Context-cost-controlled MCP management**: project-level MCP is collapsed into the
-  two atomic tools `ws_mcp_search` / `ws_mcp_call` by default, so project-level scale
-  never balloons the context (`middleware: all` folds global servers into the middleware
-  too); per-working-directory project/global config tiers let each repo carry its own
+  four atomic tools `ws_mcp_list` / `ws_mcp_detail` / `ws_mcp_search` / `ws_mcp_call`
+  by default, so project-level scale never balloons the context (`middleware: all` folds
+  global servers into the middleware too, hot-switchable from the settings page);
+  per-working-directory project/global config tiers let each repo carry its own
   MCP servers without cross-project interference
 - **Extensible usage-stats framework**: a generic v2 adapter contract with DeepSeek
   official and OpenCode Go built in out of the box; write one mjs file to plug in any
@@ -47,13 +48,13 @@ This plugin set only adapts to **rc (release-candidate) releases of DeepSeek Har
 
 | Package | What it does | Docs | Status |
 |---|---|---|---|
-| `@wingsky-1/dsh-notifier` | Approval/completion/error event notifications (browser Notification + system toast) | [README](packages/dsh-notifier/README.md) | ✅ Published |
-| `@wingsky-1/dsh-provider-usage` | Multi-provider usage float pill (generic adapter framework: DeepSeek official and OpenCode Go built in, plug in any data source with your own mjs) | [README](packages/dsh-provider-usage/README.md) | ✅ Published |
-| `@wingsky-1/dsh-lan-proxy` | Access the dsh web UI over LAN (HTTP/HTTPS/WS forwarding + TLS + HTTP response compression, Brotli/gzip) | [README](packages/dsh-lan-proxy/README.md) | ✅ Published |
-| `@wingsky-1/dsh-mcp-manager` | MCP server manager (stdio / HTTP; per-working-directory project/global config tiers, project-level MCP collapsed via middleware — no tool flood in the model surface) | [README](packages/dsh-mcp-manager/README.md) | ✅ Published |
-| `@wingsky-1/dsh-web-file-preview` | Click conversation file links to preview in the web UI (image / text / Markdown / code / Diff / Mermaid) | [README](packages/dsh-web-file-preview/README.md) | ✅ Published |
-| `@wingsky-1/dsh-verify-isolated` | Isolated-environment browser verification skill for DSH plugin development (temp DSH_HOME + independent profile, double isolation) | [README](packages/dsh-verify-isolated/README.md) | ✅ Published |
-| `@wingsky-1/dsh-codegraph` | codegraph local code-graph MCP + worktree development discipline (registered at runtime via mcp-manager) | [README](packages/dsh-codegraph/README.md) | ✅ Published (standalone, not in the bundle) |
+| `@wingsky-1/dsh-notifier` | Task-event notification center: 6 event kinds (ask / approval / completion / subagent completion / error / turn end), dual channels (browser Notification + host system toast) plus Bark/Webhook push channels (ntfy, Gotify, self-hosted gateways); quiet hours with urgent exceptions, approval-timeout re-reminders, completion-storm aggregation, notification text redaction | [README](packages/dsh-notifier/README.md) · [Architecture](docs/architecture/dsh-notifier.md) | Published |
+| `@wingsky-1/dsh-provider-usage` | Multi-provider usage stats framework (v2 adapter contract): persistent capsule + detail panel; DeepSeek official (interval-bookkeeping daily usage derivation + peak/valley countdown badge — works even without an official usage endpoint) and OpenCode Go built in; plug in any data source with a single mjs file, hot-swappable from the settings page; daily/weekly/monthly usage reports (generated via the host llm); API keys stay on the host, never reach the browser | [README](packages/dsh-provider-usage/README.md) · [Adapter guide](packages/dsh-provider-usage/docs/adapter-guide.md) · [Architecture](docs/architecture/dsh-provider-usage.md) | Published |
+| `@wingsky-1/dsh-lan-proxy` | Access the dsh web UI over LAN: HTTP/HTTPS/WS forwarding + TLS (self-signed / custom certs); dual compression for HTTP (Brotli/gzip adaptive) and WebSocket (permessage-deflate); WS half-open probing keeps mobile backgrounding from going stale; launch-token auto-injection lets LAN devices connect without fetching the token; DNS-rebinding protection + loopback target allowlist | [README](packages/dsh-lan-proxy/README.md) · [Architecture](docs/architecture/dsh-lan-proxy.md) | Published |
+| `@wingsky-1/dsh-mcp-manager` | MCP server manager (stdio / streamable-http): per-working-directory project/global config tiers; project-level MCP collapsed into 4 atomic tools via middleware by default (`middleware: all` folds in global servers, hot-switchable in the settings page); workspace isolation prevents cross-project interference; configs store `${ENV}` references only — no plaintext secrets on disk; runtime registration API for other plugins to inject MCP servers | [README](packages/dsh-mcp-manager/README.md) · [Architecture](docs/architecture/dsh-mcp-manager.md) | Published |
+| `@wingsky-1/dsh-web-file-preview` | Web-side preview for conversation file links: images (lightbox zoom) / Markdown (with Mermaid diagram rendering) / code (25+ languages highlighted) / text / git Diff / sandboxed HTML preview (iframe sandbox, no script execution); @-mention recognition + path fallback search (unique basename match inside the workspace when the referenced path is wrong) | [README](packages/dsh-web-file-preview/README.md) · [Architecture](docs/architecture/dsh-web-file-preview.md) | Published |
+| `@wingsky-1/dsh-verify-isolated` | Isolated-environment browser verification skill for DSH plugin development: temp DSH_HOME + independent profile + independent port + independent browser instance (four-way isolation), one-command launch with automatic cleanup; bundled zero-dependency raw-CDP browser driver (snapshot / click / screenshot / eval), optional isolation audit | [README](packages/dsh-verify-isolated/README.md) · [Architecture](docs/architecture/dsh-verify-isolated.md) | Published |
+| `@wingsky-1/dsh-codegraph` | codegraph local code-graph MCP + worktree development discipline: 8 wrapper tools (impact / call chains / symbol search / file structure, etc.); queries force a sync first to guarantee index freshness and auto-complete projectPath; registered at runtime via mcp-manager | [README](packages/dsh-codegraph/README.md) · [Architecture](docs/architecture/dsh-codegraph.md) | Published (standalone, not in the bundle) |
 
 > **Standalone note**: `@wingsky-1/dsh-codegraph` is published **standalone** and is **not
 > included in `dsh-plugins-all`**; install it separately (it registers the codegraph MCP at
@@ -202,6 +203,8 @@ individual package, then restart.
 ## Security notes
 
 - After installing `dsh-lan-proxy`, HTTP/HTTPS ports are opened on `0.0.0.0` — **every device on your LAN can access your dsh**. Uninstall it when not needed.
+- The launch-token auto-injection of `dsh-lan-proxy` (`injectToken`) is **on by default**: any device on the LAN that can reach the port gets full dsh control without a token (equivalent to trusting the entire LAN — bash passthrough to the host). Enable it only on a trusted intranet; turn it off in the settings card on untrusted segments.
+- When `dsh-web-file-preview` is exposed through `dsh-lan-proxy` or any proxy that forwards external traffic, the loopback fence is bypassed: **LAN devices can preview local files without any credentials (including credential/config files under `~/.dsh`)** — use it only on a trusted LAN, never expose it to public networks.
 - The stdio subprocesses of `dsh-mcp-manager` inherit host privileges; only configure MCP servers you trust.
 - All plugin routes are loopback-fenced (non-loopback → 403, wrong method → 405).
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ DSH（DeepSeek Harness）Web GUI 插件集，npm 分发：一键装全家桶，�
 
 - **安全内建于默认**：坚持最小暴露面与最小凭据流转——管理面只对本机开放，
   密钥默认不明文落盘、不进浏览器；各插件的威胁模型与加固细节见其 README 安全章节
-- **上下文成本可控的 MCP 管理**：项目级 MCP 默认经中间层收敛为 `ws_mcp_search` /
-  `ws_mcp_call` 两个原子工具，项目级接入规模不再膨胀上下文（`middleware: all`
-  可把全局服务器也收进中间层）；分工作目录维护项目级/全局两级配置，
-  多仓库各配各的 MCP，互不串台
+- **上下文成本可控的 MCP 管理**：项目级 MCP 默认经中间层收敛为 `ws_mcp_list` /
+  `ws_mcp_detail` / `ws_mcp_search` / `ws_mcp_call` 四个原子工具，项目级接入规模
+  不再膨胀上下文（`middleware: all` 可把全局服务器也收进中间层，设置页热切换）；
+  分工作目录维护项目级/全局两级配置，多仓库各配各的 MCP，互不串台
 - **可扩展的用量统计框架**：通用 v2 适配器契约，内置 DeepSeek 官方与 OpenCode Go
   开箱即用；自写一个 mjs 文件即可接入任意数据源，设置页热插拔
 - **工程质量背书**：每个插件自带 smoke 断言（路由围栏 / 客户端契约），构建契约 +
@@ -37,13 +37,13 @@ DSH（DeepSeek Harness）Web GUI 插件集，npm 分发：一键装全家桶，�
 
 | 包名 | 功能 | 文档 | 状态 |
 |---|---|---|---|
-| `@wingsky-1/dsh-notifier` | 审批/完成/错误事件通知（浏览器 Notification + 系统 toast） | [README](packages/dsh-notifier/README.md) | ✅ 已发布 |
-| `@wingsky-1/dsh-provider-usage` | 多 provider 用量统计悬浮框（通用适配器框架：内置 DeepSeek 官方与 OpenCode Go 开箱即用，自写 mjs 即可接入任意数据源） | [README](packages/dsh-provider-usage/README.md) | ✅ 已发布 |
-| `@wingsky-1/dsh-lan-proxy` | 局域网访问 dsh web UI（HTTP/HTTPS/WS 转发 + TLS + HTTP 响应压缩，Brotli/gzip 自适应） | [README](packages/dsh-lan-proxy/README.md) | ✅ 已发布 |
-| `@wingsky-1/dsh-mcp-manager` | MCP 服务器管理器（stdio/HTTP；分工作目录维护项目级/全局两级配置，项目级 MCP 经中间层收敛、免于工具洪水） | [README](packages/dsh-mcp-manager/README.md) | ✅ 已发布 |
-| `@wingsky-1/dsh-web-file-preview` | 点击对话文件链接在 web 端预览（图片/文本/Markdown/代码/Diff/Mermaid） | [README](packages/dsh-web-file-preview/README.md) | ✅ 已发布 |
-| `@wingsky-1/dsh-verify-isolated` | DSH 插件开发的隔离环境浏览器验证 skill（临时 DSH_HOME + 独立 profile 双重隔离） | [README](packages/dsh-verify-isolated/README.md) | ✅ 已发布 |
-| `@wingsky-1/dsh-codegraph` | codegraph 本地代码图谱 MCP + worktree 开发纪律（经 mcp-manager 运行时注册） | [README](packages/dsh-codegraph/README.md) | ✅ 已发布（独立发包，暂不进聚合包） |
+| `@wingsky-1/dsh-notifier` | 任务事件通知中心：6 类事件（提问/审批/完成/子代理完成/错误/轮次完成），双通道（浏览器通知 + 宿主系统 toast）+ Bark/Webhook 推送频道（ntfy、Gotify、自建网关）；免打扰时段与紧急例外、审批超时二次提醒、完成风暴聚合、通知文本脱敏 | [README](packages/dsh-notifier/README.md) · [架构图解](docs/architecture/dsh-notifier.md) | 已发布 |
+| `@wingsky-1/dsh-provider-usage` | 多 provider 用量统计框架（v2 适配器契约）：常驻胶囊 + 详情面板；内置 DeepSeek 官方（区间记账法推算每日用量 + 峰谷倒计时徽标，官方无用量接口也能算）与 OpenCode Go 开箱即用；自写一个 mjs 即可接入任意数据源、设置页热插拔；日/周/月用量报告（经宿主 llm 生成）；密钥只在宿主端不进浏览器 | [README](packages/dsh-provider-usage/README.md) · [适配器开发指南](packages/dsh-provider-usage/docs/adapter-guide.md) · [架构图解](docs/architecture/dsh-provider-usage.md) | 已发布 |
+| `@wingsky-1/dsh-lan-proxy` | 局域网访问 dsh web UI：HTTP/HTTPS/WS 转发 + TLS（自签名/自定义证书）；HTTP（Brotli/gzip 自适应）与 WebSocket（permessage-deflate）双压缩；WS 半开探活，移动端切后台不僵死；启动令牌自动注入，LAN 设备免手工拿 token；DNS 重绑定防护 + 回环目标白名单 | [README](packages/dsh-lan-proxy/README.md) · [架构图解](docs/architecture/dsh-lan-proxy.md) | 已发布 |
+| `@wingsky-1/dsh-mcp-manager` | MCP 服务器管理器（stdio / streamable-http）：项目级/全局两级配置分工作目录维护；项目级 MCP 默认经中间层收敛为 4 个原子工具（`middleware: all` 全量收敛、设置页热切换）；工作空间隔离防串台；配置只存 `${ENV}` 引用不落盘密钥；提供运行时注册接口供其他插件注入 MCP | [README](packages/dsh-mcp-manager/README.md) · [架构图解](docs/architecture/dsh-mcp-manager.md) | 已发布 |
+| `@wingsky-1/dsh-web-file-preview` | 对话文件链接 web 端预览：图片（灯箱缩放）/ Markdown（含 Mermaid 图表渲染）/ 代码（25+ 语言高亮）/ 文本 / git Diff / HTML 沙箱预览（iframe sandbox 不执行脚本）；@ 引用识别 + 路径兜底搜索（引用路径写错时按 basename 在工作区内唯一匹配） | [README](packages/dsh-web-file-preview/README.md) · [架构图解](docs/architecture/dsh-web-file-preview.md) | 已发布 |
+| `@wingsky-1/dsh-verify-isolated` | DSH 插件开发的隔离环境浏览器验证 skill：临时 DSH_HOME + 独立 profile + 独立端口 + 独立浏览器实例四重隔离，一键拉起、退出自动清理；自带 raw CDP 零依赖浏览器驱动（快照/点击/截图/求值），可选隔离审计 | [README](packages/dsh-verify-isolated/README.md) · [架构图解](docs/architecture/dsh-verify-isolated.md) | 已发布 |
+| `@wingsky-1/dsh-codegraph` | codegraph 本地代码图谱 MCP + worktree 开发纪律：8 个封装工具（影响面/调用链/符号搜索/文件结构等），查询前强制 sync 保证索引新鲜、projectPath 自动补全；经 mcp-manager 运行时注册 | [README](packages/dsh-codegraph/README.md) · [架构图解](docs/architecture/dsh-codegraph.md) | 已发布（独立发包，暂不进聚合包） |
 
 > **独立发包说明**：`@wingsky-1/dsh-codegraph` 为**独立发包**、**未包含在
 > `dsh-plugins-all` 聚合包中**，需单独安装（它经 mcp-manager 运行时注册 codegraph MCP，
@@ -183,6 +183,8 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-plugins-all
 ## 安全提醒
 
 - `dsh-lan-proxy` 装完即在 `0.0.0.0` 开放 HTTP/HTTPS 端口，**局域网所有设备可访问你的 dsh**——不需要时请卸载
+- `dsh-lan-proxy` 的启动令牌自动注入（`injectToken`）**默认开启**：局域网内任何能访问该端口的设备免 token 获得完整 dsh 控制权（等效信任整个局域网，bash 直通宿主机）——仅在可信内网开启，不可信网段务必在设置卡片关闭
+- `dsh-web-file-preview` 经 `dsh-lan-proxy` 等代理对外暴露时 loopback 围栏会被代理穿透：**局域网设备无需任何凭据即可预览本机文件（含 `~/.dsh` 下的凭据/配置文件）**——请在可信局域网使用，勿暴露到公共网络
 - `dsh-mcp-manager` 的 stdio 子进程继承宿主权限，只配置可信的 MCP 服务器
 - 各插件全部路由均 loopback 围栏（非回环 403 / 方法错 405）
 

--- a/packages/dsh-plugins-all/README.en.md
+++ b/packages/dsh-plugins-all/README.en.md
@@ -56,12 +56,12 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-plugins-all
 
 | Package | Function |
 |---|---|
-| `@wingsky-1/dsh-notifier` | Approval / completion / error event notifications (browser Notification + system toast) |
-| `@wingsky-1/dsh-provider-usage` | Multi-provider usage floating panel (adapter framework, ships with OpenCode Go) |
-| `@wingsky-1/dsh-lan-proxy` | Access dsh web UI over the LAN (HTTP/HTTPS/WS + TLS + HTTP response gzip) |
-| `@wingsky-1/dsh-mcp-manager` | MCP server manager (stdio/HTTP, tools registered for the model) |
-| `@wingsky-1/dsh-web-file-preview` | Preview conversation file links in the web UI (image/text/Markdown/code/Diff) |
-| `@wingsky-1/dsh-verify-isolated` | Isolated-verification skill for plugin development (temp DSH_HOME + dedicated profile double isolation) |
+| `@wingsky-1/dsh-notifier` | Task-event notification center (6 event kinds; browser + system toast dual channels + Bark/Webhook push channels) |
+| `@wingsky-1/dsh-provider-usage` | Multi-provider usage capsule (v2 adapter framework: DeepSeek official and OpenCode Go built in, plug in any data source with your own mjs) |
+| `@wingsky-1/dsh-lan-proxy` | Access dsh web UI over the LAN (HTTP/HTTPS/WS forwarding + TLS; Brotli/gzip + WebSocket dual compression, WS half-open probing, launch-token auto-injection) |
+| `@wingsky-1/dsh-mcp-manager` | MCP server manager (stdio/HTTP; per-working-directory project/global config tiers, project-level MCP collapsed into 4 atomic tools via the middleware) |
+| `@wingsky-1/dsh-web-file-preview` | Web-side preview for conversation file links (image / Markdown (Mermaid) / code highlighting / text / Diff / HTML sandbox + path fallback search) |
+| `@wingsky-1/dsh-verify-isolated` | Isolated-verification skill for plugin development (four-way isolation: DSH_HOME / profile / port / browser instance + bundled browser driver) |
 
 > `@wingsky-1/dsh-gzip` is retired: HTTP response compression has been merged into
 > dsh-lan-proxy and no longer ships with the bundle. Users who installed dsh-gzip

--- a/packages/dsh-plugins-all/README.md
+++ b/packages/dsh-plugins-all/README.md
@@ -50,12 +50,12 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-plugins-all
 
 | 包 | 功能 |
 |---|---|
-| `@wingsky-1/dsh-notifier` | 审批/完成/错误事件通知（浏览器 Notification + 系统 toast） |
-| `@wingsky-1/dsh-provider-usage` | 多 provider 用量悬浮框（适配器框架，内置 OpenCode Go） |
-| `@wingsky-1/dsh-lan-proxy` | 局域网访问 dsh web UI（HTTP/HTTPS/WS + TLS + HTTP 响应 gzip 压缩） |
-| `@wingsky-1/dsh-mcp-manager` | MCP 服务器管理器（stdio/HTTP，工具注册给模型） |
-| `@wingsky-1/dsh-web-file-preview` | 点击对话文件链接在 web 端预览（图片/文本/Markdown/代码/Diff） |
-| `@wingsky-1/dsh-verify-isolated` | 插件开发隔离验证 skill（临时 DSH_HOME + 独立 profile 双重隔离） |
+| `@wingsky-1/dsh-notifier` | 任务事件通知中心（6 类事件；浏览器 + 系统 toast 双通道 + Bark/Webhook 推送频道） |
+| `@wingsky-1/dsh-provider-usage` | 多 provider 用量统计胶囊（v2 适配器框架：内置 DeepSeek 官方与 OpenCode Go，自写 mjs 接入任意数据源） |
+| `@wingsky-1/dsh-lan-proxy` | 局域网访问 dsh web UI（HTTP/HTTPS/WS 转发 + TLS；Brotli/gzip 与 WebSocket 双压缩 + WS 半开探活 + 启动令牌自动注入） |
+| `@wingsky-1/dsh-mcp-manager` | MCP 服务器管理器（stdio/HTTP；项目级/全局两级配置，项目级经中间层收敛为 4 个原子工具） |
+| `@wingsky-1/dsh-web-file-preview` | 对话文件链接 web 端预览（图片 / Markdown（Mermaid）/ 代码高亮 / 文本 / Diff / HTML 沙箱 + 路径兜底搜索） |
+| `@wingsky-1/dsh-verify-isolated` | 插件开发隔离验证 skill（DSH_HOME / profile / 端口 / 浏览器实例四重隔离 + 自带浏览器驱动） |
 
 <details>
 <summary><b>历史退役说明</b>——dsh-gzip / dsh-idle-archive / dsh-subagent-model-inherit（已退役）</summary>


### PR DESCRIPTION
## 改动摘要

按各插件包 README（单一事实源）重写主 README 的插件描述与相关口径，纯文档改动、4 个文件：

### README.md / README.en.md（同构）

1. **插件列表「功能」列整体重写**（定位 + 当前功能亮点）：
   - notifier：任务事件通知中心口径——6 类事件、双通道 + Bark/Webhook 推送频道（ntfy/Gotify/自建网关）、免打扰与紧急例外、审批超时二次提醒、完成风暴聚合、文本脱敏
   - provider-usage：补峰谷倒计时徽标、区间记账法（官方无用量接口也能算）、日/周/月用量报告（经宿主 llm 生成）、密钥不出宿主
   - lan-proxy：补 WebSocket permessage-deflate 压缩、WS 半开探活（移动端切后台不僵死）、injectToken 启动令牌自动注入、DNS 重绑定防护
   - mcp-manager：三档中间层模式（`middleware: all` 全量收敛、设置页热切换）、工作空间隔离、`${ENV}` 引用不落盘密钥、运行时注册接口
   - web-file-preview：补 HTML 沙箱预览、Mermaid 图表、@ 引用识别、路径兜底搜索
   - verify-isolated：修正「双重隔离」旧口径为**四重隔离**，补自带 raw CDP 浏览器驱动与可选隔离审计
   - codegraph：突出查询前强制 sync（索引新鲜硬保证）+ projectPath 自动补全、8 个封装工具
2. **「文档」列补链接**：各插件架构图解（`docs/architecture/dsh-<name>.md`）+ provider-usage 适配器开发指南（包内 `docs/adapter-guide.md`）
3. **核心优势 MCP 条修正**：「两个原子工具」→ 四个原子工具（`ws_mcp_list`/`ws_mcp_detail`/`ws_mcp_search`/`ws_mcp_call`），补设置页热切换
4. **安全提醒补两条高危项**：
   - lan-proxy `injectToken` 默认开启 = 等效信任整个局域网（免 token 获完整控制权，不可信网段务必关闭）
   - web-file-preview 经代理对外暴露时 loopback 围栏被穿透，免凭据可读本机文件（含 `~/.dsh` 凭据文件）
5. **状态列去 emoji**：「✅ 已发布」→「已发布」（AGENTS.md 禁 emoji 红线）

### packages/dsh-plugins-all/README.md / README.en.md

「包含的插件」表同步新口径（原表仍是旧文案：「gzip 压缩」「双重隔离」、缺 DeepSeek 官方适配器等）。

## 方案评审

方案经独立子 agent 对抗性评审后修订（补 WS 半开探活、injectToken 安全条目、去 emoji 等均来自评审结论；评审员对「日/周/月报告」与 `docs/adapter-guide.md` 存在性的两条质疑经实证复核推翻——`src/report/` 全套实现 + smoke 覆盖、`packages/dsh-provider-usage/docs/adapter-guide.md` 确实存在）。

## 自查

- [x] 各插件描述与对应包 README 事实一致（写作时逐条对照）
- [x] 无 emoji；双语同构（zh/en 1:1）
- [x] 旧口径无残留（grep「双重隔离 / 两个原子工具 / gzip 压缩 / ✅」零命中）
- [x] 新增链接目标全部存在（8 个架构文档 + adapter-guide 逐一验证）
- [x] 纯文档改动，不触碰 `src/`、`lib/`、构建配置；README 不进 lib/ 产物，无需 build 验证

Closes #550
