### PR TITLE
fix(dsh-notifier): 审批通知 waterfall 链头化——prepend 修复宿主 answerer 短路致 approval/request 不可达

### DIFF
--- a/packages/dsh-notifier/src/index.ts
+++ b/packages/dsh-notifier/src/index.ts
@@ -364,8 +364,11 @@ export function apply(ctx: Context, config: NotifierApplyConfig = {}): void {
    * 审批事件（GUI 弹框一切正常但 toast/history 零记录）。{ prepend: true }
    * （cordis register 的官方 unshift 语义）把本监听器固定在链头：先通知 →
    * await next() → GUI 应答，outcome 语义零改动；global 仍负责绕过
-   * waterfall 的 scope 过滤。依赖面 = cordis register 的 unshift/push 序
-   * （smoke 以真实 cordis 链序断言固化，见 test/real-context.test.ts F 系列）。
+   * waterfall 的 scope 过滤。注意 prepend 固定的是**注册时刻**链头，之后
+   * 仍 prepend 注册的监听者会插到本监听器之前（固有博弈面；本插件不短路，
+   * 不影响任何下游 answerer 的 outcome）。依赖面 = cordis register 的
+   * unshift/push 序（smoke 以真实 cordis 链序断言固化，
+   * 见 test/real-context.test.ts F 系列）。
    */
   /** 审批超时二次提醒：per-request 定时器表；next() settle（用户已决定）即清除。 */
   const askRemindTimers = new Map<string, NodeJS.Timeout>();

--- a/packages/dsh-notifier/src/index.ts
+++ b/packages/dsh-notifier/src/index.ts
@@ -356,6 +356,16 @@ export function apply(ctx: Context, config: NotifierApplyConfig = {}): void {
    * 的 gate ask 在当前 DSH 部署中无产生者，故不挂那里）。在 await next()
    * 之前通知——next() 会阻塞到用户审批结束，这正是"等待审批"提醒的时机；
    * 不短路，返回 next() 结果。
+   *
+   * 链序契约（issue #559）：cordis waterfall 按监听器注册顺序执行，不调
+   * next() 即短路。宿主内置的浏览器审批 UI answerer（dsh-api-remotes 转发
+   * 桥）在内核启动时注册、先于 profile 挂载的第三方插件，且 GUI 应答后直接
+   * 返回 outcome 不调 next()——若按默认 push 序注册，本监听器将永远收不到
+   * 审批事件（GUI 弹框一切正常但 toast/history 零记录）。{ prepend: true }
+   * （cordis register 的官方 unshift 语义）把本监听器固定在链头：先通知 →
+   * await next() → GUI 应答，outcome 语义零改动；global 仍负责绕过
+   * waterfall 的 scope 过滤。依赖面 = cordis register 的 unshift/push 序
+   * （smoke 以真实 cordis 链序断言固化，见 test/real-context.test.ts F 系列）。
    */
   /** 审批超时二次提醒：per-request 定时器表；next() settle（用户已决定）即清除。 */
   const askRemindTimers = new Map<string, NodeJS.Timeout>();
@@ -401,7 +411,7 @@ export function apply(ctx: Context, config: NotifierApplyConfig = {}): void {
           askRemindTimers.delete(askKey);
         }
       }
-    }, { global: true })
+    }, { global: true, prepend: true })
   );
 
   /**

--- a/packages/dsh-notifier/test/real-context.test.ts
+++ b/packages/dsh-notifier/test/real-context.test.ts
@@ -10,7 +10,10 @@
  *   （untagged 放行 + {global:true} 防御），fail-closed（硬断言、无 skip/容错）；
  * - A-1/E-1 静态契约断言：src/index.ts 不得直读 `ctx.agents`、isSubagentOf 走
  *   `ctx.get("agents", false)` 安全读取；全部 `ctx.on` 注册处带 `{ global: true }`
- *   第三参数。
+ *   第三参数；
+ * - E-2/F 系列（issue #559）：approval/request 注册必须 `{ global: true,
+ *   prepend: true }` 链头契约——真实 cordis 双向固化（F-1 反证：push 序下先
+ *   注册的短路 answerer 独占执行；F-2 修复：prepend 链头先执行且 outcome 透传）。
  */
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -57,11 +60,59 @@ import { assertRealCordisContextSemantics, assertEventReachability } from "../..
   assert.ok(/ctx\.get\("agents", false\)/.test(src), "A-1：isSubagentOf 走 ctx.get(\"agents\", false) 安全读取");
   // inject 保持 ["webServer"]（不动）
   assert.ok(/export const inject = \["webServer"\]/.test(src), "A-1：inject 保持 [\"webServer\"]");
-  // E-1：全部 ctx.on 注册处均带 { global: true } 第三参数（当前主干 7 处）
+  // E-1：全部 ctx.on 注册处均带 { global: true } 第三参数（当前主干 7 处；
+  // approval/request 一处升级为 { global: true, prepend: true }——issue #559 链序契约）
   const onCalls = (src.match(/ctx\.on\(\s*"/g) ?? []).length;
-  const globalized = (src.match(/ctx\.on\(\s*"[^"]+"[^]*?\{ global: true \}/g) ?? []).length;
+  const globalized = (src.match(/ctx\.on\(\s*"[^"]+"[^]*?\{ global: true[ ,}]/g) ?? []).length;
   assert.ok(onCalls >= 7, `主干 ctx.on 注册应 ≥7 处（实测 ${onCalls}）`);
   assert.equal(globalized, onCalls, `全部 ${onCalls} 处 ctx.on 均应带 {global:true}（实测 ${globalized}）`);
+  // E-2（issue #559）：approval/request 注册处必须带 prepend: true（链头契约）
+  assert.ok(
+    /ctx\.on\(\s*"approval\/request"[^]*?\{ global: true, prepend: true \}/.test(src),
+    "E-2：approval/request 注册必须带 { global: true, prepend: true }（否则宿主内置 answerer 短路后不可达）"
+  );
+}
+
+// ── F：approval/request waterfall 链序契约（issue #559，真实 cordis 派发）──
+// 真实宿主形态：官方 remote 转发桥（dsh-api-remotes）在内核启动时注册短路
+// answerer（GUI 应答后不调 next()），先于 profile 挂载的第三方插件。notifier
+// 以 { global: true, prepend: true } 注册插到链头才可达——此处以真实 cordis
+// 复现该链序并双向固化：F-1 反证基线（push 序不可达）+ F-2 修复行为（prepend
+// 链头先执行、outcome 透传）。
+{
+  // F-1：对照基线——push 序下先注册的短路 answerer 独占执行（回归防线：
+  // 若 cordis 语义变化使 prepend 失效，本断言与 F-2 的差异面会同时暴露）
+  {
+    const root = new Context();
+    const order = [];
+    await root.plugin((ctx) => {
+      // 内核先注册：官方转发桥形态的短路 answerer（不调 next = 短路）
+      ctx.on("approval/request", () => { order.push("answerer"); return "rejected"; });
+    });
+    await root.plugin((ctx) => {
+      // 插件后注册：旧行为（默认 push 序）
+      ctx.on("approval/request", (req, next) => { order.push("notifier"); return next(); });
+    });
+    const outcome = await root.waterfall("approval/request", { agent: { id: "f1" } }, () => "unavailable");
+    assert.deepEqual(order, ["answerer"], "F-1：push 序下先注册的短路 answerer 独占执行，后注册者不可达");
+    assert.equal(outcome, "rejected", "F-1：短路 answerer 的返回值决定 outcome");
+  }
+  // F-2：修复行为——prepend 把后注册的插件监听器固定在链头（先通知再透传）；
+  // 派发用 filter carrier 形态（对无 scope 标签的 listener ctx 放行），贴近官方
+  // ApprovalService 经 scopeTarget(agent, agent) 的真实派发面。
+  {
+    const root = new Context();
+    const order = [];
+    await root.plugin((ctx) => {
+      ctx.on("approval/request", () => { order.push("answerer"); return "rejected"; });
+    });
+    await root.plugin((ctx) => {
+      ctx.on("approval/request", (req, next) => { order.push("notifier"); return next(); }, { global: true, prepend: true });
+    });
+    const outcome = await root.waterfall({ [Context.filter]: () => true }, "approval/request", { agent: { id: "f2" } }, () => "unavailable");
+    assert.deepEqual(order, ["notifier", "answerer"], "F-2：prepend 使后注册的监听器先于短路 answerer 执行");
+    assert.equal(outcome, "rejected", "F-2：outcome 语义不变（answerer 短路返回值仍决定结果）");
+  }
 }
 
 console.log("real-context: OK");

--- a/packages/dsh-notifier/test/real-context.test.ts
+++ b/packages/dsh-notifier/test/real-context.test.ts
@@ -3,9 +3,9 @@
  * dsh-notifier — 真实 cordis Context 形态测试（issue #290 C/D/E 系列）。
  *
  * 覆盖（qa 独立复核必须；纯宿主逻辑，qa 实测豁免——隔离环境用真实 cordis 复核）：
- * - C-1/C-3：smoke-lib `assertRealCordisContextSemantics` 在真实 cordis 4.0.1
- *   Context（插件 fiber 运行时上下文）上成立——未注入服务访问抛错 / ctx.get
- *   安全返回 / effect disposer 真实清理语义；
+ * - C-1/C-3：smoke-lib `assertRealCordisContextSemantics` 在真实 cordis
+ *   （catalog 锁定版）Context（插件 fiber 运行时上下文）上成立——未注入服务
+ *   访问抛错 / ctx.get 安全返回 / effect disposer 真实清理语义；
  * - D-1/D-2/D-3：真实 Context 派发 `agent/status` 与 `session/event` 可达性契约
  *   （untagged 放行 + {global:true} 防御），fail-closed（硬断言、无 skip/容错）；
  * - A-1/E-1 静态契约断言：src/index.ts 不得直读 `ctx.agents`、isSubagentOf 走


### PR DESCRIPTION
## 问题

Closes #559。

真实审批（如沙箱越界写提权）时 dsh-notifier 无 toast、history 无 `ask` 记录（连 `suppressed` 都没有）；同会话提问/完成通知正常。已在 0.1.2-rc.1 + `dsh web`（Linux）实测复现——非 DSH Desktop 特有，两者同链路。

## 根因

cordis waterfall 按监听器**注册顺序**执行，不调 `next()` 即短路：

1. 审批由内核 `ApprovalService.request` 派发：`ctx.waterfall(scopeTarget(agent, agent), "approval/request", req, fallback)`；
2. 宿主内置的浏览器审批 UI answerer（`dsh-api-remotes` 转发桥）内核启动时注册、**先于** profile 挂载的第三方插件，GUI 应答后直接返回 outcome、**不调 `next()`**；
3. `{ global: true }` 只绕过 scope 过滤、不影响顺序——排在后面的插件监听器永远不会执行。

## 修复

`approval/request` 注册升级为 `{ global: true, prepend: true }`（cordis register 官方 unshift 语义），监听器固定链头：**先通知 → await next() → GUI 应答**，outcome 语义零改动。链序依赖面（waterfall 注册序 + 转发桥短路行为）已写入源码契约注释。

## 测试

- `real-context` E-2 静态断言：approval/request 注册必须带 `prepend: true`；
- `real-context` F-1 反证基线：push 序下先注册的短路 answerer 独占执行（真实 cordis Context 派发固化语义）；
- `real-context` F-2 修复行为：prepend 使后注册监听器先于 answerer 执行、outcome 透传不变（filter carrier 派发面贴近官方 `scopeTarget` 形态）；
- 本地全门禁通过：`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck`（含 aggregate:check）。

## 验证证据

纯宿主端逻辑改动（事件注册选项 + 注释 + 测试），不涉及客户端 UI，按 DEVELOPMENT.md §4 豁免浏览器实测；真实环境复现与修复行为以 real-context 真实 cordis 断言覆盖。