### PR TITLE
docs: 消除架构文档中硬编码代码行号引用与规范冗余去重

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ test/                 共享测试工具（smoke-lib）
 
 独立验证（smoke / 浏览器实测 / 需启动 dsh 的验证）时使用**隔离环境**：`DSH_HOME`
 设到临时目录（如 `$(mktemp -d)`）、文件路径隔离，遵循
-[docs/DEVELOPMENT.md §5](docs/DEVELOPMENT.md#5-smoke-测试防-flake-纪律) 防 flake 纪律。
+[docs/DEVELOPMENT.md §5](docs/DEVELOPMENT.md#user-content-5-smoke-测试防-flake-纪律) 防 flake 纪律。
 客户端 UI 改动的浏览器实测统一用
 `@wingsky-1/dsh-verify-isolated` 插件包注册的 `dsh-verify-isolated`
 skill（临时 `DSH_HOME` + 独立 `verify_<随机>` profile 双重隔离，一键脚本自动
@@ -125,16 +125,11 @@ Conventional Commits（`type(scope): subject`；type：`feat` / `fix` / `docs` /
 
 ## 测试纪律
 
-smoke 全部无网络、无真实凭据，本地可直接运行；新功能/修复必须带 smoke 断言
-（含路由 403/405 围栏用例、client 契约断言）。防 flake 纪律（隔离文件路径 / 设 DSH_HOME
-到临时目录 / 轮询替代固定 sleep）见
-[DEVELOPMENT.md §5](docs/DEVELOPMENT.md#5-smoke-测试防-flake-纪律)。
+- **离线与断言全覆盖**：smoke 全部无网络、无真实凭据，本地可直接离线运行；新功能/修复必须带 smoke 断言（含路由 403/405 围栏用例、client 契约断言）。
+- **环境隔离与防 flake**：严格遵循临时 `DSH_HOME` 隔离与轮询等待纪律，禁止依赖全局默认路径与固定 sleep。
+- **测试产物零污染红线（#218）**：测试落盘必须进 `mkdtempSync` 隔离目录，严禁提交含 `undefined/`、`*.jsonl` 等运行时产物。
 
-**测试产物零污染纪律（#218）**：
-- 测试运行时落盘**必须**落在 `mkdtempSync` 隔离目录（DSH_HOME 已隔离），
-  **禁止**产生任何含 `undefined` 段的路径（如 `packages/*/undefined/**`）；
-- 提交前自查：`git status` 出现 `packages/*/undefined/`、`*.jsonl` 等运行时产物
-  一律视为污染，不得提交；自动收集脚本（基线等）只收白名单路径。
+详细操作守则、技术实现细节与正反例单一事实源见 [docs/DEVELOPMENT.md §5](docs/DEVELOPMENT.md#user-content-5-smoke-测试防-flake-纪律)。
 
 ## PR 贴图纪律（#566 实证）
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -344,7 +344,17 @@ export const inject: string[] = [];        // 声明 apply 用到的 ctx 服务�
 - **新增/修改客户端后**：`pnpm build && pnpm test && pnpm contract && pnpm pack:check`
   全绿再提交。
 
+<a id="5-smoke-测试防-flake-纪律"></a><a id="user-content-5-smoke-测试防-flake-纪律"></a>
 ## 5. Smoke 测试防 flake 纪律
+
+### 5.1 基本要求
+
+- **无网络与零真实凭据**：smoke 测试全部无网络、无真实凭据，本地可直接离线运行。
+- **断言全覆盖**：新功能/修复必须带 smoke 断言（含路由 403/405 围栏用例、client 契约断言）。
+- **CI 稳定性门槛**：新增 / 修改 `test/smoke.ts` 后，本地连续跑 **≥10 次**（如
+  `for i in $(seq 1 10); do node packages/<pkg>/test/smoke.ts; done`）确认无 flake 再提交。
+
+### 5.2 防 flake 核心原则
 
 背景：notifier 的 history 路由测试曾因「多个 `apply()` 实例共享同一 `history.jsonl` +
 `appendHistory` 为 fire-and-forget 异步写盘 + 固定 `setTimeout(50)` 后断言『最后一条
@@ -368,8 +378,6 @@ export const inject: string[] = [];        // 声明 apply 用到的 ctx 服务�
    （如 opencode-usage 的 `schedulePersist`、notifier 的 `appendHistory`），绝不能依赖
    「最后一条是 X」「条数 === N」等顺序敏感断言；必须**隔离文件 + 轮询**。理想情况：
    被测插件暴露 `await flushPersist()` 之类的可等待落盘钩子，测试直接 `await` 比轮询更稳。
-5. **CI 稳定性门槛**：新增 / 修改 `test/smoke.ts` 后，本地连续跑 **≥10 次**（如
-   `for i in $(seq 1 10); do node packages/<pkg>/test/smoke.ts; done`）确认无 flake 再提交。
 
 反例（notifier #17，已修）：多个 `apply(...)` 都传 `historyFile: join(work, "history.jsonl")`
 （共享文件）；`await setTimeout(resolve, 50)` 后 `assert.equal(records.at(-1).kind, "test")`。
@@ -377,6 +385,14 @@ export const inject: string[] = [];        // 声明 apply 用到的 ctx 服务�
 
 正例（mcp-manager）：设 `DSH_HOME` 到临时目录、每块显式 `storePath: join(dir, "dsh-mcp.json")`、
 写盘为 `await writeFile`（已等待）。
+
+<a id="zero-pollution"></a><a id="user-content-zero-pollution"></a>
+### 5.3 测试产物零污染纪律（#218）
+
+- **临时落盘隔离**：测试运行时落盘**必须**落在 `mkdtempSync` 隔离目录（`DSH_HOME` 已隔离），
+  **禁止**产生任何含 `undefined` 段的路径（如 `packages/*/undefined/**`）；
+- **提交前自查**：`git status` 出现 `packages/*/undefined/`、`*.jsonl` 等运行时产物
+  一律视为污染，不得提交；自动收集脚本（基线等）只收白名单路径。
 
 ## 6. 多端兼容（三操作系统 + 三访问形态 + 明暗双主题）
 

--- a/docs/ISSUE-WORKFLOW.md
+++ b/docs/ISSUE-WORKFLOW.md
@@ -43,7 +43,7 @@
    判断是否 Meta 子项，需要则挂到父 issue 并在父项清单登记。
 2. **定位**：宿主端问题看 `src/index.ts` 与 dsh web 日志（`<插件>:` 前缀行）；
    客户端问题按 DEVELOPMENT.md §2 的干净模块契约排查；CI flake 类修复**必读**
-   [DEVELOPMENT.md §5](DEVELOPMENT.md#5-smoke-测试防-flake-纪律)（隔离文件路径 /
+   [DEVELOPMENT.md §5](DEVELOPMENT.md#user-content-5-smoke-测试防-flake-纪律)（隔离文件路径 /
    设 `DSH_HOME` / 轮询替代固定 sleep）。
 3. **修复分支**：命名 `fix/<主题>` 或 `feat/<主题>`（与 CONTRIBUTING.md 开发流程一致）。
 4. **验证证据**（涉及界面行为的改动——overlay / URL 重写 / Modal 内跳转 / 双主题 /

--- a/docs/architecture/dsh-lan-proxy.md
+++ b/docs/architecture/dsh-lan-proxy.md
@@ -179,12 +179,12 @@ httpCompressEnabled, httpCompressLevel, injectToken`），GUI 在「设置 → �
 
 | 机制 | 实现位置 | 要点 |
 |---|---|---|
-| targetHost 回环白名单 | `isLoopbackTarget`（proxy.ts:275-278）+ 配置层校验 + `createLanProxy` 入口强校验 | 只允许 `localhost`/`127.0.0.1`/`::1`，防开放转发/SSRF（三层防线） |
-| 入站 Host 校验（DNS 重绑定防御） | `hostnameAllowed`（proxy.ts:261-272） | 仅接受 IP 字面量或 `localhost`，任何 DNS 域名 403/断开；对 HTTP 与 WS 入站同样生效 |
+| targetHost 回环白名单 | `isLoopbackTarget`（`proxy.ts#isLoopbackTarget`）+ 配置层校验 + `createLanProxy` 入口强校验 | 只允许 `localhost`/`127.0.0.1`/`::1`，防开放转发/SSRF（三层防线） |
+| 入站 Host 校验（DNS 重绑定防御） | `hostnameAllowed`（`proxy.ts#hostnameAllowed`） | 仅接受 IP 字面量或 `localhost`，任何 DNS 域名 403/断开；对 HTTP 与 WS 入站同样生效 |
 | 配置/health 路由围栏 | `isLoopbackRequest`（shared/loopback.js） | remoteAddress 回环 + Host 回环 + 非 cross-site + Origin 与 Host 一致 |
 | 凭据透传范围 | `rewriteHeaders` / `bridgeUpstreamHeaders` | 只覆盖 Host/Origin，Cookie/Authorization 原样透传；WS 桥接剥离 hop-by-hop 与 sec-websocket-* 头；上游被 targetHost 强制回环，凭据不出进程边界 |
 | HTTPS 私钥 | cert.ts | 自签名私钥落盘 0600；用户证书文件成对校验 |
-| injectToken | proxy.ts 303/311-818 | 仅「GET / 且无 token」注入；有 cookie 绝不注入（防 303 死循环）；401 重放一次封顶 |
+| injectToken | `proxy.ts#withLaunchToken` / `proxy.ts#isTokenMintCandidate` | 仅「GET / 且无 token」注入；有 cookie 绝不注入（防 303 死循环）；401 重放一次封顶 |
 
 > 全量安全语义（含跨站残余面分析、health 元数据可见性等）见包 README「安全模型」节。
 

--- a/docs/architecture/dsh-mcp-manager.md
+++ b/docs/architecture/dsh-mcp-manager.md
@@ -25,7 +25,7 @@
 | **中间层收敛** | `middleware: project`（默认，项目级服务器）/ `all`（全局 + runtime 也收敛） | 4 个原子工具（两级发现：list 盘点 → detail 拉 schema） | 项目级接多少台服务器、多少个工具都不膨胀系统提示词；按会话 cwd 路由连接池、跨空间不串台 | 多一跳（中间层转发）；目录是 last-good 快照，`tools/list_changed` 变化需重连/刷新 |
 | **直呼注册** | `middleware: off`（全部）/ project 模式下的全局服务器 | 每工具一个 `mcp__<server>__<tool>`（64 字符、哈希后缀） | 零中间跳，工具定义直接进系统提示词 | 服务器多时上下文膨胀；不同工作空间同名 server 会冲突 |
 
-`middlewareTakes(name, scope)`（manager.ts:646-650）是唯一判定口径：`off` → 全部直呼；
+`middlewareTakes(name, scope)`（`manager.ts#middlewareTakes`）是唯一判定口径：`off` → 全部直呼；
 `scope===project` → 中间层接管（project 与 all 模式皆然）；`all && scope===global` →
 接管（含 runtime 注入条目）。
 
@@ -86,7 +86,7 @@ sequenceDiagram
 
 要点：
 
-- **命名规则** `publicToolName`（supervisor.ts:57-68）：`mcp__<server>__<tool>`；非法字符
+- **命名规则** `publicToolName`（`supervisor.ts#publicToolName`）：`mcp__<server>__<tool>`；非法字符
   替换为 `_`；≤64 字符直接用，否则 `sha256(server\0tool)` 前 12 位做哈希后缀
   （`前51字符_<hash12>`）；
 - **工具定义**：parameters 原样直传 MCP inputSchema；输出 schema 只收严格子集，不落子集
@@ -94,7 +94,7 @@ sequenceDiagram
   `truncateText`（默认 8KB 截断）；execute 走 `client.callTool`（默认 15s 超时）；
 - **协议薄适配**（protocol.ts）：`listTools` / `callTool` 刻意走 `Protocol.request` +
   宽松 `ResultSchema`，绕过 SDK `Client.listTools()` 的 outputSchema 缓存强校验；
-- **双轨 reconcile**（manager.ts:525-573）：desired = 全局 store + 项目 store（同名全局
+- **双轨 reconcile**（`manager.ts#reconcileServers`）：desired = 全局 store + 项目 store（同名全局
   优先）+ runtimeRegistry（同名 runtime 优先），变化才动作；
 - **runtime 注入**：其他插件可经 `ctx.mcpManager.registerServer({...toolDefinitions})`
   运行时注册（内存态不落盘，同名幂等）；带 `toolDefinitions` 时 execute 来自调用方封装
@@ -119,9 +119,9 @@ stateDiagram-v2
     failed --> connecting: 手动 connect / ws_mcp_call 触发
 ```
 
-- supervisor 路径（supervisor.ts:397-427）：曾连接且离线 ≥ maxDelayMs 重置失败计数；
+- supervisor 路径（`supervisor.ts#scheduleReconnect`）：曾连接且离线 ≥ maxDelayMs 重置失败计数；
   放弃后注销全部工具并置 `failed`；
-- 中间层路径（middleware.ts:274-292）：`500*2^min(n-1,6)`，>10 次停止后台重试
+- 中间层路径（`middleware.ts#scheduleReconnect`）：`500*2^min(n-1,6)`，>10 次停止后台重试
   （保留 failed，手动 connect 或调用可复活）；
 - **防双进程探测重试**（#382）：探测到同名 `mcp__` 已注册（如官方 dsh-mcp-client）
   → 落 failed + 3s 一次性重试（每代只一次）。
@@ -185,10 +185,10 @@ sequenceDiagram
 
 ### 3.5 传输层
 
-- **stdio**（transport.ts:121-173）：包官方 `StdioClientTransport`；`buildChildEnv` 净化
+- **stdio**（`transport.ts#StdioTransport`）：包官方 `StdioClientTransport`；`buildChildEnv` 净化
   父环境（见 §5）；保留 `stderrTail`（最近 4000B 供启动失败诊断）；`onClose` 与 SDK
   叠加式链（不覆盖 SDK 内部链）；
-- **streamable-http**（transport.ts:61-92）：包官方 `StreamableHTTPClientTransport`；
+- **streamable-http**（`transport.ts#StreamableHttpTransport`）：包官方 `StreamableHTTPClientTransport`；
   headers 支持 `${ENV}` 引用展开；`Mcp-Session-Id` 会话保持、SSE 流式响应由 SDK 承担。
 
 ---

--- a/docs/architecture/dsh-notifier.md
+++ b/docs/architecture/dsh-notifier.md
@@ -63,7 +63,7 @@ apply 主体直接调会在 cordis isolate 链就绪前访问服务，触发 Cyc
 | `agent/error` | `notifyTaskError` | 脱敏 → 60s 滚动窗口合并 → `notify("error")` |
 | `agent/turn-stopping` | `notifyTurnEnd`（默认关） | `(agentId, turn)` 去重 → `notify("turn-end")`；serial 事件签名无 next，**不要调 next()** |
 
-**完成提醒双源判据**（index.ts:510-576）：以 `session/event` 推送流（`eventStreamEnds`）
+**完成提醒双源判据**（`index.ts#apply`）：以 `session/event` 推送流（`eventStreamEnds`）
 记忆的最新 `turn/end` 为**主证据**（恒定新鲜）；快照回读（`lastTurnEndOf`）仅在 push 缺失
 时兜底（插件中途挂载 / 重载窗口）；`abort-early 冻结` 防止把 `running` 期间的旧 turn
 误判为完成；kind 白名单仅 `"completed"` 通知完成——aborted/interrupted/error/blocked
@@ -140,7 +140,7 @@ info→passive）；投递终态落盘 + `wingsky-notify/sent` 广播。
 
 ### 3.4 脱敏实现（sanitizeErrorText）
 
-`SANITIZE_RULES` 有序表（message.ts:59-100，**顺序即数据**）：用户路径 → `<path>`；
+`SANITIZE_RULES` 有序表（`message.ts#SANITIZE_RULES`，**顺序即数据**）：用户路径 → `<path>`；
 PEM 私钥块 → `<private-key>`；DB/消息队列连接串凭据 → `scheme://<redacted>@host`；
 GitHub PAT（classic + fine-grained）/ JWT / AWS AKIA / ≥24hex·≥32base64 长串 → `<token>`；
 密钥字段赋值 → `键=<redacted>`；邮箱 → `<email>`。


### PR DESCRIPTION
Closes #585

### 改动说明
1. **消除架构文档中的硬编码代码行号引用**：
   - 排查并修改 `docs/architecture/dsh-mcp-manager.md`、`docs/architecture/dsh-lan-proxy.md`、`docs/architecture/dsh-notifier.md`；
   - 将形如 `manager.ts:646-650`、`proxy.ts:275-278`、`index.ts:510-576`、`supervisor.ts:57-68`、`middleware.ts:274-292`、`transport.ts:121-173` 等物理行号替换为语义函数名或代码锚点（如 `manager.ts#middlewareTakes`、`proxy.ts#isLoopbackTarget`、`index.ts#apply` 等），彻底消除行号漂移风险。
2. **规范去重与单一事实源维护**：
   - 将技术实现细节和详细操作守则（测试基础要求、防 flake 核心原则、临时 `DSH_HOME` 隔离、测试产物零污染纪律 #218）的单一事实源明确归拢到 `docs/DEVELOPMENT.md §5`，并设置双锚补位；
   - `AGENTS.md` 仅保留精简的核心执行红线，并通过双锚 Markdown 链接指向 `docs/DEVELOPMENT.md` 对应章节。

### 验收断言表

| 验收条目 | 结论 | 证据或漂移解释 |
|---|---|---|
| 消除 `docs/architecture/*.md` 中的硬编码行号引用 | PASS | grep 扫描无剩余物理行号，替换为 `manager.ts#middlewareTakes`、`proxy.ts#isLoopbackTarget` 等语义锚点 |
| `AGENTS.md` 与 `docs/DEVELOPMENT.md` 规范去重与单一事实源维护 | PASS | 详细技术守则与零污染归拢至 `docs/DEVELOPMENT.md §5`，`AGENTS.md` 精简核心红线并通过双锚补位链接指向对应章节 |
| 全仓链接与文档一致性门禁 | PASS | `node scripts/gate/verify-docs.ts --strict-en` 退出码 0 |
| 全量五连门禁验证 | PASS | `pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 退出码 0 |
