### PR TITLE
fix(ci): 修复 overlay-baseline.mjs 缺失 mkdtempSync 导入错误（#579）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,8 +347,8 @@ jobs:
   #   pnpm cov / self-cov / 判分——双指标判分统一收敛到 mutation-verdict；
   #   与 coverage job 平行无依赖（复核裁决选项 b），cov 失败不影响本矩阵跑完，
   #   由 verdict 缺席 + repo-gate 判定表兜底整体红
-  # - 基线来源（#204）：读仓库内 scripts/gate/baseline/ 版本化文件（git 跨 ref
-  #   天然可见）；首夜/基线缺失时天然降级为全量变异，门禁语义不变仅变慢
+  # - 基线来源（#572）：读孤立分支 refs/heads/baseline/mutation（git 协议
+  #   天然跨 ref 可见，零 API 鉴权要求）；首夜/基线缺失时天然降级为全量变异，门禁语义不变仅变慢
   # 已知约束：GitHub Actions 的 matrix 不允许引用 env context，但可引用 needs outputs
   mutation-gate:
     name: Mutation gate (${{ matrix.combo.package }} · ${{ matrix.combo.seg }})

--- a/.github/workflows/observe-incremental.yml
+++ b/.github/workflows/observe-incremental.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-        # #433：增量班需读 origin/main 上全量班提交的仓库内基线（对比 scripts/gate/baseline/）
+        # #572：增量班需读孤立分支 baseline/mutation 上的增量基线（git 浅拉取）
         with:
           fetch-depth: 0
 

--- a/scripts/gate/overlay-baseline.mjs
+++ b/scripts/gate/overlay-baseline.mjs
@@ -12,6 +12,7 @@ import { createHash } from 'node:crypto';
 import {
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   readdirSync,
   rmSync,

--- a/scripts/test/orphan-baseline.test.ts
+++ b/scripts/test/orphan-baseline.test.ts
@@ -6,6 +6,23 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 const scriptPath = join(process.cwd(), 'scripts', 'gate', 'orphan-baseline.mjs');
+const overlayScriptPath = join(process.cwd(), 'scripts', 'gate', 'overlay-baseline.mjs');
+
+test('#579: overlay-baseline 模块语法与依赖导入健全性', () => {
+  // node --check 验证模块语法解析无误
+  assert.doesNotThrow(() => {
+    execFileSync('node', ['--check', overlayScriptPath], { encoding: 'utf8', stdio: 'pipe' });
+  });
+
+  // 缺失 GITHUB_REPOSITORY 时 fail-closed exit 1
+  assert.throws(() => {
+    execFileSync('node', [overlayScriptPath], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      env: { ...process.env, GITHUB_REPOSITORY: '' },
+    });
+  }, /缺失 GITHUB_REPOSITORY/);
+});
 
 test('#572: orphan-baseline CLI 参数防御', () => {
   // 未知动作返回 1


### PR DESCRIPTION
## 变更内容（#579）
1. 修复 `scripts/gate/overlay-baseline.mjs` 头部遗漏 `mkdtempSync` 导入导致的 ReferenceError 异常；
2. 在 `scripts/test/orphan-baseline.test.ts` 中增加针对 `overlay-baseline.mjs` 模块语法与防御边界的健全性断言；
3. 清理 `.github/workflows/ci.yml` 与 `observe-incremental.yml` 中残留的旧版 `scripts/gate/baseline` 注释描述。

Closes #579