### PR TITLE
test(dsh-provider-usage): 客户端产物路由字面量与 ROUTES 全集对比断言

### DIFF
--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -13,7 +13,7 @@
 import { readFileSync, mkdtempSync, writeFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { assertClientProductContract, assertClientSourceContract } from "../../../test/smoke-lib.ts";
+import { assertClientProductContract, assertClientSourceContract, clientRouteLiterals } from "../../../test/smoke-lib.ts";
 import { tmpdir } from "node:os";
 import assert from "node:assert/strict";
 import { callHandler, pollUntil } from "./helpers.ts";
@@ -661,6 +661,20 @@ export function formatPanel() { return "<p>x</p>"; }
   // 断言入参为包目录（helper 自行读 lib/client.js）
   assertClientSourceContract(pkgDir);
   assertClientProductContract(pkgDir);
+
+  // #524：客户端产物路由字面量与 ROUTES 全集严格一致断言（纵深防御 fallback 漂移）
+  {
+    const clientCode = readFileSync(join(pkgDir, "lib", "client.js"), "utf8");
+    const extracted = clientRouteLiterals(
+      clientCode,
+      "[\"'`](/api/dsh-provider-usage/[a-zA-Z0-9_/.-]+)[\"'`]",
+    );
+    assert.deepEqual(
+      extracted.sort(),
+      Object.values(ROUTES).sort(),
+      "客户端产物路由字面量必须与 ROUTES 全集严格完全一致（无缺失、无多余）",
+    );
+  }
 
   // i18n 接入哨兵（issue #348）：NS / register / bind / slots locale 参数 / 双语字典进产物
   {


### PR DESCRIPTION
## 改动说明

处理 Issue #524：客户端产物路由字面量与 ROUTES 全集对比断言。
- 从 `test/smoke-lib.ts` 导入已预留的 `clientRouteLiterals` 辅助纯函数；
- 在 `packages/dsh-provider-usage/test/smoke.ts` 客户端契约区域，读取客户端编译产物 `lib/client.js`；
- 正则提取客户端中的 `/api/dsh-provider-usage/*` 路由字面量全集（包含 core.ts 与 report.ts 源码 fallback 字面量共 15 条）；
- 严格与 `ROUTES`（15 条路由，`Object.values(ROUTES)`）集合对比断言 deepEqual，缺失或多余均判红，堵住 fallback 漂移无测试网的测试盲区。

Closes #524

## 验证清单（全量断言表）

| 验收条目 | 结论 | 证据或漂移解释 |
|---|---|---|
| 1. 从 test/smoke-lib.ts 导入 clientRouteLiterals 并在 smoke.ts 断言客户端产物路由字面量 | PASS | packages/dsh-provider-usage/test/smoke.ts:665-677，提取 15 条路由与 Object.values(ROUTES) 严格 deepEqual |
| 2. 五连门禁全绿验证 | PASS | `pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 全部通过（退出码 0） |
| 3. 测试产物零污染 | PASS | `git status` 无未受控或运行时临时文件残留 |