### PR TITLE
feat(dsh-mem0): 增加环境探测、虚拟环境自愈与前端一键安装机制（#570 阶段二补充）

### DIFF
--- a/packages/dsh-mem0/src/client/MemoryCenter.ts
+++ b/packages/dsh-mem0/src/client/MemoryCenter.ts
@@ -202,8 +202,33 @@ export function MemoryCenter() {
     }
   };
 
+  const [isAutoInstalling, setIsAutoInstalling] = useState(false);
+  const [autoInstallMsg, setAutoInstallMsg] = useState("");
+
+  const handleAutoInstall = async () => {
+    setIsAutoInstalling(true);
+    setAutoInstallMsg(msg("autoInstallingBtn"));
+    try {
+      const res = await fetch("/api/dsh-mem0/install", { method: "POST" });
+      const data = await res.json();
+      if (data.ok) {
+        setAutoInstallMsg(msg("autoInstallDone"));
+        setTimeout(() => {
+          fetchStatus();
+          setAutoInstallMsg("");
+        }, 2000);
+      } else {
+        setAutoInstallMsg(`${msg("opFailed")}: ${data.error || ""}`);
+      }
+    } catch (e: any) {
+      setAutoInstallMsg(`${msg("opFailed")}: ${e?.message || String(e)}`);
+    } finally {
+      setIsAutoInstalling(false);
+    }
+  };
+
   const handleCopyCmd = () => {
-    navigator.clipboard.writeText("pip install mem0ai mcp").then(() => {
+    navigator.clipboard.writeText("pip install -i https://mirrors.aliyun.com/pypi/simple/ mem0ai==2.0.20 'mcp>=1.8,<2' fastembed==0.8.0 qdrant-client").then(() => {
       setCopiedCmd(true);
       setTimeout(() => setCopiedCmd(false), 2500);
     });
@@ -259,15 +284,34 @@ export function MemoryCenter() {
     } else if (reason === "dependency_missing") {
       diagBanner = React.createElement(
         "div",
-        { className: "dsh-mem0-diag-banner warning" },
-        React.createElement("span", null, "⚠️ "),
-        React.createElement("span", null, msg("diagDepMissing")),
-        React.createElement("code", { className: "dsh-mem0-code" }, "pip install mem0ai mcp"),
+        { className: "dsh-mem0-diag-banner warning", style: { flexDirection: "column", alignItems: "flex-start" } },
         React.createElement(
-          "button",
-          { className: "dsh-mem0-btn small", onClick: handleCopyCmd },
-          copiedCmd ? msg("copied") : msg("copyCmd"),
+          "div",
+          { style: { display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" } },
+          React.createElement("span", null, "⚠️ "),
+          React.createElement("span", null, msg("diagDepMissing")),
+          React.createElement(
+            "button",
+            {
+              className: "dsh-mem0-btn primary small",
+              disabled: isAutoInstalling,
+              onClick: handleAutoInstall,
+            },
+            isAutoInstalling ? msg("autoInstallingBtn") : msg("autoInstallBtn"),
+          ),
+          React.createElement(
+            "button",
+            { className: "dsh-mem0-btn small", onClick: handleCopyCmd },
+            copiedCmd ? msg("copied") : msg("copyCmd"),
+          ),
         ),
+        autoInstallMsg
+          ? React.createElement(
+              "div",
+              { style: { fontSize: "12px", marginTop: "4px", color: "var(--dsw-alias-brand, #2563eb)" } },
+              autoInstallMsg,
+            )
+          : null,
       );
     }
   }

--- a/packages/dsh-mem0/src/client/locales.ts
+++ b/packages/dsh-mem0/src/client/locales.ts
@@ -63,7 +63,10 @@ export const zh = {
 
   // 自愈诊断
   diagPythonNotFound: "未检测到 Python 可执行程序，长期记忆已安全降级。请在宿主环境安装 Python 3.10+。",
-  diagDepMissing: "检测到缺少 Python 依赖库，请在终端执行一键安装：",
+  diagDepMissing: "检测到缺少 Python 依赖库，推荐点击下方按钮自动一键安装修复：",
+  autoInstallBtn: "⚡ 自动安装依赖",
+  autoInstallingBtn: "正在自动下载与配置环境…",
+  autoInstallDone: "依赖环境已就绪，正在拉起记忆服务！",
   copyCmd: "复制命令",
   copied: "已复制！",
 
@@ -138,7 +141,10 @@ export const en: Record<Mem0LocaleKey, string> = {
 
   // Self-healing Diagnostics
   diagPythonNotFound: "Python executable not detected. Memory is gracefully degraded. Please install Python 3.10+.",
-  diagDepMissing: "Python dependencies missing. Please run in your terminal:",
+  diagDepMissing: "Python dependencies missing. Click below to automatically install and resolve:",
+  autoInstallBtn: "⚡ Auto Install Dependencies",
+  autoInstallingBtn: "Downloading & Configuring Environment...",
+  autoInstallDone: "Environment resolved! Starting memory service...",
   copyCmd: "Copy Command",
   copied: "Copied!",
 

--- a/packages/dsh-mem0/src/executor.ts
+++ b/packages/dsh-mem0/src/executor.ts
@@ -14,6 +14,7 @@ import { createInterface } from "node:readline";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { MemoryExecutor } from "./tool-definitions.ts";
+import { probePythonEnvironment } from "./venv-manager.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -78,6 +79,16 @@ export class StdioMemoryExecutor implements MemoryExecutor {
     this.lastEnvOverrides = envOverrides;
     this.reason = "starting";
     this.detail = undefined;
+
+    // 1. 预先探针检测环境可用性
+    const probe = await probePythonEnvironment(this.pythonBin);
+    if (!probe.ok) {
+      this.ready = false;
+      this.reason = probe.reason || "dependency_missing";
+      this.detail = probe.detail;
+      return;
+    }
+    this.pythonBin = probe.pythonBin;
 
     const env = {
       ...process.env,

--- a/packages/dsh-mem0/src/index.ts
+++ b/packages/dsh-mem0/src/index.ts
@@ -27,6 +27,7 @@ import { registerMemoryPromptHook } from "./prompt.ts";
 import { createMem0Routes } from "./routes.ts";
 import { installMem0Settings, type OwnerScopeLike } from "./settings.ts";
 import { buildAllMemoryTools } from "./tool-definitions.ts";
+import { autoInstallDependencies, probePythonEnvironment } from "./venv-manager.ts";
 
 export const name = "mem0";
 
@@ -63,6 +64,12 @@ export {
   sanitizeConfigForClient,
   mergeConfigPatch,
 } from "./config.ts";
+export {
+  DEFAULT_VENV_DIR,
+  VENV_PYTHON,
+  probePythonEnvironment,
+  autoInstallDependencies,
+} from "./venv-manager.ts";
 export type { Mem0Config } from "./config.ts";
 
 /**
@@ -184,6 +191,17 @@ export function apply(ctx: Context, initialConfig?: Partial<Mem0Config>): void {
         executor.setPythonBin(next.pythonBin);
         await executor.restart(buildEnvOverrides(next));
         return next;
+      },
+      installDependencies: async () => {
+        ctx.logger?.info?.("[dsh-mem0] 开始触发后台依赖自动安装/自愈...");
+        const res = await autoInstallDependencies(currentConfig.pythonBin, (line) => {
+          ctx.logger?.debug?.(`[dsh-mem0 install] ${line}`);
+        });
+        if (res.ok) {
+          executor.setPythonBin(res.pythonBin);
+          await executor.restart(buildEnvOverrides(currentConfig));
+        }
+        return res;
       },
     });
     webServer.register(routes);

--- a/packages/dsh-mem0/src/routes.ts
+++ b/packages/dsh-mem0/src/routes.ts
@@ -26,6 +26,7 @@ export interface RouteContext {
   getCurrentCwd: () => string | undefined;
   getConfig: () => Mem0Config;
   updateConfig: (patch: Record<string, unknown>) => Promise<Mem0Config>;
+  installDependencies?: () => Promise<{ ok: boolean; pythonBin: string; error?: string }>;
 }
 
 export function createMem0Routes(ctx: RouteContext): WebRoute[] {
@@ -78,6 +79,23 @@ export function createMem0Routes(ctx: RouteContext): WebRoute[] {
           });
         } catch (err) {
           writeJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
+        }
+      },
+    },
+    {
+      kind: "exact",
+      path: "/api/dsh-mem0/install",
+      async handler(req: IncomingMessage, res: ServerResponse) {
+        if (!guardLoopbackMethod(req, res, ["POST"])) return;
+        if (typeof ctx.installDependencies !== "function") {
+          writeJson(res, 501, { ok: false, error: "Auto-install not supported in this context" });
+          return;
+        }
+        try {
+          const result = await ctx.installDependencies();
+          writeJson(res, 200, result);
+        } catch (err) {
+          writeJson(res, 500, { ok: false, error: err instanceof Error ? err.message : String(err) });
         }
       },
     },

--- a/packages/dsh-mem0/src/venv-manager.ts
+++ b/packages/dsh-mem0/src/venv-manager.ts
@@ -10,13 +10,13 @@
 
 import { execFile, spawn } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { dshHome } from "../../../shared/dsh-home.js";
 
 const execFileAsync = promisify(execFile);
 
-export const DEFAULT_VENV_DIR = join(homedir(), ".dsh/mem0/venv");
+export const DEFAULT_VENV_DIR = join(dshHome(), "mem0/venv");
 export const VENV_PYTHON = process.platform === "win32"
   ? join(DEFAULT_VENV_DIR, "Scripts/python.exe")
   : join(DEFAULT_VENV_DIR, "bin/python3");
@@ -104,7 +104,7 @@ export async function autoInstallDependencies(
   pythonBin = "python3",
   onLog?: (line: string) => void,
 ): Promise<{ ok: boolean; pythonBin: string; error?: string }> {
-  mkdirSync(join(homedir(), ".dsh/mem0"), { recursive: true });
+  mkdirSync(join(dshHome(), "mem0"), { recursive: true });
 
   const log = (msg: string) => {
     if (onLog) onLog(msg);

--- a/packages/dsh-mem0/src/venv-manager.ts
+++ b/packages/dsh-mem0/src/venv-manager.ts
@@ -1,0 +1,176 @@
+/**
+ * dsh-mem0 — Python 环境探测、虚拟环境管理与依赖自愈机制。
+ *
+ * 核心设计：
+ * 1. probePythonEnvironment: 检查候选 Python（用户指定 / ~/.dsh/mem0/venv / 系统 python3）；
+ * 2. autoInstallDependencies: 优先尝试虚拟环境，若无 python3-venv 则自动降级使用 pip install --user；
+ * 3. 采用国内高可用阿里镜像源（https://mirrors.aliyun.com/pypi/simple/），杜绝清华源 WAF 拦截；
+ * 4. 零阻塞异步执行，状态全程透明上报。
+ */
+
+import { execFile, spawn } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export const DEFAULT_VENV_DIR = join(homedir(), ".dsh/mem0/venv");
+export const VENV_PYTHON = process.platform === "win32"
+  ? join(DEFAULT_VENV_DIR, "Scripts/python.exe")
+  : join(DEFAULT_VENV_DIR, "bin/python3");
+
+export const ALIYUN_PYPI_INDEX = "https://mirrors.aliyun.com/pypi/simple/";
+export const REQUIRED_PACKAGES = [
+  "mem0ai==2.0.20",
+  "mcp>=1.8,<2",
+  "fastembed==0.8.0",
+  "qdrant-client",
+];
+
+export interface PythonProbeResult {
+  ok: boolean;
+  pythonBin: string;
+  reason?: "python_not_found" | "dependency_missing" | "ready";
+  detail?: string;
+}
+
+/**
+ * 探测指定的 Python 解释器或候选路径是否满足运行时要求。
+ */
+export async function probePythonEnvironment(preferredBin?: string): Promise<PythonProbeResult> {
+  const candidates: string[] = [];
+
+  const trimmedPreferred = preferredBin?.trim();
+  if (trimmedPreferred && trimmedPreferred !== "auto") {
+    candidates.push(trimmedPreferred);
+  }
+  if (existsSync(VENV_PYTHON)) {
+    candidates.push(VENV_PYTHON);
+  }
+  candidates.push("python3");
+  candidates.push("python");
+
+  let foundPython = false;
+  let lastDetail = "";
+
+  for (const bin of candidates) {
+    try {
+      // 1. 测试 python 命令本身是否存在
+      await execFileAsync(bin, ["--version"]);
+      foundPython = true;
+
+      // 2. 测试关键依赖是否已装
+      await execFileAsync(bin, ["-c", "import mem0, mcp"]);
+      return {
+        ok: true,
+        pythonBin: bin,
+        reason: "ready",
+      };
+    } catch (err: any) {
+      if (err?.code === "ENOENT") {
+        continue;
+      }
+      // python 存在但 import 失败
+      foundPython = true;
+      lastDetail = err?.stderr || err?.message || String(err);
+    }
+  }
+
+  if (!foundPython) {
+    return {
+      ok: false,
+      pythonBin: preferredBin || "python3",
+      reason: "python_not_found",
+      detail: "No python executable found in system or ~/.dsh/mem0/venv",
+    };
+  }
+
+  return {
+    ok: false,
+    pythonBin: candidates[0] || "python3",
+    reason: "dependency_missing",
+    detail: lastDetail || "Required packages (mem0ai, mcp) are missing.",
+  };
+}
+
+/**
+ * 执行依赖一键自动安装（双重自愈策略）：
+ * 优先创建 ~/.dsh/mem0/venv 虚拟环境并安装；
+ * 若系统缺 python3-venv (ensurepip 报错)，自动回退执行 python3 -m pip install --user。
+ */
+export async function autoInstallDependencies(
+  pythonBin = "python3",
+  onLog?: (line: string) => void,
+): Promise<{ ok: boolean; pythonBin: string; error?: string }> {
+  mkdirSync(join(homedir(), ".dsh/mem0"), { recursive: true });
+
+  const log = (msg: string) => {
+    if (onLog) onLog(msg);
+  };
+
+  // 策略 A：尝试创建虚拟环境
+  let useVenv = false;
+  try {
+    log("正在尝试创建专属虚拟环境 ~/.dsh/mem0/venv ...");
+    await execFileAsync(pythonBin, ["-m", "venv", DEFAULT_VENV_DIR]);
+    if (existsSync(VENV_PYTHON)) {
+      useVenv = true;
+      log("虚拟环境创建成功！");
+    }
+  } catch (err: any) {
+    log("创建虚拟环境跳过（缺少系统 python3-venv 工具），自动转为用户级目录免提权安装 (--user)...");
+    useVenv = false;
+  }
+
+  const targetPython = useVenv ? VENV_PYTHON : pythonBin;
+  const pipArgs = useVenv
+    ? ["-m", "pip", "install", "-i", ALIYUN_PYPI_INDEX, ...REQUIRED_PACKAGES]
+    : ["-m", "pip", "install", "--user", "-i", ALIYUN_PYPI_INDEX, ...REQUIRED_PACKAGES];
+
+  log(`正在使用阿里镜像源下载并安装依赖: ${REQUIRED_PACKAGES.join(" ")} ...`);
+
+  return new Promise((resolve) => {
+    const proc = spawn(targetPython, pipArgs, {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stderrOutput = "";
+
+    proc.stdout?.on("data", (chunk) => {
+      log(chunk.toString("utf8"));
+    });
+
+    proc.stderr?.on("data", (chunk) => {
+      const text = chunk.toString("utf8");
+      stderrOutput += text;
+      log(text);
+    });
+
+    proc.on("close", async (code) => {
+      if (code === 0) {
+        log("依赖包安装成功，正在复核环境...");
+        const probe = await probePythonEnvironment(targetPython);
+        if (probe.ok) {
+          log("环境验证通过，记忆服务就绪！");
+          resolve({ ok: true, pythonBin: probe.pythonBin });
+          return;
+        }
+      }
+      resolve({
+        ok: false,
+        pythonBin: targetPython,
+        error: stderrOutput || `pip install exited with code ${code}`,
+      });
+    });
+
+    proc.on("error", (err) => {
+      resolve({
+        ok: false,
+        pythonBin: targetPython,
+        error: err.message,
+      });
+    });
+  });
+}

--- a/packages/dsh-mem0/test/smoke.ts
+++ b/packages/dsh-mem0/test/smoke.ts
@@ -297,6 +297,10 @@ await test("路由配置操作：/api/dsh-mem0/config GET 与 POST 正常流转"
   const parsedGet = JSON.parse(getBody);
   assert.ok(parsedGet.config.llmApiKey.includes("***"), "GET 响应的 API Key 必须脱敏");
   assert.equal(parsedGet.config.hasLlmApiKey, true);
+
+  // 2. /api/dsh-mem0/install POST 路由可用性
+  const installRoute = routes.find((r) => r.path === "/api/dsh-mem0/install")!;
+  assert.ok(installRoute, "/api/dsh-mem0/install 路由必须注册");
 });
 
 // 7. 默认本地 Embedding 与模型消耗说明


### PR DESCRIPTION
## 变更摘要

本 PR 补齐 `@wingsky-1/dsh-mem0` 在用户机器缺少依赖或不同发行版下的**环境自愈与自动化部署能力**：

1. **Python 环境智能探针与双重自愈机制** (`src/venv-manager.ts`)：
   - 自动探测 `~/.dsh/mem0/venv/bin/python` 与系统 `python3` 的依赖完备性；
   - 优先尝试创建专属虚拟环境 `~/.dsh/mem0/venv`；
   - 若系统缺失 `python3-venv`（Debian/Ubuntu 经典切包报错 `ensurepip is not available`），自动无缝降级采用用户主目录免 root 安装策略（`pip install --user`）；
   - 全程采用国内高可用阿里镜像源（`https://mirrors.aliyun.com/pypi/simple/`），杜绝清华源 WAF 拦截。

2. **Web 客户端与后端自愈路由**：
   - 增加 `POST /api/dsh-mem0/install` 路由，支持一键触发异步安装与自动热重载；
   - Web 界面增加 **`⚡ 自动安装依赖`** 按钮与安装进度反馈；
   - 复制命令同步更新为阿里源加速命令。

3. **全量门禁全绿**：
   - 全包构建成功，15 项冒烟测试、客户端契约、pack:check 与类型检查全部 PASS。
