### PR TITLE
fix(dsh-provider-usage): 趋势图 Y 域口径改按桶堆叠合计——单段最大值致多段桶堆叠顶溢出轴顶（#589）

### DIFF
--- a/packages/dsh-provider-usage/src/client/trend-math.ts
+++ b/packages/dsh-provider-usage/src/client/trend-math.ts
@@ -87,6 +87,20 @@ export function niceTicks(maxV: number): { ticks: number[]; top: number } {
   return { ticks, top };
 }
 
+/**
+ * Y 域刻度（#589）：口径 = 每桶全量段合计 point.total（与汇总卡「峰值」同源）——
+ * 堆叠图每桶的视觉高度是段之和，按单段最大值推域时多段桶的堆叠顶必然溢出轴顶
+ * （#571 遗留：刻度算法已动态化，喂入的最大值仍是 M2 起的单段口径）。
+ * total 含隐藏段 → hidden 不缩轴（兑现评审 P1-5「与汇总卡全段口径一致」）。
+ */
+export function trendYTicks(series: Array<{ total: number | null }>): { ticks: number[]; top: number } {
+  let maxV = 0;
+  for (const point of series) {
+    if (point.total !== null && point.total > maxV) maxV = point.total;
+  }
+  return niceTicks(maxV);
+}
+
 /** 图表系列离散色：前四复用宿主状态色变量（浅/暗跟随），溢出轮转稳定离散色。 */
 const CHART_COLORS: string[] = [
   "var(--dsw-alias-state-info-primary,#4a7dde)",

--- a/packages/dsh-provider-usage/src/client/trend.ts
+++ b/packages/dsh-provider-usage/src/client/trend.ts
@@ -32,7 +32,7 @@ import {
   bucketStartKey,
   trendRangeOptions,
   trendDefaultRange,
-  niceTicks,
+  trendYTicks,
   seriesColor,
   stackedBarsSvg,
   stackedAreasSvg,
@@ -233,16 +233,9 @@ export function TrendSection(): React.ReactElement {
     });
   }, [data, hidden, stackOrder, retentionDays]);
 
-  // Y 域全量（hidden 不缩轴，与汇总卡全段口径一致——评审 P1-5）；刻度按数据最大值动态推导（M2.1 后续）
-  const ticks = React.useMemo(() => {
-    let maxV = 0;
-    for (const point of data?.series ?? []) {
-      for (const p of point.parts) {
-        if (p.value !== null && p.value > maxV) maxV = p.value;
-      }
-    }
-    return niceTicks(maxV).ticks;
-  }, [data]);
+  // Y 域 = 每桶全量段合计 point.total（堆叠视觉高度的口径；hidden 不缩轴，与汇总卡
+  // 「峰值」同源——评审 P1-5）。#589 修复：原按单段最大值推域，多段桶堆叠顶溢出轴顶。
+  const ticks = React.useMemo(() => trendYTicks(data?.series ?? []).ticks, [data]);
 
   // 图表事件委托：pointerdown 全输入（触屏可用），pointermove 仅鼠标（防触屏滑动误触发）。
   // 事件类型为最小结构面（shim 无 React 合成事件类型；运行时是原生 PointerEvent 透传）。

--- a/packages/dsh-provider-usage/test/unit-trend-view.test.ts
+++ b/packages/dsh-provider-usage/test/unit-trend-view.test.ts
@@ -2,7 +2,8 @@
  * dsh-provider-usage — 使用趋势纯函数单测（#503 M2.1）。
  *
  * 覆盖方案 §3.5 要求的客户端判定面：范围档位矩阵（粒度 × retentionDays）、
- * 月键标签、部分桶起点、nice 上界、空桶/部分桶的 SVG 形态断言。
+ * 月键标签、部分桶起点、nice 上界、Y 域口径（#589 桶堆叠合计）、
+ * 空桶/部分桶的 SVG 形态断言。
  * 被测对象为 src/client/trend-math.ts 真实源码（esbuild 即时打包，同 unit-detect
  * 先例；trend.ts 顶部 import react，node 测试环境不可直载）。i18n 未装配时回落
  * key 本体（shared/client/i18n.js 行为零变化），SVG 断言不依赖文案。
@@ -36,6 +37,7 @@ const {
   trendRangeOptions,
   trendDefaultRange,
   niceTicks,
+  trendYTicks,
   seriesColor,
   stackedBarsSvg,
   stackedAreasSvg,
@@ -113,6 +115,28 @@ test("niceTicks：按数据最大值动态推导步长与刻度序列（#503 M2.
     assert.ok(top >= v, `top ${top} >= maxV ${v}`);
     assert.equal(ticks[ticks.length - 1], top);
     assert.equal(ticks[0], 0);
+  }
+});
+
+test("trendYTicks：Y 域口径 = 桶堆叠合计 point.total（#589，#571 遗留）", () => {
+  // 多段桶：单段最大 600K、桶合计 1.1M（= 汇总卡「峰值」）——旧单段口径轴顶 600K，
+  // 堆叠柱顶溢出绘图区；正确口径轴顶 1.25M ≥ 峰值
+  const a = trendYTicks([
+    { total: 1_100_000 },
+    { total: 600_000 },
+  ]);
+  assert.equal(a.top, 1_250_000);
+  assert.ok(a.top >= 1_100_000, `轴顶 ${a.top} ≥ 峰值 1.1M`);
+  assert.notEqual(a.top, niceTicks(600_000).top, "与旧单段口径区分（回归护栏）");
+  // 单段桶场景与 niceTicks 直推一致（无堆叠时不改变 #571 已修的步长行为）
+  assert.deepEqual(trendYTicks([{ total: 792_000 }]), niceTicks(792_000));
+  // 全 null series / 空窗口：回退单刻度 [0,1]
+  assert.deepEqual(trendYTicks([{ total: null }, { total: null }]), { ticks: [0, 1], top: 1 });
+  assert.deepEqual(trendYTicks([]), { ticks: [0, 1], top: 1 });
+  // 顶格 ≥ 每桶合计（任意数据形状）
+  for (const v of [792_000, 1_700_000, 12_300]) {
+    const { top } = trendYTicks([{ total: v }, { total: v / 2 }, { total: null }]);
+    assert.ok(top >= v, `top ${top} >= 桶合计 ${v}`);
   }
 });
 


### PR DESCRIPTION
Closes #589

## 问题

设置面板「使用趋势」图表(#503 M2.1)在多 provider / byModel 数据下,Y 轴顶格刻度**小于**区间峰值(汇总卡「峰值」口径),最高堆叠柱溢出绘图区顶端被裁。

## 根因

`trend.ts` 的 Y 域 useMemo 遍历 `point.parts` 取**单段最大值**喂给 `niceTicks`,但堆叠柱/堆叠面积每桶的视觉高度是桶内**所有段之和**(`point.total`,与汇总卡「峰值」同源)。最大桶由 ≥2 段构成时必然 `max(单段) < max(桶合计)`,轴顶低于真实堆叠峰值。

例:A 600K + B 500K 堆到 1.1M → 旧口径轴顶 niceTicks(600K) = 600K,溢出 45%。

与 #571 的关系:#571 已把刻度算法动态化(步长 1/2/2.5/5×10^k,算法本身正确),但喂入的最大值**口径**仍是 M2 起的单段口径——单 provider 下 `max(单段) == max(桶合计)` 掩盖了问题,本修复补齐口径。

## 修复

- `trend-math.ts` 新增纯函数 `trendYTicks(series)`:口径 = 每桶 `point.total`(全量段合计)。提取为纯函数是因 trend.ts 顶部 import react、node 测试环境不可直载(同既有 `mathBundle` 先例);
- `trend.ts` 调用点替换,并修正注释(口径描述与 P1-5 决策对齐:total 含隐藏段 → hidden 不缩轴);
- `niceTicks` 算法不动,#571 行为(单段桶场景)保持不变;
- 单测回归:多段桶 1.1M/600K → 断言轴顶 1.25M ≥ 峰值 + 与旧口径区分护栏;单段桶与 `niceTicks` 直推全等;全 null/空窗口回退 [0,1]。

## 验证

- [x] `pnpm build` / `pnpm test`(含新增 trendYTicks 用例 12/12)/ `pnpm contract` / `pnpm pack:check` / `pnpm typecheck` 全绿(worktree 实跑)
- [x] 根因数学复现:旧口径 600K 轴顶 < 1.1M 堆叠顶,新口径 1.25M ≥ 1.1M

视觉影响:轴顶数值变大、柱子整体略矮——Y 域恢复覆盖全部堆叠高度的正常表现;单 provider 用户无感知变化。