### PR TITLE
feat(gate): CRAP 圈复杂度门禁增量防劣化支持（--diff 模式）

### DIFF
--- a/scripts/gate/crap-check.mjs
+++ b/scripts/gate/crap-check.mjs
@@ -17,37 +17,28 @@
  * 噪音过滤：esbuild 内联的 node_modules 依赖段与 `__` 前缀垫片函数不计入统计
  *   （发布物自包含导致依赖代码进 bundle，但它们不是本仓自写代码）。
  *
- * 阈值与判红开关唯一事实源 = scripts/data/gauntlet.config.json 的
- *   crap.threshold / crap.strict（`--threshold` 仅作临时覆盖，strict 无 argv 覆盖）。
- *   crap.strict=false：超阈热点 exit 0，仅落盘 coverage/crap-report.json（观察期）；
- *   crap.strict=true：超阈热点 exit 1。翻期只改 config，不改本脚本。
+ * 模式说明：
+ * 1. 全量模式（默认）：
+ *    读取 scripts/data/gauntlet.config.json 的 crap.threshold / crap.strict。
+ *    crap.strict=false：超阈热点 exit 0，仅落盘 coverage/crap-report.json（观察期）；
+ *    crap.strict=true：超阈热点 exit 1。
+ *
+ * 2. 增量防劣化模式（--diff [base]）：
+ *    对比 base（默认 origin/main，自适应 fallback）与当前工作区的改动：
+ *    - 过滤只对本次改动触及的函数进行 CRAP 评估；
+ *    - 新增函数：必须满足 CRAP <= threshold（默认 16）；
+ *    - 修改的存量函数：若存量函数原本超标，修改后不得恶化（CRAP_new <= CRAP_base）；
+ *    - 未触及的存量函数：全部豁免报警；
+ *    - 存在新增超标或存量恶化时打印阻断日志并 exit 1；全部合规时 exit 0。
  */
-import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync, existsSync, mkdirSync, writeFileSync, realpathSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import * as acorn from 'acorn';
 
-const repoRoot = process.cwd();
-const configPath = join(repoRoot, 'scripts', 'data', 'gauntlet.config.json');
-const config = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf8')) : {};
-/** 阈值与 strict 唯一事实源 = scripts/data/gauntlet.config.json；--threshold 仅作临时覆盖。 */
-const DEFAULT_THRESHOLD = config.crap?.threshold ?? 12;
-const argv = process.argv.slice(2);
-const idx = argv.indexOf('--threshold');
-const threshold = Number(idx >= 0 ? argv[idx + 1] : DEFAULT_THRESHOLD);
-if (!Number.isFinite(threshold) || threshold <= 0) {
-  console.error('crap-check: invalid --threshold');
-  process.exit(2);
-}
-const strict = Boolean(config.crap?.strict);
-
-const coveragePath = join(repoRoot, 'coverage', 'coverage-final.json');
-if (!existsSync(coveragePath)) {
-  console.error('crap-check: coverage/coverage-final.json 不存在，请先运行 pnpm cov');
-  process.exit(2);
-}
-
 /** 圈复杂度 = 1 + 决策点数（口径见文件头注释）。 */
-function complexityOf(fnNode) {
+export function complexityOf(fnNode) {
   let count = 1;
   function visit(node) {
     if (!node || typeof node.type !== 'string') return;
@@ -71,7 +62,7 @@ function complexityOf(fnNode) {
  * 标记 esbuild 注入的模块边界注释，划分「本仓段 / 依赖段」：
  * 形如 `// ../../node_modules/.pnpm/...` 的注释开启依赖段，直到下一个路径注释。
  */
-function foreignSegments(code) {
+export function foreignSegments(code) {
   const segments = [];
   let current = null;
   let offset = 0;
@@ -89,7 +80,7 @@ function foreignSegments(code) {
   return segments.filter((s) => s.foreign);
 }
 
-function inForeign(offset, ranges) {
+export function inForeign(offset, ranges) {
   return ranges.some((r) => offset >= r.start && offset < r.end);
 }
 
@@ -97,7 +88,7 @@ function inForeign(offset, ranges) {
  * 收集垫片范围：esbuild 以 `var __xxx = (...) => ...` 形式定义的运行时辅助
  * （__async/__await/__generator 等），连同其函数体整体划为依赖段。
  */
-function shimRanges(ast) {
+export function shimRanges(ast) {
   const ranges = [];
   function visit(node) {
     if (!node || typeof node.type !== 'string') return;
@@ -116,8 +107,27 @@ function shimRanges(ast) {
   return ranges;
 }
 
-/** 收集一个文件的全部本仓函数，返回 {comp, line} 列表（line 为 1-based 起始行）。 */
-function functionsOf(code) {
+/** 提取 AST 函数节点名或所在变量/属性名 */
+function getFunctionName(node, parent) {
+  if (node.id?.name) return node.id.name;
+  if (parent) {
+    if (parent.type === 'VariableDeclarator' && parent.id?.name) return parent.id.name;
+    if (parent.type === 'Property' || parent.type === 'MethodDefinition') {
+      if (parent.key?.type === 'Identifier') return parent.key.name;
+      if (parent.key?.type === 'Literal') return String(parent.key.value);
+    }
+    if (parent.type === 'AssignmentExpression') {
+      if (parent.left?.type === 'Identifier') return parent.left.name;
+      if (parent.left?.type === 'MemberExpression' && parent.left.property?.name) {
+        return parent.left.property.name;
+      }
+    }
+  }
+  return '';
+}
+
+/** 收集一个文件的全部本仓函数，返回 {comp, line, startLine, endLine, name} 列表（line 为 1-based 起始行）。 */
+export function functionsOf(code) {
   // lib 宿主产物为 ESM，client 外壳为 IIFE：先按 module 解析，失败降级 script
   let ast;
   try {
@@ -129,7 +139,7 @@ function functionsOf(code) {
   const shims = shimRanges(ast);
   const out = [];
   let skippedForeign = 0;
-  function visit(node) {
+  function visit(node, parent) {
     if (!node || typeof node.type !== 'string') return;
     const isFn = node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression'
       || node.type === 'ArrowFunctionExpression';
@@ -139,81 +149,554 @@ function functionsOf(code) {
       if (isShim || inForeign(node.start, foreign) || inForeign(node.start, shims)) {
         skippedForeign++;
       } else {
-        out.push({ comp: complexityOf(node), line: node.loc.start.line });
+        const startLine = node.loc.start.line;
+        const endLine = node.loc.end.line;
+        const name = getFunctionName(node, parent);
+        out.push({
+          name,
+          comp: complexityOf(node),
+          line: startLine,
+          startLine,
+          endLine,
+        });
       }
     }
     for (const key of Object.keys(node)) {
       if (key === 'loc' || key === 'range') continue;
       const child = node[key];
-      if (Array.isArray(child)) child.forEach(visit);
-      else if (child && typeof child === 'object' && typeof child.type === 'string') visit(child);
+      if (Array.isArray(child)) {
+        for (const c of child) visit(c, node);
+      } else if (child && typeof child === 'object' && typeof child.type === 'string') {
+        visit(child, node);
+      }
     }
   }
-  visit(ast);
+  visit(ast, null);
   return { fns: out, skippedForeign };
 }
 
-const coverage = JSON.parse(readFileSync(coveragePath, 'utf8'));
-const hotspots = [];
-let totalFns = 0;
-let coveredFns = 0;
-let skippedForeignTotal = 0;
+/**
+ * 解析 git diff -U0 的输出文本，构建文件改动元数据与变更行号集合。
+ * 返回 Map<string, DiffFileEntry>，key 为相对路径。
+ */
+export function parseGitDiff(diffText) {
+  const files = new Map();
+  if (!diffText || typeof diffText !== 'string') return files;
 
-for (const [file, data] of Object.entries(coverage)) {
-  // 只关心插件包编译产物（lib 目录），跳过测试脚本与工具链文件
-  if (!/\/packages\/[^/]+\/lib\//.test(file)) continue;
-  const rel = file.startsWith(repoRoot) ? file : join(repoRoot, file);
-  if (!existsSync(rel)) continue;
-  const { fns, skippedForeign } = functionsOf(readFileSync(rel, 'utf8'));
-  skippedForeignTotal += skippedForeign;
+  const lines = diffText.split('\n');
+  let currentFile = null;
 
-  // istanbul fnMap：以 id 为键的对象；按声明起始行索引命中状态（同行多函数取「有命中即算命中」）
-  const hitByLine = new Map();
-  for (const [id, fn] of Object.entries(data.fnMap ?? {})) {
-    const line = fn.loc?.start?.line ?? fn.decl?.start?.line;
-    if (line == null) continue;
-    const hit = (data.f?.[id] ?? 0) > 0;
-    hitByLine.set(line, (hitByLine.get(line) ?? false) || hit);
-  }
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
 
-  for (const fn of fns) {
-    totalFns++;
-    const covered = hitByLine.get(fn.line) ?? false;
-    if (covered) coveredFns++;
-    const crap = fn.comp * fn.comp * (covered ? 0 : 1) + fn.comp;
-    if (crap > threshold) {
-      hotspots.push({ file: file.slice(repoRoot.length + 1), line: fn.line, comp: fn.comp, covered, crap });
+    if (line.startsWith('diff --git ')) {
+      const parts = line.slice('diff --git '.length).trim().split(' ');
+      const aPath = parts[0]?.replace(/^a\//, '') ?? '';
+      const bPath = parts[1]?.replace(/^b\//, '') ?? '';
+      const targetPath = (bPath && bPath !== '/dev/null') ? bPath : aPath;
+      currentFile = {
+        file: targetPath,
+        oldFile: aPath,
+        isNew: false,
+        isDeleted: false,
+        hunks: [],
+        newChangedLines: new Set(),
+        oldChangedLines: new Set(),
+      };
+      files.set(currentFile.file, currentFile);
+      continue;
+    }
+
+    if (!currentFile) continue;
+
+    if (line.startsWith('--- /dev/null')) {
+      currentFile.isNew = true;
+      continue;
+    }
+    if (line.startsWith('+++ /dev/null')) {
+      currentFile.isDeleted = true;
+      continue;
+    }
+    if (line.startsWith('--- a/')) {
+      currentFile.oldFile = line.slice('--- a/'.length).trim();
+      continue;
+    }
+    if (line.startsWith('+++ b/')) {
+      currentFile.file = line.slice('+++ b/'.length).trim();
+      files.set(currentFile.file, currentFile);
+      continue;
+    }
+
+    // Hunk header: @@ -oldStart[,oldCount] +newStart[,newCount] @@
+    if (line.startsWith('@@ ')) {
+      const match = /^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@/.exec(line);
+      if (match) {
+        const oldStart = parseInt(match[1], 10);
+        const oldCount = match[2] !== undefined ? parseInt(match[2], 10) : 1;
+        const newStart = parseInt(match[3], 10);
+        const newCount = match[4] !== undefined ? parseInt(match[4], 10) : 1;
+
+        currentFile.hunks.push({ oldStart, oldCount, newStart, newCount });
+
+        if (newCount > 0) {
+          for (let l = newStart; l < newStart + newCount; l++) {
+            currentFile.newChangedLines.add(l);
+          }
+        }
+        if (oldCount > 0) {
+          for (let l = oldStart; l < oldStart + oldCount; l++) {
+            currentFile.oldChangedLines.add(l);
+          }
+        }
+      }
     }
   }
+
+  return files;
 }
 
-hotspots.sort((a, b) => b.crap - a.crap);
-console.log(`crap-check: 本仓函数 ${totalFns} 个（已排除依赖/垫片 ${skippedForeignTotal} 个），`
-  + `已覆盖 ${coveredFns}（${totalFns ? Math.round((coveredFns / totalFns) * 100) : 0}%），阈值 ${threshold}`);
+/**
+ * 将新文件行号映射回老文件行号。
+ * 若行落在新增/修改的 hunk 内部，返回 null；否则返回在老文件中的对应行号。
+ */
+export function mapNewToOldLine(newLine, hunks) {
+  if (!hunks || hunks.length === 0) return newLine;
+  let cumulativeOffset = 0;
+  for (const hunk of hunks) {
+    if (newLine < hunk.newStart) {
+      return newLine - cumulativeOffset;
+    }
+    if (newLine >= hunk.newStart && newLine < hunk.newStart + hunk.newCount) {
+      return null;
+    }
+    cumulativeOffset += (hunk.newCount - hunk.oldCount);
+  }
+  return newLine - cumulativeOffset;
+}
 
-// 全量明细落盘，供 health-report 与趋势对比使用
-mkdirSync(join(repoRoot, 'coverage'), { recursive: true });
-writeFileSync(
-  join(repoRoot, 'coverage', 'crap-report.json'),
-  JSON.stringify({
-    generatedAt: new Date().toISOString(), threshold, strict,
-    totalFns, coveredFns, skippedForeignTotal, hotspots,
-  }, null, 2),
-);
+/**
+ * 将老文件行号映射到新文件行号。
+ * 若行落在被删除/修改的 hunk 内部，返回 null；否则返回在新文件中的对应行号。
+ */
+export function mapOldToNewLine(oldLine, hunks) {
+  if (!hunks || hunks.length === 0) return oldLine;
+  let cumulativeOffset = 0;
+  for (const hunk of hunks) {
+    if (oldLine < hunk.oldStart) {
+      return oldLine + cumulativeOffset;
+    }
+    if (oldLine >= hunk.oldStart && oldLine < hunk.oldStart + hunk.oldCount) {
+      return null;
+    }
+    cumulativeOffset += (hunk.newCount - hunk.oldCount);
+  }
+  return oldLine + cumulativeOffset;
+}
 
-if (hotspots.length) {
-  console.log(`crap-check: 超阈热点 ${hotspots.length} 个（Top10）：`);
-  for (const h of hotspots.slice(0, 10)) {
-    console.log(`  CRAP=${h.crap} comp=${h.comp}${h.covered ? '' : ' 未覆盖'}  ${h.file}:${h.line}`);
+/**
+ * 判断函数是否被改动触及（Touched）：
+ * 1. 文件为全新增文件；
+ * 2. 新版本中函数的 [startLine, endLine] 范围包含任何变更行；
+ * 3. 存在纯删除插入点落在函数体内（newCount === 0）。
+ */
+export function isFunctionTouched(fn, fileDiff) {
+  if (!fileDiff) return false;
+  if (fileDiff.isNew) return true;
+
+  for (let l = fn.startLine; l <= fn.endLine; l++) {
+    if (fileDiff.newChangedLines.has(l)) return true;
+  }
+
+  for (const hunk of fileDiff.hunks) {
+    if (hunk.newCount === 0 && hunk.newStart >= fn.startLine && hunk.newStart <= fn.endLine) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * 在 baseFns 中寻找与当前新函数匹配的存量函数：
+ * 优先依据行号映射匹配，次之同名匹配；未匹配则判定为新增函数。
+ */
+export function findBaseFunction(newFn, baseFns, hunks) {
+  if (!baseFns || baseFns.length === 0) return null;
+
+  // 1. 优先通过行号映射匹配
+  const mappedOldLine = mapNewToOldLine(newFn.startLine, hunks);
+  if (mappedOldLine !== null) {
+    const exactMatch = baseFns.find((bf) => bf.startLine === mappedOldLine);
+    if (exactMatch) {
+      if (!newFn.name || !exactMatch.name || newFn.name === exactMatch.name) {
+        return exactMatch;
+      }
+    }
+  }
+
+  // 2. 函数名匹配（当函数声明被修改或换行时）
+  if (newFn.name) {
+    const nameMatches = baseFns.filter((bf) => bf.name === newFn.name);
+    if (nameMatches.length === 1) {
+      return nameMatches[0];
+    }
+    if (nameMatches.length > 1) {
+      const targetLine = mappedOldLine ?? newFn.startLine;
+      return nameMatches.slice().sort((a, b) =>
+        Math.abs(a.startLine - targetLine) - Math.abs(b.startLine - targetLine)
+      )[0];
+    }
+  }
+
+  // 3. 匿名函数在替换 hunk 内的对应
+  if (!newFn.name && hunks) {
+    for (const hunk of hunks) {
+      if (newFn.startLine >= hunk.newStart && newFn.startLine < hunk.newStart + hunk.newCount) {
+        const candidates = baseFns.filter((bf) =>
+          !bf.name && bf.startLine >= hunk.oldStart && bf.startLine < hunk.oldStart + hunk.oldCount
+        );
+        if (candidates.length === 1) {
+          return candidates[0];
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * 确定有效的 base git ref（支持 fallback）。
+ */
+export function resolveBaseRef(base, cwd) {
+  const tryRef = (ref) => {
+    const res = spawnSync('git', ['rev-parse', '--verify', ref], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return res.status === 0;
+  };
+  if (base && tryRef(base)) return base;
+  if (!base || base === 'origin/main') {
+    if (tryRef('origin/main')) return 'origin/main';
+    if (tryRef('main')) return 'main';
+    if (tryRef('HEAD~1')) return 'HEAD~1';
+    if (tryRef('HEAD')) return 'HEAD';
+  }
+  return base || 'HEAD';
+}
+
+/**
+ * 规范化文件路径为相对于 repoRoot 的正斜杠路径。
+ */
+function normalizeRelativePath(file, repoRoot) {
+  const normFile = file.replace(/\\/g, '/');
+  const normRoot = repoRoot.replace(/\\/g, '/');
+  if (normFile.startsWith(normRoot + '/')) {
+    return normFile.slice(normRoot.length + 1);
+  }
+  return normFile;
+}
+
+/**
+ * 执行 --diff 增量防劣化评估
+ */
+export function runDiffCheck({ repoRoot, threshold, baseArg, coveragePath }) {
+  const baseRef = resolveBaseRef(baseArg, repoRoot);
+  const diffRes = spawnSync('git', ['diff', '-U0', baseRef, '--'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  if (diffRes.status !== 0) {
+    console.error(`crap-check [diff]: git diff 失败（base: ${baseRef}）：${diffRes.stderr || '未知错误'}`);
+    return { exitCode: 2, passed: false, violations: [] };
+  }
+
+  const diffFiles = parseGitDiff(diffRes.stdout);
+  // 仅评估 packages/*/lib/ 目录下的改动文件
+  const relevantDiffFiles = Array.from(diffFiles.entries()).filter(([path]) =>
+    /\/packages\/[^/]+\/lib\//.test('/' + path.replace(/\\/g, '/'))
+  );
+
+  if (relevantDiffFiles.length === 0) {
+    console.log(`crap-check [diff]: base=${baseRef}，未检测到插件包编译产物（packages/*/lib/）的代码变更，OK`);
+    return { exitCode: 0, passed: true, violations: [] };
+  }
+
+  let coverage = {};
+  if (existsSync(coveragePath)) {
+    try {
+      coverage = JSON.parse(readFileSync(coveragePath, 'utf8'));
+    } catch {
+      console.warn('crap-check [diff]: coverage/coverage-final.json 解析失败，默认按未覆盖评估');
+    }
+  } else {
+    console.warn('crap-check [diff]: 未检测到 coverage/coverage-final.json，默认按未覆盖（cov=0）评估');
+  }
+
+  // 构建 coverage 索引：按 relativePath -> fileData
+  const coverageByRel = new Map();
+  for (const [covFile, covData] of Object.entries(coverage)) {
+    const rel = normalizeRelativePath(covFile, repoRoot);
+    coverageByRel.set(rel, covData);
+  }
+
+  const violations = [];
+  let touchedCount = 0;
+  let compliantCount = 0;
+
+  for (const [relPath, fileDiff] of relevantDiffFiles) {
+    const absPath = join(repoRoot, relPath);
+    if (!existsSync(absPath)) continue;
+
+    const currentCode = readFileSync(absPath, 'utf8');
+    const { fns: currentFns } = functionsOf(currentCode);
+
+    // 读取 base 提交中的老文件内容
+    let baseFns = [];
+    if (!fileDiff.isNew) {
+      const showRes = spawnSync('git', ['show', `${baseRef}:${fileDiff.oldFile || relPath}`], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      if (showRes.status === 0) {
+        baseFns = functionsOf(showRes.stdout).fns;
+      }
+    }
+
+    // 提取当前文件在 coverage 中的逐行命中状态
+    const fileCov = coverageByRel.get(relPath);
+    const hitByLine = new Map();
+    if (fileCov?.fnMap) {
+      for (const [id, fn] of Object.entries(fileCov.fnMap)) {
+        const line = fn.loc?.start?.line ?? fn.decl?.start?.line;
+        if (line == null) continue;
+        const hit = (fileCov.f?.[id] ?? 0) > 0;
+        hitByLine.set(line, (hitByLine.get(line) ?? false) || hit);
+      }
+    }
+
+    for (const fn of currentFns) {
+      if (!isFunctionTouched(fn, fileDiff)) {
+        // 未触及存量函数：全部豁免
+        continue;
+      }
+      touchedCount++;
+
+      const covered = hitByLine.get(fn.line) ?? false;
+      const crapNew = fn.comp * fn.comp * (covered ? 0 : 1) + fn.comp;
+
+      if (crapNew <= threshold) {
+        // 合规放行
+        compliantCount++;
+        continue;
+      }
+
+      // CRAP 超标，判定存量恶化或新增超标
+      const baseFn = findBaseFunction(fn, baseFns, fileDiff.hunks);
+
+      if (!baseFn) {
+        // 新增函数超标
+        violations.push({
+          type: 'NEW_EXCEEDED',
+          file: relPath,
+          line: fn.startLine,
+          name: fn.name || '<anonymous>',
+          comp: fn.comp,
+          covered,
+          crap: crapNew,
+          threshold,
+        });
+      } else {
+        // 修改的存量函数：计算 base CRAP
+        const crapBase = baseFn.comp * baseFn.comp * (covered ? 0 : 1) + baseFn.comp;
+        if (crapNew > crapBase) {
+          // 恶化拦截
+          violations.push({
+            type: 'REGRESSION',
+            file: relPath,
+            line: fn.startLine,
+            name: fn.name || '<anonymous>',
+            compNew: fn.comp,
+            compBase: baseFn.comp,
+            covered,
+            crapNew,
+            crapBase,
+            threshold,
+          });
+        } else {
+          // 未恶化（重构降复杂度或持平），放行
+          compliantCount++;
+        }
+      }
+    }
+  }
+
+  // 输出结果与报告
+  if (violations.length > 0) {
+    console.error(`crap-check [diff]: FAIL - 发现 ${violations.length} 处 CRAP 增量违规（base: ${baseRef}，阈值: ${threshold}）：`);
+    for (const v of violations) {
+      if (v.type === 'NEW_EXCEEDED') {
+        console.error(`  [新增超标] ${v.file}:${v.line} (${v.name}) CRAP=${v.crap} > ${threshold}（comp=${v.comp}，${v.covered ? '已覆盖' : '未覆盖'}）`);
+      } else if (v.type === 'REGRESSION') {
+        console.error(`  [存量恶化] ${v.file}:${v.line} (${v.name}) CRAP 恶化: ${v.crapBase} -> ${v.crapNew}（comp: ${v.compBase} -> ${v.compNew}，${v.covered ? '已覆盖' : '未覆盖'}）`);
+      }
+    }
+    return { exitCode: 1, passed: false, violations, touchedCount, compliantCount };
+  }
+
+  console.log(`crap-check [diff]: OK - base=${baseRef}，改动触及 ${touchedCount} 个函数，全部合规放行（未触及存量函数全部豁免）。`);
+  return { exitCode: 0, passed: true, violations: [], touchedCount, compliantCount };
+}
+
+/**
+ * 执行默认的全量评估逻辑
+ */
+export function runFullCheck({ repoRoot, threshold, strict, coveragePath }) {
+  if (!existsSync(coveragePath)) {
+    console.error('crap-check: coverage/coverage-final.json 不存在，请先运行 pnpm cov');
+    return { exitCode: 2, passed: false, hotspots: [] };
+  }
+
+  const coverage = JSON.parse(readFileSync(coveragePath, 'utf8'));
+  const hotspots = [];
+  let totalFns = 0;
+  let coveredFns = 0;
+  let skippedForeignTotal = 0;
+
+  for (const [file, data] of Object.entries(coverage)) {
+    if (!/\/packages\/[^/]+\/lib\//.test(file)) continue;
+    const rel = file.startsWith(repoRoot) ? file : join(repoRoot, file);
+    if (!existsSync(rel)) continue;
+    const { fns, skippedForeign } = functionsOf(readFileSync(rel, 'utf8'));
+    skippedForeignTotal += skippedForeign;
+
+    const hitByLine = new Map();
+    for (const [id, fn] of Object.entries(data.fnMap ?? {})) {
+      const line = fn.loc?.start?.line ?? fn.decl?.start?.line;
+      if (line == null) continue;
+      const hit = (data.f?.[id] ?? 0) > 0;
+      hitByLine.set(line, (hitByLine.get(line) ?? false) || hit);
+    }
+
+    for (const fn of fns) {
+      totalFns++;
+      const covered = hitByLine.get(fn.line) ?? false;
+      if (covered) coveredFns++;
+      const crap = fn.comp * fn.comp * (covered ? 0 : 1) + fn.comp;
+      if (crap > threshold) {
+        hotspots.push({
+          file: file.slice(repoRoot.length + 1),
+          line: fn.line,
+          comp: fn.comp,
+          covered,
+          crap,
+        });
+      }
+    }
+  }
+
+  hotspots.sort((a, b) => b.crap - a.crap);
+  console.log(`crap-check: 本仓函数 ${totalFns} 个（已排除依赖/垫片 ${skippedForeignTotal} 个），`
+    + `已覆盖 ${coveredFns}（${totalFns ? Math.round((coveredFns / totalFns) * 100) : 0}%），阈值 ${threshold}`);
+
+  mkdirSync(join(repoRoot, 'coverage'), { recursive: true });
+  writeFileSync(
+    join(repoRoot, 'coverage', 'crap-report.json'),
+    JSON.stringify({
+      generatedAt: new Date().toISOString(),
+      threshold,
+      strict,
+      totalFns,
+      coveredFns,
+      skippedForeignTotal,
+      hotspots,
+    }, null, 2),
+  );
+
+  if (hotspots.length) {
+    console.log(`crap-check: 超阈热点 ${hotspots.length} 个（Top10）：`);
+    for (const h of hotspots.slice(0, 10)) {
+      console.log(`  CRAP=${h.crap} comp=${h.comp}${h.covered ? '' : ' 未覆盖'}  ${h.file}:${h.line}`);
+    }
+  }
+
+  if (strict) {
+    if (hotspots.length > 0) {
+      console.error(`crap-check: [strict] 超阈热点 ${hotspots.length} 个，判定为红`);
+      return { exitCode: 1, passed: false, hotspots };
+    }
+    console.log('crap-check: [strict] 无超阈热点，OK');
+    return { exitCode: 0, passed: true, hotspots: [] };
+  }
+
+  console.log('crap-check: OK（strict=false 观察期，strict 来源 gauntlet.config.json: crap.strict，明细已落盘 coverage/crap-report.json）');
+  return { exitCode: 0, passed: true, hotspots };
+}
+
+/**
+ * 主入口解析与分发
+ */
+export function runCrapCheck(argv = process.argv.slice(2), { shouldExit = true } = {}) {
+  const repoRoot = process.cwd();
+  const configPath = join(repoRoot, 'scripts', 'data', 'gauntlet.config.json');
+  const config = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf8')) : {};
+  const DEFAULT_THRESHOLD = config.crap?.threshold ?? 16;
+
+  const idx = argv.indexOf('--threshold');
+  const threshold = Number(idx >= 0 ? argv[idx + 1] : DEFAULT_THRESHOLD);
+  if (!Number.isFinite(threshold) || threshold <= 0) {
+    console.error('crap-check: invalid --threshold');
+    if (shouldExit) process.exit(2);
+    return { exitCode: 2 };
+  }
+  const strict = Boolean(config.crap?.strict);
+  const coveragePath = join(repoRoot, 'coverage', 'coverage-final.json');
+
+  // 解析 --diff 参数
+  let isDiff = false;
+  let baseArg = null;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--diff') {
+      isDiff = true;
+      if (i + 1 < argv.length && !argv[i + 1].startsWith('-')) {
+        baseArg = argv[i + 1];
+      }
+    } else if (argv[i].startsWith('--diff=')) {
+      isDiff = true;
+      baseArg = argv[i].slice('--diff='.length);
+    }
+  }
+
+  let result;
+  if (isDiff) {
+    result = runDiffCheck({ repoRoot, threshold, baseArg, coveragePath });
+  } else {
+    result = runFullCheck({ repoRoot, threshold, strict, coveragePath });
+  }
+
+  if (shouldExit && typeof result.exitCode === 'number') {
+    process.exit(result.exitCode);
+  }
+  return result;
+}
+
+// 判定是否作为 CLI 主脚本运行
+function isDirectExecution() {
+  if (!process.argv[1]) return false;
+  try {
+    const scriptPath = realpathSync(fileURLToPath(import.meta.url));
+    const execPath = realpathSync(process.argv[1]);
+    return scriptPath === execPath;
+  } catch {
+    return false;
   }
 }
 
-if (strict) {
-  if (hotspots.length > 0) {
-    console.error(`crap-check: [strict] 超阈热点 ${hotspots.length} 个，判定为红`);
-    process.exit(1);
-  }
-  console.log('crap-check: [strict] 无超阈热点，OK');
-} else {
-  console.log(`crap-check: OK（strict=false 观察期，strict 来源 gauntlet.config.json: crap.strict，明细已落盘 coverage/crap-report.json）`);
+if (isDirectExecution()) {
+  runCrapCheck(process.argv.slice(2), { shouldExit: true });
 }

--- a/scripts/test/crap-check-diff.test.ts
+++ b/scripts/test/crap-check-diff.test.ts
@@ -1,0 +1,374 @@
+#!/usr/bin/env node
+// @ts-nocheck
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync, execFileSync } from 'node:child_process'
+import {
+  parseGitDiff,
+  mapNewToOldLine,
+  mapOldToNewLine,
+  isFunctionTouched,
+  findBaseFunction,
+  functionsOf,
+  complexityOf,
+} from '../gate/crap-check.mjs'
+
+const ROOT = join(import.meta.dirname, '../..')
+const SCRIPT = join(ROOT, 'scripts/gate/crap-check.mjs')
+
+// ── 单元测试：Diff 解析与行号映射算法 ──────────────────────────────
+
+test('parseGitDiff: 正确解析 unified diff hunk 并提取变更行号集合', () => {
+  const diffSample = `
+diff --git a/packages/fake/lib/index.js b/packages/fake/lib/index.js
+index 1111111..2222222 100644
+--- a/packages/fake/lib/index.js
++++ b/packages/fake/lib/index.js
+@@ -10,3 +10,5 @@
+ funcA()
+`
+  const diffMap = parseGitDiff(diffSample.trim())
+  assert.ok(diffMap.has('packages/fake/lib/index.js'))
+  const entry = diffMap.get('packages/fake/lib/index.js')
+  assert.equal(entry.hunks.length, 1)
+  assert.deepEqual(entry.hunks[0], { oldStart: 10, oldCount: 3, newStart: 10, newCount: 5 })
+  // newChangedLines: 10, 11, 12, 13, 14
+  assert.equal(entry.newChangedLines.size, 5)
+  assert.ok(entry.newChangedLines.has(10))
+  assert.ok(entry.newChangedLines.has(14))
+  assert.ok(!entry.newChangedLines.has(15))
+  // oldChangedLines: 10, 11, 12
+  assert.equal(entry.oldChangedLines.size, 3)
+  assert.ok(entry.oldChangedLines.has(10))
+  assert.ok(entry.oldChangedLines.has(12))
+})
+
+test('mapNewToOldLine & mapOldToNewLine: 准确处理增删与行号偏移', () => {
+  // 场景：在第 5 行替换了 2 行为 4 行（行数净增 2 行）
+  const hunks = [{ oldStart: 5, oldCount: 2, newStart: 5, newCount: 4 }]
+
+  // 1. hunk 前的行号映射一致
+  assert.equal(mapNewToOldLine(1, hunks), 1)
+  assert.equal(mapNewToOldLine(4, hunks), 4)
+  assert.equal(mapOldToNewLine(1, hunks), 1)
+  assert.equal(mapOldToNewLine(4, hunks), 4)
+
+  // 2. hunk 内部的改动行映射为 null
+  assert.equal(mapNewToOldLine(5, hunks), null)
+  assert.equal(mapNewToOldLine(8, hunks), null)
+  assert.equal(mapOldToNewLine(5, hunks), null)
+  assert.equal(mapOldToNewLine(6, hunks), null)
+
+  // 3. hunk 之后的行号精准偏移（new 行 9 对应 old 行 7；old 行 7 对应 new 行 9）
+  assert.equal(mapNewToOldLine(9, hunks), 7)
+  assert.equal(mapOldToNewLine(7, hunks), 9)
+})
+
+test('isFunctionTouched: 仅触及范围内的函数返回 true，其余豁免', () => {
+  const fileDiff = {
+    isNew: false,
+    newChangedLines: new Set([20, 21, 22]),
+    hunks: [{ oldStart: 20, oldCount: 1, newStart: 20, newCount: 3 }],
+  }
+
+  // 函数 A：行 1~10（在改动之前，未触及）
+  assert.equal(isFunctionTouched({ startLine: 1, endLine: 10 }, fileDiff), false)
+
+  // 函数 B：行 18~25（改动行 20~22 落在函数内，触及）
+  assert.equal(isFunctionTouched({ startLine: 18, endLine: 25 }, fileDiff), true)
+
+  // 函数 C：行 30~40（在改动之后，未触及）
+  assert.equal(isFunctionTouched({ startLine: 30, endLine: 40 }, fileDiff), false)
+
+  // 新增文件一律触及
+  assert.equal(isFunctionTouched({ startLine: 1, endLine: 5 }, { isNew: true, hunks: [] }), true)
+})
+
+test('findBaseFunction: 支持行号映射与同名函数查找', () => {
+  const baseFns = [
+    { name: 'foo', startLine: 10, endLine: 20, comp: 5 },
+    { name: 'bar', startLine: 30, endLine: 40, comp: 8 },
+  ]
+  const hunks = [{ oldStart: 5, oldCount: 2, newStart: 5, newCount: 4 }] // 偏移 +2
+
+  // 1. 行号映射命中（new 行 32 对应 old 行 30）
+  const matchA = findBaseFunction({ name: 'bar', startLine: 32, endLine: 42 }, baseFns, hunks)
+  assert.ok(matchA)
+  assert.equal(matchA.name, 'bar')
+
+  // 2. 声明行被修改但名称相同命中
+  const matchB = findBaseFunction({ name: 'foo', startLine: 7, endLine: 20 }, baseFns, hunks)
+  assert.ok(matchB)
+  assert.equal(matchB.name, 'foo')
+
+  // 3. 全新函数返回 null
+  const matchC = findBaseFunction({ name: 'brandNewFunc', startLine: 50, endLine: 60 }, baseFns, hunks)
+  assert.equal(matchC, null)
+})
+
+// ── 端到端测试辅助：搭建临时 Git Fixture ────────────────────────────
+
+function setupGitFixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'crap-diff-test-'))
+
+  // 初始化 git 仓库
+  execFileSync('git', ['init', '-b', 'main'], { cwd: dir, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.name', 'test-bot'], { cwd: dir, stdio: 'pipe' })
+  execFileSync('git', ['config', 'user.email', 'test@bot.local'], { cwd: dir, stdio: 'pipe' })
+
+  mkdirSync(join(dir, 'scripts/data'), { recursive: true })
+  mkdirSync(join(dir, 'coverage'), { recursive: true })
+  mkdirSync(join(dir, 'packages/fake/lib'), { recursive: true })
+
+  // 写入默认配置：threshold=16, strict=false
+  writeFileSync(join(dir, 'scripts/data/gauntlet.config.json'), JSON.stringify({ crap: { threshold: 16, strict: false } }))
+
+  return dir
+}
+
+// ── 端到端集成测试：拦截与放行逻辑 ──────────────────────────────
+
+test('#592 crap-check --diff: 新增函数 CRAP 超标拦截（exit 1）', () => {
+  const dir = setupGitFixture()
+  try {
+    const pkgLib = join(dir, 'packages/fake/lib/index.js')
+    writeFileSync(pkgLib, 'function baseFunc() { return 1; }\nbaseFunc();\n')
+    execFileSync('git', ['add', '.'], { cwd: dir, stdio: 'pipe' })
+    execFileSync('git', ['commit', '-m', 'initial commit'], { cwd: dir, stdio: 'pipe' })
+
+    // 在 PR 中新增超标函数（复杂度为 5，未覆盖，CRAP = 5^2 * 1 + 5 = 30 > 16）
+    const newCode = `function baseFunc() { return 1; }
+baseFunc();
+
+function complexNew(a, b, c, d) {
+  if (a) return 1;
+  if (b) return 2;
+  if (c) return 3;
+  if (d) return 4;
+  return 0;
+}
+`
+    writeFileSync(pkgLib, newCode)
+    writeFileSync(join(dir, 'coverage/coverage-final.json'), JSON.stringify({
+      [pkgLib]: {
+        fnMap: {
+          '0': { loc: { start: { line: 1, column: 0 } } },
+          '1': { loc: { start: { line: 4, column: 0 } } },
+        },
+        f: { '0': 1, '1': 0 }, // complexNew 未覆盖
+      },
+    }))
+
+    const res = spawnSync(process.execPath, [SCRIPT, '--diff', 'HEAD'], { cwd: dir, encoding: 'utf8' })
+    assert.equal(res.status, 1, `新增超标函数必须 exit 1，实际输出：${res.stdout} ${res.stderr}`)
+    assert.match(res.stderr, /\[新增超标\]/)
+    assert.match(res.stderr, /complexNew/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('#592 crap-check --diff: 新增函数 CRAP 合规放行（exit 0）', () => {
+  const dir = setupGitFixture()
+  try {
+    const pkgLib = join(dir, 'packages/fake/lib/index.js')
+    writeFileSync(pkgLib, 'function baseFunc() { return 1; }\nbaseFunc();\n')
+    execFileSync('git', ['add', '.'], { cwd: dir, stdio: 'pipe' })
+    execFileSync('git', ['commit', '-m', 'initial commit'], { cwd: dir, stdio: 'pipe' })
+
+    // 在 PR 中新增合规函数（复杂度 2，未覆盖，CRAP = 2^2 * 1 + 2 = 6 <= 16）
+    const newCode = `function baseFunc() { return 1; }
+baseFunc();
+
+function simpleNew(a) {
+  if (a) return 1;
+  return 0;
+}
+`
+    writeFileSync(pkgLib, newCode)
+    writeFileSync(join(dir, 'coverage/coverage-final.json'), JSON.stringify({
+      [pkgLib]: {
+        fnMap: {
+          '0': { loc: { start: { line: 1, column: 0 } } },
+          '1': { loc: { start: { line: 4, column: 0 } } },
+        },
+        f: { '0': 1, '1': 0 },
+      },
+    }))
+
+    const res = spawnSync(process.execPath, [SCRIPT, '--diff', 'HEAD'], { cwd: dir, encoding: 'utf8' })
+    assert.equal(res.status, 0, `新增合规函数必须 exit 0，实际输出：${res.stdout} ${res.stderr}`)
+    assert.match(res.stdout, /OK - base=HEAD/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('#592 crap-check --diff: 修改存量超标函数导致复杂度恶化拦截（exit 1）', () => {
+  const dir = setupGitFixture()
+  try {
+    const pkgLib = join(dir, 'packages/fake/lib/index.js')
+    // base: 存量超标函数，复杂度 4，未覆盖，CRAP = 4^2 + 4 = 20 > 16
+    const baseCode = `function legacyHeavy(a, b, c) {
+  if (a) return 1;
+  if (b) return 2;
+  if (c) return 3;
+  return 0;
+}
+legacyHeavy();
+`
+    writeFileSync(pkgLib, baseCode)
+    execFileSync('git', ['add', '.'], { cwd: dir, stdio: 'pipe' })
+    execFileSync('git', ['commit', '-m', 'initial commit'], { cwd: dir, stdio: 'pipe' })
+
+    // PR 修改该函数，增加了分支，复杂度从 4 提升到 5（CRAP 恶化为 30）
+    const regressedCode = `function legacyHeavy(a, b, c, d) {
+  if (a) return 1;
+  if (b) return 2;
+  if (c) return 3;
+  if (d) return 4;
+  return 0;
+}
+legacyHeavy();
+`
+    writeFileSync(pkgLib, regressedCode)
+    writeFileSync(join(dir, 'coverage/coverage-final.json'), JSON.stringify({
+      [pkgLib]: {
+        fnMap: { '0': { loc: { start: { line: 1, column: 0 } } } },
+        f: { '0': 0 }, // 未覆盖
+      },
+    }))
+
+    const res = spawnSync(process.execPath, [SCRIPT, '--diff', 'HEAD'], { cwd: dir, encoding: 'utf8' })
+    assert.equal(res.status, 1, `存量恶化必须 exit 1，实际输出：${res.stdout} ${res.stderr}`)
+    assert.match(res.stderr, /\[存量恶化\]/)
+    assert.match(res.stderr, /legacyHeavy/)
+    assert.match(res.stderr, /CRAP 恶化: 20 -> 30/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('#592 crap-check --diff: 修改存量超标函数但复杂度降低/持平放行（exit 0）', () => {
+  const dir = setupGitFixture()
+  try {
+    const pkgLib = join(dir, 'packages/fake/lib/index.js')
+    // base: 存量超标函数，复杂度 5，未覆盖，CRAP = 5^2 + 5 = 30 > 16
+    const baseCode = `function legacyHeavy(a, b, c, d) {
+  if (a) return 1;
+  if (b) return 2;
+  if (c) return 3;
+  if (d) return 4;
+  return 0;
+}
+legacyHeavy();
+`
+    writeFileSync(pkgLib, baseCode)
+    execFileSync('git', ['add', '.'], { cwd: dir, stdio: 'pipe' })
+    execFileSync('git', ['commit', '-m', 'initial commit'], { cwd: dir, stdio: 'pipe' })
+
+    // PR 重构该函数，减少了分支，复杂度从 5 降为 4（CRAP 从 30 降为 20，虽仍 > 16 但防劣化放行）
+    const improvedCode = `function legacyHeavy(a, b, c) {
+  if (a) return 1;
+  if (b) return 2;
+  if (c) return 3;
+  return 0;
+}
+legacyHeavy();
+`
+    writeFileSync(pkgLib, improvedCode)
+    writeFileSync(join(dir, 'coverage/coverage-final.json'), JSON.stringify({
+      [pkgLib]: {
+        fnMap: { '0': { loc: { start: { line: 1, column: 0 } } } },
+        f: { '0': 0 },
+      },
+    }))
+
+    const res = spawnSync(process.execPath, [SCRIPT, '--diff', 'HEAD'], { cwd: dir, encoding: 'utf8' })
+    assert.equal(res.status, 0, `存量优化必须 exit 0 放行，实际输出：${res.stdout} ${res.stderr}`)
+    assert.match(res.stdout, /全部合规放行/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('#592 crap-check --diff: 未触及的存量超标函数全部豁免报警（exit 0）', () => {
+  const dir = setupGitFixture()
+  try {
+    const pkgLib = join(dir, 'packages/fake/lib/index.js')
+    // base 包含一个严重超标的存量函数和一个普通函数
+    const baseCode = `function untouchedHeavy(a, b, c, d, e) {
+  if (a) return 1;
+  if (b) return 2;
+  if (c) return 3;
+  if (d) return 4;
+  if (e) return 5;
+  return 0;
+}
+
+function touchedSmall(x) {
+  return x + 1;
+}
+untouchedHeavy();
+touchedSmall(1);
+`
+    writeFileSync(pkgLib, baseCode)
+    execFileSync('git', ['add', '.'], { cwd: dir, stdio: 'pipe' })
+    execFileSync('git', ['commit', '-m', 'initial commit'], { cwd: dir, stdio: 'pipe' })
+
+    // PR 只修改了 touchedSmall（未触及 untouchedHeavy）
+    const newCode = `function untouchedHeavy(a, b, c, d, e) {
+  if (a) return 1;
+  if (b) return 2;
+  if (c) return 3;
+  if (d) return 4;
+  if (e) return 5;
+  return 0;
+}
+
+function touchedSmall(x) {
+  if (x > 0) return x + 2;
+  return 0;
+}
+untouchedHeavy();
+touchedSmall(1);
+`
+    writeFileSync(pkgLib, newCode)
+    writeFileSync(join(dir, 'coverage/coverage-final.json'), JSON.stringify({
+      [pkgLib]: {
+        fnMap: {
+          '0': { loc: { start: { line: 1, column: 0 } } },
+          '1': { loc: { start: { line: 10, column: 0 } } },
+        },
+        f: { '0': 0, '1': 1 }, // touchedSmall covered (comp=2, CRAP=2 <= 16)
+      },
+    }))
+
+    const res = spawnSync(process.execPath, [SCRIPT, '--diff', 'HEAD'], { cwd: dir, encoding: 'utf8' })
+    assert.equal(res.status, 0, `未触及的存量超标函数必须豁免 exit 0，实际输出：${res.stdout} ${res.stderr}`)
+    assert.match(res.stdout, /全部合规放行/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('#592 crap-check --diff: 无相关代码变更时放行（exit 0）', () => {
+  const dir = setupGitFixture()
+  try {
+    writeFileSync(join(dir, 'README.md'), '# Initial README\n')
+    execFileSync('git', ['add', '.'], { cwd: dir, stdio: 'pipe' })
+    execFileSync('git', ['commit', '-m', 'initial commit'], { cwd: dir, stdio: 'pipe' })
+
+    // 仅修改 README
+    writeFileSync(join(dir, 'README.md'), '# Updated README\n')
+
+    const res = spawnSync(process.execPath, [SCRIPT, '--diff', 'HEAD'], { cwd: dir, encoding: 'utf8' })
+    assert.equal(res.status, 0, `无相关变更必须 exit 0，实际输出：${res.stdout} ${res.stderr}`)
+    assert.match(res.stdout, /未检测到插件包编译产物/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## 背景与改动说明

Partially addresses #592（阶段一：CRAP 门禁开启 `--diff` 增量防劣化）。

### 改动内容
1. 改造 `scripts/gate/crap-check.mjs`，增加 `--diff [base]` 参数支持：
   - 通过 `git diff -U0 ${base || 'origin/main'}` 获取变更文件及变更行号范围；
   - 过滤只对本次改动触及的函数进行 CRAP 评估（未触及的存量超标函数全部豁免）；
   - 新增函数：严格要求 `CRAP <= threshold`（默认 16），超标即 exit 1；
   - 修改的存量函数：严格要求不得恶化（`CRAP_new <= CRAP_base`），复杂度降低或持平放行 exit 0，恶化即 exit 1；
   - 保持非 `--diff` 模式原有行为（读取 `gauntlet.config.json`，strict=false 观察期仅落盘）。
2. 配套单元测试 `scripts/test/crap-check-diff.test.ts`：
   - 覆盖行号映射、新增函数超标拦截、新增函数合规放行、存量恶化拦截、存量重构降低复杂度放行、未触及存量超标函数豁免报警、无相关代码变更放行等 10 项单测用例。

### 验收全量断言表

| 验收条目 | 结论 | 证据或漂移解释 |
|---|---|---|
| 验收标准 1：`crap-check.mjs --diff` 增量定位变更函数，对合规改动 exit 0，对新增超标与存量恶化 fail-loud exit 1 | PASS | `scripts/test/crap-check-diff.test.ts` 10 项断言全部通过；退出码与 stderr 校验准确 |
| 验收标准 2：存量无劣化的改动与未触及存量超标函数豁免放行 | PASS | `scripts/test/crap-check-diff.test.ts` 存量优化与未触及豁免用例 exit 0；实际仓库运行验证 exit 0 |
| 验收标准 3：五连门禁与测试全量通过 | PASS | `pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 全部 PASS（退出码 0），`pnpm test:scripts` 186 用例全通过 |
