### PR TITLE
fix(provider-usage): 用量报告统一按已闭环上一周期统计并升级提示词语义块 (#600)

### DIFF
--- a/packages/dsh-provider-usage/src/apply.ts
+++ b/packages/dsh-provider-usage/src/apply.ts
@@ -54,7 +54,7 @@ import { TrendTracker } from "./trend/index.ts";
 import { metricValue } from "./trend/aggregator.ts";
 import { sumToken, type TrendCell } from "./trend/types.ts";
 // #503 会话用量报告（M3 接线）：调度/生成/落盘/路由
-import { candidateWindow, presetLastRunForNewlyEnabled, type DueReport } from "./report/schedule.ts";
+import { candidateWindow, presetLastRunForNewlyEnabled, previousClosedWindow, type DueReport } from "./report/schedule.ts";
 import { normalizeReportConfig, promptFor, readReportConfig, writeReportConfig, DEFAULT_PROMPTS, type ReportConfig, type ReportPeriod } from "./report/config.ts";
 import { ReportScheduler, readLastRun, writeLastRun } from "./report/scheduler.ts";
 import { generateReport, buildStatsSnapshot, type ReportMeta, type ReportMetaSummary, type ReportStatsSnapshot } from "./report/generate.ts";
@@ -1266,8 +1266,8 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
       if (typeof period !== "string" || !REPORT_PERIODS.has(period as ReportPeriod)) {
         return writeJson(res, 400, { error: "invalid-period" });
       }
-      // 候选窗口（不检查 enabled：手动生成为用户主动行为；UI 空态亦引导「立即手动生成」）
-      const due = candidateWindow(period as ReportPeriod, reportCfg, Date.now());
+      // 手动生成恒定锚定已闭环的上一完整周期（日报=昨天全天，消灭凌晨漂移；不检查 enabled）
+      const due = previousClosedWindow(period as ReportPeriod, reportCfg, Date.now());
       try {
         const meta = await reportMutex.runExclusive(() => runDue(due));
         // 成功推进 lastRun（读改写：调度器同窗不再重复生成——防 tick 双生成）

--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -84,7 +84,7 @@ export { parseHHMM, normalizeReportConfig, DEFAULT_REPORT_CONFIG, DEFAULT_PROMPT
 export type { ReportConfig, ReportPeriod, ReportPeriodConfig } from "./report/config.ts";
 export { generateReport, applyPromptTemplate, buildStatsSnapshot } from "./report/generate.ts";
 export { reportBodyToHtml } from "./report/format.ts";
-export { DEFAULT_DAILY_PROMPT, DEFAULT_WEEKLY_PROMPT, DEFAULT_MONTHLY_PROMPT, DEFAULT_PROMPTS, LEGACY_PROMPT_TEMPLATE, LEGACY_DAILY_PROMPT_V1, LEGACY_WEEKLY_PROMPT_V1, LEGACY_MONTHLY_PROMPT_V1, promptFor } from "./report/config.ts";
+export { DEFAULT_DAILY_PROMPT, DEFAULT_WEEKLY_PROMPT, DEFAULT_MONTHLY_PROMPT, DEFAULT_PROMPTS, LEGACY_PROMPT_TEMPLATE, LEGACY_DAILY_PROMPT_V1, LEGACY_WEEKLY_PROMPT_V1, LEGACY_MONTHLY_PROMPT_V1, LEGACY_DAILY_PROMPT_V2, LEGACY_WEEKLY_PROMPT_V2, LEGACY_MONTHLY_PROMPT_V2, promptFor } from "./report/config.ts";
 export type { ReportPrompts } from "./report/config.ts";
 export type { ReportMeta, ReportResult, ReportStatsSnapshot, ReportLlmService, ReportTokenUsage } from "./report/generate.ts";
 export { ReportScheduler } from "./report/scheduler.ts";

--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -78,13 +78,13 @@ export { TrendStore } from "./trend/store.ts";
 export { TREND_ROW_VERSION, TREND_UNIDENTIFIED, sumToken, isValidShardRow, safeToken, safeId } from "./trend/types.ts";
 export type { TrendAttribution, TrendTokens, TrendDetailRow, TrendCounterRow, TrendAggRow, TrendCell } from "./trend/types.ts";
 // #503 会话用量报告（M3 接线）：report 模块公共面（测试/外部消费者从 lib/index.js 导入）
-export { candidateWindow, pendingReports, presetLastRunForNewlyEnabled } from "./report/schedule.ts";
+export { candidateWindow, pendingReports, presetLastRunForNewlyEnabled, previousClosedWindow } from "./report/schedule.ts";
 export type { DueReport } from "./report/schedule.ts";
 export { parseHHMM, normalizeReportConfig, DEFAULT_REPORT_CONFIG, DEFAULT_PROMPT_TEMPLATE, readReportConfig, writeReportConfig, reportConfigFile } from "./report/config.ts";
 export type { ReportConfig, ReportPeriod, ReportPeriodConfig } from "./report/config.ts";
 export { generateReport, applyPromptTemplate, buildStatsSnapshot } from "./report/generate.ts";
 export { reportBodyToHtml } from "./report/format.ts";
-export { DEFAULT_DAILY_PROMPT, DEFAULT_WEEKLY_PROMPT, DEFAULT_MONTHLY_PROMPT, DEFAULT_PROMPTS, LEGACY_PROMPT_TEMPLATE, promptFor } from "./report/config.ts";
+export { DEFAULT_DAILY_PROMPT, DEFAULT_WEEKLY_PROMPT, DEFAULT_MONTHLY_PROMPT, DEFAULT_PROMPTS, LEGACY_PROMPT_TEMPLATE, LEGACY_DAILY_PROMPT_V1, LEGACY_WEEKLY_PROMPT_V1, LEGACY_MONTHLY_PROMPT_V1, promptFor } from "./report/config.ts";
 export type { ReportPrompts } from "./report/config.ts";
 export type { ReportMeta, ReportResult, ReportStatsSnapshot, ReportLlmService, ReportTokenUsage } from "./report/generate.ts";
 export { ReportScheduler } from "./report/scheduler.ts";

--- a/packages/dsh-provider-usage/src/report/config.ts
+++ b/packages/dsh-provider-usage/src/report/config.ts
@@ -59,17 +59,8 @@ export const LEGACY_PROMPT_TEMPLATE = [
   "{stats}",
 ].join("\n");
 
-// #544 默认提示词（三周期统一年报叙事风格：把真实数值翻译成生活画面；{stats} 占位统一）。
-// 评审定稿（风格 + 工程双维度对抗评审）：核心纪律——
-// 1) 全局 null 降级：字段为 null/缺失即跳过，绝不输出 null/0/NaN，也不当 0 处理
-//    （单次生成无重试，弱模型遇 null 高频原样写出或当 0 编造）；
-// 2) 推算边界：除占比与倍数外不得推算；占比分母口径 = totals.total（非 null 且 > 0），
-//    否则改 calls 口径，再否则不提；百分比取整、倍数一位小数；
-// 3) cacheRead 语义是「缓存读取的 token 数」而非「命中次数」（防「命中 N 次」事实错误）；
-// 4) 日期/星期一律以 JSON 为准（UTC 键），禁按本地时区推断；
-// 5) 渲染白名单 ##/-/**：日报禁 ##、全部禁编号列表与代码围栏（弱模型高频自发输出）；
-// 6) 「示例仅示意」防逐字照搬；月报反煽情红线 + 超字先砍修饰句。
-export const DEFAULT_DAILY_PROMPT = [
+/** v0.3.x 旧版三周期默认提示词（#544 年报化初版，包含“当日/今天”、“本周”、“本月”；迁移判定基准，文本勿改动）。 */
+export const LEGACY_DAILY_PROMPT_V1 = [
   "你是「AI 用量年报」主笔。{stats} 注入的是用户当日的用量统计 JSON。",
   "请用第二人称写一段 80–150 字的中文日报，像音乐 App 年报里的「单日一页」：有画面、有温度，但每个数字都来自 JSON。字数宁取中段，避免顶格。",
   "写法（按顺序）：",
@@ -80,7 +71,7 @@ export const DEFAULT_DAILY_PROMPT = [
   "硬规则：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时直接跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。数据稀疏时用一句有动作感的轻句带过次数（手法示意，禁止编造），不堆砌抒情。标记仅可用 **加粗** 与 - 列表；禁止小标题、编号列表与代码围栏。日期以 JSON 为准。时间尺度以「今天」为准。",
 ].join("\n");
 
-export const DEFAULT_WEEKLY_PROMPT = [
+export const LEGACY_WEEKLY_PROMPT_V1 = [
   "你是「AI 用量年报」主笔。{stats} 注入的是用户本周的用量统计 JSON。",
   "请用第二人称写一份 200–300 字的中文周报，像音乐 App 年报的「每周一页」：娓娓道来，每个数字都来自 JSON。全文只允许两个小标题，宁少勿多。",
   "## 本周",
@@ -91,7 +82,7 @@ export const DEFAULT_WEEKLY_PROMPT = [
   "硬规则：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。日期与星期一律以 JSON 为准，不要按本地时区推断或自行推日历。标记仅可用 ##、-、**；禁止编号列表与代码围栏。超字数先删修饰句，不删数据句。时间尺度以「这一周」为准；数据稀疏时收窄叙事、平实收笔。",
 ].join("\n");
 
-export const DEFAULT_MONTHLY_PROMPT = [
+export const LEGACY_MONTHLY_PROMPT_V1 = [
   "你是「AI 用量年报」主笔。{stats} 注入的是用户本月的用量统计 JSON。",
   "请用第二人称写一份 400–600 字的中文月报，像音乐 App 的年度听歌报告：有画面、有温度、有仪式感，每个数字都来自 JSON。小标题自拟（4–8 字，如「被省下的重复」「一直在线的那位」——仅示意结构，禁止照抄），全文四到五节。",
   "开场（无标题）：两句金句，从 activeDays/windowDays、longestStreak 与 wowRatio（非 null 时）中挑一两个最打动人的事实起笔。",
@@ -100,6 +91,50 @@ export const DEFAULT_MONTHLY_PROMPT = [
   "被省下的重复：totals.cacheRead 与 totals.total 均非 null 且分母大于 0 时，写缓存读取占比（百分比取整）背后的省力感；否则跳过本段，改写 totals.toolCalls 与 totals.turns 各一笔。",
   "结语：两句寄语，至少复用开场的一个意象或一个数字；禁止「愿你我……」「致敬每一位……」式套话。",
   "硬规则：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。日期与星期一律以 JSON 为准，不要按本地时区推断，也不要质疑 JSON 里的月份边界。标记仅可用 ##、-、**；禁止编号列表与代码围栏。超字数先删修饰句，不删数据句。数据稀疏的月份收窄叙事、平实收笔，不堆砌抒情。时间尺度以「这个月」为准。",
+].join("\n");
+
+// #544 默认提示词（三周期统一年报叙事风格：把真实数值翻译成生活画面；{stats} 占位统一）。
+// 评审定稿（风格 + 工程双维度对抗评审）：核心纪律——
+// 1) 全局 null 降级：字段为 null/缺失即跳过，绝不输出 null/0/NaN，也不当 0 处理
+//    （单次生成无重试，弱模型遇 null 高频原样写出或当 0 编造）；
+// 2) 推算边界：除占比与倍数外不得推算；占比分母口径 = totals.total（非 null 且 > 0），
+//    否则改 calls 口径，再否则不提；百分比取整、倍数一位小数；
+// 3) cacheRead 语义是「缓存读取的 token 数」而非「命中次数」（防「命中 N 次」事实错误）；
+// 4) 日期/星期一律以 JSON 为准（UTC 键），禁按本地时区推断；
+// 5) 渲染白名单 ##/-/**：日报禁 ##、全部禁编号列表与代码围栏（弱模型高频自发输出）；
+// 6) 「示例仅示意」防逐字照搬；月报反煽情红线 + 超字先砍修饰句；
+// 7) 统一“上一个周期”时间尺度：日报=昨天、周报=上周、月报=上个月。
+export const DEFAULT_DAILY_PROMPT = [
+  "你是「AI 用量年报」主笔。{stats} 注入的是用户昨日（前一天）的用量统计 JSON。",
+  "请用第二人称写一段 80–150 字的中文日报，像音乐 App 年报里的「单日一页」：有画面、有温度，但每个数字都来自 JSON。字数宁取中段，避免顶格。",
+  "写法（按顺序）：",
+  "- 开场一句：把 totals.calls（对话次数）或 totals.total（总 token 数）放进一个生活化场景。某一项为 null 时改用另一项。",
+  "- 中间点一个最出画面的细节，只写一个：优先选能换算成时间或体量的数字——totals.cacheRead（缓存读取的 token 数，即「少打的字」）、totals.toolCalls（工具调用次数）、或最常用模型（byProvider 第一位，名称原样引用）。",
+  "- wowRatio 非 null 时，把升降翻成体感（约是上一期的 X 倍：大于 1 为增、小于 1 为减），可并入开场句；为 null 则完全不提对比。",
+  "- 收尾一句轻的寄语；字数已到上限时，寄语与对比句二选一。",
+  "硬规则：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时直接跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。数据稀疏时用一句有动作感的轻句带过次数（手法示意，禁止编造），不堆砌抒情。标记仅可用 **加粗** 与 - 列表；禁止小标题、编号列表与代码围栏。日期以 JSON 为准。时间尺度以「昨天」为准。",
+].join("\n");
+
+export const DEFAULT_WEEKLY_PROMPT = [
+  "你是「AI 用量年报」主笔。{stats} 注入的是用户上周（过去一周）的用量统计 JSON。",
+  "请用第二人称写一份 200–300 字的中文周报，像音乐 App 年报的「每周一页」：娓娓道来，每个数字都来自 JSON。全文只允许两个小标题，宁少勿多。",
+  "## 上周",
+  "一段金句开场加要点列表。开场按优先序挑一个最亮眼的事实落笔：wowRatio 明显偏离 1（为 null 则跳过此项）→ longestStreak 达到 4 天以上 → activeDays/windowDays 出勤率（可写成 5/7 形式）；三个都不亮眼时，用 activeDays 平实开场。",
+  "用 - 列表写一至两条高光（字数紧张就减到一条）：峰值日 peakDay（哪天、当日总量；为 null 则跳过此条）；最常用的模型（byProvider 第一位，名称原样引用，不翻译不补全）。占比仅在可计算时给出：第一位 total ÷ totals.total，两者均非 null 且分母大于 0，百分比取整；否则改用 calls 口径，再否则不提占比。",
+  "## 结语",
+  "一句对上周节奏的观察加一句寄语：byWeekday 最高与次高接近、或全周接近 0 时，改为一句中性的整体观察，不硬找「最勤的一天」。",
+  "硬规则：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。日期与星期一律以 JSON 为准，不要按本地时区推断或自行推日历。标记仅可用 ##、-、**；禁止编号列表与代码围栏。超字数先删修饰句，不删数据句。时间尺度以「上周」为准；数据稀疏时收窄叙事、平实收笔。",
+].join("\n");
+
+export const DEFAULT_MONTHLY_PROMPT = [
+  "你是「AI 用量年报」主笔。{stats} 注入的是用户上月（上一自然月）的用量统计 JSON。",
+  "请用第二人称写一份 400–600 字的中文月报，像音乐 App 的年度听歌报告：有画面、有温度、有仪式感，每个数字都来自 JSON。小标题自拟（4–8 字，如「被省下的重复」「一直在线的那位」——仅示意结构，禁止照抄），全文四到五节。",
+  "开场（无标题）：两句金句，从 activeDays/windowDays、longestStreak 与 wowRatio（非 null 时）中挑一两个最打动人的事实起笔。",
+  "高光时刻：peakDay 那天的故事——当日总量是多少；avgPerActiveDay 非 null 且大于 0 时给倍数（保留一位小数或「约 N 倍」），否则只报绝对值。peakDay 为 null 时整节收缩为一句活跃天数。",
+  "一直在线的那位：byProvider 拟人化——最依赖的模型是谁、承担的比例（分母口径与取整规则同下）；仅一个模型时集中写它，不提「其他」；名称原样引用，不翻译、不补全、不解读含义。",
+  "被省下的重复：totals.cacheRead 与 totals.total 均非 null 且分母大于 0 时，写缓存读取占比（百分比取整）背后的省力感；否则跳过本段，改写 totals.toolCalls 与 totals.turns 各一笔。",
+  "结语：两句寄语，至少复用开场的一个意象或一个数字；禁止「愿你我……」「致敬每一位……」式套话。",
+  "硬规则：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。日期与星期一律以 JSON 为准，不要按本地时区推断，也不要质疑 JSON 里的月份边界。标记仅可用 ##、-、**；禁止编号列表与代码围栏。超字数先删修饰句，不删数据句。数据稀疏的月份收窄叙事、平实收笔，不堆砌抒情。时间尺度以「上个月」为准。",
 ].join("\n");
 
 /** 默认提示词模板表。 */
@@ -117,7 +152,7 @@ export const DEFAULT_PROMPT_TEMPLATE = DEFAULT_MONTHLY_PROMPT;
 
 /** 默认报告配置。 */
 export const DEFAULT_REPORT_CONFIG: ReportConfig = {
-  daily: { enabled: false, time: "22:00" },
+  daily: { enabled: false, time: "08:00" },
   weekly: { enabled: false, time: "09:00", weekStartsOn: 1 },
   monthly: { enabled: false, time: "09:00", dayOfMonth: 1 },
   provider: "",
@@ -148,9 +183,11 @@ function normalizePeriod(raw: unknown, dflt: ReportPeriodConfig): ReportPeriodCo
   };
 }
 
-/** 单模板归一化（非空字符串且 ≤20000 用之，否则回退该周期默认）。 */
-function normalizePrompt(raw: unknown, dflt: string): string {
-  return typeof raw === "string" && raw.trim().length > 0 && raw.length <= 20000 ? raw : dflt;
+/** 单模板归一化（非空字符串且 ≤20000 用之；若严格等于旧版默认模板则自动升级新版；否则回退该周期默认）。 */
+function normalizePrompt(raw: unknown, dflt: string, legacyV1?: string): string {
+  if (typeof raw !== "string" || raw.trim().length === 0 || raw.length > 20000) return dflt;
+  if (legacyV1 !== undefined && raw === legacyV1) return dflt;
+  return raw;
 }
 
 /**
@@ -159,7 +196,7 @@ function normalizePrompt(raw: unknown, dflt: string): string {
  * - 旧值为自定义文本 → 三周期均以该文本起始（用户文本不丢，自行按周期微调）。
  */
 function migrateLegacyPrompt(legacy: string): ReportPrompts {
-  if (legacy === LEGACY_PROMPT_TEMPLATE) return { ...DEFAULT_PROMPTS };
+  if (legacy === LEGACY_PROMPT_TEMPLATE || legacy === LEGACY_MONTHLY_PROMPT_V1) return { ...DEFAULT_PROMPTS };
   return { daily: legacy, weekly: legacy, monthly: legacy };
 }
 
@@ -169,7 +206,7 @@ function legacyPromptOf(src: Record<string, unknown>): string | null {
   return typeof v === "string" && v.trim().length > 0 && v.length <= 20000 ? v : null;
 }
 
-/** 校验并归一化报告配置（非法值回退默认；旧单模板自动迁移为三周期表）。 */
+/** 校验并归一化报告配置（非法值回退默认；旧单模板自动迁移为三周期表；未自定义的旧三周期模板平滑升级）。 */
 export function normalizeReportConfig(raw: unknown): ReportConfig {
   const src = (typeof raw === "object" && raw !== null ? raw : {}) as Record<string, unknown>;
   const weeklySrc = (typeof src.weekly === "object" && src.weekly !== null ? src.weekly : {}) as Record<string, unknown>;
@@ -183,9 +220,9 @@ export function normalizeReportConfig(raw: unknown): ReportConfig {
   const promptsSrc = (typeof src.prompts === "object" && src.prompts !== null ? src.prompts : null) as Record<string, unknown> | null;
   const prompts: ReportPrompts = promptsSrc !== null
     ? {
-        daily: normalizePrompt(promptsSrc.daily, d.promptTemplate),
-        weekly: normalizePrompt(promptsSrc.weekly, d.promptTemplate),
-        monthly: normalizePrompt(promptsSrc.monthly, d.promptTemplate),
+        daily: normalizePrompt(promptsSrc.daily, d.prompts.daily, LEGACY_DAILY_PROMPT_V1),
+        weekly: normalizePrompt(promptsSrc.weekly, d.prompts.weekly, LEGACY_WEEKLY_PROMPT_V1),
+        monthly: normalizePrompt(promptsSrc.monthly, d.prompts.monthly, LEGACY_MONTHLY_PROMPT_V1),
       }
     : migrateLegacyPrompt(legacyPromptOf(src) ?? LEGACY_PROMPT_TEMPLATE);
   return {

--- a/packages/dsh-provider-usage/src/report/config.ts
+++ b/packages/dsh-provider-usage/src/report/config.ts
@@ -59,7 +59,7 @@ export const LEGACY_PROMPT_TEMPLATE = [
   "{stats}",
 ].join("\n");
 
-/** v0.3.x 旧版三周期默认提示词（#544 年报化初版，包含“当日/今天”、“本周”、“本月”；迁移判定基准，文本勿改动）。 */
+/** v0.3.x 旧版三周期默认提示词（#544 年报化初版单段，包含“当日/今天”、“本周”、“本月”；迁移判定基准，文本勿改动）。 */
 export const LEGACY_DAILY_PROMPT_V1 = [
   "你是「AI 用量年报」主笔。{stats} 注入的是用户当日的用量统计 JSON。",
   "请用第二人称写一段 80–150 字的中文日报，像音乐 App 年报里的「单日一页」：有画面、有温度，但每个数字都来自 JSON。字数宁取中段，避免顶格。",
@@ -93,7 +93,41 @@ export const LEGACY_MONTHLY_PROMPT_V1 = [
   "硬规则：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。日期与星期一律以 JSON 为准，不要按本地时区推断，也不要质疑 JSON 里的月份边界。标记仅可用 ##、-、**；禁止编号列表与代码围栏。超字数先删修饰句，不删数据句。数据稀疏的月份收窄叙事、平实收笔，不堆砌抒情。时间尺度以「这个月」为准。",
 ].join("\n");
 
-// #544 默认提示词（三周期统一年报叙事风格：把真实数值翻译成生活画面；{stats} 占位统一）。
+/** v0.3.x 第二版过渡单段提示词（对齐上一周期但未分块；迁移判定基准，文本勿改动）。 */
+export const LEGACY_DAILY_PROMPT_V2 = [
+  "你是「AI 用量年报」主笔。{stats} 注入的是用户昨日（前一天）的用量统计 JSON。",
+  "请用第二人称写一段 80–150 字的中文日报，像音乐 App 年报里的「单日一页」：有画面、有温度，但每个数字都来自 JSON。字数宁取中段，避免顶格。",
+  "写法（按顺序）：",
+  "- 开场一句：把 totals.calls（对话次数）或 totals.total（总 token 数）放进一个生活化场景。某一项为 null 时改用另一项。",
+  "- 中间点一个最出画面的细节，只写一个：优先选能换算成时间或体量的数字——totals.cacheRead（缓存读取的 token 数，即「少打的字」）、totals.toolCalls（工具调用次数）、或最常用模型（byProvider 第一位，名称原样引用）。",
+  "- wowRatio 非 null 时，把升降翻成体感（约是上一期的 X 倍：大于 1 为增、小于 1 为减），可并入开场句；为 null 则完全不提对比。",
+  "- 收尾一句轻的寄语；字数已到上限时，寄语与对比句二选一。",
+  "硬规则：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时直接跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。数据稀疏时用一句有动作感的轻句带过次数（手法示意，禁止编造），不堆砌抒情。标记仅可用 **加粗** 与 - 列表；禁止小标题、编号列表与代码围栏。日期以 JSON 为准。时间尺度以「昨天」为准。",
+].join("\n");
+
+export const LEGACY_WEEKLY_PROMPT_V2 = [
+  "你是「AI 用量年报」主笔。{stats} 注入的是用户上周（过去一周）的用量统计 JSON。",
+  "请用第二人称写一份 200–300 字的中文周报，像音乐 App 年报的「每周一页」：娓娓道来，每个数字都来自 JSON。全文只允许两个小标题，宁少勿多。",
+  "## 上周",
+  "一段金句开场加要点列表。开场按优先序挑一个最亮眼的事实落笔：wowRatio 明显偏离 1（为 null 则跳过此项）→ longestStreak 达到 4 天以上 → activeDays/windowDays 出勤率（可写成 5/7 形式）；三个都不亮眼时，用 activeDays 平实开场。",
+  "用 - 列表写一至两条高光（字数紧张就减到一条）：峰值日 peakDay（哪天、当日总量；为 null 则跳过此条）；最常用的模型（byProvider 第一位，名称原样引用，不翻译不补全）。占比仅在可计算时给出：第一位 total ÷ totals.total，两者均非 null 且分母大于 0，百分比取整；否则改用 calls 口径，再否则不提占比。",
+  "## 结语",
+  "一句对上周节奏的观察加一句寄语：byWeekday 最高与次高接近、或全周接近 0 时，改为一句中性的整体观察，不硬找「最勤的一天」。",
+  "硬规则：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。日期与星期一律以 JSON 为准，不要按本地时区推断或自行推日历。标记仅可用 ##、-、**；禁止编号列表与代码围栏。超字数先删修饰句，不删数据句。时间尺度以「上周」为准；数据稀疏时收窄叙事、平实收笔。",
+].join("\n");
+
+export const LEGACY_MONTHLY_PROMPT_V2 = [
+  "你是「AI 用量年报」主笔。{stats} 注入的是用户上月（上一自然月）的用量统计 JSON。",
+  "请用第二人称写一份 400–600 字的中文月报，像音乐 App 的年度听歌报告：有画面、有温度、有仪式感，每个数字都来自 JSON。小标题自拟（4–8 字，如「被省下的重复」「一直在线的那位」——仅示意结构，禁止照抄），全文四到五节。",
+  "开场（无标题）：两句金句，从 activeDays/windowDays、longestStreak 与 wowRatio（非 null 时）中挑一两个最打动人的事实起笔。",
+  "高光时刻：peakDay 那天的故事——当日总量是多少；avgPerActiveDay 非 null 且大于 0 时给倍数（保留一位小数或「约 N 倍」），否则只报绝对值。peakDay 为 null 时整节收缩为一句活跃天数。",
+  "一直在线的那位：byProvider 拟人化——最依赖的模型是谁、承担的比例（分母口径与取整规则同下）；仅一个模型时集中写它，不提「其他」；名称原样引用，不翻译、不补全、不解读含义。",
+  "被省下的重复：totals.cacheRead 与 totals.total 均非 null 且分母大于 0 时，写缓存读取占比（百分比取整）背后的省力感；否则跳过本段，改写 totals.toolCalls 与 totals.turns 各一笔。",
+  "结语：两句寄语，至少复用开场的一个意象或一个数字；禁止「愿你我……」「致敬每一位……」式套话。",
+  "硬规则：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。日期与星期一律以 JSON 为准，不要按本地时区推断，也不要质疑 JSON 里的月份边界。标记仅可用 ##、-、**；禁止编号列表与代码围栏。超字数先删修饰句，不删数据句。数据稀疏的月份收窄叙事、平实收笔，不堆砌抒情。时间尺度以「上个月」为准。",
+].join("\n");
+
+// #544 默认提示词（三周期统一年报叙事风格：中文轻量语义块 + 数据物理隔离 + 约束原子化）。
 // 评审定稿（风格 + 工程双维度对抗评审）：核心纪律——
 // 1) 全局 null 降级：字段为 null/缺失即跳过，绝不输出 null/0/NaN，也不当 0 处理
 //    （单次生成无重试，弱模型遇 null 高频原样写出或当 0 编造）；
@@ -105,36 +139,63 @@ export const LEGACY_MONTHLY_PROMPT_V1 = [
 // 6) 「示例仅示意」防逐字照搬；月报反煽情红线 + 超字先砍修饰句；
 // 7) 统一“上一个周期”时间尺度：日报=昨天、周报=上周、月报=上个月。
 export const DEFAULT_DAILY_PROMPT = [
-  "你是「AI 用量年报」主笔。{stats} 注入的是用户昨日（前一天）的用量统计 JSON。",
-  "请用第二人称写一段 80–150 字的中文日报，像音乐 App 年报里的「单日一页」：有画面、有温度，但每个数字都来自 JSON。字数宁取中段，避免顶格。",
-  "写法（按顺序）：",
+  "【任务目标】",
+  "你是「AI 用量年报」主笔。请根据下方提供的统计数据，以第二人称写一段 80–150 字的中文日报（字数宁取中段，避免顶格）。",
+  "风格类似音乐 App 年报里的「单日一页」：有画面、有温度，但每个数字都来自 JSON。字数宁取中段，避免顶格。",
+  "",
+  "【统计数据】",
+  "{stats}",
+  "",
+  "【撰写结构（按顺序）】",
   "- 开场一句：把 totals.calls（对话次数）或 totals.total（总 token 数）放进一个生活化场景。某一项为 null 时改用另一项。",
   "- 中间点一个最出画面的细节，只写一个：优先选能换算成时间或体量的数字——totals.cacheRead（缓存读取的 token 数，即「少打的字」）、totals.toolCalls（工具调用次数）、或最常用模型（byProvider 第一位，名称原样引用）。",
   "- wowRatio 非 null 时，把升降翻成体感（约是上一期的 X 倍：大于 1 为增、小于 1 为减），可并入开场句；为 null 则完全不提对比。",
   "- 收尾一句轻的寄语；字数已到上限时，寄语与对比句二选一。",
-  "硬规则：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时直接跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。数据稀疏时用一句有动作感的轻句带过次数（手法示意，禁止编造），不堆砌抒情。标记仅可用 **加粗** 与 - 列表；禁止小标题、编号列表与代码围栏。日期以 JSON 为准。时间尺度以「昨天」为准。",
+  "",
+  "【硬性约束（违背将视为严重错误）】",
+  "- 数据红线：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时直接跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。数据稀疏时用一句有动作感的轻句带过次数（手法示意，禁止编造），不堆砌抒情。",
+  "- 排版白名单：标记仅可用 **加粗** 与 - 列表；禁止小标题、编号列表与代码围栏。",
+  "- 事实基准：日期以 JSON 为准。时间尺度以「昨天」为准。",
 ].join("\n");
 
 export const DEFAULT_WEEKLY_PROMPT = [
-  "你是「AI 用量年报」主笔。{stats} 注入的是用户上周（过去一周）的用量统计 JSON。",
-  "请用第二人称写一份 200–300 字的中文周报，像音乐 App 年报的「每周一页」：娓娓道来，每个数字都来自 JSON。全文只允许两个小标题，宁少勿多。",
+  "【任务目标】",
+  "你是「AI 用量年报」主笔。请根据下方提供的统计数据，以第二人称写一份 200–300 字的中文周报，像音乐 App 年报的「每周一页」：娓娓道来，每个数字都来自 JSON。全文只允许两个小标题，宁少勿多。",
+  "",
+  "【统计数据】",
+  "{stats}",
+  "",
+  "【撰写结构】",
   "## 上周",
   "一段金句开场加要点列表。开场按优先序挑一个最亮眼的事实落笔：wowRatio 明显偏离 1（为 null 则跳过此项）→ longestStreak 达到 4 天以上 → activeDays/windowDays 出勤率（可写成 5/7 形式）；三个都不亮眼时，用 activeDays 平实开场。",
   "用 - 列表写一至两条高光（字数紧张就减到一条）：峰值日 peakDay（哪天、当日总量；为 null 则跳过此条）；最常用的模型（byProvider 第一位，名称原样引用，不翻译不补全）。占比仅在可计算时给出：第一位 total ÷ totals.total，两者均非 null 且分母大于 0，百分比取整；否则改用 calls 口径，再否则不提占比。",
   "## 结语",
   "一句对上周节奏的观察加一句寄语：byWeekday 最高与次高接近、或全周接近 0 时，改为一句中性的整体观察，不硬找「最勤的一天」。",
-  "硬规则：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。日期与星期一律以 JSON 为准，不要按本地时区推断或自行推日历。标记仅可用 ##、-、**；禁止编号列表与代码围栏。超字数先删修饰句，不删数据句。时间尺度以「上周」为准；数据稀疏时收窄叙事、平实收笔。",
+  "",
+  "【硬性约束（违背将视为严重错误）】",
+  "- 数据红线：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。分母大于 0 且两者均非 null 时方可计算占比。",
+  "- 排版白名单：标记仅可用 ##、-、**；禁止编号列表与代码围栏。超字数先删修饰句，不删数据句。",
+  "- 事实基准：日期与星期一律以 JSON 为准，不要按本地时区推断或自行推日历。时间尺度以「上周」为准；数据稀疏时收窄叙事、平实收笔。",
 ].join("\n");
 
 export const DEFAULT_MONTHLY_PROMPT = [
-  "你是「AI 用量年报」主笔。{stats} 注入的是用户上月（上一自然月）的用量统计 JSON。",
-  "请用第二人称写一份 400–600 字的中文月报，像音乐 App 的年度听歌报告：有画面、有温度、有仪式感，每个数字都来自 JSON。小标题自拟（4–8 字，如「被省下的重复」「一直在线的那位」——仅示意结构，禁止照抄），全文四到五节。",
+  "【任务目标】",
+  "你是「AI 用量年报」主笔。请根据下方提供的统计数据，以第二人称写一份 400–600 字的中文月报，像音乐 App 的年度听歌报告：有画面、有温度、有仪式感，每个数字都来自 JSON。小标题自拟（4–8 字，如「被省下的重复」「一直在线的那位」——仅示意结构，禁止照抄），全文四到五节。",
+  "",
+  "【统计数据】",
+  "{stats}",
+  "",
+  "【撰写结构】",
   "开场（无标题）：两句金句，从 activeDays/windowDays、longestStreak 与 wowRatio（非 null 时）中挑一两个最打动人的事实起笔。",
   "高光时刻：peakDay 那天的故事——当日总量是多少；avgPerActiveDay 非 null 且大于 0 时给倍数（保留一位小数或「约 N 倍」），否则只报绝对值。peakDay 为 null 时整节收缩为一句活跃天数。",
   "一直在线的那位：byProvider 拟人化——最依赖的模型是谁、承担的比例（分母口径与取整规则同下）；仅一个模型时集中写它，不提「其他」；名称原样引用，不翻译、不补全、不解读含义。",
   "被省下的重复：totals.cacheRead 与 totals.total 均非 null 且分母大于 0 时，写缓存读取占比（百分比取整）背后的省力感；否则跳过本段，改写 totals.toolCalls 与 totals.turns 各一笔。",
   "结语：两句寄语，至少复用开场的一个意象或一个数字；禁止「愿你我……」「致敬每一位……」式套话。",
-  "硬规则：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。日期与星期一律以 JSON 为准，不要按本地时区推断，也不要质疑 JSON 里的月份边界。标记仅可用 ##、-、**；禁止编号列表与代码围栏。超字数先删修饰句，不删数据句。数据稀疏的月份收窄叙事、平实收笔，不堆砌抒情。时间尺度以「上个月」为准。",
+  "",
+  "【硬性约束（违背将视为严重错误）】",
+  "- 数据红线：只依据 JSON，除占比与倍数外不得推算任何数值；字段为 null 或缺失时跳过该项，绝不输出 null/0/NaN，也不要当 0 处理。仅一个模型时集中写它，不提「其他」；分母大于 0 且非 null 时方计算百分比。",
+  "- 排版白名单：标记仅可用 ##、-、**；禁止编号列表与代码围栏。超字数先删修饰句，不删数据句。",
+  "- 事实基准：日期与星期一律以 JSON 为准，不要按本地时区推断，也不要质疑 JSON 里的月份边界。时间尺度以「上个月」为准。数据稀疏的月份收窄叙事、平实收笔，不堆砌抒情。",
 ].join("\n");
 
 /** 默认提示词模板表。 */
@@ -183,10 +244,10 @@ function normalizePeriod(raw: unknown, dflt: ReportPeriodConfig): ReportPeriodCo
   };
 }
 
-/** 单模板归一化（非空字符串且 ≤20000 用之；若严格等于旧版默认模板则自动升级新版；否则回退该周期默认）。 */
-function normalizePrompt(raw: unknown, dflt: string, legacyV1?: string): string {
+/** 单模板归一化（非空字符串且 ≤20000 用之；若严格等于任何旧版默认模板则自动升级新版；否则回退该周期默认）。 */
+function normalizePrompt(raw: unknown, dflt: string, legacyTemplates?: string[]): string {
   if (typeof raw !== "string" || raw.trim().length === 0 || raw.length > 20000) return dflt;
-  if (legacyV1 !== undefined && raw === legacyV1) return dflt;
+  if (legacyTemplates !== undefined && legacyTemplates.includes(raw)) return dflt;
   return raw;
 }
 
@@ -196,7 +257,11 @@ function normalizePrompt(raw: unknown, dflt: string, legacyV1?: string): string 
  * - 旧值为自定义文本 → 三周期均以该文本起始（用户文本不丢，自行按周期微调）。
  */
 function migrateLegacyPrompt(legacy: string): ReportPrompts {
-  if (legacy === LEGACY_PROMPT_TEMPLATE || legacy === LEGACY_MONTHLY_PROMPT_V1) return { ...DEFAULT_PROMPTS };
+  if (
+    legacy === LEGACY_PROMPT_TEMPLATE ||
+    legacy === LEGACY_MONTHLY_PROMPT_V1 ||
+    legacy === LEGACY_MONTHLY_PROMPT_V2
+  ) return { ...DEFAULT_PROMPTS };
   return { daily: legacy, weekly: legacy, monthly: legacy };
 }
 
@@ -220,9 +285,9 @@ export function normalizeReportConfig(raw: unknown): ReportConfig {
   const promptsSrc = (typeof src.prompts === "object" && src.prompts !== null ? src.prompts : null) as Record<string, unknown> | null;
   const prompts: ReportPrompts = promptsSrc !== null
     ? {
-        daily: normalizePrompt(promptsSrc.daily, d.prompts.daily, LEGACY_DAILY_PROMPT_V1),
-        weekly: normalizePrompt(promptsSrc.weekly, d.prompts.weekly, LEGACY_WEEKLY_PROMPT_V1),
-        monthly: normalizePrompt(promptsSrc.monthly, d.prompts.monthly, LEGACY_MONTHLY_PROMPT_V1),
+        daily: normalizePrompt(promptsSrc.daily, d.prompts.daily, [LEGACY_DAILY_PROMPT_V1, LEGACY_DAILY_PROMPT_V2]),
+        weekly: normalizePrompt(promptsSrc.weekly, d.prompts.weekly, [LEGACY_WEEKLY_PROMPT_V1, LEGACY_WEEKLY_PROMPT_V2]),
+        monthly: normalizePrompt(promptsSrc.monthly, d.prompts.monthly, [LEGACY_MONTHLY_PROMPT_V1, LEGACY_MONTHLY_PROMPT_V2]),
       }
     : migrateLegacyPrompt(legacyPromptOf(src) ?? LEGACY_PROMPT_TEMPLATE);
   return {

--- a/packages/dsh-provider-usage/src/report/schedule.ts
+++ b/packages/dsh-provider-usage/src/report/schedule.ts
@@ -2,9 +2,9 @@
  * dsh-provider-usage/report — 触发调度纯函数（#503 M3）。
  *
  * 语义（单一模型，三期统一）：
- * - 每期有「锚点触发时刻」：daily=当日 HH:MM；weekly=周起点日 HH:MM（覆盖紧邻的
- *   前 7 天）；monthly=月内 dayOfMonth 日 HH:MM（覆盖上一自然月）；
- * - 候选窗口 = 最近一次「锚点 <= now」的触发；其覆盖区间由 runAt 唯一推导；
+ * - 每期有「锚点触发时刻」：daily=当日 HH:MM（覆盖昨日全天）；weekly=周起点日 HH:MM（覆盖紧邻的前 7 天）；
+ *   monthly=月内 dayOfMonth 日 HH:MM（覆盖上一自然月）；
+ * - 候选窗口 = 最近一次「锚点 <= now」的触发；其覆盖区间由 runAt 唯一推导（均为已闭环的上一完整周期）；
  * - 幂等：lastRun[period] 存已生成的窗口键（日期序单调）；候选键 <= lastRun 即已扣期；
  * - 补跑：进程停机跨过锚点后重启，候选键 > lastRun 即自然补生成（只补最近一个，
  *   更早窗口不追溯——文档化口径）；
@@ -75,9 +75,11 @@ function addDays(dateKey: string, n: number): string {
  */
 export function candidateWindow(period: ReportPeriod, cfg: ReportConfig, now: number): DueReport {
   if (period === "daily") {
-    // 候选锚点日：now 已过当日时刻 → 当日（报告覆盖今天至今）；未过 → 昨日（全天）
-    const runDay = todayAt(now, cfg.daily.time) <= now ? dayKey(now) : addDays(dayKey(now), -1);
-    return { period, key: runDay, startDay: runDay, endDay: runDay };
+    // 候选锚点日：最近一次 <= now 的触发日（已过当日时刻为今日，未过为昨日）
+    const anchorDay = todayAt(now, cfg.daily.time) <= now ? dayKey(now) : addDays(dayKey(now), -1);
+    // 覆盖上一自然日（昨日全天）：[anchorDay-1, anchorDay-1]
+    const targetDay = addDays(anchorDay, -1);
+    return { period, key: targetDay, startDay: targetDay, endDay: targetDay };
   }
   if (period === "weekly") {
     const runAt = lastWeekAnchor(now, cfg.weekly.weekStartsOn, cfg.weekly.time);
@@ -92,6 +94,34 @@ export function candidateWindow(period: ReportPeriod, cfg: ReportConfig, now: nu
   // 覆盖上一自然月
   const start = new Date(runDate.getFullYear(), runDate.getMonth() - 1, 1);
   const end = new Date(runDate.getFullYear(), runDate.getMonth(), 0); // 本月 0 日 = 上月末
+  const key = `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, "0")}`;
+  return { period, key, startDay: dayKey(start.getTime()), endDay: dayKey(end.getTime()) };
+}
+
+/**
+ * 已闭环的上一完整周期窗口（手动生成专用：恒定取已结束的上一周期，不受定时触发时刻是否到达的约束）。
+ * - daily：恒为昨日全天 [today-1, today-1]；
+ * - weekly：恒为上一完整周（覆盖距今最近已闭环的前 7 天）；
+ * - monthly：恒为上一完整自然月 [上月1日, 上月末]。
+ */
+export function previousClosedWindow(period: ReportPeriod, cfg: ReportConfig, now: number): DueReport {
+  if (period === "daily") {
+    const yesterday = addDays(dayKey(now), -1);
+    return { period, key: yesterday, startDay: yesterday, endDay: yesterday };
+  }
+  if (period === "weekly") {
+    const d = new Date(now);
+    const back = (d.getDay() - cfg.weekly.weekStartsOn + 7) % 7;
+    d.setDate(d.getDate() - back);
+    const currentWeekStart = dayKey(d.getTime());
+    const start = addDays(currentWeekStart, -7);
+    const end = addDays(currentWeekStart, -1);
+    return { period, key: start, startDay: start, endDay: end };
+  }
+  // monthly
+  const d = new Date(now);
+  const start = new Date(d.getFullYear(), d.getMonth() - 1, 1);
+  const end = new Date(d.getFullYear(), d.getMonth(), 0);
   const key = `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, "0")}`;
   return { period, key, startDay: dayKey(start.getTime()), endDay: dayKey(end.getTime()) };
 }

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -40,6 +40,7 @@ import {
   apply,
   ROUTES,
   candidateWindow,
+  previousClosedWindow,
   ADAPTER_CONTRACT_VERSION,
   OPENCODE_GO_PROVIDER,
   OPENCODE_GO_ADAPTER_ID,
@@ -1682,9 +1683,8 @@ console.log("[smoke] #503 trend 挂接 + /trend 集成断言全部通过 ✓");
   }
 
   // f. 前置：合成一点趋势数据（生成「不入统计」断言的对照快照）
-  // #532：事件时间必须落在 daily 候选窗口内（runDay 依锚点可为昨日或今日；空窗口
-  // 现在会走 noData 短路，不再调模型）——取窗口 endDay 当日 12:00 本地时间合成。
-  const dueDaily = candidateWindow("daily", savedCfg.config, Date.now());
+  // 事件时间必须落在手动生成的闭环窗口内（昨日全天；空窗口会走 noData 短路不再调模型）
+  const dueDaily = previousClosedWindow("daily", savedCfg.config, Date.now());
   const [wy, wm, wd] = dueDaily.endDay.split("-").map(Number);
   const t = new Date(wy, wm - 1, wd, 12, 0, 0).getTime();
   const sess = { id: "sess-report" };
@@ -1730,11 +1730,11 @@ console.log("[smoke] #503 trend 挂接 + /trend 集成断言全部通过 ✓");
       ],
     });
     await apply(xssCtx.ctx, { ...ISOLATED_CONFIG, historyDir: join(xssDir, "hist") });
-    // #532：空窗口会 noData 短路不落盘——先向本 ctx 合成落在 daily 候选窗口内的用量
+    // #532：空窗口会 noData 短路不落盘——先向本 ctx 合成落在 daily 闭环窗口内的用量
     {
       const xssCfgRoute = xssCtx.routes.find((r) => r.path === ROUTES.reportConfig);
       const xssCfg = await callHandler(xssCfgRoute, fakeReq({ url: ROUTES.reportConfig }));
-      const xssDue = candidateWindow("daily", xssCfg.config, Date.now());
+      const xssDue = previousClosedWindow("daily", xssCfg.config, Date.now());
       const [xy, xm, xd] = xssDue.endDay.split("-").map(Number);
       const xt = new Date(xy, xm - 1, xd, 12, 0, 0).getTime();
       const xssSess = { id: "sess-xss" };

--- a/packages/dsh-provider-usage/test/unit-report.test.ts
+++ b/packages/dsh-provider-usage/test/unit-report.test.ts
@@ -21,6 +21,7 @@ import { tmpdir } from "node:os";
 import { assert } from "./helpers.ts";
 import {
   candidateWindow,
+  previousClosedWindow,
   pendingReports,
   presetLastRunForNewlyEnabled,
   parseHHMM,
@@ -31,6 +32,9 @@ import {
   DEFAULT_MONTHLY_PROMPT,
   DEFAULT_PROMPTS,
   LEGACY_PROMPT_TEMPLATE,
+  LEGACY_DAILY_PROMPT_V1,
+  LEGACY_WEEKLY_PROMPT_V1,
+  LEGACY_MONTHLY_PROMPT_V1,
   promptFor,
   reportBodyToHtml,
   sanitizeHtml,
@@ -98,14 +102,21 @@ const GEN = (over = {}) => ({
 
 {
   const cfg = CFG();
-  // daily：now 12:00 未过当日 22:00 → 候选=昨日全天
+  // daily：now 12:00 未过当日 22:00 → 最近已到达锚点为昨日 22:00，覆盖前日全天（2026-09-02）
   let due = candidateWindow("daily", cfg, T0);
-  assert.equal(due.key, "2026-09-03", "daily 未过锚点 → 昨日");
-  assert.equal(due.startDay, "2026-09-03", "daily 起于锚点日");
-  assert.equal(due.endDay, "2026-09-03", "daily 止于锚点日（单日窗口）");
-  // daily：now 已过当日 22:00 → 候选=当日
+  assert.equal(due.key, "2026-09-02", "daily 未过锚点 → 前日全天");
+  assert.equal(due.startDay, "2026-09-02", "daily 起于前日");
+  assert.equal(due.endDay, "2026-09-02", "daily 止于前日（单日窗口）");
+  // daily：now 23:00 已过当日 22:00 → 当日锚点已到达，覆盖昨日全天（2026-09-03）
   due = candidateWindow("daily", cfg, T0 + 11 * HOUR);
-  assert.equal(due.key, "2026-09-04", "daily 已过锚点 → 当日");
+  assert.equal(due.key, "2026-09-03", "daily 已过锚点 → 昨日全天");
+  assert.equal(due.startDay, "2026-09-03", "daily 起于昨日");
+  assert.equal(due.endDay, "2026-09-03", "daily 止于昨日");
+  // previousClosedWindow：手动生成专用——无论当前时刻是否过锚点，恒定生成昨天（2026-09-03），消灭凌晨漂移
+  const manualDue = previousClosedWindow("daily", cfg, T0);
+  assert.equal(manualDue.key, "2026-09-03", "手动生成恒为昨日全天");
+  assert.equal(manualDue.startDay, "2026-09-03", "手动生成起于昨日");
+  assert.equal(manualDue.endDay, "2026-09-03", "手动生成止于昨日");
   // weekly：2026-09-04 周五，本周锚点=周一 08-31 09:00（已过）→ 覆盖紧邻前 7 天 08-24..08-30
   due = candidateWindow("weekly", cfg, T0);
   assert.equal(due.key, "2026-08-24", "weekly 候选键=周起点-7（[runDay-7, runDay-1] 闭区间 7 天）");
@@ -126,13 +137,13 @@ const GEN = (over = {}) => ({
   const due = pendingReports(cfg, T0, {});
   assert.deepEqual(due.map((d) => d.period), ["daily", "weekly", "monthly"], "lastRun 空 → 三期全部补生成");
   // lastRun 已记候选键 → 扣期跳过
-  const lastRun = { daily: "2026-09-03", weekly: "2026-08-24", monthly: "2026-08" };
+  const lastRun = { daily: "2026-09-02", weekly: "2026-08-24", monthly: "2026-08" };
   assert.deepEqual(pendingReports(cfg, T0, lastRun), [], "候选键 <= lastRun → 已扣期");
   // lastRun 为更晚窗口 → 该期跳过（日期序单调，防回退重复生成）；未记录期照常补跑
   assert.ok(!pendingReports(cfg, T0, { daily: "2026-09-10" }).some((d) => d.period === "daily"), "lastRun 更晚 → 该期跳过");
-  // 跨过锚点（now 前移到次日）→ daily 新窗口补跑；weekly/monthly 无 lastRun 记录照常补跑
-  const nextDay = pendingReports(CFG(), T0 + 25 * HOUR, { daily: "2026-09-03" });
-  assert.deepEqual(nextDay.map((d) => d.period), ["daily", "weekly", "monthly"], "新锚点候选键 > lastRun → 补跑（未记录期同补）");
+  // 跨过锚点（now 前移到 23:00 跨过 22:00）→ daily 新窗口（2026-09-03）补跑；weekly/monthly 无 lastRun 记录照常补跑
+  const nextRun = pendingReports(CFG(), T0 + 11 * HOUR, { daily: "2026-09-02" });
+  assert.deepEqual(nextRun.map((d) => d.period), ["daily", "weekly", "monthly"], "新锚点候选键 > lastRun → 补跑（未记录期同补）");
   // enabled 关闭不调度
   const off = pendingReports(CFG({ weekly: { enabled: false, time: "09:00", weekStartsOn: 1 } }), T0, {});
   assert.ok(!off.some((d) => d.period === "weekly"), "weekly 关闭 → 不调度");
@@ -325,11 +336,32 @@ const GEN = (over = {}) => ({
   // 自定义旧模板 → 三周期以该文本起始（不丢用户文本）
   const custom = normalizeReportConfig({ promptTemplate: "我的自定义模板 {stats}" });
   assert.deepEqual(custom.prompts, { daily: "我的自定义模板 {stats}", weekly: "我的自定义模板 {stats}", monthly: "我的自定义模板 {stats}" }, "自定义旧模板三周期继承");
-  // 非法 prompts 值回退默认
+  // 存量老用户三周期旧默认提示词（V1：含“今天/本周/本月”）自动无损升级为新版默认（昨日/上周/上月）
+  const legacyV1 = normalizeReportConfig({
+    prompts: {
+      daily: LEGACY_DAILY_PROMPT_V1,
+      weekly: LEGACY_WEEKLY_PROMPT_V1,
+      monthly: LEGACY_MONTHLY_PROMPT_V1,
+    },
+  });
+  assert.equal(legacyV1.prompts.daily, DEFAULT_DAILY_PROMPT, "未自定义的旧版日报模板自动升级");
+  assert.equal(legacyV1.prompts.weekly, DEFAULT_WEEKLY_PROMPT, "未自定义的旧版周报模板自动升级");
+  assert.equal(legacyV1.prompts.monthly, DEFAULT_MONTHLY_PROMPT, "未自定义的旧版月报模板自动升级");
+  // 若老用户对日报有自定义修改，则保留自定义内容，不被覆写
+  const userCustomPrompts = normalizeReportConfig({
+    prompts: {
+      daily: "用户自定义日报：{stats}",
+      weekly: LEGACY_WEEKLY_PROMPT_V1,
+      monthly: LEGACY_MONTHLY_PROMPT_V1,
+    },
+  });
+  assert.equal(userCustomPrompts.prompts.daily, "用户自定义日报：{stats}", "自定义修改过的模板保留原样");
+  assert.equal(userCustomPrompts.prompts.weekly, DEFAULT_WEEKLY_PROMPT, "同时存在的未自定义周报仍平滑升级");
+  // 非法 prompts 值回退各周期自身默认模板
   const bad = normalizeReportConfig({ prompts: { daily: "", weekly: 42, monthly: "x".repeat(20001) } });
-  assert.equal(bad.prompts.daily, DEFAULT_MONTHLY_PROMPT, "空串回退默认（promptTemplate 默认=月报）");
-  assert.equal(bad.prompts.weekly, DEFAULT_MONTHLY_PROMPT, "非字符串回退默认");
-  assert.equal(bad.prompts.monthly, DEFAULT_MONTHLY_PROMPT, "超长回退默认");
+  assert.equal(bad.prompts.daily, DEFAULT_DAILY_PROMPT, "空串回退该周期默认");
+  assert.equal(bad.prompts.weekly, DEFAULT_WEEKLY_PROMPT, "非字符串回退该周期默认");
+  assert.equal(bad.prompts.monthly, DEFAULT_MONTHLY_PROMPT, "超长回退该周期默认");
   // promptFor 按周期取模板
   assert.equal(promptFor(n, "daily"), "日模板{stats}", "promptFor daily");
   assert.equal(promptFor(n, "weekly"), "周模板{stats}", "promptFor weekly");

--- a/packages/dsh-provider-usage/test/unit-report.test.ts
+++ b/packages/dsh-provider-usage/test/unit-report.test.ts
@@ -35,6 +35,9 @@ import {
   LEGACY_DAILY_PROMPT_V1,
   LEGACY_WEEKLY_PROMPT_V1,
   LEGACY_MONTHLY_PROMPT_V1,
+  LEGACY_DAILY_PROMPT_V2,
+  LEGACY_WEEKLY_PROMPT_V2,
+  LEGACY_MONTHLY_PROMPT_V2,
   promptFor,
   reportBodyToHtml,
   sanitizeHtml,
@@ -347,6 +350,17 @@ const GEN = (over = {}) => ({
   assert.equal(legacyV1.prompts.daily, DEFAULT_DAILY_PROMPT, "未自定义的旧版日报模板自动升级");
   assert.equal(legacyV1.prompts.weekly, DEFAULT_WEEKLY_PROMPT, "未自定义的旧版周报模板自动升级");
   assert.equal(legacyV1.prompts.monthly, DEFAULT_MONTHLY_PROMPT, "未自定义的旧版月报模板自动升级");
+  // 存量老用户过渡单段提示词（V2：未分块单段）同样自动升级为最新语义块结构
+  const legacyV2 = normalizeReportConfig({
+    prompts: {
+      daily: LEGACY_DAILY_PROMPT_V2,
+      weekly: LEGACY_WEEKLY_PROMPT_V2,
+      monthly: LEGACY_MONTHLY_PROMPT_V2,
+    },
+  });
+  assert.equal(legacyV2.prompts.daily, DEFAULT_DAILY_PROMPT, "V2 单段日报模板自动升级为语义块");
+  assert.equal(legacyV2.prompts.weekly, DEFAULT_WEEKLY_PROMPT, "V2 单段周报模板自动升级为语义块");
+  assert.equal(legacyV2.prompts.monthly, DEFAULT_MONTHLY_PROMPT, "V2 单段月报模板自动升级为语义块");
   // 若老用户对日报有自定义修改，则保留自定义内容，不被覆写
   const userCustomPrompts = normalizeReportConfig({
     prompts: {


### PR DESCRIPTION
Closes #600

### 改动背景
用户配置每天 06:00 触发日报时，系统统计的是当天凌晨 00:00 至 06:00 的 6 小时数据，导致昨天全天数据漏报，且当天触发时刻至午夜之间的数据成为永久无法闭环的暗账区。

### 核心改动
1. **调度与窗口计算重构（schedule.ts）**：
   - `candidateWindow` 中日报统一按已闭环的前一自然日（昨天全天 `[anchorDay-1, anchorDay-1]`）计算，消灭漏报与暗账；
   - 新增导出 `previousClosedWindow` 专供手动生成路由使用，解耦定时时刻与手动即时生成，消灭凌晨生成倒退漂移至前天的 bug。
2. **默认配置与提示词升级（config.ts）**：
   - 日报默认触发时刻由 22:00 优化为次晨 08:00（早间复盘昨日）；
   - 三周期提示词统一重构为【任务目标】【统计数据】【撰写结构】【硬性约束】中文轻量语义块；
   - 物理隔离 `{stats}`，原子化拆解硬约束；
   - 支持老版本 V1/V2 默认提示词静默平滑升级，同时严格保护用户自定义提示词。
3. **路由接线与测试覆盖（apply.ts / unit-report.test.ts / smoke.ts）**：
   - 手动生成路由使用 `previousClosedWindow`；
   - 单测覆盖已过/未过触发时刻候选窗口、手动生成专用断言、老配置平滑升级与自定义保护；
   - 本地全量门禁检查全绿。

### 验证状态
- `pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 全部通过。