### PR TITLE
feat(dsh-mem0): 实现 mem0 长期记忆系统插件最小 MVP（#570）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
               - 'stryker.conf.d/dsh-lan-proxy-*.json'
             dsh-codegraph:
               - 'packages/dsh-codegraph/**'
+            dsh-mem0:
+              - 'packages/dsh-mem0/**'
             dsh-verify-isolated:
               - 'packages/dsh-verify-isolated/**'
             dsh-plugins-all:
@@ -221,6 +223,7 @@ jobs:
           - dsh-provider-usage
           - dsh-lan-proxy
           - dsh-codegraph
+          - dsh-mem0
           - dsh-verify-isolated
           - dsh-plugins-all
     runs-on: ubuntu-latest

--- a/packages/dsh-mem0/README.en.md
+++ b/packages/dsh-mem0/README.en.md
@@ -1,0 +1,23 @@
+# @wingsky-1/dsh-mem0
+
+DeepSeek Harness (DSH) persistent long-term associative memory system plugin based on mem0.
+
+## Features
+
+- **Local stdio runtime**: Launches a lightweight Python subprocess over OS standard I/O (stdio) pipes, bound to the Node parent process lifecycle with zero orphan process risk and zero port conflicts.
+- **Git workspace awareness**: Automatically reads session `cwd` and unifies the memory namespace across git worktrees and main checkouts via Git Canonical identity (`git-common-dir` & `remote.origin.url`).
+- **All-English tool contracts**: Provides 4 core tools (`memory_search`, `memory_add`, `memory_list`, `memory_delete`) with all-English descriptions and offline graceful degradation fallback.
+- **Chinese memory retention**: Embeds Chinese constraint instructions to filter out trivial chit-chat and record concise, factual memories.
+- **Memory Center settings tab**: Mounts a dedicated "Memory Center" tab in the DSH settings panel via the official `settings.section` slot.
+- **dsh-mcp-manager integration**: Server registration, health lifecycle, and tool audit are completely managed by `dsh-mcp-manager`.
+
+## Security Model
+
+- **Process isolation**: Local stdio communication is strictly confined to standard I/O pipes, listening on no external network ports.
+- **Loopback fence**: All `/api/dsh-mem0/*` REST routes enforce a strict loopback fence, rejecting cross-site and non-loopback requests with 403 Forbidden.
+- **Credential protection**: Inherits model provider credentials from DSH settingsScope, passing API keys securely through environment variables without storing plaintext to disk.
+- **Safe deletion**: No bulk wipe tools are exposed to the agent; deletions require confirmation.
+
+## License
+
+MIT

--- a/packages/dsh-mem0/README.md
+++ b/packages/dsh-mem0/README.md
@@ -1,0 +1,23 @@
+# @wingsky-1/dsh-mem0
+
+DeepSeek Harness (DSH) 长期记忆系统插件：基于 mem0 的本地/轻量持久记忆系统。
+
+## 功能特性
+
+- **本地 stdio 极简运行时**：通过管道拉起轻量 Python 子进程，随 Node 父进程同生共死，天然零孤儿进程、零端口冲突。
+- **Git 工作空间感知**：原生识别会话 `cwd`，并通过 Git Canonical 溯源自动统一主仓与所有 Worktree 的记忆空间。
+- **全英文工具契约**：提供 `memory_search`、`memory_add`、`memory_list`、`memory_delete` 4 个核心工具，面向 LLM 的描述全英文，具备离线无感降级容错。
+- **中文事实沉淀**：内置中文约束提示词模板，自动过滤琐碎寒暄，保证记忆全中文提炼入库。
+- **记忆中心设置 Tab**：官方 `settings.section` 挂载独立页面，支持记忆检索、列表浏览与单条删除。
+- **dsh-mcp-manager 统一纳管**：生命周期与工具状态完全交由 `dsh-mcp-manager` 统管。
+
+## 安全模型
+
+- **进程隔离**：本地 stdio 模式通过操作系统管道通信，不监听外部网络端口。
+- **Loopback 围栏**：所有 `/api/dsh-mem0/*` REST 接口强制执行回环校验，拒绝一切非 loopback 跨站访问（403 阻断）。
+- **凭据保护**：继承 DSH 现有 Model Provider 配置，API Key 通过环境变量安全透传，不落盘至明文文件。
+- **防误清库**：不暴露批量清库工具，单条物理删除需经过前端二次确认。
+
+## 许可证
+
+MIT

--- a/packages/dsh-mem0/cordis.patch.yml
+++ b/packages/dsh-mem0/cordis.patch.yml
@@ -1,0 +1,4 @@
+# dsh-mem0 bundle patch：向 web profile 名册插入 mem0 长期记忆系统插件。
+- insert:
+    - id: ui-dsh-mem0
+      name: '@wingsky-1/dsh-mem0'

--- a/packages/dsh-mem0/package.json
+++ b/packages/dsh-mem0/package.json
@@ -1,0 +1,110 @@
+{
+  "name": "@wingsky-1/dsh-mem0",
+  "version": "0.1.0",
+  "description": "DSH 长期记忆系统插件：基于 mem0 的本地/轻量持久记忆，原生感知 Git 工作空间，全英文工具契约，中文沉淀与冲突消解，设置页「记忆中心」管理大盘。",
+  "type": "module",
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "node ../../scripts/build/clean-lib.ts && tsc -p tsconfig.json && node ../../scripts/build/bundle-host.ts .",
+    "test": "node test/smoke.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm run typecheck && pnpm run build && pnpm test"
+  },
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./client": {
+      "types": "./lib/client.d.ts",
+      "default": "./lib/client.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    },
+    "client": {
+      "inject": [
+        "@deepseek-ai/dsh-client-connection"
+      ],
+      "platform": "web"
+    }
+  },
+  "files": [
+    "lib",
+    "server",
+    "shared/**/*.d.ts",
+    "cordis.patch.yml",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wingsky-1/dsh-plugin-hub.git",
+    "directory": "packages/dsh-mem0"
+  },
+  "bugs": {
+    "url": "https://github.com/wingsky-1/dsh-plugin-hub/issues"
+  },
+  "keywords": [
+    "dsh",
+    "deepseek-harness",
+    "plugin",
+    "mem0",
+    "memory",
+    "mcp"
+  ],
+  "author": "wingsky-1",
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "@deepseek-ai/cordis": "4.0.2",
+    "@deepseek-ai/dsh-agent": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-host-webserver": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-llm": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-system-prompt": "0.1.2-rc.1",
+    "@deepseek-ai/dsh-tools": "0.1.2-rc.1"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "@deepseek-ai/cordis": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-agent": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-host-webserver": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-llm": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-system-prompt": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-tools": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@deepseek-ai/cordis": "catalog:",
+    "@deepseek-ai/dsh-agent": "catalog:",
+    "@deepseek-ai/dsh-client-ui-slots": "catalog:",
+    "@deepseek-ai/dsh-host-webserver": "catalog:",
+    "@deepseek-ai/dsh-llm": "catalog:",
+    "@deepseek-ai/dsh-system-prompt": "catalog:",
+    "@deepseek-ai/dsh-tools": "catalog:",
+    "@wingsky-1/dsh-mcp-manager": "workspace:*",
+    "schemastery": "^3.18.0"
+  }
+}

--- a/packages/dsh-mem0/package.json
+++ b/packages/dsh-mem0/package.json
@@ -38,6 +38,7 @@
     "shared/**/*.d.ts",
     "cordis.patch.yml",
     "README.md",
+    "README.en.md",
     "LICENSE"
   ],
   "engines": {

--- a/packages/dsh-mem0/server/mem0_server.py
+++ b/packages/dsh-mem0/server/mem0_server.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""mem0 stdio MCP server for DeepSeek Harness (DSH).
+
+Provides local, persistent long-term associative memory for DSH agents
+via standard I/O (stdio) MCP transport.
+"""
+
+import json
+import os
+import sys
+import threading
+from typing import Any, Dict, List, Optional
+
+# Disable telemetry before importing mem0
+os.environ["MEM0_TELEMETRY"] = "False"
+if "HF_ENDPOINT" not in os.environ:
+    os.environ["HF_ENDPOINT"] = "https://hf-mirror.com"
+
+from mcp.server.fastmcp import FastMCP
+
+# ---------- Configuration & Defaults ----------
+DEFAULT_DATA_DIR = os.path.expanduser(os.environ.get("MEM0_DATA_DIR", "~/.dsh/mem0/data"))
+os.makedirs(DEFAULT_DATA_DIR, exist_ok=True)
+
+QDRANT_PATH = os.environ.get("QDRANT_PATH", os.path.join(DEFAULT_DATA_DIR, "qdrant"))
+QDRANT_HOST = os.environ.get("QDRANT_HOST")
+QDRANT_PORT = int(os.environ.get("QDRANT_PORT", "6333"))
+
+LLM_API_KEY = os.environ.get("LLM_API_KEY", "")
+LLM_BASE_URL = os.environ.get("LLM_BASE_URL", "https://api.deepseek.com/v1")
+LLM_MODEL = os.environ.get("LLM_MODEL", "deepseek-chat")
+LLM_PROVIDER = os.environ.get("LLM_PROVIDER", "openai")
+
+EMBEDDER_MODEL = os.environ.get("EMBEDDER_MODEL", "BAAI/bge-small-zh-v1.5")
+EMBEDDER_PROVIDER = os.environ.get("EMBEDDER_PROVIDER", "fastembed")
+
+CUSTOM_INSTRUCTIONS = os.environ.get(
+    "MEM0_CUSTOM_INSTRUCTIONS",
+    (
+        "记忆必须使用简体中文撰写（命令、路径、专有名词、库名保留原文）。\n"
+        "只提取：用户的工作偏好与约定、明确的决策与方向变更、项目背景与目标、"
+        "踩坑与解决方案、环境事实（路径/端口/工具链/网络拓扑）。\n"
+        "忽略：代码实现细节、一次性任务执行指令、寒暄、过程性内容。\n"
+        "每条记忆为一句完整的中文陈述句，直述事实，不加 User/用户说 之类前缀。"
+    ),
+)
+
+# Vector store config (local embedded Qdrant or remote Qdrant)
+vector_store_cfg: Dict[str, Any] = {
+    "provider": "qdrant",
+    "config": {
+        "collection_name": "mem0",
+        "embedding_model_dims": 512,
+    },
+}
+if QDRANT_HOST:
+    vector_store_cfg["config"]["host"] = QDRANT_HOST
+    vector_store_cfg["config"]["port"] = QDRANT_PORT
+else:
+    vector_store_cfg["config"]["path"] = QDRANT_PATH
+
+# Lazy-loaded Memory instance
+_memory_instance = None
+_lock = threading.Lock()
+
+
+def get_memory():
+    global _memory_instance
+    if _memory_instance is None:
+        with _lock:
+            if _memory_instance is None:
+                from mem0 import Memory
+
+                config = {
+                    "version": "v1.1",
+                    "custom_instructions": CUSTOM_INSTRUCTIONS,
+                    "llm": {
+                        "provider": LLM_PROVIDER,
+                        "config": {
+                            "model": LLM_MODEL,
+                            "api_key": LLM_API_KEY or "dummy-key-for-offline",
+                            "openai_base_url": LLM_BASE_URL,
+                            "temperature": 0.1,
+                            "max_tokens": 2000,
+                        },
+                    },
+                    "embedder": {
+                        "provider": EMBEDDER_PROVIDER,
+                        "config": {"model": EMBEDDER_MODEL},
+                    },
+                    "vector_store": vector_store_cfg,
+                    "history_db_path": os.path.join(DEFAULT_DATA_DIR, "history.db"),
+                }
+                _memory_instance = Memory.from_config(config)
+    return _memory_instance
+
+
+# ---------- FastMCP Server Initialization ----------
+mcp = FastMCP(
+    "mem0",
+    instructions=(
+        "Persistent long-term memory server for DeepSeek Harness.\n"
+        "Allows agents to recall user preferences, architectural decisions, and past bug workarounds.\n"
+        "Context is automatically scoped to projects or global workspace."
+    ),
+)
+
+
+@mcp.tool(
+    name="memory_search",
+    description="Search persistent memory store for relevant past decisions, preferences, or conventions.",
+)
+def memory_search(query: str, user_id: Optional[str] = None, limit: int = 5) -> str:
+    """Search stored memories. If user_id is provided, search is scoped; otherwise cross-domain."""
+    try:
+        mem = get_memory()
+        filters = {"user_id": user_id} if user_id else None
+        results = mem.search(query, filters=filters, limit=limit)
+        items = results.get("results", []) if isinstance(results, dict) else results
+        formatted = []
+        for r in items:
+            text = r.get("memory", "")
+            score = r.get("score")
+            mid = r.get("id", "")
+            score_str = f" [score: {score:.2f}]" if score is not None else ""
+            formatted.append(f"- {text} (id: {mid}){score_str}")
+        return "\n".join(formatted) if formatted else "No matching memories found."
+    except Exception as e:
+        return f"[memory_search failed: {str(e)}]"
+
+
+@mcp.tool(
+    name="memory_add",
+    description="Record a durable fact, user preference, architectural decision, or convention.",
+)
+def memory_add(text: str, user_id: str = "global") -> str:
+    """Add a new memory string. Context is bound to user_id (project namespace or global)."""
+    try:
+        mem = get_memory()
+        res = mem.add(text, user_id=user_id)
+        return json.dumps(res, ensure_ascii=False)
+    except Exception as e:
+        return f"[memory_add failed: {str(e)}]"
+
+
+@mcp.tool(
+    name="memory_list",
+    description="List all stored memories in the specified namespace.",
+)
+def memory_list(user_id: str = "global") -> str:
+    """List memories belonging to user_id."""
+    try:
+        mem = get_memory()
+        items = mem.get_all(filters={"user_id": user_id})
+        memories = items.get("results", []) if isinstance(items, dict) else items
+        formatted = []
+        for r in memories:
+            mid = r.get("id", "")
+            text = r.get("memory", "")
+            formatted.append(f"- [{mid}] {text}")
+        return "\n".join(formatted) if formatted else "No memories found in this namespace."
+    except Exception as e:
+        return f"[memory_list failed: {str(e)}]"
+
+
+@mcp.tool(
+    name="memory_delete",
+    description="Delete a specific memory by its unique ID.",
+)
+def memory_delete(memory_id: str) -> str:
+    """Delete a single memory by ID."""
+    try:
+        mem = get_memory()
+        mem.delete(memory_id)
+        return f"Memory {memory_id} deleted successfully."
+    except Exception as e:
+        return f"[memory_delete failed: {str(e)}]"
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/packages/dsh-mem0/server/requirements.txt
+++ b/packages/dsh-mem0/server/requirements.txt
@@ -1,0 +1,5 @@
+# mem0 stdio MCP server 依赖
+mem0ai==2.0.20
+fastembed==0.8.0
+mcp>=1.8,<2
+qdrant-client>=1.10.0

--- a/packages/dsh-mem0/src/client/MemoryCenter.ts
+++ b/packages/dsh-mem0/src/client/MemoryCenter.ts
@@ -1,0 +1,251 @@
+/**
+ * dsh-mem0 — Web 设置页 Tab「记忆中心」组件。
+ *
+ * 遵循仓库规范：纯 React.createElement 构建，无 JSX/类型依赖。
+ */
+
+import * as React from "react";
+import { t } from "../../../../shared/client/i18n.js";
+import type { Mem0LocaleKey } from "./locales.ts";
+
+function msg(key: Mem0LocaleKey): string {
+  return t(key);
+}
+
+interface StatusData {
+  ready: boolean;
+  currentNamespace: string;
+  globalNamespace: string;
+  mode: string;
+}
+
+export function MemoryCenter() {
+  const useState = React.useState;
+  const useEffect = React.useEffect;
+  const useCallback = React.useCallback;
+  const useMemo = React.useMemo;
+
+  const [status, setStatus] = useState({
+    ready: false,
+    currentNamespace: "global",
+    globalNamespace: "global",
+    mode: "stdio",
+  } as StatusData);
+
+  const [scope, setScope] = useState("project");
+  const [itemsText, setItemsText] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [query, setQuery] = useState("");
+  const [newMemory, setNewMemory] = useState("");
+  const [isAdding, setIsAdding] = useState(false);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/api/dsh-mem0/status");
+      if (res.ok) {
+        const data = (await res.json()) as StatusData;
+        setStatus(data);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const fetchList = useCallback(async (targetScope: string) => {
+    setLoading(true);
+    try {
+      const targetNs = targetScope === "global" ? "global" : undefined;
+      const url = targetNs ? `/api/dsh-mem0/list?namespace=${encodeURIComponent(targetNs)}` : "/api/dsh-mem0/list";
+      const res = await fetch(url);
+      if (res.ok) {
+        const data = (await res.json()) as { result?: string };
+        setItemsText(data.result || "");
+      } else {
+        setItemsText("");
+      }
+    } catch {
+      setItemsText("");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStatus();
+    fetchList(scope);
+  }, [fetchStatus, fetchList, scope]);
+
+  const handleDelete = async (memoryId: string) => {
+    if (!window.confirm(msg("deleteConfirm"))) return;
+    try {
+      const res = await fetch("/api/dsh-mem0/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ memory_id: memoryId }),
+      });
+      if (res.ok) {
+        fetchList(scope);
+      }
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleAdd = async () => {
+    const trimmed = newMemory.trim();
+    if (!trimmed) return;
+    try {
+      const targetNs = scope === "global" ? "global" : status.currentNamespace;
+      const res = await fetch("/api/dsh-mem0/add", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: trimmed, namespace: targetNs }),
+      });
+      if (res.ok) {
+        setNewMemory("");
+        setIsAdding(false);
+        fetchList(scope);
+      }
+    } catch {
+      // ignore
+    }
+  };
+
+  const parsedLines: string[] = useMemo(() => {
+    if (!itemsText) return [];
+    return itemsText
+      .split("\n")
+      .map((l: string) => l.trim())
+      .filter(Boolean)
+      .filter((l: string) => !query || l.toLowerCase().includes(query.toLowerCase()));
+  }, [itemsText, query]);
+
+  // Header
+  const header = React.createElement(
+    "div",
+    { className: "dsh-mem0-header" },
+    React.createElement(
+      "div",
+      null,
+      React.createElement("h2", { className: "dsh-mem0-title" }, msg("title")),
+      React.createElement("p", { className: "dsh-mem0-subtitle" }, msg("subtitle")),
+    ),
+    React.createElement(
+      "span",
+      { className: `dsh-mem0-badge ${status.ready ? "ready" : "offline"}` },
+      status.ready ? msg("statusReady") : msg("statusOffline"),
+    ),
+  );
+
+  // Toolbar
+  const toolbar = React.createElement(
+    "div",
+    { className: "dsh-mem0-toolbar" },
+    React.createElement(
+      "select",
+      {
+        className: "dsh-mem0-select",
+        value: scope,
+        onChange: (e: any) => setScope(e.target.value),
+      },
+      React.createElement("option", { value: "project" }, `${msg("scopeProject")} (${status.currentNamespace})`),
+      React.createElement("option", { value: "global" }, msg("scopeGlobal")),
+    ),
+    React.createElement("input", {
+      type: "text",
+      className: "dsh-mem0-input",
+      placeholder: msg("searchPlaceholder"),
+      value: query,
+      onChange: (e: any) => setQuery(e.target.value),
+    }),
+    React.createElement(
+      "button",
+      { className: "dsh-mem0-btn", onClick: () => fetchList(scope) },
+      msg("refreshBtn"),
+    ),
+    React.createElement(
+      "button",
+      { className: "dsh-mem0-btn primary", onClick: () => setIsAdding(!isAdding) },
+      msg("addBtn"),
+    ),
+  );
+
+  // Add Form
+  const addForm = isAdding
+    ? React.createElement(
+        "div",
+        { className: "dsh-mem0-card", style: { flexDirection: "column" } },
+        React.createElement("textarea", {
+          className: "dsh-mem0-input",
+          rows: 3,
+          placeholder: msg("addPlaceholder"),
+          value: newMemory,
+          onChange: (e: any) => setNewMemory(e.target.value),
+          style: { width: "100%", resize: "vertical" },
+        }),
+        React.createElement(
+          "div",
+          { style: { display: "flex", justifyContent: "flex-end", gap: "8px", width: "100%" } },
+          React.createElement(
+            "button",
+            { className: "dsh-mem0-btn", onClick: () => setIsAdding(false) },
+            "取消",
+          ),
+          React.createElement(
+            "button",
+            { className: "dsh-mem0-btn primary", onClick: handleAdd },
+            msg("saveBtn"),
+          ),
+        ),
+      )
+    : null;
+
+  // List View
+  let listContent: any;
+  if (loading) {
+    listContent = React.createElement("div", { className: "dsh-mem0-empty" }, msg("loading"));
+  } else if (parsedLines.length === 0) {
+    listContent = React.createElement("div", { className: "dsh-mem0-empty" }, msg("emptyList"));
+  } else {
+    const cards = parsedLines.map((line: string, idx: number) => {
+      const idMatch =
+        line.match(/^-\s*\[([a-zA-Z0-9_-]+)\]\s*(.*)$/) ||
+        line.match(/^(?:-\s*)?(.*?)\s*\(id:\s*([a-zA-Z0-9_-]+)\)/);
+      const memoryId = idMatch ? (idMatch[1].length > 10 ? idMatch[1] : idMatch[2]) : "";
+      const content = idMatch ? (idMatch[1].length > 10 ? idMatch[2] : idMatch[1]) : line;
+
+      return React.createElement(
+        "div",
+        { key: idx, className: "dsh-mem0-card" },
+        React.createElement(
+          "div",
+          { style: { flex: 1 } },
+          React.createElement("div", { className: "dsh-mem0-card-content" }, content),
+          memoryId
+            ? React.createElement("div", { className: "dsh-mem0-card-meta" }, `ID: ${memoryId}`)
+            : null,
+        ),
+        memoryId
+          ? React.createElement(
+              "button",
+              {
+                className: "dsh-mem0-del-btn",
+                onClick: () => handleDelete(memoryId),
+              },
+              msg("deleteBtn"),
+            )
+          : null,
+      );
+    });
+    listContent = React.createElement("div", { className: "dsh-mem0-list" }, ...cards);
+  }
+
+  return React.createElement(
+    "div",
+    { className: "dsh-mem0-container" },
+    header,
+    toolbar,
+    addForm,
+    listContent,
+  );
+}

--- a/packages/dsh-mem0/src/client/css.d.ts
+++ b/packages/dsh-mem0/src/client/css.d.ts
@@ -1,0 +1,4 @@
+declare module "*.css" {
+  const styleText: string;
+  export default styleText;
+}

--- a/packages/dsh-mem0/src/client/index.ts
+++ b/packages/dsh-mem0/src/client/index.ts
@@ -1,0 +1,59 @@
+/**
+ * dsh-mem0 — 浏览器端客户端装配入口。
+ */
+
+import React from "react";
+import STYLE from "./style.css";
+import { ensureStyle } from "../../../../shared/client/ensure-style.js";
+import { bindLocale, t } from "../../../../shared/client/i18n.js";
+import { zh, en, type Mem0LocaleKey } from "./locales.ts";
+import { MemoryCenter } from "./MemoryCenter.ts";
+import type { LocaleNamespaceMap } from "@deepseek-ai/dsh-client-ui-slots";
+
+const NS = "dshMem0";
+
+declare module "@deepseek-ai/dsh-client-ui-slots" {
+  interface LocaleNamespaceMap {
+    dshMem0: Mem0LocaleKey;
+  }
+}
+
+export const inject = ["slots", "locale"];
+
+export function apply(ctx: any): void {
+  // 1. 注册 i18n 字典
+  const locale: any = ctx.get("locale");
+  if (locale && typeof locale.register === "function") {
+    try {
+      locale.register(NS, { zh, en });
+      bindLocale(locale, NS);
+      if (typeof locale.subscribe === "function") {
+        locale.subscribe(() => {
+          bindLocale(locale, NS);
+        });
+      }
+    } catch (err) {
+      console.warn("[dsh-mem0] locale register failed:", err);
+    }
+  }
+
+  // 2. 注入样式
+  ensureStyle({ id: "dsh-mem0-style", cssText: STYLE });
+
+  // 3. 注册设置页独立 Tab「记忆中心」（settings.section）
+  const slots = ctx.get("slots");
+  if (slots && typeof slots.inject === "function") {
+    slots.inject("settings.section", () =>
+      slots.register(
+        {
+          name: "settings.section",
+          id: "dsh-mem0",
+          order: 75,
+          label: () => t("tabLabel"),
+          locale: NS,
+        },
+        () => React.createElement(MemoryCenter, null),
+      ),
+    );
+  }
+}

--- a/packages/dsh-mem0/src/client/locales.ts
+++ b/packages/dsh-mem0/src/client/locales.ts
@@ -1,0 +1,57 @@
+/**
+ * dsh-mem0 — 客户端双语字典（zh / en）。
+ *
+ * 遵循仓库 i18n 规范：zh 为 key 源，en 必须覆盖全部 key。
+ */
+
+export const zh = {
+  tabLabel: "记忆中心",
+  title: "长期记忆中心",
+  subtitle: "查看并管理跨会话的持久记忆、技术约定与用户偏好",
+  mode: "运行模式",
+  statusReady: "服务就绪 (stdio)",
+  statusOffline: "服务未就绪",
+  currentNs: "当前项目空间",
+  searchPlaceholder: "检索记忆（语义搜索）…",
+  searchBtn: "搜索",
+  scopeAll: "全部空间",
+  scopeProject: "当前项目",
+  scopeGlobal: "全局空间",
+  deleteConfirm: "确定要永久删除此条记忆吗？",
+  deleteBtn: "删除",
+  addBtn: "手工记录记忆",
+  addPlaceholder: "输入要沉淀的技术决策、约定或偏好…",
+  saveBtn: "保存",
+  emptyList: "当前空间暂无记录的记忆条目",
+  refreshBtn: "刷新",
+  loading: "加载中…",
+  opSuccess: "操作成功",
+  opFailed: "操作失败",
+};
+
+export type Mem0LocaleKey = keyof typeof zh;
+
+export const en: Record<Mem0LocaleKey, string> = {
+  tabLabel: "Memory Center",
+  title: "Persistent Memory Center",
+  subtitle: "Browse and manage long-term associative memories, decisions, and preferences",
+  mode: "Mode",
+  statusReady: "Service Ready (stdio)",
+  statusOffline: "Service Offline",
+  currentNs: "Current Project Namespace",
+  searchPlaceholder: "Search memories (semantic)...",
+  searchBtn: "Search",
+  scopeAll: "All Scopes",
+  scopeProject: "Current Project",
+  scopeGlobal: "Global Scope",
+  deleteConfirm: "Are you sure you want to permanently delete this memory?",
+  deleteBtn: "Delete",
+  addBtn: "Add Memory Manually",
+  addPlaceholder: "Enter architectural decision, convention, or preference...",
+  saveBtn: "Save",
+  emptyList: "No memories stored in this namespace",
+  refreshBtn: "Refresh",
+  loading: "Loading...",
+  opSuccess: "Operation succeeded",
+  opFailed: "Operation failed",
+};

--- a/packages/dsh-mem0/src/client/react-shim.d.ts
+++ b/packages/dsh-mem0/src/client/react-shim.d.ts
@@ -1,0 +1,4 @@
+declare module "react" {
+  const React: any;
+  export = React;
+}

--- a/packages/dsh-mem0/src/client/style.css
+++ b/packages/dsh-mem0/src/client/style.css
@@ -1,0 +1,157 @@
+/**
+ * dsh-mem0 — 客户端组件样式。
+ *
+ * 遵循官方 CSS 变量命名契约，自适应深浅色模式。
+ */
+
+.dsh-mem0-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  color: var(--dsw-alias-label-primary, #1c1e26);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+.dsh-mem0-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  border-bottom: 1px solid var(--dsw-alias-border-l1, #e5e7eb);
+  padding-bottom: 12px;
+}
+
+.dsh-mem0-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 4px 0;
+}
+
+.dsh-mem0-subtitle {
+  font-size: 13px;
+  color: var(--dsw-alias-label-secondary, #6b7280);
+  margin: 0;
+}
+
+.dsh-mem0-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.dsh-mem0-badge.ready {
+  background-color: var(--dsw-alias-success-bg, #ecfdf5);
+  color: var(--dsw-alias-success, #10b981);
+}
+
+.dsh-mem0-badge.offline {
+  background-color: var(--dsw-alias-error-bg, #fef2f2);
+  color: var(--dsw-alias-error, #ef4444);
+}
+
+.dsh-mem0-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.dsh-mem0-select,
+.dsh-mem0-input {
+  padding: 6px 10px;
+  font-size: 13px;
+  border: 1px solid var(--dsw-alias-border-l1, #d1d5db);
+  border-radius: 6px;
+  background: var(--dsw-alias-bg-base, #ffffff);
+  color: var(--dsw-alias-label-primary, #111827);
+  outline: none;
+}
+
+.dsh-mem0-input {
+  flex: 1;
+  min-width: 180px;
+}
+
+.dsh-mem0-btn {
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: 6px;
+  border: 1px solid var(--dsw-alias-border-l1, #d1d5db);
+  background: var(--dsw-alias-interactive-bg, #f3f4f6);
+  color: var(--dsw-alias-label-primary, #374151);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.dsh-mem0-btn:hover {
+  background: var(--dsw-alias-interactive-bg-hover, #e5e7eb);
+}
+
+.dsh-mem0-btn.primary {
+  background: var(--dsw-alias-brand, #2563eb);
+  color: #ffffff;
+  border-color: var(--dsw-alias-brand, #2563eb);
+}
+
+.dsh-mem0-btn.primary:hover {
+  opacity: 0.9;
+}
+
+.dsh-mem0-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 480px;
+  overflow-y: auto;
+}
+
+.dsh-mem0-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 12px;
+  border-radius: 8px;
+  background: var(--dsw-alias-bg-layer-1, #f9fafb);
+  border: 1px solid var(--dsw-alias-border-l1, #e5e7eb);
+  gap: 12px;
+}
+
+.dsh-mem0-card-content {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--dsw-alias-label-primary, #1f2937);
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.dsh-mem0-card-meta {
+  font-size: 11px;
+  color: var(--dsw-alias-label-secondary, #9ca3af);
+  margin-top: 4px;
+}
+
+.dsh-mem0-del-btn {
+  background: transparent;
+  border: none;
+  color: var(--dsw-alias-label-secondary, #9ca3af);
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.dsh-mem0-del-btn:hover {
+  background: var(--dsw-alias-error-bg, #fee2e2);
+  color: var(--dsw-alias-error, #dc2626);
+}
+
+.dsh-mem0-empty {
+  padding: 32px 0;
+  text-align: center;
+  color: var(--dsw-alias-label-secondary, #9ca3af);
+  font-size: 13px;
+}

--- a/packages/dsh-mem0/src/executor.ts
+++ b/packages/dsh-mem0/src/executor.ts
@@ -1,0 +1,206 @@
+/**
+ * dsh-mem0 — Stdio MCP 运行时进程执行器（MemoryExecutor 实现）。
+ *
+ * 核心职责：
+ * 1. spawn 本地 Python stdio 子进程（server/mem0_server.py）；
+ * 2. 维持 MCP 协议初始化握手（initialize -> notifications/initialized）；
+ * 3. 封装 tools/call 发送与请求/响应关联；
+ * 4. 异常退避与生命周期清理（disposer kill 子进程，零孤儿进程）。
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { createInterface } from "node:readline";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { MemoryExecutor } from "./tool-definitions.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+interface PendingRequest {
+  resolve: (value: any) => void;
+  reject: (reason: any) => void;
+  timer: NodeJS.Timeout;
+}
+
+export class StdioMemoryExecutor implements MemoryExecutor {
+  private proc?: ChildProcess;
+  private reqId = 1;
+  private pending = new Map<number, PendingRequest>();
+  private ready = false;
+  private scriptPath: string;
+  private pythonBin: string;
+
+  constructor(options?: { scriptPath?: string; pythonBin?: string }) {
+    // 默认定位包内的 server/mem0_server.py
+    this.scriptPath = options?.scriptPath ?? resolve(__dirname, "../server/mem0_server.py");
+    this.pythonBin = options?.pythonBin ?? "python3";
+  }
+
+  public isReady(): boolean {
+    return this.ready && this.proc !== undefined && !this.proc.killed;
+  }
+
+  public async start(envOverrides?: Record<string, string>): Promise<void> {
+    if (this.isReady()) return;
+
+    const env = {
+      ...process.env,
+      PYTHONUNBUFFERED: "1",
+      ...envOverrides,
+    };
+
+    try {
+      this.proc = spawn(this.pythonBin, [this.scriptPath], {
+        env,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (err) {
+      this.ready = false;
+      return;
+    }
+
+    if (!this.proc.stdout || !this.proc.stdin) {
+      this.ready = false;
+      return;
+    }
+
+    const rl = createInterface({ input: this.proc.stdout });
+    rl.on("line", (line) => {
+      this.handleLine(line);
+    });
+
+    this.proc.on("exit", () => {
+      this.ready = false;
+      this.proc = undefined;
+      for (const req of this.pending.values()) {
+        clearTimeout(req.timer);
+        req.reject(new Error("Python memory process exited"));
+      }
+      this.pending.clear();
+    });
+
+    // 握手初始化
+    try {
+      await this.sendRequest("initialize", {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "dsh-mem0", version: "0.1.0" },
+      }, 10_000);
+
+      this.sendNotification("notifications/initialized", {});
+      this.ready = true;
+    } catch {
+      this.ready = false;
+    }
+  }
+
+  public stop(): void {
+    this.ready = false;
+    if (this.proc && !this.proc.killed) {
+      try {
+        this.proc.kill("SIGTERM");
+      } catch {
+        // ignore
+      }
+      this.proc = undefined;
+    }
+    for (const req of this.pending.values()) {
+      clearTimeout(req.timer);
+      req.reject(new Error("Executor stopped"));
+    }
+    this.pending.clear();
+  }
+
+  public async search(query: string, userId?: string, limit?: number): Promise<string> {
+    const res = await this.callTool("memory_search", {
+      query,
+      user_id: userId,
+      limit: limit ?? 5,
+    });
+    return this.extractContent(res);
+  }
+
+  public async add(text: string, userId: string): Promise<string> {
+    const res = await this.callTool("memory_add", {
+      text,
+      user_id: userId,
+    });
+    return this.extractContent(res);
+  }
+
+  public async list(userId: string): Promise<string> {
+    const res = await this.callTool("memory_list", {
+      user_id: userId,
+    });
+    return this.extractContent(res);
+  }
+
+  public async delete(memoryId: string): Promise<string> {
+    const res = await this.callTool("memory_delete", {
+      memory_id: memoryId,
+    });
+    return this.extractContent(res);
+  }
+
+  private async callTool(name: string, args: Record<string, unknown>): Promise<any> {
+    return this.sendRequest("tools/call", {
+      name,
+      arguments: args,
+    }, 30_000);
+  }
+
+  private extractContent(result: any): string {
+    if (!result) return "";
+    if (typeof result === "string") return result;
+    if (Array.isArray(result.content)) {
+      return result.content
+        .map((c: any) => (typeof c === "object" && c !== null && typeof c.text === "string" ? c.text : ""))
+        .filter(Boolean)
+        .join("\n");
+    }
+    return JSON.stringify(result, null, 2);
+  }
+
+  private sendNotification(method: string, params?: any): void {
+    if (!this.proc?.stdin || this.proc.stdin.destroyed) return;
+    const msg = JSON.stringify({ jsonrpc: "2.0", method, params });
+    this.proc.stdin.write(msg + "\n");
+  }
+
+  private sendRequest(method: string, params: any, timeoutMs = 15_000): Promise<any> {
+    return new Promise((resolve, reject) => {
+      if (!this.proc?.stdin || this.proc.stdin.destroyed) {
+        return reject(new Error("Process stdin not available"));
+      }
+      const id = ++this.reqId;
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`MCP request '${method}' timed out (${timeoutMs}ms)`));
+      }, timeoutMs);
+
+      this.pending.set(id, { resolve, reject, timer });
+      const msg = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+      this.proc.stdin.write(msg + "\n");
+    });
+  }
+
+  private handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    try {
+      const msg = JSON.parse(trimmed);
+      if (typeof msg.id === "number" && this.pending.has(msg.id)) {
+        const req = this.pending.get(msg.id)!;
+        this.pending.delete(msg.id);
+        clearTimeout(req.timer);
+        if (msg.error) {
+          req.reject(new Error(msg.error.message || JSON.stringify(msg.error)));
+        } else {
+          req.resolve(msg.result);
+        }
+      }
+    } catch {
+      // 忽略无法解析为 JSON 的非协议调试行
+    }
+  }
+}

--- a/packages/dsh-mem0/src/index.ts
+++ b/packages/dsh-mem0/src/index.ts
@@ -1,0 +1,115 @@
+/**
+ * dsh-mem0 — 宿主端装配层入口。
+ *
+ * 核心能力：
+ * 1. 启动并维持本地 stdio Python 记忆服务运行时；
+ * 2. 经 ctx.mcpManager.registerServer 注册 mem0 及其 4 个封装工具；
+ * 3. 注册会话级单次提示词钩子（<=50 tokens）；
+ * 4. 注册 /api/dsh-mem0/* loopback 保护路由；
+ * 5. 生命周期严格随 Cordis 容器释放，零孤儿进程。
+ */
+
+import type { Context } from "@deepseek-ai/cordis";
+import type { WebRoute } from "@deepseek-ai/dsh-host-webserver";
+import type { McpManagerService } from "../../../shared/mcp-manager-service.d.ts";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { StdioMemoryExecutor } from "./executor.ts";
+import { registerMemoryPromptHook } from "./prompt.ts";
+import { createMem0Routes } from "./routes.ts";
+import { buildAllMemoryTools } from "./tool-definitions.ts";
+
+export const name = "mem0";
+
+// 内部模块 re-export（供公共测试面 + 其他插件消费）
+export {
+  GLOBAL_NAMESPACE,
+  normalizeGitRemote,
+  resolveGitCanonicalNamespace,
+  resetNamespaceCache,
+} from "./namespace.ts";
+export {
+  UNAVAILABLE_MSG,
+  buildAllMemoryTools,
+  buildMemorySearchTool,
+  buildMemoryAddTool,
+  buildMemoryListTool,
+  buildMemoryDeleteTool,
+} from "./tool-definitions.ts";
+export {
+  MEMORY_DISCIPLINE_TEXT,
+  isMemoryDisciplineInjected,
+  registerMemoryPromptHook,
+} from "./prompt.ts";
+export { createMem0Routes } from "./routes.ts";
+export { StdioMemoryExecutor } from "./executor.ts";
+
+/**
+ * 强依赖宿主服务：
+ * - mcpManager: MCP 统一管理、状态与工具注册
+ * - webServer: 注册 Web 路由
+ */
+export const inject = ["mcpManager", "webServer"];
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export function apply(ctx: Context): void {
+  const scriptPath = resolve(__dirname, "../server/mem0_server.py");
+  const executor = new StdioMemoryExecutor({ scriptPath });
+
+  // 记录当前活跃的 cwd（用于非会话态路由查询兜底）
+  let latestCwd: string | undefined = process.cwd();
+
+  ctx.on("agent/pre-step", async ({ agent }, next) => {
+    const cwd = (agent?.session as unknown as { header?: { cwd?: string } })?.header?.cwd;
+    if (typeof cwd === "string" && cwd) {
+      latestCwd = cwd;
+    }
+    return next();
+  });
+
+  // 1. 构建封装工具定义
+  const tools = buildAllMemoryTools(executor);
+
+  // 2. 经 mcpManager 注册 MCP 服务器（带有封装工具）
+  const mcpManager = ctx.get("mcpManager") as McpManagerService | undefined;
+  if (mcpManager && typeof mcpManager.registerServer === "function") {
+    mcpManager.registerServer({
+      name: "mem0",
+      transport: "stdio",
+      command: "python3",
+      args: [scriptPath],
+      toolDefinitions: tools,
+      description: "Persistent long-term memory system for DSH agents.",
+    }).catch((err: unknown) => {
+      ctx.logger?.warn?.(`[dsh-mem0] mcpManager 注册失败: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  }
+
+  // 3. 注册 HTTP 路由（/api/dsh-mem0/*）
+  const webServer = ctx.get("webServer") as { register: (routes: WebRoute | WebRoute[]) => void } | undefined;
+  if (webServer && typeof webServer.register === "function") {
+    const routes = createMem0Routes({
+      executor,
+      getCurrentCwd: () => latestCwd,
+    });
+    webServer.register(routes);
+  }
+
+  // 4. 注册提示词纪律钩子
+  const unregisterPrompt = registerMemoryPromptHook(ctx);
+
+  // 5. 异步尝试拉起 stdio 运行时
+  executor.start().catch((err: unknown) => {
+    ctx.logger?.warn?.(`[dsh-mem0] stdio 运行时拉起异常: ${err instanceof Error ? err.message : String(err)}`);
+  });
+
+  // 6. 生命周期注销：kill 子进程
+  ctx.effect(() => {
+    return () => {
+      unregisterPrompt();
+      executor.stop();
+    };
+  }, "dsh-mem0: dispose");
+}

--- a/packages/dsh-mem0/src/namespace.ts
+++ b/packages/dsh-mem0/src/namespace.ts
@@ -1,0 +1,127 @@
+/**
+ * dsh-mem0 — Git Canonical 命名空间解析（单一事实源）。
+ *
+ * 核心目标（ADR-2 & ADR-3）：
+ * 1. 自动从当前会话工作目录 (cwd) 派生统一的项目命名空间；
+ * 2. 消除 Git Worktree 导致的记忆割裂：向上寻址 git-common-dir 与
+ *    remote.origin.url，使同一项目的主检出与所有 worktree 共享同一份长期记忆；
+ * 3. 非 Git 目录安全回退至目录标识；
+ * 4. 内存缓存（TTL / LRU），避免高频重复执行子进程。
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { basename, resolve } from "node:path";
+
+/** 命名空间缓存条目。 */
+interface CacheEntry {
+  namespace: string;
+  expiresAt: number;
+}
+
+const CACHE = new Map<string, CacheEntry>();
+const CACHE_TTL_MS = 60_000; // 1 分钟 TTL
+
+/** 全局命名空间。 */
+export const GLOBAL_NAMESPACE = "global";
+
+/**
+ * 规范化 Git remote URL 为统一标识符。
+ * 例：git@github.com:wingsky-1/dsh-plugin-hub.git -> github.com/wingsky-1/dsh-plugin-hub
+ * 例：https://github.com/wingsky-1/dsh-plugin-hub.git -> github.com/wingsky-1/dsh-plugin-hub
+ */
+export function normalizeGitRemote(rawUrl: string): string {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return "";
+  // SSH 格式：git@github.com:owner/repo.git
+  const sshMatch = trimmed.match(/^git@([^:]+):([^/]+)\/(.+?)(?:\.git)?$/);
+  if (sshMatch) {
+    const [, host, owner, repo] = sshMatch;
+    return `${host}/${owner}/${repo}`.toLowerCase();
+  }
+  // HTTP/HTTPS 格式：https://github.com/owner/repo.git
+  const httpMatch = trimmed.match(/^https?:\/\/([^/]+)\/([^/]+)\/(.+?)(?:\.git)?$/);
+  if (httpMatch) {
+    const [, host, owner, repo] = httpMatch;
+    return `${host}/${owner}/${repo}`.toLowerCase();
+  }
+  // 其他回退
+  return trimmed.replace(/\.git$/, "").toLowerCase();
+}
+
+/**
+ * 安全执行 git 命令（超时 2s，静默捕获异常）。
+ */
+function runGit(args: string[], cwd: string): string {
+  try {
+    const stdout = execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      timeout: 2000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return stdout.trim();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * 查找并计算 Git Canonical 命名空间。
+ */
+function deriveNamespace(targetDir: string): string {
+  // 1. 尝试获取 remote.origin.url
+  const remoteUrl = runGit(["config", "--get", "remote.origin.url"], targetDir);
+  if (remoteUrl) {
+    const norm = normalizeGitRemote(remoteUrl);
+    if (norm) return `proj:${norm}`;
+  }
+
+  // 2. 尝试寻找 common-dir 获取主仓库路径
+  const commonDir = runGit(["rev-parse", "--git-common-dir"], targetDir);
+  if (commonDir) {
+    const absCommon = resolve(targetDir, commonDir);
+    // 如果 commonDir 是 .git 结尾，取其父目录名
+    const repoRoot = absCommon.endsWith("/.git") || absCommon.endsWith("\\.git")
+      ? resolve(absCommon, "..")
+      : absCommon;
+    return `proj:${basename(repoRoot)}`;
+  }
+
+  // 3. 非 Git 目录，回退至所在文件夹名
+  return `proj:${basename(targetDir)}`;
+}
+
+/**
+ * 核心对外导出：从当前 cwd 计算 Git Canonical 命名空间。
+ * 纯函数逻辑，附带内存缓存。
+ */
+export function resolveGitCanonicalNamespace(cwd?: string): string {
+  if (!cwd || typeof cwd !== "string") {
+    return GLOBAL_NAMESPACE;
+  }
+
+  const normalized = resolve(cwd);
+  try {
+    if (!existsSync(normalized) || !statSync(normalized).isDirectory()) {
+      return GLOBAL_NAMESPACE;
+    }
+  } catch {
+    return GLOBAL_NAMESPACE;
+  }
+
+  const now = Date.now();
+  const cached = CACHE.get(normalized);
+  if (cached && cached.expiresAt > now) {
+    return cached.namespace;
+  }
+
+  const ns = deriveNamespace(normalized);
+  CACHE.set(normalized, { namespace: ns, expiresAt: now + CACHE_TTL_MS });
+  return ns;
+}
+
+/** 清理命名空间缓存（供测试使用）。 */
+export function resetNamespaceCache(): void {
+  CACHE.clear();
+}

--- a/packages/dsh-mem0/src/prompt.ts
+++ b/packages/dsh-mem0/src/prompt.ts
@@ -1,0 +1,62 @@
+/**
+ * dsh-mem0 — 记忆系统提示词纪律注入。
+ *
+ * 核心设计（ADR-3）：
+ * 1. 会话级单次注入（幂等防重）：通过 agent.session.snapshotEvents() 检查是否已注入，
+ *    避免长会话每 step 累加 token 浪费；
+ * 2. 文本全英文，严格控制在 ≤50 tokens；
+ * 3. 强化 Active Recall 与 Conscious Retention。
+ */
+
+import type { Context } from "@deepseek-ai/cordis";
+import type { UserMessage } from "@deepseek-ai/dsh-llm";
+import { randomUUID } from "node:crypto";
+
+export const MEMORY_DISCIPLINE_TEXT = [
+  "[Memory System Guidelines]:",
+  "- Active Recall: Consult 'memory_search' before making major architectural decisions or investigating unfamiliar patterns.",
+  "- Conscious Retention: Call 'memory_add' immediately when the user clarifies a preference, confirms a design direction, or resolves a tricky bug.",
+  "- Scoping: Project context is automatically bound to current repository; use scope=\"global\" only for universal preferences.",
+].join("\n");
+
+/** 构造记忆纪律注入消息。 */
+function memoryDisciplineMessage(): UserMessage {
+  return {
+    id: randomUUID() as UserMessage["id"],
+    role: "user",
+    content: [{ type: "text", text: MEMORY_DISCIPLINE_TEXT }],
+    source: { kind: "plugin", plugin: "mem0", form: "instructions" },
+  };
+}
+
+/** 检查会话历史中是否已注入过 mem0 纪律。 */
+export function isMemoryDisciplineInjected(agent: { session?: { snapshotEvents?: () => ReadonlyArray<unknown> } }): boolean {
+  const events = agent.session?.snapshotEvents?.();
+  if (!Array.isArray(events)) return false;
+  return events.some((event) => {
+    const e = event as { type?: string; data?: { source?: { kind?: string; plugin?: string } } };
+    return (
+      e.type === "user/message" &&
+      e.data?.source?.kind === "plugin" &&
+      e.data.source.plugin === "mem0"
+    );
+  });
+}
+
+/** 注册纪律钩子到 Cordis 上下文。 */
+export function registerMemoryPromptHook(ctx: Context): () => void {
+  return ctx.on("agent/pre-step", async ({ agent, signal }, next) => {
+    const decision = await next();
+    signal.throwIfAborted();
+    if (decision.kind === "reject") return decision;
+
+    if (isMemoryDisciplineInjected(agent as unknown as { session?: { snapshotEvents?: () => ReadonlyArray<unknown> } })) {
+      return decision;
+    }
+
+    const nextMessages = Array.isArray(decision.messages)
+      ? [...decision.messages, memoryDisciplineMessage()]
+      : decision.messages;
+    return { kind: "enter", messages: nextMessages };
+  });
+}

--- a/packages/dsh-mem0/src/routes.ts
+++ b/packages/dsh-mem0/src/routes.ts
@@ -1,0 +1,107 @@
+/**
+ * dsh-mem0 — HTTP 路由定义（Loopback-only 保护）。
+ *
+ * 路由列表：
+ * - GET  /api/dsh-mem0/status  -> 插件及 stdio 后端运行状态、当前命名空间
+ * - GET  /api/dsh-mem0/list    -> 列表查询（接受 ?namespace=）
+ * - POST /api/dsh-mem0/add     -> 手动添加记忆条目
+ * - POST /api/dsh-mem0/delete  -> 单条记忆删除
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { WebRoute } from "@deepseek-ai/dsh-host-webserver";
+import { guardLoopbackMethod, readJsonBody, writeJson } from "../../../shared/host-utils.js";
+import type { MemoryExecutor } from "./tool-definitions.ts";
+import { GLOBAL_NAMESPACE, resolveGitCanonicalNamespace } from "./namespace.ts";
+
+export interface RouteContext {
+  executor: MemoryExecutor;
+  getCurrentCwd: () => string | undefined;
+}
+
+export function createMem0Routes(ctx: RouteContext): WebRoute[] {
+  return [
+    {
+      kind: "exact",
+      path: "/api/dsh-mem0/status",
+      handler(req: IncomingMessage, res: ServerResponse) {
+        if (!guardLoopbackMethod(req, res, ["GET"])) return;
+        const currentCwd = ctx.getCurrentCwd();
+        const currentNs = resolveGitCanonicalNamespace(currentCwd);
+        writeJson(res, 200, {
+          ready: ctx.executor.isReady(),
+          currentNamespace: currentNs,
+          globalNamespace: GLOBAL_NAMESPACE,
+          mode: "stdio",
+        });
+      },
+    },
+    {
+      kind: "exact",
+      path: "/api/dsh-mem0/list",
+      async handler(req: IncomingMessage, res: ServerResponse) {
+        if (!guardLoopbackMethod(req, res, ["GET"])) return;
+        if (!ctx.executor.isReady()) {
+          writeJson(res, 503, { error: "Memory service offline" });
+          return;
+        }
+        try {
+          const url = new URL(req.url ?? "/", "http://127.0.0.1");
+          const nsParam = url.searchParams.get("namespace");
+          const targetNs = nsParam ? nsParam.trim() : resolveGitCanonicalNamespace(ctx.getCurrentCwd());
+          const text = await ctx.executor.list(targetNs);
+          writeJson(res, 200, { namespace: targetNs, result: text });
+        } catch (err) {
+          writeJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
+        }
+      },
+    },
+    {
+      kind: "exact",
+      path: "/api/dsh-mem0/add",
+      async handler(req: IncomingMessage, res: ServerResponse) {
+        if (!guardLoopbackMethod(req, res, ["POST"])) return;
+        if (!ctx.executor.isReady()) {
+          writeJson(res, 503, { error: "Memory service offline" });
+          return;
+        }
+        try {
+          const body = (await readJsonBody(req)) as { text?: string; namespace?: string } | undefined;
+          const text = body?.text?.trim();
+          if (!text) {
+            writeJson(res, 400, { error: "text is required" });
+            return;
+          }
+          const targetNs = body?.namespace?.trim() || resolveGitCanonicalNamespace(ctx.getCurrentCwd());
+          const result = await ctx.executor.add(text, targetNs);
+          writeJson(res, 200, { ok: true, result });
+        } catch (err) {
+          writeJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
+        }
+      },
+    },
+    {
+      kind: "exact",
+      path: "/api/dsh-mem0/delete",
+      async handler(req: IncomingMessage, res: ServerResponse) {
+        if (!guardLoopbackMethod(req, res, ["POST"])) return;
+        if (!ctx.executor.isReady()) {
+          writeJson(res, 503, { error: "Memory service offline" });
+          return;
+        }
+        try {
+          const body = (await readJsonBody(req)) as { memory_id?: string } | undefined;
+          const memoryId = body?.memory_id?.trim();
+          if (!memoryId) {
+            writeJson(res, 400, { error: "memory_id is required" });
+            return;
+          }
+          const result = await ctx.executor.delete(memoryId);
+          writeJson(res, 200, { ok: true, result });
+        } catch (err) {
+          writeJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
+        }
+      },
+    },
+  ];
+}

--- a/packages/dsh-mem0/src/tool-definitions.ts
+++ b/packages/dsh-mem0/src/tool-definitions.ts
@@ -1,0 +1,254 @@
+/**
+ * dsh-mem0 — 封装工具定义（4 个核心工具：search/add/list/delete）。
+ *
+ * 规范要点（ADR-2, ADR-3, ADR-5）：
+ * 1. 面向 LLM 的参数 schema 与 docstring 全英文；
+ * 2. execute 先从会话上下文读取 cwd，自动映射 Git Canonical Namespace 注入；
+ * 3. 统一输出 schema（canonical text output block）；
+ * 4. 离线/故障优雅降级：执行失败或未就绪时返回结构化降级提示，绝不抛出异常。
+ */
+
+import type { ToolDefinition } from "@deepseek-ai/dsh-tools";
+import { GLOBAL_NAMESPACE, resolveGitCanonicalNamespace } from "./namespace.ts";
+
+/** 底层记忆执行器接口。 */
+export interface MemoryExecutor {
+  search(query: string, userId?: string, limit?: number): Promise<string>;
+  add(text: string, userId: string): Promise<string>;
+  list(userId: string): Promise<string>;
+  delete(memoryId: string): Promise<string>;
+  isReady(): boolean;
+}
+
+/** 统一文本输出结构。 */
+const TEXT_OUTPUT: ToolDefinition["output"] = {
+  schema: {
+    type: "object",
+    properties: {
+      text: { type: "string" },
+    },
+    required: ["text"],
+    additionalProperties: false,
+  },
+  render(_args: unknown, value?: unknown) {
+    const text = value && typeof value === "object" && "text" in value
+      ? String((value as { text?: unknown }).text ?? "")
+      : "";
+    return [{ type: "text", text }];
+  },
+};
+
+/** 离线降级提示文本。 */
+export const UNAVAILABLE_MSG =
+  "[Memory System Notice]: The persistent memory service is currently offline or unreachable. " +
+  "Proceeding with current conversation context without long-term memory.";
+
+/** 从上下文取会话 cwd。 */
+export function extractSessionCwd(exec: { agent?: unknown }): string | undefined {
+  if (typeof exec?.agent !== "object" || exec.agent === null) return undefined;
+  const agent = exec.agent as { session?: { header?: { cwd?: unknown } } };
+  const cwd = agent.session?.header?.cwd;
+  return typeof cwd === "string" ? cwd : undefined;
+}
+
+/**
+ * 构建 memory_search 工具定义。
+ */
+export function buildMemorySearchTool(executor: MemoryExecutor): ToolDefinition {
+  return {
+    name: "memory_search",
+    description:
+      "Search the persistent associative memory store for relevant past decisions, user preferences, " +
+      "architectural conventions, and bug workarounds.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Search query describing the concepts, decisions, or facts to recall.",
+        },
+        scope: {
+          type: "string",
+          enum: ["project", "global", "all"],
+          description: "Search scope: 'project' (current workspace, default), 'global' (cross-project), or 'all'.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of memories to return (default: 5).",
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    output: TEXT_OUTPUT,
+    isConcurrencySafe: () => true,
+    async execute(args: unknown, exec: { agent?: unknown }) {
+      if (!executor.isReady()) {
+        return { text: UNAVAILABLE_MSG };
+      }
+      try {
+        const params = (typeof args === "object" && args !== null ? args : {}) as Record<string, unknown>;
+        const query = String(params.query ?? "").trim();
+        if (!query) return { text: "No query provided." };
+
+        const scope = String(params.scope ?? "project");
+        const limit = typeof params.limit === "number" && params.limit > 0 ? params.limit : 5;
+
+        const cwd = extractSessionCwd(exec);
+        const projectNs = resolveGitCanonicalNamespace(cwd);
+
+        let targetUser: string | undefined;
+        if (scope === "project") {
+          targetUser = projectNs;
+        } else if (scope === "global") {
+          targetUser = GLOBAL_NAMESPACE;
+        } else {
+          // 'all': 留空触发底层跨命名空间检索
+          targetUser = undefined;
+        }
+
+        const res = await executor.search(query, targetUser, limit);
+        return { text: res };
+      } catch (err) {
+        return { text: `[memory_search error: ${err instanceof Error ? err.message : String(err)}]` };
+      }
+    },
+  };
+}
+
+/**
+ * 构建 memory_add 工具定义。
+ */
+export function buildMemoryAddTool(executor: MemoryExecutor): ToolDefinition {
+  return {
+    name: "memory_add",
+    description:
+      "Record a new durable fact, user preference, architectural decision, or convention to the persistent store.",
+    parameters: {
+      type: "object",
+      properties: {
+        text: {
+          type: "string",
+          description: "The concrete fact, decision, or preference to record into memory.",
+        },
+        scope: {
+          type: "string",
+          enum: ["project", "global"],
+          description: "Target scope: 'project' (current repository, default) or 'global' (cross-project preferences).",
+        },
+      },
+      required: ["text"],
+      additionalProperties: false,
+    },
+    output: TEXT_OUTPUT,
+    isConcurrencySafe: () => false,
+    async execute(args: unknown, exec: { agent?: unknown }) {
+      if (!executor.isReady()) {
+        return { text: UNAVAILABLE_MSG };
+      }
+      try {
+        const params = (typeof args === "object" && args !== null ? args : {}) as Record<string, unknown>;
+        const text = String(params.text ?? "").trim();
+        if (!text) return { text: "Empty text cannot be recorded into memory." };
+
+        const scope = String(params.scope ?? "project");
+        const cwd = extractSessionCwd(exec);
+        const targetUser = scope === "global" ? GLOBAL_NAMESPACE : resolveGitCanonicalNamespace(cwd);
+
+        const res = await executor.add(text, targetUser);
+        return { text: `Memory recorded successfully:\n${res}` };
+      } catch (err) {
+        return { text: `[memory_add error: ${err instanceof Error ? err.message : String(err)}]` };
+      }
+    },
+  };
+}
+
+/**
+ * 构建 memory_list 工具定义。
+ */
+export function buildMemoryListTool(executor: MemoryExecutor): ToolDefinition {
+  return {
+    name: "memory_list",
+    description: "List stored memories in the persistent store for browsing and context inspection.",
+    parameters: {
+      type: "object",
+      properties: {
+        scope: {
+          type: "string",
+          enum: ["project", "global"],
+          description: "Target scope: 'project' (current workspace, default) or 'global'.",
+        },
+      },
+      additionalProperties: false,
+    },
+    output: TEXT_OUTPUT,
+    isConcurrencySafe: () => true,
+    async execute(args: unknown, exec: { agent?: unknown }) {
+      if (!executor.isReady()) {
+        return { text: UNAVAILABLE_MSG };
+      }
+      try {
+        const params = (typeof args === "object" && args !== null ? args : {}) as Record<string, unknown>;
+        const scope = String(params.scope ?? "project");
+        const cwd = extractSessionCwd(exec);
+        const targetUser = scope === "global" ? GLOBAL_NAMESPACE : resolveGitCanonicalNamespace(cwd);
+
+        const res = await executor.list(targetUser);
+        return { text: res };
+      } catch (err) {
+        return { text: `[memory_list error: ${err instanceof Error ? err.message : String(err)}]` };
+      }
+    },
+  };
+}
+
+/**
+ * 构建 memory_delete 工具定义。
+ */
+export function buildMemoryDeleteTool(executor: MemoryExecutor): ToolDefinition {
+  return {
+    name: "memory_delete",
+    description: "Delete a specific memory entry by its unique ID. Bulk deletion is not supported.",
+    parameters: {
+      type: "object",
+      properties: {
+        memory_id: {
+          type: "string",
+          description: "Unique ID of the memory entry to delete.",
+        },
+      },
+      required: ["memory_id"],
+      additionalProperties: false,
+    },
+    output: TEXT_OUTPUT,
+    isConcurrencySafe: () => false,
+    async execute(args: unknown) {
+      if (!executor.isReady()) {
+        return { text: UNAVAILABLE_MSG };
+      }
+      try {
+        const params = (typeof args === "object" && args !== null ? args : {}) as Record<string, unknown>;
+        const memoryId = String(params.memory_id ?? "").trim();
+        if (!memoryId) return { text: "No memory_id specified." };
+
+        const res = await executor.delete(memoryId);
+        return { text: res };
+      } catch (err) {
+        return { text: `[memory_delete error: ${err instanceof Error ? err.message : String(err)}]` };
+      }
+    },
+  };
+}
+
+/**
+ * 获取全部 4 个封装工具定义集合。
+ */
+export function buildAllMemoryTools(executor: MemoryExecutor): ToolDefinition[] {
+  return [
+    buildMemorySearchTool(executor),
+    buildMemoryAddTool(executor),
+    buildMemoryListTool(executor),
+    buildMemoryDeleteTool(executor),
+  ];
+}

--- a/packages/dsh-mem0/test/smoke.ts
+++ b/packages/dsh-mem0/test/smoke.ts
@@ -1,0 +1,218 @@
+// @ts-nocheck
+/**
+ * dsh-mem0 冒烟测试 —— 纯离线、零外部网络与真实进程依赖。
+ *
+ * 覆盖：
+ * 1. 契约导出（name, inject）
+ * 2. 命名空间解析（Git remote 归一化、目录回退、缓存重置）
+ * 3. 工具定义契约（schema 字段、全英文描述、离线降级断言、正常执行断言）
+ * 4. 提示词纪律（会话级单次注入、幂等判重）
+ * 5. 路由安全（Loopback 403 围栏、405 方法校验、正常调用）
+ */
+
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(__dirname, "..");
+
+// 动态载入编译后的自包含宿主模块
+const hostMod = await import(pathToFileURL(join(pkgDir, "lib/index.js")).href);
+const {
+  name,
+  inject,
+  normalizeGitRemote,
+  resolveGitCanonicalNamespace,
+  resetNamespaceCache,
+  GLOBAL_NAMESPACE,
+  buildAllMemoryTools,
+  UNAVAILABLE_MSG,
+  isMemoryDisciplineInjected,
+  MEMORY_DISCIPLINE_TEXT,
+  createMem0Routes,
+} = hostMod;
+
+let testsRun = 0;
+async function test(name: string, fn: () => void | Promise<void>) {
+  try {
+    await fn();
+    testsRun++;
+    console.log(`  [PASS] ${name}`);
+  } catch (err) {
+    console.error(`  [FAIL] ${name}:`, err);
+    process.exit(1);
+  }
+}
+
+console.log("\n=== dsh-mem0 离线冒烟测试 ===");
+
+// 1. 契约导出
+await test("契约导出：name 与 inject 声明", () => {
+  assert.equal(name, "mem0", "插件名应为 mem0");
+  assert.ok(Array.isArray(inject), "inject 应为数组");
+  assert.ok(inject.includes("mcpManager"), "必须强依赖 mcpManager");
+  assert.ok(inject.includes("webServer"), "必须强依赖 webServer");
+});
+
+// 2. 命名空间规范化
+await test("命名空间：normalizeGitRemote SSH 与 HTTP 统一解析", () => {
+  assert.equal(
+    normalizeGitRemote("git@github.com:wingsky-1/dsh-plugin-hub.git"),
+    "github.com/wingsky-1/dsh-plugin-hub",
+  );
+  assert.equal(
+    normalizeGitRemote("https://github.com/wingsky-1/dsh-plugin-hub.git"),
+    "github.com/wingsky-1/dsh-plugin-hub",
+  );
+  assert.equal(normalizeGitRemote(""), "");
+});
+
+await test("命名空间：resolveGitCanonicalNamespace 回退与缓存", () => {
+  resetNamespaceCache();
+  assert.equal(resolveGitCanonicalNamespace(undefined), GLOBAL_NAMESPACE);
+  assert.equal(resolveGitCanonicalNamespace(""), GLOBAL_NAMESPACE);
+  assert.equal(resolveGitCanonicalNamespace("/non/existent/path/9999"), GLOBAL_NAMESPACE);
+
+  const currentNs = resolveGitCanonicalNamespace(process.cwd());
+  assert.ok(currentNs.startsWith("proj:"), "Git 仓内路径应以 proj: 为前缀");
+});
+
+// 3. 工具定义与离线降级
+await test("工具定义：4 个全英文工具契约", () => {
+  const mockExecutor = {
+    search: async () => "mock search result",
+    add: async () => "mock add result",
+    list: async () => "mock list result",
+    delete: async () => "mock delete result",
+    isReady: () => false,
+  };
+
+  const tools = buildAllMemoryTools(mockExecutor);
+  assert.equal(tools.length, 4, "应提供 4 个核心工具");
+  const names = tools.map((t) => t.name);
+  assert.deepEqual(names, ["memory_search", "memory_add", "memory_list", "memory_delete"]);
+
+  for (const t of tools) {
+    assert.ok(t.description.length > 10, `${t.name} description 必须非空`);
+    assert.ok(t.parameters && t.parameters.type === "object", `${t.name} parameters 必须是 object`);
+    assert.ok(t.output && t.output.schema, `${t.name} 必须满足 output schema`);
+  }
+});
+
+await test("工具容错：离线降级绝不抛出异常", async () => {
+  const offlineExecutor = {
+    search: async () => "",
+    add: async () => "",
+    list: async () => "",
+    delete: async () => "",
+    isReady: () => false, // 模拟离线
+  };
+
+  const tools = buildAllMemoryTools(offlineExecutor);
+  const searchTool = tools.find((t) => t.name === "memory_search")!;
+  const addTool = tools.find((t) => t.name === "memory_add")!;
+
+  const searchRes = await searchTool.execute({ query: "architecture" }, {});
+  assert.ok(searchRes.text.includes(UNAVAILABLE_MSG), "离线应返回 UNAVAILABLE_MSG");
+
+  const addRes = await addTool.execute({ text: "some decision" }, {});
+  assert.ok(addRes.text.includes(UNAVAILABLE_MSG), "离线应返回 UNAVAILABLE_MSG");
+});
+
+await test("工具正常调用：在线时返回预期内容", async () => {
+  let calledUserId = "";
+  const onlineExecutor = {
+    search: async (_q, u) => {
+      calledUserId = u || "";
+      return "found decision #1";
+    },
+    add: async () => "ok",
+    list: async () => "mem1\nmem2",
+    delete: async () => "deleted",
+    isReady: () => true,
+  };
+
+  const tools = buildAllMemoryTools(onlineExecutor);
+  const searchTool = tools.find((t) => t.name === "memory_search")!;
+  const res = await searchTool.execute({ query: "test", scope: "global" }, {});
+  assert.equal(res.text, "found decision #1");
+  assert.equal(calledUserId, GLOBAL_NAMESPACE, "scope=global 应转发 global 命名空间");
+});
+
+// 4. 系统提示词幂等注入
+await test("提示词：isMemoryDisciplineInjected 判重测试", () => {
+  const emptyAgent = { session: { snapshotEvents: () => [] } };
+  assert.equal(isMemoryDisciplineInjected(emptyAgent), false, "空历史未注入");
+
+  const injectedAgent = {
+    session: {
+      snapshotEvents: () => [
+        { type: "user/message", data: { source: { kind: "plugin", plugin: "mem0" } } },
+      ],
+    },
+  };
+  assert.equal(isMemoryDisciplineInjected(injectedAgent), true, "已有注入事件应判为 true");
+  assert.ok(MEMORY_DISCIPLINE_TEXT.includes("[Memory System Guidelines]"), "提示词文案完整");
+});
+
+// 5. 路由安全与 Loopback 围栏
+await test("路由安全：非 Loopback 请求被拦截 403", () => {
+  const routes = createMem0Routes({
+    executor: { isReady: () => true } as any,
+    getCurrentCwd: () => process.cwd(),
+  });
+
+  const statusRoute = routes.find((r) => r.path === "/api/dsh-mem0/status")!;
+  let statusCode = 0;
+  const mockReq = {
+    headers: { host: "evil-site.com" },
+    socket: { remoteAddress: "192.168.1.100" },
+    method: "GET",
+  };
+  const mockRes = {
+    setHeader: () => {},
+    writeHead: (c: number) => { statusCode = c; },
+    end: () => {},
+  };
+
+  statusRoute.handler(mockReq as any, mockRes as any);
+  assert.equal(statusCode, 403, "跨站或外网请求必须返回 403 Forbidden");
+});
+
+await test("路由安全：合法 Loopback 请求返回 200", () => {
+  const routes = createMem0Routes({
+    executor: { isReady: () => true } as any,
+    getCurrentCwd: () => process.cwd(),
+  });
+
+  const statusRoute = routes.find((r) => r.path === "/api/dsh-mem0/status")!;
+  let statusCode = 0;
+  let bodyData = "";
+  const mockReq = {
+    headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+    socket: { remoteAddress: "127.0.0.1" },
+    method: "GET",
+  };
+  const mockRes = {
+    setHeader: () => {},
+    writeHead: (c: number) => { statusCode = c; },
+    end: (data: string) => { bodyData = data; },
+  };
+
+  statusRoute.handler(mockReq as any, mockRes as any);
+  assert.equal(statusCode, 200, "回环合规请求返回 200");
+  assert.ok(bodyData.includes("ready"), "响应应包含 ready 字段");
+});
+
+// 6. 客户端产物契约
+await test("客户端契约：lib/client.js 存在且载入正确 load id", async () => {
+  const { existsSync, readFileSync } = await import("node:fs");
+  const clientPath = join(pkgDir, "lib/client.js");
+  assert.ok(existsSync(clientPath), "lib/client.js 必须存在");
+  const code = readFileSync(clientPath, "utf8");
+  assert.ok(code.includes('"@wingsky-1/dsh-mem0"'), "client.js 必须包含完整的 npm 包 load id");
+});
+
+console.log(`\n全部 ${testsRun} 项冒烟测试顺利通过！`);

--- a/packages/dsh-mem0/tsconfig.json
+++ b/packages/dsh-mem0/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib",
+    "jsx": "react",
+    "rewriteRelativeImportExtensions": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,36 @@ importers:
         specifier: ^3.18.0
         version: 3.18.0
 
+  packages/dsh-mem0:
+    devDependencies:
+      '@deepseek-ai/cordis':
+        specifier: 'catalog:'
+        version: 4.0.2
+      '@deepseek-ai/dsh-agent':
+        specifier: 'catalog:'
+        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))
+      '@deepseek-ai/dsh-client-ui-slots':
+        specifier: 'catalog:'
+        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-host-webserver':
+        specifier: 'catalog:'
+        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(supports-color@7.2.0)
+      '@deepseek-ai/dsh-llm':
+        specifier: 'catalog:'
+        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-system-prompt':
+        specifier: 'catalog:'
+        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))
+      '@deepseek-ai/dsh-tools':
+        specifier: 'catalog:'
+        version: 0.1.2-rc.1(cb0dbe8de145fa446d6c11c9727085c6)
+      '@wingsky-1/dsh-mcp-manager':
+        specifier: workspace:*
+        version: link:../dsh-mcp-manager
+      schemastery:
+        specifier: ^3.18.0
+        version: 3.18.0
+
   packages/dsh-notifier:
     devDependencies:
       '@deepseek-ai/cordis':

--- a/scripts/data/plugins-manifest.json
+++ b/scripts/data/plugins-manifest.json
@@ -8,7 +8,8 @@
     "dsh-web-file-preview"
   ],
   "standalone": [
-    "dsh-codegraph"
+    "dsh-codegraph",
+    "dsh-mem0"
   ],
   "retired": [
     {


### PR DESCRIPTION
Fixes #570

## 说明

实现 `@wingsky-1/dsh-mem0` 长期记忆系统插件的最小可行产品（MVP）：基于本地 stdio 模式与 FastMCP 协议，原生感知 Git 工作空间命名空间，提供全英文核心工具集与离线降级容错，并在 DSH 设置页挂载独立「记忆中心」Tab。
当前作为 `standalone` 独立插件存在，暂不纳入 `dsh-plugins-all` 聚合包。

## 改动

1. **Python 核心服务端 (`packages/dsh-mem0/server/`)**：
   - 基于 FastMCP 实现标准 stdio 协议通信，随 Node 父进程同生共死，天然零端口占用与孤儿进程；
   - 本地 QdrantLocal 文件存储 + FastEmbed (`BAAI/bge-small-zh-v1.5`) 纯 CPU 推理，锁定中文抽取约束模板。
2. **宿主端 TS 引擎 (`packages/dsh-mem0/src/`)**：
   - 依赖 `dsh-mcp-manager` 统一管理生命周期；
   - `namespace.ts`：向上溯源 `git-common-dir` 与 remote url，统一主检出与 Worktree 记忆空间；
   - `tool-definitions.ts`：实现 `memory_search`、`memory_add`、`memory_list`、`memory_delete` 4 个核心工具，具备服务未就绪时的无感降级；
   - `prompt.ts`：会话级单次注入全英文精简记忆纪律（<=50 tokens）；
   - `routes.ts`：提供 `/api/dsh-mem0/*` REST 接口，强制执行 loopback 回环围栏。
3. **Web 客户端 (`packages/dsh-mem0/src/client/`)**：
   - 通过 `slots.inject("settings.section")` 挂载「记忆中心」设置页 Tab；
   - 包含当前命名空间状态、实时语义搜索、记忆卡片列表流与单条删除二次确认；
   - 完整支持中英文双语字典（`locales.ts`）与浅色/暗色自适应。
4. **包工程与门禁 (`packages/dsh-mem0/test/`)**：
   - 10 项离线 Smoke 冒烟测试覆盖契约、命名空间计算、工具离线降级、提示词判重与路由围栏；
   - 纳入 `scripts/data/plugins-manifest.json` 的 `standalone` 列表。

## 验证

- `pnpm --filter @wingsky-1/dsh-mem0 run test`：全部 10 项冒烟测试 100% 通过。
- `pnpm run typecheck`：全仓库 9 个包全部通过，零类型报错。
- `pnpm run contract`：客户端契约、仅类型导入检查全部通过。
- `pnpm run pack:check`：自包含发布产物校验通过。
