### PR TITLE
refactor(prompt): 优化 codegraph 与 mcp-manager 提示词为全英文并改系统提示词注入

### DIFF
--- a/packages/dsh-codegraph/src/discipline.ts
+++ b/packages/dsh-codegraph/src/discipline.ts
@@ -1,96 +1,66 @@
 /**
- * agent 纪律钩子——按会话 cwd 条件注入 worktree 开发纪律（#359 三轮，B2）。
+ * agent 纪律钩子——按会话 cwd 条件注入 worktree 开发纪律（系统提示词）。
  *
- * 注入方式：**agent/pre-step user 消息注入**（与 dsh-tool-skill / dsh-time-context
- * 官方插件同款载体，出现在 GUI「上下文注入」面板）。
+ * 注入方式：**ctx.systemPrompt.section 系统提示词注入**（order: 170，紧跟在
+ * dsh-mcp-manager order: 160 之后）。
  *
- * 幂等（官方模式）：查**会话历史** `agent.session.snapshotEvents()` 是否已注入过本插件的
- * 纪律消息（source.kind=plugin && source.plugin=codegraph）——与 dsh-time-context
- * 的 `latestInjectionTime(agent)` 同款（pre-step 的 messages 不含历史注入，
- * 不能靠查 messages 判重）。compaction/resume 后历史被压缩 → 重新注入（幂等自愈）。
- *
- * 内容正交（B2：#360 曾与 mcp 能力目录排先后，实测脆弱且耦合——目录讲
- * "有哪些 MCP 服务器"，纪律讲 "codegraph_explore 工具怎么用"，本就不该有
- * 先后依赖）。纪律只保留工具层差异化信息（裸工具名、自动 sync、无索引引导）。
- *
- * 判定：payload.agent.session.header.cwd（dsh-session 类型，mcp-manager 中间层
- * 已实证可得）→ 沿 cwd 找 .git 标记（findGitRoot）：
- * - 是 git 仓（主 checkout / worktree）→ 注入纪律（~200 tokens/次，非每 step）；
- * - 非 git 仓（日常维护/讨论空间）→ 不注入（静默跳过，agent 正常讨论无噪声）。
- * 多工作空间天然区分：每个会话独立判定，互不影响。
+ * 判定：context.agent.session.header.cwd → 沿 cwd 找 .git 标记（findGitRoot）：
+ * - 是 git 仓（主 checkout / worktree）→ 注入纪律（~140 tokens/次，全英文紧凑决策表）；
+ * - 非 git 仓（日常维护/讨论空间）或无 session → 返回空字符串（零注入零 Token 浪费，
+ *   严格杜绝 process.cwd 宿主逃逸）。
  */
 import type { Context } from "@deepseek-ai/cordis";
-import type { UserMessage } from "@deepseek-ai/dsh-llm";
-import type {} from "@deepseek-ai/dsh-agent";
-import { randomUUID } from "node:crypto";
 import { findGitRoot } from "./guard.ts";
 
-/** 注入给 agent 的 worktree 开发纪律文案（≤250 tokens，紧凑决策表）。
- * 只保留目录注入覆盖不到的**差异化纪律**（#359 去重 / B2 正交化）：
- * - 场景→首选工具→兜底的决策表（#417 A 项：删实现细节，模型按场景选工具）；
- * - 自动 sync 语义（worktree 索引新鲜度）；
- * - 无索引时返回引导（init 由 agent/用户决策）。
- * "codegraph 可用/注册形态"等能力声明由 mcp-manager 能力目录
- * （<available_mcp_servers>）承担，不在此重复；与目录**无先后依赖**（内容正交）。 */
-export const DISCIPLINE_TEXT = [
-  "【codegraph 开发纪律】git 仓内结构类查询优先用 codegraph（工具自动 sync",
-  "当前 worktree 索引并补全 projectPath）：",
-  "- 谁调用 X / 改 X 影响谁 → `codegraph_impact`（或 `codegraph_explore` 综合查）；",
-  "- 单符号源码 + 调用/被调 trail、读文件 → `codegraph_node`；",
-  "- 「谁调用 X」→ `codegraph_callers`；「X 调用了谁」→ `codegraph_callees`；",
-  "- 记不清精确符号名 → `codegraph_search`；找文件路径/项目结构 → `codegraph_files`；",
-  "- 查索引状态 → `codegraph_status`；",
-  "- 全文搜词才用 grep；正在编辑的文件一律 Read 原文，不依赖图谱；",
-  "- 没有 .codegraph 索引的目录会返回引导（codegraph init <path>），索引与否是用户决定。",
+/** 注入给 agent 的 worktree 开发纪律文案（全英文，紧凑决策表，强调优先搜索）。 */
+export const CODEGRAPH_SYSTEM_PROMPT = [
+  "[Code Graph: codegraph_* tools]",
+  "In git repositories, ALWAYS prioritize `codegraph_*` tools over grep or direct file reads for code search, symbol navigation, and architecture exploration. The tool layer auto-syncs the worktree index before queries.",
+  "",
+  "Quick Dispatch:",
+  "- Search by keyword/concept: `codegraph_search` (PRIMARY entry point for discovering symbols)",
+  "- Architecture & definitions: `codegraph_explore` (comprehensive multi-hop code context)",
+  "- Call hierarchy: `codegraph_callers` (\"who calls X\") / `codegraph_callees` (\"what does X call\")",
+  "- Pre-refactoring impact: `codegraph_impact` (analyze blast radius before modifying/deleting)",
+  "- Source & symbol breakdown: `codegraph_node` (inspect single symbol or file symbol table)",
+  "- Directory layout: `codegraph_files`",
+  "- Check index status: `codegraph_status`",
+  "",
+  "Rules:",
+  "- NEVER grep for code symbols or functions. Use grep ONLY for raw literal text (logs, strings, configs).",
+  "- Directly invoke bare `codegraph_*` tools; DO NOT use `mcp__` prefixes.",
+  "- For files actively being edited, read raw files directly. If unindexed, run `codegraph init <path>`.",
 ].join("\n");
+
+/** @deprecated Kept for backwards compatibility with earlier contracts. */
+export const DISCIPLINE_TEXT = CODEGRAPH_SYSTEM_PROMPT;
 
 /** 按会话 cwd 判定是否注入纪律（纯函数，便于单测）。 */
 export function shouldInject(cwd: string | undefined): boolean {
   return findGitRoot(cwd) !== undefined;
 }
 
-/** 构造纪律注入消息（完整 UserMessage 契约：id + content block + source）。
- * source.kind=plugin → 出现在 GUI「上下文注入」面板（与 dsh-tool-skill 同载体）。 */
-function disciplineMessage(): UserMessage {
-  return {
-    id: randomUUID() as UserMessage["id"],
-    role: "user",
-    content: [{ type: "text", text: DISCIPLINE_TEXT }],
-    source: { kind: "plugin", plugin: "codegraph", form: "instructions" },
-  };
+/**
+ * 动态计算系统提示词文本（纯函数，供 systemPrompt.section(text) 回调）。
+ * 安全防御：提取不到有效的 session cwd 时一律返回空字符串（杜绝 process.cwd 宿主污染）。
+ */
+export function codegraphPromptText(context?: unknown): string {
+  const ctx = context as { agent?: { session?: { header?: { cwd?: string } } } } | undefined;
+  const cwd = ctx?.agent?.session?.header?.cwd;
+  if (!cwd || !shouldInject(cwd)) return "";
+  return CODEGRAPH_SYSTEM_PROMPT;
 }
 
-/** 会话历史里是否已注入过纪律消息（官方模式：查 agent.session.snapshotEvents()，
- * 仿 dsh-time-context 的 latestInjectionTime）。compaction 后历史不可见 → false
- * → 重新注入（幂等自愈）。 */
-function alreadyInjected(agent: { session?: { snapshotEvents?: () => ReadonlyArray<unknown> } }): boolean {
-  const events = agent.session?.snapshotEvents?.();
-  if (!Array.isArray(events)) return false;
-  return events.some((event) => {
-    const e = event as { type?: string; data?: { source?: { kind?: string; plugin?: string } } };
-    return e.type === "user/message"
-      && e.data?.source?.kind === "plugin"
-      && e.data.source.plugin === "codegraph";
+/** 注册系统提示词段落（order 170，在 mcp-manager order 160 之后）。返回 disposer。 */
+export function registerCodegraphPrompt(ctx: Context): () => void {
+  const systemPrompt = (ctx as unknown as { systemPrompt?: { section: (opts: Record<string, unknown>) => () => void } }).systemPrompt;
+  if (!systemPrompt || typeof systemPrompt.section !== "function") return () => {};
+  return systemPrompt.section({
+    name: "plugin:dsh-codegraph",
+    order: 170,
+    text: codegraphPromptText,
   });
 }
 
-/** 注册纪律注入（根 ctx pre-step 监听器，按 agent cwd 条件注入）。返回 disposer。 */
-export function registerDisciplineHook(ctx: Context): () => void {
-  const disposer = ctx.on("agent/pre-step", async ({ agent, signal }, next) => {
-    const decision = await next();
-    signal.throwIfAborted();
-    // 尊重 reject 决策（如其他监听器拒绝进入本轮 step），不覆盖为 enter。
-    if (decision.kind === "reject") return decision;
-    // 按会话 cwd 判定：非 git 仓 → 零注入（静默跳过）。
-    const cwd = (agent.session as unknown as { header?: { cwd?: string } })?.header?.cwd;
-    if (!shouldInject(cwd)) return decision;
-    // 幂等：会话历史已注入过 → 原样放行。
-    if (alreadyInjected(agent as unknown as { session?: { snapshotEvents?: () => ReadonlyArray<unknown> } })) return decision;
-    // 不可变注入：追加纪律消息（内容与 mcp 能力目录正交，无先后依赖）。
-    const nextMessages = Array.isArray(decision.messages)
-      ? [...decision.messages, disciplineMessage()]
-      : decision.messages;
-    return { kind: "enter", messages: nextMessages };
-  });
-  return disposer;
-}
+/** @deprecated Kept for backwards compatibility. */
+export const registerDisciplineHook = registerCodegraphPrompt;

--- a/packages/dsh-codegraph/src/index.ts
+++ b/packages/dsh-codegraph/src/index.ts
@@ -32,7 +32,14 @@ import type { ToolDefinition } from "@deepseek-ai/dsh-tools";
 // shared/mcp-manager-service.d.ts，类型单一事实源仍在 shared/，消费入口走包）。
 import type { McpManagerServerInput, McpManagerService } from "@wingsky-1/dsh-mcp-manager";
 import { installGuidance, isCodegraphInstalled, runInstall } from "./install.ts";
-import { registerDisciplineHook } from "./discipline.ts";
+import {
+  CODEGRAPH_SYSTEM_PROMPT,
+  DISCIPLINE_TEXT,
+  codegraphPromptText,
+  registerCodegraphPrompt,
+  registerDisciplineHook,
+  shouldInject,
+} from "./discipline.ts";
 import {
   buildCalleesToolDefinition,
   buildCallersToolDefinition,
@@ -47,11 +54,11 @@ import {
 /** Stable cordis plugin name. */
 export const name = "codegraph";
 
-/** 需要的宿主服务：mcpManager（MCP 注册/管理/使用；封装定义经其注册）。
+/** 需要的宿主服务：mcpManager（MCP 注册/管理/使用；封装定义经其注册）、systemPrompt（系统提示词段落注入）。
  *  均经 inject 强依赖声明——缺失时 cordis 内核自动停用本插件。
- *  注：纪律注入为根 ctx agent/pre-step 监听（#359 B2），不依赖 agents/systemPrompt；
+ *  注：提示词注入为 ctx.systemPrompt.section（order: 170，在 mcp-manager 之后）；
  *  工具经 mcp-manager 注册（#363 补充 3），不再依赖 tools。 */
-export const inject = ["mcpManager"];
+export const inject = ["mcpManager", "systemPrompt"];
 
 // 内部模块 re-export（公共测试面 + 其他插件可复用纯函数）。
 export { isCodegraphInstalled, installGuidance, runInstall } from "./install.ts";
@@ -69,7 +76,14 @@ export {
   SYNC_TTL_MS,
   exploreCodegraph,
 } from "./guard.ts";
-export { shouldInject, DISCIPLINE_TEXT, registerDisciplineHook } from "./discipline.ts";
+export {
+  shouldInject,
+  CODEGRAPH_SYSTEM_PROMPT,
+  DISCIPLINE_TEXT,
+  codegraphPromptText,
+  registerCodegraphPrompt,
+  registerDisciplineHook,
+} from "./discipline.ts";
 export {
   buildExploreToolDefinition,
   buildImpactToolDefinition,
@@ -158,11 +172,8 @@ export async function apply(ctx: Context, config: CodegraphConfig = {}): Promise
       // #363 补充 3：封装定义经 mcp-manager 注册（manager 侧 #362 补充 4 消费）。
       const registerInput: McpManagerServerInput = {
         name: "codegraph",
-        // A2（#417）：能力目录 available_mcp_servers 的条目描述优先取服务器
-        // description，缺省 fallback 到工具描述摘要（恰好是 codegraph_files
-        // 的「列文件结构」，埋没 explore/impact/callers 核心能力）。补上后
-        // 目录如实展示结构类查询能力，引导模型优先想起 codegraph。
-        description: "codegraph 本地代码图谱：结构类查询（谁调用 X / 改 X 影响谁 / 找符号定义与调用链）优先用它；自动先 sync 当前 worktree 索引",
+        description:
+          "Local code graph: ALWAYS prioritize for code search, symbol definitions, caller/callee relationships, and impact analysis. Call encapsulated bare tools directly (e.g. codegraph_search, codegraph_explore); DO NOT use mcp__ prefixes. Auto-syncs worktree index.",
         transport: "stdio",
         command: "codegraph",
         args: ["serve", "--mcp"],
@@ -183,13 +194,13 @@ export async function apply(ctx: Context, config: CodegraphConfig = {}): Promise
     }
   }
 
-  // 3. agent 纪律钩子（git 仓会话才注入）。
-  const disposeHook = injectDiscipline ? registerDisciplineHook(ctx) : () => {};
+  // 3. agent 系统提示词钩子（order: 170，在 mcp-manager 之后，git 仓会话才注入）。
+  const disposePrompt = injectDiscipline ? registerCodegraphPrompt(ctx) : () => {};
 
   // 卸载清理（effect disposer）。
   ctx.effect(() => {
     return () => {
-      disposeHook();
+      disposePrompt();
       // 卸载时注销 MCP 服务器（不影响 store 持久化条目；inject 保证 mcpManager 在场）。
       void mcpManager.unregisterServer("codegraph").catch(() => {});
     };

--- a/packages/dsh-codegraph/src/tool-definition.ts
+++ b/packages/dsh-codegraph/src/tool-definition.ts
@@ -44,7 +44,7 @@ const TEXT_OUTPUT: ToolDefinition["output"] = {
 /** 公共样板文案单一事实源（防描述漂移；#414）：各工具参数/描述统一引用，
  * 不再手抄。projectPath 语义：显式传入优先，缺省补全为当前会话 worktree。 */
 const SHARED = {
-  projectPath: "目标 worktree 路径（缺省补全为当前会话 worktree）",
+  projectPath: "Target worktree path (defaults to current session worktree)",
 };
 
 /** 从 execute 上下文取会话 cwd（缺省 undefined）。 */
@@ -58,14 +58,14 @@ export function buildExploreToolDefinition(): ToolDefinition {
   return {
     name: "codegraph_explore",
     description:
-      "查询 codegraph 代码图谱（本地索引）：返回命中符号的定义源码与调用路径。" +
-      "会自动先 sync 目标 worktree 索引；projectPath 缺省补全为当前会话 worktree；" +
-      "无索引/无法定位时拒绝并返回引导。结构/依赖类问题（谁调用 X、改 X 影响谁、找符号定义）优先用它。" +
-      "NOT 用于逐字文本搜索——那是 grep 的事；本工具查调用图/符号定义。查单个符号源码/调用关系用 codegraph_node；列文件结构用 codegraph_files。",
+      "Explore code architecture and symbol definitions with call paths. Returns matching symbol source and usage context. " +
+      "ALWAYS prioritize this over plain grep or direct file reading for structural code navigation. " +
+      "Auto-syncs worktree index; projectPath defaults to current session worktree. " +
+      "NOT for literal text search (use grep) or call hierarchy (use callers/callees).",
     parameters: {
       type: "object",
       properties: {
-        query: { type: "string", description: "代码问题/符号名（如：X 被谁调用）" },
+        query: { type: "string", description: "Code question or symbol name (e.g. 'how is X called')" },
         projectPath: { type: "string", description: SHARED.projectPath },
       },
       required: ["query"],
@@ -185,13 +185,13 @@ function buildCliTool(
 export function buildImpactToolDefinition(): ToolDefinition {
   return buildCliTool(
     "codegraph_impact",
-    "分析「修改/删除某符号会影响哪些代码」（调用方及其下游）。改代码前用它看影响面。" +
-      "symbol 必填；同名符号先用 codegraph_search 找归属、传限定名；depth 默认 2（1-5），" +
-      "越大结果越全但越慢。NOT 用于全文搜词——查文本位置用 grep。只想看单符号源码与直接调用/被调关系用 codegraph_node；" +
-      "找「谁调用 X」用 codegraph_callers。",
+    "Analyze downstream blast radius before modifying or deleting a symbol. Returns affected callers and dependents. " +
+      "MANDATORY before modifying, refactoring, or deleting any shared code symbol. " +
+      "symbol is required (use fully-qualified name if ambiguous); depth defaults to 2 (1-5). " +
+      "NOT for literal text search (use grep) or inspect single symbol source (use codegraph_node).",
     {
-      symbol: { type: "string", description: "目标符号名（同名时传完整限定名）" },
-      depth: { type: "number", description: "遍历深度（默认 2，范围 1-5；越大结果越全但越慢）", minimum: 1, maximum: 5 },
+      symbol: { type: "string", description: "Target symbol name (use fully-qualified name if ambiguous)" },
+      depth: { type: "number", description: "Traversal depth (default 2, range 1-5; higher means more comprehensive but slower)", minimum: 1, maximum: 5 },
       projectPath: { type: "string", description: SHARED.projectPath },
     },
     ["symbol"],
@@ -213,17 +213,15 @@ export function buildImpactToolDefinition(): ToolDefinition {
 export function buildNodeToolDefinition(): ToolDefinition {
   return buildCliTool(
     "codegraph_node",
-    "查单个符号的源码与调用/被调 trail（符号模式），或按行号读文件并附符号表与依赖方" +
-      "（文件模式）。**symbol 与 file 二选一**：查符号用 symbol；读文件用 file" +
-      "（可带 offset/limit 分页；只要符号表用 symbolsOnly）。都传以 symbol 优先；" +
-      "都不传报错给用法。NOT 用于全文搜词——查文本位置用 grep；本工具按符号/文件读源码。" +
-      "查影响面用 codegraph_impact；查谁调用用 codegraph_callers。",
+    "Inspect exact source and call trails for a specific symbol, or view a file's symbol table and dependencies. " +
+      "Provide either symbol or file. Efficient alternative to reading entire large files into context. " +
+      "NOT for literal text search (use grep) or impact analysis (use codegraph_impact).",
     {
-      symbol: { type: "string", description: "符号名（符号模式；与 file 二选一，都传以 symbol 优先）" },
-      file: { type: "string", description: "文件路径（文件模式；与 symbol 二选一，如 'src/auth.ts'）" },
-      offset: { type: "number", description: "文件模式：1-based 起始行（分页）", minimum: 1 },
-      limit: { type: "number", description: "文件模式：最大行数（分页）", minimum: 1 },
-      symbolsOnly: { type: "boolean", description: "文件模式：只要符号表 + 依赖方，不读源码" },
+      symbol: { type: "string", description: "Symbol name (symbol mode; mutually exclusive with file, symbol takes precedence). Required: provide either 'symbol' or 'file'" },
+      file: { type: "string", description: "File path (file mode; mutually exclusive with symbol, e.g. 'src/auth.ts'). Required: provide either 'symbol' or 'file'" },
+      offset: { type: "number", description: "File mode: 1-based start line (pagination)", minimum: 1 },
+      limit: { type: "number", description: "File mode: max line count (pagination)", minimum: 1 },
+      symbolsOnly: { type: "boolean", description: "File mode: return symbol table and dependencies only, omit raw source" },
       projectPath: { type: "string", description: SHARED.projectPath },
     },
     [],
@@ -247,16 +245,16 @@ export function buildNodeToolDefinition(): ToolDefinition {
 function buildCallersCalleesTool(name: "codegraph_callers" | "codegraph_callees"): ToolDefinition {
   const sub = name === "codegraph_callers" ? "callers" : "callees";
   const description = name === "codegraph_callers"
-    ? "列出所有调用「符号 X」的函数/方法。查「X 被谁用、改它影响谁」；limit 默认 20、上限 100。" +
-      "NOT 用于全文搜词——查文本位置用 grep；本工具按符号查调用者。想看符号本身源码用 codegraph_node；看 X 调用了谁用 codegraph_callees。"
-    : "列出「符号 X」调用的所有函数/方法。查「X 依赖谁」；limit 默认 20、上限 100。" +
-      "NOT 用于全文搜词——查文本位置用 grep；本工具按符号查被调者。想看符号本身源码用 codegraph_node；看谁调用 X 用 codegraph_callers。";
+    ? "List all incoming callers of a symbol ('who calls X'). Use this to understand how a function, class, or method is consumed across the codebase. " +
+      "NOT for literal text search (use grep) or outgoing dependencies (use codegraph_callees)."
+    : "List all outgoing dependencies and function calls made by a symbol ('what does X call'). Use this to inspect internal implementation dependencies. " +
+      "NOT for literal text search (use grep) or incoming callers (use codegraph_callers).";
   return buildCliTool(
     name,
     description,
     {
-      symbol: { type: "string", description: "目标符号名（同名时传完整限定名）" },
-      limit: { type: "number", description: "最大结果数（默认 20，范围 1-100）", minimum: 1, maximum: 100 },
+      symbol: { type: "string", description: "Target symbol name (use fully-qualified name if ambiguous)" },
+      limit: { type: "number", description: "Max results to return (default 20, range 1-100)", minimum: 1, maximum: 100 },
       projectPath: { type: "string", description: SHARED.projectPath },
     },
     ["symbol"],
@@ -288,18 +286,17 @@ export function buildCalleesToolDefinition(): ToolDefinition {
 export function buildSearchToolDefinition(): ToolDefinition {
   return buildCliTool(
     "codegraph_search",
-    "按关键词搜索代码库符号（函数/类/变量等），返回位置与摘要。不知道精确符号名时用它找；" +
-      "找到后用 codegraph_node 查详情、callers/callees 查关系。NOT 用于查调用关系——那是 callers/callees；" +
-      "本工具按名找符号。kind 限定符号种类" +
-      "（function/method/class/interface/type/variable/route/component）；limit 默认 10。",
+    "Search codebase symbols and definitions by keyword or query text. " +
+      "PRIMARY entry point for discovering symbols, functions, classes, and types across the codebase. " +
+      "ALWAYS prioritize this over grep for locating code symbols. NOT for call hierarchy (use callers/callees) or raw strings (use grep).",
     {
-      query: { type: "string", description: "搜索关键词（符号名/片段）" },
+      query: { type: "string", description: "Search query or keyword (symbol name or snippet)" },
       kind: {
         type: "string",
-        description: "限定符号种类：function/method/class/interface/type/variable/route/component",
+        description: "Filter by symbol kind: function/method/class/interface/type/variable/route/component",
         enum: ["function", "method", "class", "interface", "type", "variable", "route", "component"],
       },
-      limit: { type: "number", description: "最大结果数（默认 10）", minimum: 1 },
+      limit: { type: "number", description: "Max results to return (default 10)", minimum: 1 },
       projectPath: { type: "string", description: SHARED.projectPath },
     },
     ["query"],
@@ -320,19 +317,17 @@ export function buildSearchToolDefinition(): ToolDefinition {
 export function buildFilesToolDefinition(): ToolDefinition {
   return buildCliTool(
     "codegraph_files",
-    "从索引列出项目文件结构（tree/flat/grouped）。找文件路径或了解项目结构时用；" +
-      "filter 只列该目录下文件；pattern 按 glob 过滤；maxDepth 限制 tree 深度。" +
-      "NOT 用于查调用关系——那是 callers/callees；本工具只列文件结构。" +
-      "注意：只覆盖已索引文件（index/sync 时存在的文件）。",
+    "List indexed project file structure (tree, flat, or grouped) with optional glob or path filtering. " +
+      "Use for exploring directory layout. Note: only covers indexed files.",
     {
-      filter: { type: "string", description: "只列该目录下的文件（如 'src'）" },
-      pattern: { type: "string", description: "按 glob 模式过滤文件（如 '*.ts'）" },
+      filter: { type: "string", description: "Directory prefix filter (e.g. 'src')" },
+      pattern: { type: "string", description: "Glob pattern filter (e.g. '*.ts')" },
       format: {
         type: "string",
-        description: "输出格式：tree（默认）/ flat / grouped",
+        description: "Output format: tree (default) / flat / grouped",
         enum: ["tree", "flat", "grouped"],
       },
-      maxDepth: { type: "number", description: "tree 格式的最大目录深度", minimum: 1 },
+      maxDepth: { type: "number", description: "Max directory depth for tree format", minimum: 1 },
       projectPath: { type: "string", description: SHARED.projectPath },
     },
     [],
@@ -356,10 +351,9 @@ export function buildFilesToolDefinition(): ToolDefinition {
 export function buildStatusToolDefinition(): ToolDefinition {
   return buildCliTool(
     "codegraph_status",
-    "查看当前 codegraph 索引的状态与统计（是否完整、文件/符号数、待同步变更数、是否需要重索引）。" +
-      "本工具只查状态不执行查询；索引新鲜度由查询类工具自动维护。path 为位置参数。",
+    "Inspect local codegraph index health, symbol/file counts, and pending sync status for the current worktree.",
     {
-      path: { type: "string", description: "目标 worktree 路径（缺省补全为当前会话 worktree；位置参数）" },
+      path: { type: "string", description: "Target worktree path (defaults to current session worktree; positional argument)" },
     },
     [],
     // 位置参数由 execute 按 pathStyle: "positional" 统一追加（#465：buildArgs 不再

--- a/packages/dsh-codegraph/test/smoke.ts
+++ b/packages/dsh-codegraph/test/smoke.ts
@@ -824,7 +824,7 @@ check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpMa
 // ---- apply ----
 {
   const makeCtx = (overrides = {}) => {
-    const state = { disposers: [], registered: [], hooks: [], logs: [], tools: [], registerCalls: [], preStepCbs: [] };
+    const state = { disposers: [], registered: [], hooks: [], logs: [], tools: [], registerCalls: [], preStepCbs: [], sections: [] };
     const ctx = {
       logger: { warn: (m) => state.logs.push(`warn:${m}`), info: (m) => state.logs.push(`info:${m}`) },
       // inject 强依赖：ctx.mcpManager 直接可用（不再 get 探测）。registerServer
@@ -836,19 +836,25 @@ check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpMa
         getTools: () => [],
         list: () => [],
       },
+      systemPrompt: overrides.systemPrompt ?? {
+        section: (opts) => {
+          state.sections.push(opts);
+          return () => {};
+        },
+      },
       // 注意：不再提供 ctx.tools——#363 补充 3 撤销自注册，apply 不应触碰 tools
-      // （inject 也不含 tools）。纪律注入为根 ctx pre-step 监听（main b01ced7）。
+      // （inject 也不含 tools）。系统提示词注入为 ctx.systemPrompt.section。
       on: (event, cb) => { if (event === "agent/pre-step") state.preStepCbs.push(cb); return () => {}; },
       effect: (fn) => { const d = fn(); state.disposers.push(d); return d; },
     };
     return { ctx, state };
   };
 
-  check("契约: inject 含 mcpManager、不含 tools（#363 撤销自注册；纪律注入走根 ctx pre-step 不需 agents/systemPrompt）", () => {
+  check("契约: inject 含 mcpManager 与 systemPrompt、不含 tools", () => {
     assert.ok(inject.includes("mcpManager"), `inject 应含 mcpManager，实际 ${JSON.stringify(inject)}`);
+    assert.ok(inject.includes("systemPrompt"), `inject 应含 systemPrompt，实际 ${JSON.stringify(inject)}`);
     assert.ok(!inject.includes("tools"), "inject 不应再含 tools（#363 补充 3 撤销自注册）");
-    assert.ok(!inject.includes("agents"), "inject 不应含 agents（纪律注入为 pre-step，b01ced7）");
-    assert.ok(!inject.includes("systemPrompt"), "inject 不应含 systemPrompt（纪律注入为 pre-step，b01ced7）");
+    assert.ok(!inject.includes("agents"), "inject 不应含 agents");
   });
 
   // 回归（启动崩溃根因）：apply 不读取 ctx.session（无 session 字段也能 apply）。
@@ -935,6 +941,9 @@ check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpMa
         getTools: () => [],
         list: () => [],
       },
+      systemPrompt: {
+        section: () => () => {},
+      },
       on: () => () => {},
       effect: (fn) => { const d = fn(); return d; },
     };
@@ -945,7 +954,7 @@ check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpMa
     assert.equal(registeredInput.name, "codegraph");
     // A2（#417）：注册时携带服务器级 description——能力目录条目优先取它，
     // 避免 fallback 到 codegraph_files 工具摘要（「列文件结构」埋没核心查询能力）。
-    assert.ok(typeof registeredInput.description === "string" && registeredInput.description.includes("结构类查询"), "入参携带 description（能力目录如实展示）");
+    assert.ok(typeof registeredInput.description === "string" && registeredInput.description.includes("Local code graph"), "入参携带 description（能力目录如实展示）");
     assert.ok(Array.isArray(registeredInput.toolDefinitions), "入参携带 toolDefinitions");
     assert.equal(registeredInput.toolDefinitions.length, 8, "8 个封装定义");
     rmSync(dir, { recursive: true, force: true });
@@ -955,71 +964,52 @@ check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpMa
   // dsh-tool-skill 载体）；git 仓注入、非 git 不注入；幂等查会话历史
   // （agent.session.snapshotEvents()，官方 dsh-time-context 模式）。内容与 mcp 目录正交。
   {
-    const runPreStep = async (state, messages, cwd, events = []) => {
-      const next = async () => ({ kind: "enter", messages });
-      let result;
-      for (const cb of state.preStepCbs ?? []) {
-        result = await cb({ agent: { id: "a1", session: { header: { cwd }, snapshotEvents: () => events } }, messages, signal: { throwIfAborted: () => {} } }, next);
-      }
-      return result;
-    };
-    checkAsync("discipline: git 仓会话 pre-step 注入纪律消息（面板可见 + #363 文案）", async () => {
+    checkAsync("discipline: git 仓会话注册系统提示词段落（order 170 + 全英文决策表）", async () => {
       const dir = mkdtempSync(join(tmpdir(), "cg-disc-git-"));
       mkdirSync(join(dir, "repo", ".git"), { recursive: true });
       try {
         const { ctx, state } = makeCtx();
-        const { registerDisciplineHook } = await import(pathToFileURL(join(pkgDir, "lib/index.js")).href);
-        registerDisciplineHook(ctx);
-        assert.equal((state.preStepCbs ?? []).length, 1, "注册了 pre-step 监听器");
-        const decision = await runPreStep(state, [{ id: "m1", role: "user", content: [{ type: "text", text: "hi" }], source: { kind: "user" } }], join(dir, "repo"));
-        assert.equal(decision.kind, "enter");
-        assert.equal(decision.messages.length, 2, "追加 1 条纪律消息");
-        const injected = decision.messages[1];
-        assert.equal(injected.role, "user");
-        assert.equal(injected.source.kind, "plugin", "source.kind=plugin → GUI 上下文注入面板可见");
-        assert.equal(injected.source.plugin, "codegraph");
-        const text = injected.content[0].text;
-        assert.ok(text.includes("codegraph_explore"), "纪律文本含工具名");
-        // #363 验收 6/18 + #417 A 项：纪律文案含全部工具引导；注册形态
-        // 说明已随决策表化删除（由能力目录承担），断言跟随新文案。
-        for (const tool of ["codegraph_impact", "codegraph_node", "codegraph_callers", "codegraph_callees", "codegraph_search", "codegraph_files", "codegraph_status"]) {
-          assert.ok(text.includes(tool), `纪律文案应引导 ${tool}`);
+        const { registerCodegraphPrompt } = await import(pathToFileURL(join(pkgDir, "lib/index.js")).href);
+        registerCodegraphPrompt(ctx);
+        assert.equal(state.sections.length, 1, "注册了 1 个系统提示词段落");
+        const section = state.sections[0];
+        assert.equal(section.name, "plugin:dsh-codegraph");
+        assert.equal(section.order, 170, "order 为 170，排在 mcp-manager 160 之后");
+        assert.equal(typeof section.text, "function", "text 为函数支持会话级动态计算");
+
+        // 在 git 仓会话中求值
+        const contextGit = { agent: { session: { header: { cwd: join(dir, "repo") } } } };
+        const text = section.text(contextGit);
+        assert.ok(text.length > 0, "git 仓会话返回非空提示词");
+        assert.ok(text.includes("[Code Graph: codegraph_* tools]"), "包含标题");
+        assert.ok(text.includes("ALWAYS prioritize `codegraph_*` tools"), "强调优先使用图谱");
+        for (const tool of ["codegraph_explore", "codegraph_impact", "codegraph_node", "codegraph_callers", "codegraph_callees", "codegraph_search", "codegraph_files", "codegraph_status"]) {
+          assert.ok(text.includes(tool), `提示词应引导 ${tool}`);
         }
-        assert.ok(text.includes("全文搜词才用 grep"), "含决策表兜底（grep 只用于全文搜索）");
-        assert.ok(text.includes("正在编辑的文件一律 Read 原文"), "保留正在编辑的文件 Read 原文纪律");
+        assert.ok(text.includes("NEVER grep for code symbols"), "排他性规则约束 grep");
+        assert.ok(text.includes("DO NOT use `mcp__` prefixes"), "明确禁止 mcp__ 前缀防止臆造");
         assert.ok(text.includes("codegraph init <path>"), "保留无索引引导");
-        assert.ok(!text.includes("mcp__codegraph__impact"), "不再有双轨说明（去 mcp__ 官方工具直呼）");
-        assert.ok(!text.includes("裸名纪律工具"), "不再有裸名 vs mcp__ 双轨措辞");
-        assert.ok(!text.includes("全部经 mcp-manager 统一管理"), "注册形态声明已移除（#417 A 项：实现细节交能力目录）");
-        assert.ok(!text.includes("本插件不直接注册工具"), "注册形态声明已移除（#417 A 项）");
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }
     });
-    checkAsync("discipline: 会话历史已注入 → 不重复注入（幂等）", async () => {
-      const dir = mkdtempSync(join(tmpdir(), "cg-disc-idem-"));
-      mkdirSync(join(dir, "repo", ".git"), { recursive: true });
-      try {
-        const { ctx, state } = makeCtx();
-        const { registerDisciplineHook } = await import(pathToFileURL(join(pkgDir, "lib/index.js")).href);
-        registerDisciplineHook(ctx);
-        // 会话历史已有纪律消息（source.kind=plugin && plugin=codegraph）
-        const events = [{ type: "user/message", data: { source: { kind: "plugin", plugin: "codegraph" } } }];
-        const decision = await runPreStep(state, [{ id: "m1", role: "user", content: [{ type: "text", text: "hi" }], source: { kind: "user" } }], join(dir, "repo"), events);
-        assert.equal(decision.messages.length, 1, "历史已注入 → 不再追加");
-      } finally {
-        rmSync(dir, { recursive: true, force: true });
-      }
-    });
-    checkAsync("discipline: 非 git 会话不注入纪律（零注入）", async () => {
+
+    checkAsync("discipline: 非 git 会话或无 session 返回空串（零注入零污染）", async () => {
       const dir = mkdtempSync(join(tmpdir(), "cg-disc-nongit-"));
       mkdirSync(join(dir, "nongit"), { recursive: true });
       try {
         const { ctx, state } = makeCtx();
-        const { registerDisciplineHook } = await import(pathToFileURL(join(pkgDir, "lib/index.js")).href);
-        registerDisciplineHook(ctx);
-        const decision = await runPreStep(state, [{ id: "m1", role: "user", content: [{ type: "text", text: "hi" }], source: { kind: "user" } }], join(dir, "nongit"));
-        assert.equal(decision.messages.length, 1, "非 git 不注入纪律");
+        const { registerCodegraphPrompt } = await import(pathToFileURL(join(pkgDir, "lib/index.js")).href);
+        registerCodegraphPrompt(ctx);
+        const section = state.sections[0];
+
+        // 1. 非 git 目录
+        const contextNonGit = { agent: { session: { header: { cwd: join(dir, "nongit") } } } };
+        assert.equal(section.text(contextNonGit), "", "非 git 仓返回空串实现零注入");
+
+        // 2. 杜绝 process.cwd 逃逸：无 agent 或空 session 时返回空串
+        assert.equal(section.text({}), "", "无 agent 时返回空串");
+        assert.equal(section.text(undefined), "", "无 context 时返回空串");
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }

--- a/packages/dsh-mcp-manager/src/apply.ts
+++ b/packages/dsh-mcp-manager/src/apply.ts
@@ -24,7 +24,10 @@ import { sseData } from "../../../shared/host-utils.js";
  * （<available_mcp_servers>，见 L1）承担，此处只保留插件存在、安全边界与术语约定，
  * 不再复述 UI 配置路径与调用流程（那部分由能力目录与中间层工具描述承担）。 */
 export const MCP_GUIDANCE =
-  "本机已安装 dsh-mcp-manager（DSH MCP 管理器）：统一管理 MCP 服务器连接，不预设任何服务器。MCP 工具在真实服务器上执行，stdio 子进程继承宿主权限，结果可能含敏感信息——涉及写/敏感操作先向用户说明并征得同意。用户提到「MCP / mcp 服务 / 上下文服务器」即指本插件；已配置服务器与调用规则见会话内的能力目录。";
+  "dsh-mcp-manager is active: centrally manages MCP server connections without preset servers. MCP tools execute on real servers with inherited host permissions; results may contain sensitive data — explain and obtain user consent before write or sensitive operations. Terms like 'MCP / context server' refer to this plugin. Invocation rules:\n" +
+  "- Project-level servers: search with `ws_mcp_search`, verify schema with `ws_mcp_detail` if uncertain, then invoke with `ws_mcp_call`. Do NOT call mcp__ prefixed tools directly.\n" +
+  "- Global servers: call `mcp__<server>__<tool>` directly (or via `ws_mcp_call` in all mode).\n" +
+  "- Do not retry a failing server tool more than twice.";
 
 /**
  * 挂载 MCP 管理器：加载存储、启动已启用服务器、注册路由与提示词。

--- a/packages/dsh-mcp-manager/src/catalog.ts
+++ b/packages/dsh-mcp-manager/src/catalog.ts
@@ -77,6 +77,9 @@ export function catalogCacheFile() {
 export const CATALOG_SUMMARY_MAX_CHARS = 240;
 /** 目录摘要单句上限（字符）：无句读语言 / 超长描述的安全截断点。 */
 export const CATALOG_SUMMARY_PER_TOOL_CHARS = 120;
+/** 目录单条服务器描述上限（字符）：Level 1 发现层防远端超长说明书（如 context7 500 词）
+ * 撑爆会话上下文，符合渐进式披露原则。详细使用说明由 ws_mcp_detail / ws_mcp_search 按需承载。 */
+export const CATALOG_ENTRY_MAX_CHARS = 180;
 
 /**
  * 从工具描述集合计算目录摘要（每工具取首句，按工具名升序 + 精确去重后拼接）。
@@ -110,11 +113,11 @@ export function summarizeToolDescriptions(toolMeta: Map<string, { description?: 
       ? sentence
       : `${charTruncate(sentence, CATALOG_SUMMARY_PER_TOOL_CHARS - 1)}…`);
   }
-  const prefix = collected.length >= 2 ? `共 ${collected.length} 个工具：` : "";
-  // ③ 拼接（"；" 分隔），超总长按句整段回退补 "…"（绝不句中切）。
+  const prefix = collected.length >= 2 ? `${collected.length} tools: ` : "";
+  // ③ 拼接（"; " 分隔），超总长按句整段回退补 "…"（绝不句中切）。
   let text = prefix;
   for (const sentence of sentences) {
-    const separator = text === prefix ? "" : "；";
+    const separator = text === prefix ? "" : "; ";
     if (text.length + separator.length + sentence.length <= CATALOG_SUMMARY_MAX_CHARS - 1) {
       text += separator + sentence;
     } else if (text === prefix) {
@@ -177,7 +180,9 @@ export function composeCatalogEntries(supervisors: Map<string, SupervisorLite>, 
     const server = supervisor.server;
     let text;
     if (typeof server.description === "string" && server.description !== "") {
-      text = server.description;
+      const sentence = firstSentenceOf(server.description);
+      const raw = sentence !== "" ? sentence : server.description.trim().replace(/\s+/gu, " ");
+      text = raw.length <= CATALOG_ENTRY_MAX_CHARS ? raw : `${charTruncate(raw, CATALOG_ENTRY_MAX_CHARS - 1)}…`;
     } else {
       const cached = cache?.get(name);
       if (typeof cached?.summary === "string" && cached.summary !== "") text = cached.summary;
@@ -221,26 +226,26 @@ export function digestCatalogEntries(entries: CatalogEntry[]): string {
 export function renderMcpCatalogMessage(entries: CatalogEntry[], mode?: string): CatalogMessage {
   const hasProject = entries.some((entry) => entry.scope === "project");
   const projectGuidance =
-    "项目级服务器一律经中间层工具访问：先用 `ws_mcp_search` 检索当前工作空间的 MCP 工具，再用 `ws_mcp_call` 调用（server/tool 取自检索结果；完整盘点全部服务器与工具清单用 `ws_mcp_list`，查单个工具的完整 inputSchema 用 `ws_mcp_detail`）。**项目级服务器不直接调用其 mcp__ 前缀工具**。";
+    "Project-level servers MUST be accessed via middleware tools: search with `ws_mcp_search`, verify schema with `ws_mcp_detail` if uncertain, then invoke with `ws_mcp_call` (use `ws_mcp_list` for full inventory audits). **Do NOT invoke project-level servers using mcp__ prefixed tools directly**.";
   const globalGuidance =
     mode === "all"
-      ? "全局服务器同样经中间层访问（all 模式全局不注册 mcp__ 工具）：先用 `ws_mcp_search` 检索，再经 `ws_mcp_call` 调用，与项目级同一套 `ws_mcp_*` 工具。"
-      : "全局服务器仍以 `mcp__<server>__<tool>` 前缀工具直呼调用（project 模式全局不经中间层检索）。";
+      ? "Global servers are also accessed via middleware in all mode: search with `ws_mcp_search`, then invoke with `ws_mcp_call` using the same `ws_mcp_*` suite."
+      : "Global servers are directly invoked using `mcp__<server>__<tool>` prefixed tools (project mode does not route global servers through middleware).";
   const guidance = hasProject
-    ? `${projectGuidance}${globalGuidance}`
+    ? `${projectGuidance} ${globalGuidance}`
     : mode === "all"
       ? globalGuidance
-      : `任务匹配某服务器能力时，直接调用其 \`mcp__<server>__<tool>\` 工具（具体工具名与参数见工具列表）。${globalGuidance}`;
+      : `When a task matches a server's capability, call its \`mcp__<server>__<tool>\` tool directly (see tool list for parameters). ${globalGuidance}`;
   const lines = [
     "<system-reminder>",
-    "本会话已配置以下 MCP 服务器（**仅描述能力，不代表当前连接状态**；服务器在 GUI「MCP」浮窗中连接后，其工具才会注册可用）：",
+    "Configured MCP servers in this session (**capability descriptions only, does not reflect active connection status**; tools register once connected via GUI \"MCP\" popup):",
     "",
     "<available_mcp_servers>",
     ...entries.map((entry) => (entry.text === undefined ? `- \`${entry.name}\`` : `- \`${entry.name}\`: ${escapeCatalogText(entry.text)}`)),
     "</available_mcp_servers>",
     "",
     guidance,
-    "若某服务器此前可用而现在不可用，请勿反复重试同一工具超过两次，改用其他方式或提示用户检查「MCP」浮窗。",
+    "If a server was available but is now disconnected, do not retry the same tool more than twice. Switch to an alternative method or ask the user to check the \"MCP\" popup.",
     "</system-reminder>",
   ].join("\n");
   return {
@@ -315,7 +320,7 @@ export function renderMcpCatalogUpdate(entries: CatalogEntry[], mode?: string): 
   const inner = body.content![0].text!.split("\n").slice(3).join("\n");
   const text = [
     "<system-reminder>",
-    "MCP 服务器集合已变化。**本目录替换此前所有 available_mcp_servers 列表**：",
+    "MCP server configuration has changed. **This catalog replaces all previous available_mcp_servers lists**:",
     "",
     inner,
     "</system-reminder>",

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -112,6 +112,7 @@ export {
   catalogCacheFile,
   CATALOG_SUMMARY_MAX_CHARS,
   CATALOG_SUMMARY_PER_TOOL_CHARS,
+  CATALOG_ENTRY_MAX_CHARS,
   summarizeToolDescriptions,
   composeCatalogEntries,
   digestCatalogEntries,

--- a/packages/dsh-mcp-manager/src/middleware-register.ts
+++ b/packages/dsh-mcp-manager/src/middleware-register.ts
@@ -36,7 +36,7 @@ import type { MiddlewareMode, DisabledToolsMap } from "./middleware-types.ts";
 
 /** 空 query 搜索无命中时的可归因提示（纯 render 文案，C 项）。 */
 const SEARCH_EMPTY_HINT =
-  "（当前工作空间没有匹配的 MCP 工具；可用 ws_mcp_list 完整盘点全部服务器与工具，确认 server 名/工具名后再检索）";
+  "(No matching MCP tools found in current workspace; use ws_mcp_list for full inventory or verify server/tool names before searching)";
 
 /** 项目级可见服务器名列表（A1 归因文案用；排序去重）。 */
 function visibleProjectServers(mw: McpMiddleware, root: string): string[] {
@@ -125,13 +125,13 @@ export function registerMiddlewareTools(
   const search: ToolDefinition = {
     name: "ws_mcp_search",
     description:
-      "检索当前工作空间的 MCP 工具目录（关键词命中 server 名/工具名/描述/参数名，返回命中条目）。先用本工具检索，再 ws_mcp_call 调用；完整盘点请用 ws_mcp_list（本工具仅关键词检索）。空 query 返回能力摘要表。",
+      "Search workspace MCP tools catalog by keyword (matches server, tool, description, and parameter names). Search first, then invoke with ws_mcp_call; use ws_mcp_list for full inventory audits. Empty query returns capability summary.",
     parameters: {
       type: "object",
       properties: {
-        query: { type: "string", description: "意图/关键词；空则列能力摘要" },
-        server: { type: "string", description: "可选：@<root>/<server> 全名过滤" },
-        limit: { type: "number", description: "返回条数上限（默认 5，上限 10）" },
+        query: { type: "string", description: "Search query / keywords; empty returns capability summary" },
+        server: { type: "string", description: "Optional: @<root>/<server> full name filter" },
+        limit: { type: "number", description: "Max results to return (default 5, max 10)" },
       },
     },
     output: {
@@ -154,9 +154,9 @@ export function registerMiddlewareTools(
           return `${server}/${tool}: ${description}`;
         });
         let body = lines.length > 0 ? lines.join("\n") : SEARCH_EMPTY_HINT;
-        if (v.truncated === true) body += "\n（结果已达 limit，可能未列全——可调大 limit 或用 ws_mcp_list 完整盘点）";
+        if (v.truncated === true) body += "\n(Results reached limit and may be incomplete — increase limit or use ws_mcp_list for full audit)";
         const unavailable = (v.unavailable ?? []).map((entry) => `${String(entry.server ?? "")}: ${String(entry.reason ?? "")}`);
-        return [{ type: "text", text: unavailable.length > 0 ? `${body}\n\n不可用服务器：\n${unavailable.join("\n")}` : body }];
+        return [{ type: "text", text: unavailable.length > 0 ? `${body}\n\nUnavailable servers:\n${unavailable.join("\n")}` : body }];
       },
     },
     isConcurrencySafe: () => true,
@@ -191,16 +191,17 @@ export function registerMiddlewareTools(
   const call: ToolDefinition = {
     name: "ws_mcp_call",
     description:
-      "调用当前工作空间的一个 MCP 工具（在真实服务器上执行）。参数 schema 先用 ws_mcp_detail 核对（已知 server/tool 时可直呼免搜索）；涉及写/敏感操作前先向用户说明并征得同意。",
+      "Invoke an MCP tool in the current workspace (executes on live server). Verify parameter schema with ws_mcp_detail beforehand (can invoke directly if server and tool are known); obtain user consent before write or sensitive operations.",
     parameters: {
       type: "object",
       properties: {
-        server: { type: "string", description: "必须：@<root>/<server> 全名（来自 ws_mcp_search / ws_mcp_list）" },
-        tool: { type: "string", description: "必须：远端工具裸名（来自 ws_mcp_search / ws_mcp_list）" },
+        server: { type: "string", description: "Required: @<root>/<server> full name (from ws_mcp_search / ws_mcp_list)" },
+        tool: { type: "string", description: "Required: bare remote tool name (from ws_mcp_search / ws_mcp_list)" },
         arguments: {
           type: "object",
           additionalProperties: true,
-          description: "参数，匹配 ws_mcp_detail 返回的 inputSchema（properties/required/enum/description）；拿不准时先用 ws_mcp_detail 核对",
+          description:
+            "Arguments matching inputSchema from ws_mcp_detail (properties/required/enum/description); check with ws_mcp_detail when uncertain",
         },
       },
       required: ["server", "tool"],
@@ -265,17 +266,17 @@ export function registerMiddlewareTools(
   const list: ToolDefinition = {
     name: "ws_mcp_list",
     description:
-      "列出当前工作空间全部 MCP 服务器与每台服务器的完整工具清单（不受检索 limit 截断），供盘点。返回服务器全名、工具名与描述。不返回 inputSchema——查单个工具完整 schema 用 ws_mcp_detail。all 模式下含全局服务器。",
+      "List all MCP servers and their complete tool inventories in current workspace (not truncated by search limit). Returns full server names, tool names, and descriptions. Does not return inputSchema (use ws_mcp_detail for full schemas). Includes global servers in all mode.",
     parameters: {
       type: "object",
       properties: {
         server: {
           type: "string",
-          description: `可选：@<root>/<server> 全名或裸名过滤，只列出该服务器的工具（全名 root 不属于当前工作空间 → 抛路由一致性错误）`,
+          description: "Optional: @<root>/<server> full name or bare name filter (error if root is not in current workspace)",
         },
         perServerLimit: {
           type: "number",
-          description: `可选：每服务器工具条数上限（默认 ${LIST_DEFAULT_TOOLS_PER_SERVER}，上限 ${LIST_MAX_TOOLS_PER_SERVER}；超过置 toolsTruncated=true，模型可按需调大）`,
+          description: `Optional: max tools per server (default ${LIST_DEFAULT_TOOLS_PER_SERVER}, max ${LIST_MAX_TOOLS_PER_SERVER}; sets toolsTruncated=true when exceeded)`,
         },
       },
     },
@@ -308,15 +309,15 @@ export function registerMiddlewareTools(
         const lines = servers.map((entry) => {
           const server = String(entry.server ?? "");
           const tools = Array.isArray(entry.tools) ? (entry.tools as Array<Record<string, unknown>>) : [];
-          const head = tools.length > 0 ? `${server}（${tools.length} 个工具）：\n${tools.map((t) => `  - ${String(t.tool ?? "")}: ${String(t.description ?? "")}`).join("\n")}` : `${server}（0 个工具）`;
+          const head = tools.length > 0 ? `${server} (${tools.length} tools):\n${tools.map((t) => `  - ${String(t.tool ?? "")}: ${String(t.description ?? "")}`).join("\n")}` : `${server} (0 tools)`;
           const disabled = entry.disabled === true ? " [disabled]" : "";
           const unavailable = typeof entry.unavailable === "string" && entry.unavailable !== "" ? ` [unavailable: ${entry.unavailable}]` : "";
-          const truncated = entry.toolsTruncated === true ? " [toolsTruncated: 工具数已达上限，可调大 perServerLimit 后重试]" : "";
+          const truncated = entry.toolsTruncated === true ? " [toolsTruncated: tool count reached limit, increase perServerLimit to retry]" : "";
           return `${head}${disabled}${unavailable}${truncated}`;
         });
-        const prefix = `工作空间 ${String(v.workspace ?? "")}（mode=${String(v.mode ?? "")}）：共 ${String(v.totalServers ?? 0)} 台服务器 / ${String(v.totalTools ?? 0)} 个工具`;
-        const body = lines.length > 0 ? lines.join("\n\n") : String(v.message ?? "（当前工作空间没有 MCP 服务器）");
-        const truncated = v.toolsTruncated === true ? "\n（部分服务器工具清单被截断，可按需调大 perServerLimit）" : "";
+        const prefix = `Workspace ${String(v.workspace ?? "")} (mode=${String(v.mode ?? "")}): ${String(v.totalServers ?? 0)} servers / ${String(v.totalTools ?? 0)} tools in total`;
+        const body = lines.length > 0 ? lines.join("\n\n") : String(v.message ?? "(No MCP servers found in current workspace)");
+        const truncated = v.toolsTruncated === true ? "\n(Some server tool lists were truncated; increase perServerLimit if needed)" : "";
         return [{ type: "text", text: `${prefix}\n\n${body}${truncated}` }];
       },
     },
@@ -373,12 +374,12 @@ export function registerMiddlewareTools(
   const detail: ToolDefinition = {
     name: "ws_mcp_detail",
     description:
-      "按 @<root>/<server> 全名 + 工具裸名精确查询单个 MCP 工具的完整参数 schema（inputSchema：properties/required/enum/description）。供 ws_mcp_call 前核对参数。不做关键词检索——找工具用 ws_mcp_list 或 ws_mcp_search。",
+      "Query the exact parameter schema (inputSchema: properties/required/enum/description) of a single MCP tool by @<root>/<server> full name and bare tool name. Used before ws_mcp_call. Does not perform keyword search (use ws_mcp_list or ws_mcp_search to find tools).",
     parameters: {
       type: "object",
       properties: {
-        server: { type: "string", description: "必须：@<root>/<server> 全名（来自 ws_mcp_list / ws_mcp_search）" },
-        tool: { type: "string", description: "必须：远端工具裸名（来自 ws_mcp_list / ws_mcp_search；兼容 mcp__<server>__<tool> 前缀）" },
+        server: { type: "string", description: "Required: @<root>/<server> full name (from ws_mcp_list / ws_mcp_search)" },
+        tool: { type: "string", description: "Required: bare remote tool name (from ws_mcp_list / ws_mcp_search; supports mcp__<server>__<tool> prefix)" },
       },
       required: ["server", "tool"],
     },

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -224,9 +224,9 @@ const main = async () => {
     assert.match(registered.find((d) => d.name === "ws_mcp_search").description, /ws_mcp_list/, "search 描述互引完整盘点");
     assert.match(registered.find((d) => d.name === "ws_mcp_call").description, /ws_mcp_detail/, "call 描述互引参数 schema 查询");
     assert.match(registered.find((d) => d.name === "ws_mcp_list").description, /ws_mcp_detail/, "list 描述互引 detail");
-    assert.match(registered.find((d) => d.name === "ws_mcp_list").description, /不返回 inputSchema/, "list 描述写明不做什么");
+    assert.match(registered.find((d) => d.name === "ws_mcp_list").description, /Does not return inputSchema/, "list 描述写明不做什么");
     assert.match(registered.find((d) => d.name === "ws_mcp_detail").description, /inputSchema/, "detail 描述说明完整 schema");
-    assert.match(registered.find((d) => d.name === "ws_mcp_detail").description, /不做关键词检索/, "detail 描述写明不做什么");
+    assert.match(registered.find((d) => d.name === "ws_mcp_detail").description, /Does not perform keyword search/, "detail 描述写明不做什么");
     // Anthropic 规范：parameters 每个字段都带 description。
     for (const def of registered) {
       const props = def.parameters?.properties ?? {};
@@ -2078,7 +2078,7 @@ const main = async () => {
     const tavilySummary = summarizeToolDescriptions(tavily)!;
     assert.ok(tavilySummary.includes("Search the web"), "摘要含 search 语义（防 crawler 误导）");
     assert.ok(tavilySummary.includes("research"), "摘要含 research 语义");
-    assert.ok(tavilySummary.startsWith("共 5 个工具："), "多工具前缀标注真实工具数");
+    assert.ok(tavilySummary.startsWith("5 tools: "), "多工具前缀标注真实工具数");
   });
   check("recordCatalogTools 仅实质变化落盘", async () => {
     const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-catalog-"));
@@ -2134,7 +2134,7 @@ const main = async () => {
     assert.equal(msg.source.kind, "mcp-catalog");
     assert.equal(msg.content[0].type, "text");
     assert.match(msg.content[0].text, /available_mcp_servers/);
-    assert.match(msg.content[0].text, /不代表当前连接状态/);
+    assert.match(msg.content[0].text, /does not reflect active connection status/);
     assert.match(msg.content[0].text, /ws_mcp_search/, "#228 目录文案引导经中间层调用");
     assert.match(msg.content[0].text, /`code-graph`: 代码图谱/);
     assert.ok(typeof msg.id === "string" && msg.id.length > 0);
@@ -2305,7 +2305,7 @@ const main = async () => {
     result = runStep({ kind: "enter", messages: [...messages, { id: "u3", role: "user", content: [] }] }, messages, added, undefined, agent);
     const afterAdd = agent.session.snapshotEvents().filter((e) => e.data?.source?.kind === "mcp-catalog");
     assert.equal(afterAdd.length, 2, "集合变化注入更新消息（历史目录无法删除，新消息声明作废）");
-    assert.match(afterAdd[1].data.content[0].text, /替换此前所有/);
+    assert.match(afterAdd[1].data.content[0].text, /replaces all previous available_mcp_servers/);
     assert.match(afterAdd[1].data.content[0].text, /playwright/);
 
     // 更新后同集合不再注入

--- a/packages/dsh-mcp-manager/test/unit-catalog.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-catalog.test.ts
@@ -44,7 +44,7 @@ assert.equal(DEFAULT_CATALOG_MAX_ENTRIES, 6);
     ["a", { description: "alpha" }],
   ]);
   // #569：每工具取首句、按工具名升序聚合（不再只取字典序第一条）。
-  assert.equal(summarizeToolDescriptions(meta), "共 2 个工具：alpha；beta tool");
+  assert.equal(summarizeToolDescriptions(meta), "2 tools: alpha; beta tool");
   const onlyBlank = new Map([["x", { description: "   " }]]);
   assert.equal(summarizeToolDescriptions(onlyBlank), undefined, "全空白 → undefined");
   // 顺序抖动 → 摘要稳定（按工具名排序，不随 Map 插入序/描述变化）。
@@ -52,7 +52,7 @@ assert.equal(DEFAULT_CATALOG_MAX_ENTRIES, 6);
     ["b", { description: "beta tool" }],
     ["a", { description: "alpha" }],
   ]);
-  assert.equal(summarizeToolDescriptions(shuffled), "共 2 个工具：alpha；beta tool", "顺序抖动摘要稳定");
+  assert.equal(summarizeToolDescriptions(shuffled), "2 tools: alpha; beta tool", "顺序抖动摘要稳定");
   // 首句提取：句点后随大写开新句；"1." 编号不误切；无句读整行返回。
   assert.equal(
     summarizeToolDescriptions(new Map([["x", { description: "Search the web. Use for facts." }]])),
@@ -72,7 +72,7 @@ assert.equal(DEFAULT_CATALOG_MAX_ENTRIES, 6);
   // 精确去重：同句两个工具只出现一次。
   assert.equal(
     summarizeToolDescriptions(new Map([["a", { description: "同句" }], ["b", { description: "同句" }]])),
-    "共 2 个工具：同句",
+    "2 tools: 同句",
     "重复描述去重",
   );
   // 超长截断：总长 ≤ 240 字符（UTF-16 安全；截断处补 …）。
@@ -85,7 +85,7 @@ assert.equal(DEFAULT_CATALOG_MAX_ENTRIES, 6);
   const dedupMap = new Map<string, { description?: unknown }>();
   for (let i = 0; i < 30; i += 1) dedupMap.set(`t${String(i).padStart(2, "0")}`, { description: "同句说明" });
   const dedup = summarizeToolDescriptions(dedupMap)!;
-  assert.equal(dedup, "共 30 个工具：同句说明", "重复描述去重后单条即完整");
+  assert.equal(dedup, "30 tools: 同句说明", "重复描述去重后单条即完整");
   // 极端长句（无句读超单句上限）→ 单句内截断 + 省略号。
   const single = summarizeToolDescriptions(new Map([["x", { description: "长".repeat(500) }]]))!;
   assert.ok(single.length <= 240, "极端长句截断受控");
@@ -116,6 +116,14 @@ assert.equal(DEFAULT_CATALOG_MAX_ENTRIES, 6);
   const noCache = composeCatalogEntries(new Map([["z", { server: { name: "z" } }]]));
   assert.equal(noCache[0].text, undefined);
   assert.equal(composeCatalogEntries(new Map()).length, 0);
+
+  // 超长 description 提取首句防上下文膨胀（渐进式披露：丢弃后续多行与长说明书）。
+  const verboseDesc =
+    "Resolves package name to library ID. You MUST call this first. Step 1. Do something. Selection Process: very long text...";
+  const verboseEntries = composeCatalogEntries(
+    new Map([["context7", { server: { name: "context7", description: verboseDesc } }]]),
+  );
+  assert.equal(verboseEntries[0].text, "Resolves package name to library ID.");
 }
 
 // ---- digestCatalogEntries ----
@@ -150,7 +158,7 @@ assert.equal(DEFAULT_CATALOG_MAX_ENTRIES, 6);
   const text = message.content[0].text;
   assert.ok(text.includes("<available_mcp_servers>"));
   assert.ok(text.includes("- `m1`: t&lt;1"), "条目转义渲染");
-  assert.ok(text.includes("不代表当前连接状态"));
+  assert.ok(text.includes("does not reflect active connection status"));
 
   assert.equal(findCatalogMessage([message]), message);
   assert.equal(findCatalogMessage([]), undefined);
@@ -178,8 +186,8 @@ assert.equal(DEFAULT_CATALOG_MAX_ENTRIES, 6);
   const update = renderMcpCatalogUpdate([{ name: "u1" }]);
   const text = update.content[0].text;
   assert.ok(text.startsWith("<system-reminder>"), "update 帧头");
-  assert.ok(text.includes("本目录替换此前所有 available_mcp_servers"), "替换声明");
-  assert.ok(!text.includes("不代表当前连接状态"), "内层裁掉原头部说明");
+  assert.ok(text.includes("This catalog replaces all previous available_mcp_servers"), "替换声明");
+  assert.ok(!text.includes("does not reflect active connection status"), "内层裁掉原头部说明");
   assert.ok(update.content[0].text.split("\n").length >= 6);
 }
 
@@ -279,19 +287,19 @@ assert.equal(DEFAULT_CATALOG_MAX_ENTRIES, 6);
   const injected = resolveCatalogInjection(baseDecision(), [], supervisors, 6, new Map(), undefined);
   assert.equal(injected.kind, "enter");
   assert.equal(injected.messages.length, 1);
-  assert.ok(injected.messages[0].content[0].text.includes("本会话已配置以下 MCP 服务器"), "首次注入用普通帧");
+  assert.ok(injected.messages[0].content[0].text.includes("Configured MCP servers in this session"), "首次注入用普通帧");
 
   // 6b. 已发布但 digest 变化 → 注入更新帧。
   const agentOther = { session: { surface: { nodes: [] }, snapshotEvents: () => [{ type: "user/message", seq: 1, data: { source: { kind: "mcp-catalog", entries: [{ name: "old" }] } } }] } };
   const updated = resolveCatalogInjection(baseDecision(), [], supervisors, 6, new Map(), agentOther);
-  assert.ok(updated.messages[0].content[0].text.includes("MCP 服务器集合已变化"), "digest 变化 → 更新帧");
+  assert.ok(updated.messages[0].content[0].text.includes("MCP server configuration has changed"), "digest 变化 → 更新帧");
 
   // 6c. 本轮已有旧目录且 digest 变化 → 原位替换而非追加。
   const stale = renderMcpCatalogMessage([{ name: "stale" }]);
   const replaced = resolveCatalogInjection({ kind: "enter", messages: [plainMessage("k2"), stale] }, [], supervisors, 6, new Map(), agentOther);
   assert.equal(replaced.messages.length, 2, "替换不追加");
   assert.equal(replaced.messages[0].id, "k2");
-  assert.ok(replaced.messages[1].content[0].text.includes("MCP 服务器集合已变化"));
+  assert.ok(replaced.messages[1].content[0].text.includes("MCP server configuration has changed"));
   assert.notEqual(replaced.messages[1].id, stale.id);
 }
 


### PR DESCRIPTION
## 背景与目标

优化 `dsh-codegraph` 与 `dsh-mcp-manager` 的提示词与工具描述，提升 Agent 执行效率与指令遵循率（Instruction Following）：
1. **改为全英文与极致精炼**：消灭中英混杂，Token 压缩 ~40%，提高模型理解确定性；
2. **codegraph 系统提示词化（Order 170）**：彻底移除原先在 `agent/pre-step` 插入普通 UserMessage 的做法，通过 `ctx.systemPrompt.section` 挂载在 `dsh-mcp-manager`（order 160）之后；
3. **强化代码图谱优先搜索与防臆造**：决策树明确将 `codegraph_*` 作为代码符号/定义的绝对首选，限制 grep 仅用于字面量文本；明确直接调用裸名工具，禁止 `mcp__` 前缀；
4. **渐进式披露（Progressive Disclosure）防护**：针对第三方 MCP 服务器（如 context7）的超长说明书，在一级目录注入时增加首句提取与 180 字符安全上限，彻底消除上下文膨胀。

## 改动清单

### 1. `packages/dsh-codegraph`
- `src/discipline.ts`:
  - 改造为系统提示词注册函数 `registerCodegraphPrompt`（`order: 170`）；
  - 动态从 `context.agent.session.header.cwd` 判断是否处于 git 仓，非 git 仓返回空串，杜绝 `process.cwd()` 宿主逃逸；
  - 导出全英文决策表 `CODEGRAPH_SYSTEM_PROMPT`，保留 `DISCIPLINE_TEXT` 与 `registerDisciplineHook` 兼容别名。
- `src/index.ts`:
  - `inject` 声明增加 `systemPrompt`；
  - 注册 MCP 的 `server.description` 更新为全英文，并包含直接调用裸名工具的指引。
- `src/tool-definition.ts`:
  - 8 个封装工具及参数描述全英文规范化；
  - `codegraph_node` 明确 `symbol` 与 `file` 必选其一。
- `test/smoke.ts`:
  - 适配系统提示词注册断言、英文描述校验以及非 git 仓/无会话防宿主逃逸断言。

### 2. `packages/dsh-mcp-manager`
- `src/apply.ts`:
  - `MCP_GUIDANCE` 优化为全英文系统提示词（含权限提示与两步调用法则）。
- `src/catalog.ts`:
  - 目录模板及更新声明全英文规范化；
  - `summarizeToolDescriptions` 工具数前缀及分号英文规范化（`${count} tools: ...; ...`）；
  - `composeCatalogEntries` 引入 `CATALOG_ENTRY_MAX_CHARS = 180`，对 `server.description` 实施首句语义提取与超长截断，保障 Level 1 渐进式披露。
- `src/middleware-register.ts`:
  - 4 个中间层工具（`ws_mcp_*`）及其参数描述全英文规范化；
  - `SEARCH_EMPTY_HINT` 及 natural language render 模板英文规范化。
- `test/unit-catalog.test.ts` & `test/smoke.ts`:
  - 适配英文能力目录模板与首句渐进式披露截断断言。

## QA 验收结论（参考 agents/qa.md）

| 验收条目 | 结论 | 证据或核验说明 |
| :--- | :---: | :--- |
| **1. 提示词与描述全英文** | **PASS** | 源码逐行复核，两包全部系统提示词、能力目录、工具与参数描述均为纯英文。 |
| **2. codegraph 系统提示词化（Order 170）** | **PASS** | 挂载于 order 170（紧随 mcp-manager 160），严格按 session cwd 隔离，非 git 仓返回空串，无 UserMessage 污染。 |
| **3. 强调优先使用 codegraph 进行搜索** | **PASS** | 明确决策树首选 codegraph，排他性限制 grep，严禁 mcp__ 前缀。 |
| **4. 门禁实测验证** | **PASS** | `pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 全部退出码 0。 |
| **5. 零代码污染与干净工作区** | **PASS** | 工作区 clean，保留向后兼容别名，无环境泄露。 |

**裁决结果：【可出环】（无界面改动，无截图）**