### PR TITLE
fix(dsh-lan-proxy): 将 schemastery 从 dependencies 移入 devDependencies 维持零运行时依赖

### DIFF
--- a/packages/dsh-lan-proxy/package.json
+++ b/packages/dsh-lan-proxy/package.json
@@ -34,9 +34,6 @@
       "platform": "web"
     }
   },
-  "dependencies": {
-    "schemastery": "^3.18.0"
-  },
   "peerDependencies": {
     "react": "^18.2.0",
     "@deepseek-ai/cordis": "4.0.2",
@@ -93,6 +90,7 @@
     "@types/ws": "^8.18.1",
     "compression": "^1.8.1",
     "http-proxy": "1.18.1",
+    "schemastery": "^3.18.0",
     "selfsigned": "^2.4.1",
     "ws": "^8.21.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,10 +85,6 @@ importers:
         version: link:../dsh-mcp-manager
 
   packages/dsh-lan-proxy:
-    dependencies:
-      schemastery:
-        specifier: ^3.18.0
-        version: 3.18.0
     devDependencies:
       '@deepseek-ai/cordis':
         specifier: 'catalog:'
@@ -114,6 +110,9 @@ importers:
       http-proxy:
         specifier: 1.18.1
         version: 1.18.1(debug@4.4.3(supports-color@7.2.0))
+      schemastery:
+        specifier: ^3.18.0
+        version: 3.18.0
       selfsigned:
         specifier: ^2.4.1
         version: 2.4.1


### PR DESCRIPTION
## 改动说明
- 将 `packages/dsh-lan-proxy/package.json` 中的 `"schemastery"` 从 `dependencies` 移除并移入 `devDependencies`（维持版本声明 `^3.18.0` 一致）；
- 同步更新 `pnpm-lock.yaml`；
- esbuild 在构建期正常内联该第三方库并由 license 收集脚本归集至 `lib/THIRD-PARTY-LICENSES`，维持全包发布物“零外部运行时依赖分发”的架构原则。

Closes #583

## 验收断言表

| 验收条目 | 结论 | 证据或漂移解释 |
|---|---|---|
| 验收标准 1：schemastery 从 dependencies 移入 devDependencies | PASS | `packages/dsh-lan-proxy/package.json` 与 `pnpm-lock.yaml` 均完成转移 |
| 验收标准 2：五连门禁全绿 | PASS | `pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 全部 PASS，退出码 0 |
| 验收标准 3：pack:check 自包含与 license 归集验证 | PASS | `pnpm pack:check` PASS，`THIRD-PARTY-LICENSES` 完整覆盖 schemastery |