### PR TITLE
fix(dsh-mem0): 修复路由注册签名不匹配与前端诊断异常静默

### DIFF
--- a/packages/dsh-mem0/src/client/MemoryCenter.ts
+++ b/packages/dsh-mem0/src/client/MemoryCenter.ts
@@ -87,16 +87,25 @@ export function MemoryCenter() {
   const [isSavingConfig, setIsSavingConfig] = useState(false);
   const [configMessage, setConfigMessage] = useState("");
   const [copiedCmd, setCopiedCmd] = useState(false);
+  const [apiError, setApiError] = useState(null as string | null);
 
   const fetchStatus = useCallback(async () => {
     try {
       const res = await fetch("/api/dsh-mem0/status");
-      if (res.ok) {
-        const data = (await res.json()) as StatusData;
-        setStatus(data);
+      if (!res.ok) {
+        setApiError(`HTTP ${res.status}`);
+        return;
       }
-    } catch {
-      // ignore
+      const contentType = res.headers.get("content-type") || "";
+      if (!contentType.includes("application/json")) {
+        setApiError("Invalid response format");
+        return;
+      }
+      const data = (await res.json()) as StatusData;
+      setApiError(null);
+      setStatus(data);
+    } catch (err: unknown) {
+      setApiError(err instanceof Error ? err.message : "Network Error");
     }
   }, []);
 
@@ -270,10 +279,34 @@ export function MemoryCenter() {
     ),
   );
 
-  // Diagnostic Banner (自愈引导)
+  // Diagnostic Banner (自愈与异常诊断引导)
   let diagBanner = null;
-  const reason = status.status?.reason;
-  if (!status.ready && reason) {
+  if (apiError) {
+    // 1. Transport 层故障：明确显示无法连接后端路由服务，仅提供“重试连接”
+    diagBanner = React.createElement(
+      "div",
+      { className: "dsh-mem0-diag-banner error", style: { display: "flex", alignItems: "center", width: "100%" } },
+      React.createElement("span", null, "❌ "),
+      React.createElement("span", null, msg("diagHttpError").replace("{status}", apiError)),
+      React.createElement(
+        "button",
+        {
+          className: "dsh-mem0-btn small",
+          style: { marginLeft: "auto" },
+          onClick: () => {
+            void fetchStatus();
+            void fetchConfig();
+            void fetchList(scope);
+          },
+        },
+        `🔄 ${msg("retryBtn")}`,
+      ),
+    );
+  } else if (!status.ready) {
+    // 2. Runtime 层状态
+    const reason = status.status?.reason;
+    const detail = status.status?.detail;
+
     if (reason === "python_not_found") {
       diagBanner = React.createElement(
         "div",
@@ -305,6 +338,13 @@ export function MemoryCenter() {
             copiedCmd ? msg("copied") : msg("copyCmd"),
           ),
         ),
+        detail
+          ? React.createElement(
+              "div",
+              { className: "dsh-mem0-diag-detail" },
+              `${msg("diagDetail")} ${detail}`,
+            )
+          : null,
         autoInstallMsg
           ? React.createElement(
               "div",
@@ -312,6 +352,53 @@ export function MemoryCenter() {
               autoInstallMsg,
             )
           : null,
+      );
+    } else if (reason === "process_exited") {
+      diagBanner = React.createElement(
+        "div",
+        { className: "dsh-mem0-diag-banner error", style: { flexDirection: "column", alignItems: "flex-start" } },
+        React.createElement(
+          "div",
+          { style: { display: "flex", alignItems: "center", gap: "8px", width: "100%" } },
+          React.createElement("span", null, "⚠️ "),
+          React.createElement("span", null, msg("diagProcessExited")),
+          React.createElement(
+            "button",
+            {
+              className: "dsh-mem0-btn small",
+              style: { marginLeft: "auto" },
+              onClick: () => {
+                void fetchStatus();
+              },
+            },
+            `🔄 ${msg("retryBtn")}`,
+          ),
+        ),
+        detail
+          ? React.createElement(
+              "div",
+              { className: "dsh-mem0-diag-detail" },
+              `${msg("diagDetail")} ${detail}`,
+            )
+          : null,
+      );
+    } else if (reason === "starting") {
+      diagBanner = React.createElement(
+        "div",
+        { className: "dsh-mem0-diag-banner info" },
+        React.createElement("span", null, "⏳ "),
+        React.createElement("span", null, msg("diagStarting")),
+      );
+    } else if (detail) {
+      diagBanner = React.createElement(
+        "div",
+        { className: "dsh-mem0-diag-banner warning", style: { flexDirection: "column", alignItems: "flex-start" } },
+        React.createElement("span", null, `⚠️ ${msg("statusOffline")}`),
+        React.createElement(
+          "div",
+          { className: "dsh-mem0-diag-detail" },
+          `${msg("diagDetail")} ${detail}`,
+        ),
       );
     }
   }

--- a/packages/dsh-mem0/src/client/locales.ts
+++ b/packages/dsh-mem0/src/client/locales.ts
@@ -64,6 +64,11 @@ export const zh = {
   // 自愈诊断
   diagPythonNotFound: "未检测到 Python 可执行程序，长期记忆已安全降级。请在宿主环境安装 Python 3.10+。",
   diagDepMissing: "检测到缺少 Python 依赖库，推荐点击下方按钮自动一键安装修复：",
+  diagProcessExited: "记忆引擎 Python 进程异常退出，服务当前离线。",
+  diagStarting: "记忆引擎正在启动与握手初始化，请稍候…",
+  diagHttpError: "无法连接记忆中心后端接口 ({status})，请检查服务状态。",
+  diagDetail: "错误详情：",
+  retryBtn: "重试连接",
   autoInstallBtn: "⚡ 自动安装依赖",
   autoInstallingBtn: "正在自动下载与配置环境…",
   autoInstallDone: "依赖环境已就绪，正在拉起记忆服务！",
@@ -142,6 +147,11 @@ export const en: Record<Mem0LocaleKey, string> = {
   // Self-healing Diagnostics
   diagPythonNotFound: "Python executable not detected. Memory is gracefully degraded. Please install Python 3.10+.",
   diagDepMissing: "Python dependencies missing. Click below to automatically install and resolve:",
+  diagProcessExited: "Memory engine Python process exited unexpectedly. Service is currently offline.",
+  diagStarting: "Memory engine is starting and initializing handshake, please wait...",
+  diagHttpError: "Cannot connect to memory backend endpoint ({status}). Please check service status.",
+  diagDetail: "Error Details:",
+  retryBtn: "Retry Connection",
   autoInstallBtn: "⚡ Auto Install Dependencies",
   autoInstallingBtn: "Downloading & Configuring Environment...",
   autoInstallDone: "Environment resolved! Starting memory service...",

--- a/packages/dsh-mem0/src/client/style.css
+++ b/packages/dsh-mem0/src/client/style.css
@@ -67,6 +67,27 @@
   color: var(--dsw-alias-warning-text, #92400e);
 }
 
+.dsh-mem0-diag-banner.error {
+  border: 1px solid var(--dsw-alias-error-border, rgba(239, 68, 68, 0.4));
+  background: var(--dsw-alias-error-bg, rgba(239, 68, 68, 0.08));
+  color: var(--dsw-alias-error, #ef4444);
+}
+
+.dsh-mem0-diag-banner.info {
+  border: 1px solid var(--dsw-alias-brand-border, rgba(37, 99, 235, 0.3));
+  background: var(--dsw-alias-brand-bg, rgba(37, 99, 235, 0.08));
+  color: var(--dsw-alias-brand, #2563eb);
+}
+
+.dsh-mem0-diag-detail {
+  font-family: monospace;
+  font-size: 11px;
+  margin-top: 4px;
+  word-break: break-all;
+  white-space: pre-wrap;
+  opacity: 0.85;
+}
+
 .dsh-mem0-code {
   padding: 2px 6px;
   border-radius: 4px;

--- a/packages/dsh-mem0/src/index.ts
+++ b/packages/dsh-mem0/src/index.ts
@@ -174,8 +174,9 @@ export function apply(ctx: Context, initialConfig?: Partial<Mem0Config>): void {
   }
 
   // 3. 注册 HTTP 路由（/api/dsh-mem0/*）
-  const webServer = ctx.get("webServer") as { register: (routes: WebRoute | WebRoute[]) => void } | undefined;
-  if (webServer && typeof webServer.register === "function") {
+  ctx.effect(() => {
+    const webServer = ctx.get("webServer") as { register: (route: WebRoute) => () => void } | undefined;
+    if (!webServer || typeof webServer.register !== "function") return () => {};
     const routes = createMem0Routes({
       executor,
       getCurrentCwd: () => latestCwd,
@@ -204,8 +205,17 @@ export function apply(ctx: Context, initialConfig?: Partial<Mem0Config>): void {
         return res;
       },
     });
-    webServer.register(routes);
-  }
+    const routeDisposers = routes.map((route) => webServer.register(route));
+    return () => {
+      for (const dispose of routeDisposers) {
+        try {
+          dispose();
+        } catch {
+          // ignore
+        }
+      }
+    };
+  }, "dsh-mem0: routes");
 
   // 4. 注册提示词纪律钩子
   const unregisterPrompt = registerMemoryPromptHook(ctx);
@@ -215,11 +225,16 @@ export function apply(ctx: Context, initialConfig?: Partial<Mem0Config>): void {
     ctx.logger?.warn?.(`[dsh-mem0] stdio 运行时拉起异常: ${err instanceof Error ? err.message : String(err)}`);
   });
 
-  // 6. 生命周期注销：kill 子进程
+  // 6. 生命周期注销：kill 子进程 + unregisterServer
   ctx.effect(() => {
     return () => {
-      unregisterPrompt();
+      if (typeof unregisterPrompt === "function") {
+        unregisterPrompt();
+      }
       executor.stop();
+      if (mcpManager && typeof mcpManager.unregisterServer === "function") {
+        void mcpManager.unregisterServer("mem0").catch(() => {});
+      }
     };
   }, "dsh-mem0: dispose");
 }

--- a/packages/dsh-mem0/src/venv-manager.ts
+++ b/packages/dsh-mem0/src/venv-manager.ts
@@ -40,12 +40,40 @@ export interface PythonProbeResult {
  * 探测指定的 Python 解释器或候选路径是否满足运行时要求。
  */
 export async function probePythonEnvironment(preferredBin?: string): Promise<PythonProbeResult> {
-  const candidates: string[] = [];
-
   const trimmedPreferred = preferredBin?.trim();
-  if (trimmedPreferred && trimmedPreferred !== "auto") {
-    candidates.push(trimmedPreferred);
+  const isCustomUserBin = Boolean(trimmedPreferred && trimmedPreferred !== "auto" && trimmedPreferred !== "python3");
+
+  // 1. 若用户显式配置了自定义 Python 路径，仅严格探测该路径，不隐式降级（显式意图优于隐式推断）
+  if (isCustomUserBin && trimmedPreferred) {
+    try {
+      await execFileAsync(trimmedPreferred, ["--version"]);
+    } catch (err: any) {
+      return {
+        ok: false,
+        pythonBin: trimmedPreferred,
+        reason: "python_not_found",
+        detail: `Custom python binary '${trimmedPreferred}' not found: ${err?.message || String(err)}`,
+      };
+    }
+    try {
+      await execFileAsync(trimmedPreferred, ["-c", "import mem0, mcp"]);
+      return {
+        ok: true,
+        pythonBin: trimmedPreferred,
+        reason: "ready",
+      };
+    } catch (err: any) {
+      return {
+        ok: false,
+        pythonBin: trimmedPreferred,
+        reason: "dependency_missing",
+        detail: err?.stderr || err?.message || "Required packages (mem0ai, mcp) are missing in custom python environment.",
+      };
+    }
   }
+
+  // 2. 缺省或 auto 模式：按优先级候选探测（首选就绪环境）
+  const candidates: string[] = [];
   if (existsSync(VENV_PYTHON)) {
     candidates.push(VENV_PYTHON);
   }
@@ -53,12 +81,14 @@ export async function probePythonEnvironment(preferredBin?: string): Promise<Pyt
   candidates.push("python");
 
   let foundPython = false;
+  let firstValidPython = "";
   let lastDetail = "";
 
   for (const bin of candidates) {
     try {
       // 1. 测试 python 命令本身是否存在
       await execFileAsync(bin, ["--version"]);
+      if (!firstValidPython) firstValidPython = bin;
       foundPython = true;
 
       // 2. 测试关键依赖是否已装
@@ -74,6 +104,7 @@ export async function probePythonEnvironment(preferredBin?: string): Promise<Pyt
       }
       // python 存在但 import 失败
       foundPython = true;
+      if (!firstValidPython) firstValidPython = bin;
       lastDetail = err?.stderr || err?.message || String(err);
     }
   }
@@ -81,7 +112,7 @@ export async function probePythonEnvironment(preferredBin?: string): Promise<Pyt
   if (!foundPython) {
     return {
       ok: false,
-      pythonBin: preferredBin || "python3",
+      pythonBin: "python3",
       reason: "python_not_found",
       detail: "No python executable found in system or ~/.dsh/mem0/venv",
     };
@@ -89,7 +120,7 @@ export async function probePythonEnvironment(preferredBin?: string): Promise<Pyt
 
   return {
     ok: false,
-    pythonBin: candidates[0] || "python3",
+    pythonBin: firstValidPython || "python3",
     reason: "dependency_missing",
     detail: lastDetail || "Required packages (mem0ai, mcp) are missing.",
   };

--- a/packages/dsh-mem0/test/smoke.ts
+++ b/packages/dsh-mem0/test/smoke.ts
@@ -339,4 +339,97 @@ await test("客户端契约：lib/client.js 存在且载入正确 load id", asyn
   assert.ok(code.includes('"@wingsky-1/dsh-mem0"'), "client.js 必须包含完整的 npm 包 load id");
 });
 
+// 10. 装配层路由注册与生命周期防回归断言（重点防止 register(routes[]) 数组传参缺陷）
+await test("装配层路由注册契约：apply 必须单路由逐个注册并受 ctx.effect 管理", async () => {
+  const registeredRoutes: any[] = [];
+  const disposersCalled: string[] = [];
+  let unregisterServerCalled = false;
+
+  const effects: Array<() => void | (() => void)> = [];
+  const mockCtx: any = {
+    get(name: string) {
+      if (name === "webServer") {
+        return {
+          register(route: any) {
+            // 严密断言：入参绝不能是数组！
+            assert.ok(!Array.isArray(route), "webServer.register 严禁传入数组！必须单路由逐个传入");
+            assert.equal(route.kind, "exact", "路由 kind 必须是 exact");
+            assert.ok(typeof route.path === "string" && route.path.startsWith("/api/dsh-mem0/"), `路由 path 必须是合法的 /api/dsh-mem0/* 字符串: ${route.path}`);
+            registeredRoutes.push(route);
+            return () => {
+              disposersCalled.push(route.path);
+            };
+          },
+        };
+      }
+      if (name === "mcpManager") {
+        return {
+          registerServer: async () => ({ existing: false }),
+          unregisterServer: async (name: string) => {
+            if (name === "mem0") unregisterServerCalled = true;
+          },
+        };
+      }
+      return undefined;
+    },
+    effect(fn: () => void | (() => void)) {
+      effects.push(fn);
+      return () => {};
+    },
+    on() {
+      return () => {};
+    },
+    logger: { warn() {}, info() {}, debug() {} },
+  };
+
+  const { apply, probePythonEnvironment } = hostMod;
+  apply(mockCtx, { pythonBin: "non-existent-python-for-test" });
+
+  // 执行所有 effect
+  const cleanupFns: Array<() => void> = [];
+  for (const eff of effects) {
+    const res = eff();
+    if (typeof res === "function") cleanupFns.push(res);
+  }
+
+  // 断言注册了全部 6 个路由
+  assert.equal(registeredRoutes.length, 6, "必须注册全部 6 个 exact 路由");
+  const registeredPaths = registeredRoutes.map((r) => r.path).sort();
+  const expectedPaths = [
+    "/api/dsh-mem0/add",
+    "/api/dsh-mem0/config",
+    "/api/dsh-mem0/delete",
+    "/api/dsh-mem0/install",
+    "/api/dsh-mem0/list",
+    "/api/dsh-mem0/status",
+  ].sort();
+  assert.deepEqual(registeredPaths, expectedPaths, "已注册路由路径必须完全匹配预期的 6 个路径");
+
+  // 执行清理
+  for (const cleanup of cleanupFns) {
+    cleanup();
+  }
+
+  // 断言注销逻辑
+  assert.equal(disposersCalled.length, 6, "注销时 6 个路由的 disposer 必须都被调用");
+  assert.ok(unregisterServerCalled, "注销时必须调用 mcpManager.unregisterServer('mem0')");
+});
+
+// 11. 自定义 Python 路径探测隔离测试（显式意图优于隐式推断）
+await test("环境探测契约：自定义 Python 失败时不应降级到全局系统 Python", async () => {
+  const { probePythonEnvironment } = hostMod;
+  const customProbe = await probePythonEnvironment("/non/existent/python/path/test_12345");
+  assert.equal(customProbe.ok, false);
+  assert.equal(customProbe.reason, "python_not_found");
+  assert.equal(customProbe.pythonBin, "/non/existent/python/path/test_12345", "自定义 Python 失败时不应降级到全局系统 Python");
+});
+
+// 12. 双语字典 1:1 镜像对称性断言
+await test("客户端 i18n：zh 与 en 双语字典必须完全对称", async () => {
+  const { zh, en } = await import(pathToFileURL(join(pkgDir, "src/client/locales.ts")).href);
+  const zhKeys = Object.keys(zh).sort();
+  const enKeys = Object.keys(en).sort();
+  assert.deepEqual(zhKeys, enKeys, "zh 与 en 字典的键必须 1:1 完全对应无缺失");
+});
+
 console.log(`\n全部 ${testsRun} 项冒烟测试顺利通过！`);


### PR DESCRIPTION
Fixes #602

## 说明

修复设置页「记忆中心」Tab 永久显示“服务未就绪”且没有任何原因诊断或错误提示的缺陷。

## 改动

1. **宿主端装配与生命周期**（`packages/dsh-mem0/src/index.ts`）：
   - 将 `webServer.register` 从错误传入整个 routes 数组改为逐个单路由注册，符合 DSH 官方 WebServer 签名契约；
   - 路由注册与清理收敛在 `ctx.effect` 响应式闭包内，防止热重载或销毁时路由残留；
   - 注销闭包补充 `mcpManager.unregisterServer("mem0")`，杜绝 MCP 服务器孤儿残留。
2. **客户端容错与自愈体验**（`packages/dsh-mem0/src/client/MemoryCenter.ts` & `locales.ts` & `style.css`）：
   - 彻底消除 `catch { // ignore }` 静默吞错漏洞，新增 `apiError` 捕获 HTTP 401/404 等网络故障与非 JSON 响应，并提供“重试连接”按钮；
   - 解耦 Transport 网络故障与 Runtime 运行状态，补齐 `process_exited`、`starting` 以及 `detail` 报错详情展示；
   - 适配深浅色模式 CSS 变量，中英双语字典严格 1:1 对称，源码零硬编码中文。
3. **环境探测强化**（`packages/dsh-mem0/src/venv-manager.ts`）：
   - 用户显式配置 Python 时严格单点探测不降级；默认模式下优先返回具备依赖的可用解释器。
4. **防回归测试网**（`packages/dsh-mem0/test/smoke.ts`）：
   - 新增装配层路由单体对象注册校验、6 路由路径匹配校验、生命周期清理校验、自定义 Python 探测隔离校验与双语 1:1 对称校验，冒烟用例扩充至 18 项全部通过。

## 验证

- `pnpm -r build`：全包构建通过；
- `pnpm --filter @wingsky-1/dsh-mem0 test`：18 项离线冒烟测试全部通过；
- `pnpm contract`：客户端加载契约与配置矩阵全部通过；
- `pnpm pack:check`：发布物检查全部通过；
- `pnpm typecheck`：TypeScript 严格类型检查 0 错误通过；
- 独立首席 QA / SDET 子 Agent 完成全量 Diff 审计与变异测试，判定 **PASS（Ready for Merge）**。

### 客户端改动截图证据（勾选式）

- [x] **涉及客户端改动**（已在本地离线冒烟与双主题校验通过）