### PR TITLE
refactor(client): 客户端构建支持 TSX 语法与轻量 JSX 类型垫片

### DIFF
--- a/packages/dsh-codegraph/tsconfig.json
+++ b/packages/dsh-codegraph/tsconfig.json
@@ -6,6 +6,7 @@
     "rewriteRelativeImportExtensions": true
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "src/**/*.tsx"
   ]
 }

--- a/packages/dsh-lan-proxy/src/client/react-shim.d.ts
+++ b/packages/dsh-lan-proxy/src/client/react-shim.d.ts
@@ -5,3 +5,12 @@ declare module "react" {
   const React: any;
   export = React;
 }
+
+declare global {
+  namespace JSX {
+    interface Element extends any {}
+    interface IntrinsicElements {
+      [elemName: string]: any;
+    }
+  }
+}

--- a/packages/dsh-lan-proxy/tsconfig.json
+++ b/packages/dsh-lan-proxy/tsconfig.json
@@ -6,6 +6,7 @@
     "rewriteRelativeImportExtensions": true
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "src/**/*.tsx"
   ]
 }

--- a/packages/dsh-mcp-manager/src/client/react-shim.d.ts
+++ b/packages/dsh-mcp-manager/src/client/react-shim.d.ts
@@ -5,3 +5,12 @@ declare module "react" {
   const React: any;
   export = React;
 }
+
+declare global {
+  namespace JSX {
+    interface Element extends any {}
+    interface IntrinsicElements {
+      [elemName: string]: any;
+    }
+  }
+}

--- a/packages/dsh-mcp-manager/tsconfig.json
+++ b/packages/dsh-mcp-manager/tsconfig.json
@@ -6,6 +6,7 @@
     "rewriteRelativeImportExtensions": true
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "src/**/*.tsx"
   ]
 }

--- a/packages/dsh-mem0/src/client/react-shim.d.ts
+++ b/packages/dsh-mem0/src/client/react-shim.d.ts
@@ -2,3 +2,12 @@ declare module "react" {
   const React: any;
   export = React;
 }
+
+declare global {
+  namespace JSX {
+    interface Element extends any {}
+    interface IntrinsicElements {
+      [elemName: string]: any;
+    }
+  }
+}

--- a/packages/dsh-mem0/tsconfig.json
+++ b/packages/dsh-mem0/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "lib",
-    "jsx": "react",
     "rewriteRelativeImportExtensions": true
   },
   "include": [

--- a/packages/dsh-notifier/src/client/react-shim.d.ts
+++ b/packages/dsh-notifier/src/client/react-shim.d.ts
@@ -5,3 +5,12 @@ declare module "react" {
   const React: any;
   export = React;
 }
+
+declare global {
+  namespace JSX {
+    interface Element extends any {}
+    interface IntrinsicElements {
+      [elemName: string]: any;
+    }
+  }
+}

--- a/packages/dsh-notifier/tsconfig.json
+++ b/packages/dsh-notifier/tsconfig.json
@@ -6,6 +6,7 @@
     "rewriteRelativeImportExtensions": true
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "src/**/*.tsx"
   ]
 }

--- a/packages/dsh-provider-usage/src/client/react-shim.d.ts
+++ b/packages/dsh-provider-usage/src/client/react-shim.d.ts
@@ -53,3 +53,12 @@ declare module "react" {
     ...children: ReactNode[]
   ): ReactElement;
 }
+
+declare global {
+  namespace JSX {
+    interface Element extends any {}
+    interface IntrinsicElements {
+      [elemName: string]: any;
+    }
+  }
+}

--- a/packages/dsh-provider-usage/tsconfig.json
+++ b/packages/dsh-provider-usage/tsconfig.json
@@ -6,6 +6,7 @@
     "rewriteRelativeImportExtensions": true
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "src/**/*.tsx"
   ]
 }

--- a/packages/dsh-web-file-preview/tsconfig.json
+++ b/packages/dsh-web-file-preview/tsconfig.json
@@ -6,6 +6,7 @@
     "rewriteRelativeImportExtensions": true
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "src/**/*.tsx"
   ]
 }

--- a/scripts/build/bundle-host.ts
+++ b/scripts/build/bundle-host.ts
@@ -92,11 +92,15 @@ console.log(`[bundle-host] ${process.argv[2]}: shared 已内联（lib/index.js �
 
 // 1b. 客户端构建（有客户端源码时）：统一走共享预设 build-client
 // （注入 load id + 契约外壳生成 wrapper/legacy 双模式 + 内建「load id === 包名」校验）
-const clientSrc = existsSync(join(pkgDir, 'src', 'client.ts'))
-  ? join(pkgDir, 'src', 'client.ts')
-  : existsSync(join(pkgDir, 'src', 'client', 'index.ts'))
-    ? join(pkgDir, 'src', 'client', 'index.ts')
-    : null
+const clientSrc = existsSync(join(pkgDir, 'src', 'client.tsx'))
+  ? join(pkgDir, 'src', 'client.tsx')
+  : existsSync(join(pkgDir, 'src', 'client.ts'))
+    ? join(pkgDir, 'src', 'client.ts')
+    : existsSync(join(pkgDir, 'src', 'client', 'index.tsx'))
+      ? join(pkgDir, 'src', 'client', 'index.tsx')
+      : existsSync(join(pkgDir, 'src', 'client', 'index.ts'))
+        ? join(pkgDir, 'src', 'client', 'index.ts')
+        : null
 if (clientSrc) {
   const pkgJson = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'))
   const pkgName = pkgJson.name

--- a/scripts/test/build-client.test.ts
+++ b/scripts/test/build-client.test.ts
@@ -155,3 +155,68 @@ test('自动识别：源码 import React 不传 externals → 走 externals 路�
     assert.ok(ok, '自动 externals 产物契约通过')
   } finally { t.rm() }
 })
+
+test('TSX 语法支持：.tsx 客户端源码中 JSX 语法正确编译为 React.createElement 并符合契约', async () => {
+  const t = tempDir()
+  try {
+    const src = t.src('client.tsx', [
+      'import * as React from "react";',
+      'export const inject: string[] = [];',
+      'export function apply() {',
+      '  return () => <div className="test-settings-root"><span>Hello TSX</span></div>;',
+      '}',
+      '',
+    ].join('\n'))
+    const out = join(t.dir, 'client.js')
+    const { mode } = await buildClient({ src, outfile: out, packageName: PKG })
+    assert.equal(mode, 'wrapper')
+    const code = readFileSync(out, 'utf8')
+    assert.ok(/require\(["']react["']\)/.test(code), 'bare import react 应走 external require')
+    assert.ok(code.includes('createElement'), 'JSX 语法应被 esbuild 编译为 createElement 调用')
+    assert.ok(code.includes('test-settings-root'), 'JSX 属性应被保留')
+    const { ok, checks } = assertClientContract(PKG, code)
+    assert.ok(ok, `TSX 客户端产物契约校验失败: ${JSON.stringify(checks)}`)
+
+    // 运行时行为验证：注入 fake react 验证 createElement 正确执行
+    const factories = new Map()
+    const sandbox = { window: {}, console, Symbol, Object, Array, JSON, Math, Date, Promise, __ModuleLoader__: { load: (h) => factories.set(h.id, h.factory) } }
+    sandbox.window = sandbox
+    vm.createContext(sandbox)
+    vm.runInContext(code, sandbox)
+    const factory = factories.get(PKG)
+    const calls = []
+    const fakeReact = {
+      createElement: (type, props, ...children) => {
+        const elem = { type, props, children }
+        calls.push(elem)
+        return elem
+      },
+    }
+    const mod = factory((spec) => (spec === 'react' ? fakeReact : {}))
+    const render = mod.apply()
+    const vdom = render()
+    assert.ok(calls.length >= 2, 'JSX 嵌套应至少调用 2 次 createElement')
+    assert.equal(calls[calls.length - 1].type, 'div')
+    assert.equal(vdom.props.className, 'test-settings-root')
+  } finally { t.rm() }
+})
+
+test('TSX 语法支持：零依赖干净 .tsx 模块走 IIFE wrapper 并符合契约', async () => {
+  const t = tempDir()
+  try {
+    const src = t.src('client.tsx', [
+      'export const inject: string[] = [];',
+      'export function apply() {',
+      '  return () => "tsx-clean";',
+      '}',
+      '',
+    ].join('\n'))
+    const out = join(t.dir, 'client.js')
+    const { mode } = await buildClient({ src, outfile: out, packageName: PKG })
+    assert.equal(mode, 'wrapper')
+    const code = readFileSync(out, 'utf8')
+    const { ok, checks } = assertClientContract(PKG, code)
+    assert.ok(ok, `零依赖 TSX 客户端产物契约校验失败: ${JSON.stringify(checks)}`)
+  } finally { t.rm() }
+})
+

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,7 @@
     "skipLibCheck": true,
     "declaration": true,
     "sourceMap": true,
+    "jsx": "react",
     "noEmitOnError": true,
     "useDefineForClassFields": true,
     "types": [


### PR DESCRIPTION
Partially addresses #584

### 改动说明
打通 TSX 客户端构建基础设施与类型声明，验证构建闭环；存量 3000+ 行既有手写代码保持不动，待后续阶段渐进采用与迁移：
1. **客户端构建入口探测**：修改 `scripts/build/bundle-host.ts`，扩展客户端源码入口探测逻辑，按优先级支持 `src/client.tsx`、`src/client.ts`、`src/client/index.tsx`、`src/client/index.ts`；
2. **轻量通配 JSX 类型声明**：在各客户端插件的 `src/client/react-shim.d.ts` 中增加全局 `JSX` 命名空间（`Element` 与 `IntrinsicElements` 通配 any），维持零运行时与类型库依赖；
3. **TypeScript 编译器支持**：在 `tsconfig.base.json` 的 `compilerOptions` 中添加 `"jsx": "react"`，并在各包 `tsconfig.json` 的 `include` 中放行 `"src/**/*.tsx"`；
4. **单测与断言覆盖**：在 `scripts/test/build-client.test.ts` 中增加对 `.tsx` 客户端源码构建及 JSX 语法编译打包为 `React.createElement` 的行为与契约验证断言。

### 验收断言表

| 验收条目 | 结论 | 证据或漂移解释 |
|---|---|---|
| 1. bundle-host 入口探测扩展支持 .tsx | PASS | scripts/build/bundle-host.ts:95-103，按优先级识别 client.tsx / client.ts / client/index.tsx / client/index.ts |
| 2. 轻量通配 JSX 类型声明就位 | PASS | packages/dsh-*/src/client/react-shim.d.ts 补齐 declare global JSX 命名空间，零外部依赖 |
| 3. tsconfig 支持 JSX 与 include TSX | PASS | tsconfig.base.json 配置 "jsx": "react"，各包 tsconfig.json include 放行 "src/**/*.tsx" |
| 4. build-client 单测验证 TSX 语法与契约闭环 | PASS | scripts/test/build-client.test.ts 8 个测试全部 PASS（含 TSX 语法编译验证与零依赖 wrapper 验证） |
| 5. 存量各包构建不受任何负面影响 | PASS | 存量 6 个客户端包与纯宿主包 pnpm build 产物与契约校验完全一致 |
| 6. 本地五连门禁全绿 | PASS | pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck 全部通过（退出码 0） |
