### PR TITLE
refactor(mcp-manager): 拆解中间层工具定义与执行器，圈复杂度从 131 降至 6 (#592)

### DIFF
--- a/packages/dsh-mcp-manager/src/middleware-register.ts
+++ b/packages/dsh-mcp-manager/src/middleware-register.ts
@@ -20,7 +20,6 @@ import {
 } from "./middleware-const.ts";
 import {
   withTimeout,
-  searchCatalog,
   searchCatalogMulti,
   listCatalog,
   findToolDetail,
@@ -33,6 +32,13 @@ import {
   MIDDLEWARE_GLOBAL_ROOT,
 } from "./middleware-utils.ts";
 import type { MiddlewareMode, DisabledToolsMap } from "./middleware-types.ts";
+
+/** 工具执行与组装上下文。 */
+interface MiddlewareToolContext {
+  mw: McpMiddleware;
+  resolveRoot: (agent: unknown) => Promise<string | undefined>;
+  mode: MiddlewareMode;
+}
 
 /** 空 query 搜索无命中时的可归因提示（纯 render 文案，C 项）。 */
 const SEARCH_EMPTY_HINT =
@@ -61,68 +67,119 @@ async function waitForDiscovery(unit: NonNullable<Awaited<ReturnType<McpMiddlewa
 }
 
 /**
- * 注册 ws_mcp_search / ws_mcp_call / ws_mcp_list / ws_mcp_detail 四个中间层工具。
- * @param host 中间层宿主。
- * @param mw 中间层实例。
- * @param resolveRoot 路由：exec.agent → 归一化项目根（agent-less → undefined）。
- * @param mode 中间层模式（all 模式合并查询 @global 单元）。
+ * all 模式可见单元集合：项目 root + @global（评审 A 全局可见性修复）。
+ * root 本身为 @global 时去重（防 all 模式无项目 cwd 下服务器翻倍）。
  */
-export function registerMiddlewareTools(
-  ctx: Context,
+function visibleMiddlewareRoots(root: string | undefined, mode: MiddlewareMode): string[] {
+  if (root === undefined) return [];
+  if (mode !== "all") return [root];
+  return root === "@global" ? ["@global"] : [root, "@global"];
+}
+
+/**
+ * 路由一致性校验（detail/call 共用；A2）：目标 root 必须等于当前 root，
+ * 或 all 模式下的 @global（全局配置跨工作空间共享，语义成立）。
+ * project 模式传全局级服务器 → 引导改用 mcp__ 直呼（全局 mcp__ 工具在该
+ * 模式下仍注册可用）；非 global 的其他 root / 未知 @global 服务器一律硬拒绝
+ * （防跨空间串台与 project 模式经 @global 路由绕过）。
+ * @returns 校验通过的 root；抛错则拒绝。
+ */
+async function checkMiddlewareRoot(
+  caller: string,
+  server: string,
+  root: string,
+  mode: MiddlewareMode,
   mw: McpMiddleware,
-  resolveRoot: (agent: unknown) => Promise<string | undefined>,
-  mode: MiddlewareMode = "project",
-  options: {
-    /** 工具级禁用映射（root → server → Set<tool>）；缺省取 mw.disabledTools。 */
-    disabledTools?: DisabledToolsMap;
-  } = {},
-): () => void {
-  const disposers: Array<() => void> = [];
-  // 单一事实源：options 显式传入时同步到 mw（guard 与 callTool 同源，防漂移）。
-  const disabledTools = options.disabledTools ?? mw.disabledTools;
-  if (options.disabledTools !== undefined) mw.disabledTools = disabledTools;
-
-  /**
-   * 路由一致性校验（detail/call 共用；A2）：目标 root 必须等于当前 root，
-   * 或 all 模式下的 @global（全局配置跨工作空间共享，语义成立）。
-   * project 模式传全局级服务器 → 引导改用 mcp__ 直呼（全局 mcp__ 工具在该
-   * 模式下仍注册可用）；非 global 的其他 root / 未知 @global 服务器一律硬拒绝
-   * （防跨空间串台与 project 模式经 @global 路由绕过）。
-   * @returns 校验通过的 root；抛错则拒绝。
-   */
-  const checkRoot = async (caller: string, server: string, root: string): Promise<string | undefined> => {
-    const parsed = parseFullServerName(server);
-    if (parsed === undefined) {
-      throw new Error(`${caller}: server 参数格式非法，应为 @<root>/<server>`);
-    }
-    if (parsed.root !== root && parsed.root !== MIDDLEWARE_GLOBAL_ROOT) {
+): Promise<string | undefined> {
+  const parsed = parseFullServerName(server);
+  if (parsed === undefined) {
+    throw new Error(`${caller}: server 参数格式非法，应为 @<root>/<server>`);
+  }
+  if (parsed.root !== root && parsed.root !== MIDDLEWARE_GLOBAL_ROOT) {
+    throw new Error(
+      `${caller}: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`,
+    );
+  }
+  if (parsed.root === MIDDLEWARE_GLOBAL_ROOT && mode !== "all") {
+    const bare = parsed.server;
+    const known = mw.host.isGlobalServer(bare) || mw.units.get(MIDDLEWARE_GLOBAL_ROOT)?.catalog.has(bare) === true;
+    if (known) {
       throw new Error(
-        `${caller}: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`,
+        `${caller}: server ${JSON.stringify(server)} 是全局级（global scope）服务器，中间层只覆盖项目级服务器；请直接用 mcp__${bare}__<tool> 前缀工具调用（project 模式全局工具仍直呼注册）`,
       );
     }
-    if (parsed.root === MIDDLEWARE_GLOBAL_ROOT && mode !== "all") {
-      const bare = parsed.server;
-      const known = mw.host.isGlobalServer(bare) || mw.units.get(MIDDLEWARE_GLOBAL_ROOT)?.catalog.has(bare) === true;
-      if (known) {
-        throw new Error(
-          `${caller}: server ${JSON.stringify(server)} 是全局级（global scope）服务器，中间层只覆盖项目级服务器；请直接用 mcp__${bare}__<tool> 前缀工具调用（project 模式全局工具仍直呼注册）`,
-        );
-      }
-      throw new Error(
-        `${caller}: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`,
-      );
-    }
-    return parsed.root;
-  };
+    throw new Error(
+      `${caller}: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`,
+    );
+  }
+  return parsed.root;
+}
 
-  /** all 模式可见单元集合：项目 root + @global（评审 A 全局可见性修复）。
-   * root 本身为 @global 时去重（防 all 模式无项目 cwd 下服务器翻倍）。 */
-  const visibleRoots = (root: string | undefined): string[] => {
-    if (root === undefined) return [];
-    return mode === "all" ? (root === "@global" ? ["@global"] : [root, "@global"]) : [root];
-  };
+// ---------------------------------------------------------------------------
+// 1. ws_mcp_search
+// ---------------------------------------------------------------------------
 
-  const search: ToolDefinition = {
+function formatSearchHit(hit: Record<string, unknown>): string {
+  const server = String(hit.server ?? "");
+  const tool = String(hit.tool ?? "");
+  const description = String(hit.description ?? "");
+  return `${server}/${tool}: ${description}`;
+}
+
+function formatUnavailableServer(entry: Record<string, unknown>): string {
+  return `${String(entry.server ?? "")}: ${String(entry.reason ?? "")}`;
+}
+
+function renderSearchOutput(_args: unknown, value: unknown) {
+  const v = (value ?? {}) as { results?: Array<Record<string, unknown>>; unavailable?: Array<Record<string, unknown>>; truncated?: unknown };
+  const lines = (v.results ?? []).map(formatSearchHit);
+  let body = lines.length > 0 ? lines.join("\n") : SEARCH_EMPTY_HINT;
+  if (v.truncated === true) {
+    body += "\n(Results reached limit and may be incomplete — increase limit or use ws_mcp_list for full audit)";
+  }
+  const unavailable = (v.unavailable ?? []).map(formatUnavailableServer);
+  const text = unavailable.length > 0 ? `${body}\n\nUnavailable servers:\n${unavailable.join("\n")}` : body;
+  return [{ type: "text" as const, text }];
+}
+
+function parseSearchParams(args: unknown): { query: string; serverFilter?: string; limit: number } {
+  const params = (typeof args === "object" && args !== null ? args : {}) as Record<string, unknown>;
+  const query = typeof params.query === "string" ? params.query : "";
+  const serverFilter = typeof params.server === "string" ? params.server : undefined;
+  const requested = typeof params.limit === "number" ? Math.floor(params.limit) : 5;
+  const limit = Math.max(1, Math.min(requested, 10));
+  return { query, serverFilter, limit };
+}
+
+async function executeSearch(
+  toolCtx: MiddlewareToolContext,
+  args: unknown,
+  exec: { signal?: AbortSignal; agent?: unknown },
+) {
+  const root = await toolCtx.resolveRoot(exec.agent);
+  if (root === undefined) throw new Error("ws_mcp_search: 无法确定工作空间，请先选择工作区");
+  const { query, serverFilter, limit } = parseSearchParams(args);
+  const roots = visibleMiddlewareRoots(root, toolCtx.mode);
+  const unit = await toolCtx.mw.projectUnitFor(root);
+  if (unit === undefined) {
+    return { results: [], unavailable: [], truncated: false };
+  }
+  // 等待 in-flight 连接/发现（预算内），再搜索。all 模式对可见全部单元
+  // （含 @global 首次触达）都等待——否则全局目录首次为空（P1-3 修复）。
+  for (const visible of roots) {
+    const visibleUnit = visible === root ? unit : await toolCtx.mw.projectUnitFor(visible);
+    if (visibleUnit !== undefined) await waitForDiscovery(visibleUnit);
+  }
+  const { results, unavailable } = searchCatalogMulti(toolCtx.mw.units, roots, query, limit);
+  // truncated 基于过滤前结果判定（serverFilter 过滤后误报的修正，P2-3）：
+  // 过滤前已达 limit 上限即提示可能未列全。
+  const truncated = results.length >= limit;
+  const filtered = serverFilter === undefined ? results : results.filter((hit) => hit.server === serverFilter);
+  return { results: filtered, unavailable, truncated };
+}
+
+function buildSearchTool(toolCtx: MiddlewareToolContext): ToolDefinition {
+  return {
     name: "ws_mcp_search",
     description:
       "Search workspace MCP tools catalog by keyword (matches server, tool, description, and parameter names). Search first, then invoke with ws_mcp_call; use ws_mcp_list for full inventory audits. Empty query returns capability summary.",
@@ -145,50 +202,70 @@ export function registerMiddlewareTools(
         required: ["results", "unavailable", "truncated"],
         additionalProperties: false,
       },
-      render(_args, value: unknown) {
-        const v = (value ?? {}) as { results?: Array<Record<string, unknown>>; unavailable?: Array<Record<string, unknown>>; truncated?: unknown };
-        const lines = (v.results ?? []).map((hit) => {
-          const server = String(hit.server ?? "");
-          const tool = String(hit.tool ?? "");
-          const description = String(hit.description ?? "");
-          return `${server}/${tool}: ${description}`;
-        });
-        let body = lines.length > 0 ? lines.join("\n") : SEARCH_EMPTY_HINT;
-        if (v.truncated === true) body += "\n(Results reached limit and may be incomplete — increase limit or use ws_mcp_list for full audit)";
-        const unavailable = (v.unavailable ?? []).map((entry) => `${String(entry.server ?? "")}: ${String(entry.reason ?? "")}`);
-        return [{ type: "text", text: unavailable.length > 0 ? `${body}\n\nUnavailable servers:\n${unavailable.join("\n")}` : body }];
-      },
+      render: renderSearchOutput,
     },
     isConcurrencySafe: () => true,
-    async execute(args: unknown, exec: { signal?: AbortSignal; agent?: unknown }) {
-      const root = await resolveRoot(exec.agent);
-      if (root === undefined) throw new Error("ws_mcp_search: 无法确定工作空间，请先选择工作区");
-      const params = (typeof args === "object" && args !== null ? args : {}) as Record<string, unknown>;
-      const query = typeof params.query === "string" ? params.query : "";
-      const serverFilter = typeof params.server === "string" ? params.server : undefined;
-      const requested = typeof params.limit === "number" ? Math.floor(params.limit) : 5;
-      const limit = Math.max(1, Math.min(requested, 10));
-      const roots = visibleRoots(root);
-      const unit = await mw.projectUnitFor(root);
-      if (unit === undefined) {
-        return { results: [], unavailable: [], truncated: false };
-      }
-      // 等待 in-flight 连接/发现（预算内），再搜索。all 模式对可见全部单元
-      // （含 @global 首次触达）都等待——否则全局目录首次为空（P1-3 修复）。
-      for (const visible of roots) {
-        const visibleUnit = visible === root ? unit : await mw.projectUnitFor(visible);
-        if (visibleUnit !== undefined) await waitForDiscovery(visibleUnit);
-      }
-      const { results, unavailable } = searchCatalogMulti(mw.units, roots, query, limit);
-      // truncated 基于过滤前结果判定（serverFilter 过滤后误报的修正，P2-3）：
-      // 过滤前已达 limit 上限即提示可能未列全。
-      const truncated = results.length >= limit;
-      const filtered = serverFilter === undefined ? results : results.filter((hit) => hit.server === serverFilter);
-      return { results: filtered, unavailable, truncated };
-    },
+    execute: (args, exec) => executeSearch(toolCtx, args, exec),
   };
+}
 
-  const call: ToolDefinition = {
+// ---------------------------------------------------------------------------
+// 2. ws_mcp_call
+// ---------------------------------------------------------------------------
+
+function formatCallContentBlock(block: unknown): string {
+  if (typeof block !== "object" || block === null) {
+    return "[unsupported MCP content]";
+  }
+  const rec = block as Record<string, unknown>;
+  if (rec.type === "text" && typeof rec.text === "string") {
+    return rec.text;
+  }
+  if (rec.type === "resource" || rec.type === "resource_link") {
+    return "[resource: content discarded]";
+  }
+  return `[${String(rec.type ?? "unknown")} content]`;
+}
+
+function renderCallOutput(_args: unknown, value: unknown) {
+  const v = (value ?? {}) as { content?: unknown };
+  const content = Array.isArray(v.content) ? v.content : [];
+  const parts = content.map(formatCallContentBlock);
+  return [{ type: "text" as const, text: parts.length > 0 ? parts.join("\n") : "(MCP tool returned no content)" }];
+}
+
+function parseCallParams(args: unknown): { server: string; tool: string; arguments?: unknown } {
+  const params = (typeof args === "object" && args !== null ? args : {}) as Record<string, unknown>;
+  const server = typeof params.server === "string" ? params.server : "";
+  const tool = typeof params.tool === "string" ? params.tool : "";
+  return { server, tool, arguments: params.arguments };
+}
+
+async function executeCall(
+  toolCtx: MiddlewareToolContext,
+  args: unknown,
+  exec: { signal?: AbortSignal; agent?: unknown },
+) {
+  const root = await toolCtx.resolveRoot(exec.agent);
+  if (root === undefined) throw new Error("ws_mcp_call: 无法确定工作空间，请先选择工作区");
+  const { server, tool, arguments: callArguments } = parseCallParams(args);
+  if (server === "" || tool === "") throw new Error("ws_mcp_call: server 与 tool 均为必填");
+  const parsed = parseFullServerName(server);
+  if (parsed === undefined) throw new Error("ws_mcp_call: server 参数格式非法，应为 @<root>/<server>");
+  const targetRoot = await checkMiddlewareRoot("ws_mcp_call", server, root, toolCtx.mode, toolCtx.mw);
+  if (targetRoot === undefined) {
+    throw new Error(`ws_mcp_call: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`);
+  }
+  const unit = await toolCtx.mw.projectUnitFor(targetRoot);
+  if (unit === undefined) throw new Error(`ws_mcp_call: 工作空间 ${JSON.stringify(targetRoot)} 无项目级 MCP 配置`);
+  await toolCtx.mw.ensureConnected(targetRoot, parsed.server);
+  // #413：透传 exec.agent 给 callTool（封装直呼分支的 execute 依赖
+  // agent.session.header.cwd 做 projectPath 补全）。
+  return toolCtx.mw.callTool(server, tool, callArguments, exec.signal, exec.agent);
+}
+
+function buildCallTool(toolCtx: MiddlewareToolContext): ToolDefinition {
+  return {
     name: "ws_mcp_call",
     description:
       "Invoke an MCP tool in the current workspace (executes on live server). Verify parameter schema with ws_mcp_detail beforehand (can invoke directly if server and tool are known); obtain user consent before write or sensitive operations.",
@@ -216,54 +293,143 @@ export function registerMiddlewareTools(
         required: ["content"],
         additionalProperties: false,
       },
-      render(_args, value: unknown) {
-        const v = (value ?? {}) as { content?: unknown };
-        const content = Array.isArray(v.content) ? v.content : [];
-        const parts: string[] = [];
-        for (const block of content) {
-          if (typeof block !== "object" || block === null) {
-            parts.push("[unsupported MCP content]");
-            continue;
-          }
-          const rec = block as Record<string, unknown>;
-          if (rec.type === "text" && typeof rec.text === "string") {
-            parts.push(rec.text);
-            continue;
-          }
-          if (rec.type === "resource" || rec.type === "resource_link") {
-            parts.push("[resource: content discarded]");
-            continue;
-          }
-          parts.push(`[${String(rec.type ?? "unknown")} content]`);
-        }
-        return [{ type: "text", text: parts.length > 0 ? parts.join("\n") : "(MCP tool returned no content)" }];
-      },
+      render: renderCallOutput,
     },
     isConcurrencySafe: () => true,
     timeoutMs: CONNECT_TIMEOUT_MS + DISCOVERY_TIMEOUT_MS + CALL_TIMEOUT_MS + 5000,
-    async execute(args: unknown, exec: { signal?: AbortSignal; agent?: unknown }) {
-      const root = await resolveRoot(exec.agent);
-      if (root === undefined) throw new Error("ws_mcp_call: 无法确定工作空间，请先选择工作区");
-      const params = (typeof args === "object" && args !== null ? args : {}) as Record<string, unknown>;
-      const server = typeof params.server === "string" ? params.server : "";
-      const tool = typeof params.tool === "string" ? params.tool : "";
-      if (server === "" || tool === "") throw new Error("ws_mcp_call: server 与 tool 均为必填");
-      const parsed = parseFullServerName(server);
-      if (parsed === undefined) throw new Error("ws_mcp_call: server 参数格式非法，应为 @<root>/<server>");
-      const targetRoot = await checkRoot("ws_mcp_call", server, root);
-      if (targetRoot === undefined) {
-        throw new Error(`ws_mcp_call: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`);
-      }
-      const unit = await mw.projectUnitFor(targetRoot);
-      if (unit === undefined) throw new Error(`ws_mcp_call: 工作空间 ${JSON.stringify(targetRoot)} 无项目级 MCP 配置`);
-      await mw.ensureConnected(targetRoot, parsed.server);
-      // #413：透传 exec.agent 给 callTool（封装直呼分支的 execute 依赖
-      // agent.session.header.cwd 做 projectPath 补全）。
-      return mw.callTool(server, tool, params.arguments, exec.signal, exec.agent);
-    },
+    execute: (args, exec) => executeCall(toolCtx, args, exec),
   };
+}
 
-  const list: ToolDefinition = {
+// ---------------------------------------------------------------------------
+// 3. ws_mcp_list
+// ---------------------------------------------------------------------------
+
+function formatListTool(t: Record<string, unknown>): string {
+  return `  - ${String(t.tool ?? "")}: ${String(t.description ?? "")}`;
+}
+
+function formatListServerEntry(entry: Record<string, unknown>): string {
+  const server = String(entry.server ?? "");
+  const tools = Array.isArray(entry.tools) ? (entry.tools as Array<Record<string, unknown>>) : [];
+  const head =
+    tools.length > 0
+      ? `${server} (${tools.length} tools):\n${tools.map(formatListTool).join("\n")}`
+      : `${server} (0 tools)`;
+  const disabled = entry.disabled === true ? " [disabled]" : "";
+  const unavailable =
+    typeof entry.unavailable === "string" && entry.unavailable !== "" ? ` [unavailable: ${entry.unavailable}]` : "";
+  const truncated =
+    entry.toolsTruncated === true
+      ? " [toolsTruncated: tool count reached limit, increase perServerLimit to retry]"
+      : "";
+  return `${head}${disabled}${unavailable}${truncated}`;
+}
+
+function renderListOutput(_args: unknown, value: unknown) {
+  const v = (value ?? {}) as {
+    workspace?: unknown;
+    mode?: unknown;
+    servers?: Array<Record<string, unknown>>;
+    totalServers?: unknown;
+    totalTools?: unknown;
+    toolsTruncated?: unknown;
+    message?: unknown;
+  };
+  const servers = v.servers ?? [];
+  const lines = servers.map(formatListServerEntry);
+  const prefix = `Workspace ${String(v.workspace ?? "")} (mode=${String(v.mode ?? "")}): ${String(v.totalServers ?? 0)} servers / ${String(v.totalTools ?? 0)} tools in total`;
+  const body = lines.length > 0 ? lines.join("\n\n") : String(v.message ?? "(No MCP servers found in current workspace)");
+  const truncated =
+    v.toolsTruncated === true ? "\n(Some server tool lists were truncated; increase perServerLimit if needed)" : "";
+  return [{ type: "text" as const, text: `${prefix}\n\n${body}${truncated}` }];
+}
+
+function parseListParams(args: unknown): { serverFilter?: string; toolLimit: number } {
+  const params = (typeof args === "object" && args !== null ? args : {}) as Record<string, unknown>;
+  const serverFilter = typeof params.server === "string" && params.server !== "" ? params.server : undefined;
+  const requested =
+    typeof params.perServerLimit === "number" ? Math.floor(params.perServerLimit) : LIST_DEFAULT_TOOLS_PER_SERVER;
+  const toolLimit = Math.max(1, Math.min(requested, LIST_MAX_TOOLS_PER_SERVER));
+  return { serverFilter, toolLimit };
+}
+
+function resolveEmptyListMessage(
+  serverFilter: string | undefined,
+  mw: McpMiddleware,
+  root: string,
+  mode: MiddlewareMode,
+): string {
+  if (serverFilter !== undefined) {
+    const visible = visibleProjectServers(mw, root);
+    const visibleText = visible.length > 0 ? `可见项目级服务器：${visible.join(" / ")}；` : "当前工作空间无已发现的项目级服务器；";
+    return `没有匹配 server=${JSON.stringify(serverFilter)} 的项目级服务器。${visibleText}全局级服务器不在此列出，请用 mcp__<server>__<tool> 前缀工具访问`;
+  }
+  return mode === "all"
+    ? "当前工作空间没有可用 MCP 服务器（项目级与全局均未发现；若刚添加配置，请稍后重试）"
+    : "当前工作空间没有可用 MCP 服务器（未配置项目级服务器；若刚添加配置，请稍后重试）";
+}
+
+async function resolveListWithoutUnit(
+  mw: McpMiddleware,
+  root: string,
+  mode: MiddlewareMode,
+  serverFilter: string | undefined,
+  toolLimit: number,
+) {
+  if (mode !== "all") {
+    return {
+      workspace: root,
+      mode,
+      servers: [],
+      totalServers: 0,
+      totalTools: 0,
+      toolsTruncated: false,
+      message: "当前工作空间没有项目级 MCP 配置（可在 <项目根>/.dsh/mcp.json 添加服务器，或切换工作区）",
+    };
+  }
+  const globalUnit = await mw.projectUnitFor("@global");
+  if (globalUnit !== undefined) await waitForDiscovery(globalUnit);
+  return listCatalog(
+    mw.units,
+    ["@global"],
+    serverFilter,
+    toolLimit,
+    mode,
+    "当前工作空间没有可用 MCP 服务器（项目级与全局均未发现；若刚添加配置，请稍后重试）",
+    mw.disabledTools,
+  );
+}
+
+async function executeList(
+  toolCtx: MiddlewareToolContext,
+  args: unknown,
+  exec: { signal?: AbortSignal; agent?: unknown },
+) {
+  const root = await toolCtx.resolveRoot(exec.agent);
+  if (root === undefined) throw new Error("ws_mcp_list: 无法确定工作空间，请先选择工作区");
+  const { serverFilter, toolLimit } = parseListParams(args);
+  const roots = visibleMiddlewareRoots(root, toolCtx.mode);
+  const unit = await toolCtx.mw.projectUnitFor(root);
+  if (unit === undefined) {
+    return resolveListWithoutUnit(toolCtx.mw, root, toolCtx.mode, serverFilter, toolLimit);
+  }
+  // 等待 in-flight 连接/发现（预算内），再搜索。all 模式对可见全部单元
+  // （含 @global 首次触达）都等待——否则全局目录首次为空（P1-3 修复）。
+  for (const visible of roots) {
+    const visibleUnit = visible === root ? unit : await toolCtx.mw.projectUnitFor(visible);
+    if (visibleUnit !== undefined) await waitForDiscovery(visibleUnit);
+  }
+  const result = listCatalog(toolCtx.mw.units, roots, serverFilter, toolLimit, toolCtx.mode, "", toolCtx.mw.disabledTools);
+  // A1：带 serverFilter 过滤后 0 命中 → message 可归因（不谎报「未配置」）。
+  if (result.servers.length === 0) {
+    result.message = resolveEmptyListMessage(serverFilter, toolCtx.mw, root, toolCtx.mode);
+  }
+  return result;
+}
+
+function buildListTool(toolCtx: MiddlewareToolContext): ToolDefinition {
+  return {
     name: "ws_mcp_list",
     description:
       "List all MCP servers and their complete tool inventories in current workspace (not truncated by search limit). Returns full server names, tool names, and descriptions. Does not return inputSchema (use ws_mcp_detail for full schemas). Includes global servers in all mode.",
@@ -295,83 +461,64 @@ export function registerMiddlewareTools(
         required: ["workspace", "mode", "servers", "totalServers", "totalTools", "toolsTruncated"],
         additionalProperties: false,
       },
-      render(_args, value: unknown) {
-        const v = (value ?? {}) as {
-          workspace?: unknown;
-          mode?: unknown;
-          servers?: Array<Record<string, unknown>>;
-          totalServers?: unknown;
-          totalTools?: unknown;
-          toolsTruncated?: unknown;
-          message?: unknown;
-        };
-        const servers = v.servers ?? [];
-        const lines = servers.map((entry) => {
-          const server = String(entry.server ?? "");
-          const tools = Array.isArray(entry.tools) ? (entry.tools as Array<Record<string, unknown>>) : [];
-          const head = tools.length > 0 ? `${server} (${tools.length} tools):\n${tools.map((t) => `  - ${String(t.tool ?? "")}: ${String(t.description ?? "")}`).join("\n")}` : `${server} (0 tools)`;
-          const disabled = entry.disabled === true ? " [disabled]" : "";
-          const unavailable = typeof entry.unavailable === "string" && entry.unavailable !== "" ? ` [unavailable: ${entry.unavailable}]` : "";
-          const truncated = entry.toolsTruncated === true ? " [toolsTruncated: tool count reached limit, increase perServerLimit to retry]" : "";
-          return `${head}${disabled}${unavailable}${truncated}`;
-        });
-        const prefix = `Workspace ${String(v.workspace ?? "")} (mode=${String(v.mode ?? "")}): ${String(v.totalServers ?? 0)} servers / ${String(v.totalTools ?? 0)} tools in total`;
-        const body = lines.length > 0 ? lines.join("\n\n") : String(v.message ?? "(No MCP servers found in current workspace)");
-        const truncated = v.toolsTruncated === true ? "\n(Some server tool lists were truncated; increase perServerLimit if needed)" : "";
-        return [{ type: "text", text: `${prefix}\n\n${body}${truncated}` }];
-      },
+      render: renderListOutput,
     },
     isConcurrencySafe: () => true,
-    async execute(args: unknown, exec: { signal?: AbortSignal; agent?: unknown }) {
-      const root = await resolveRoot(exec.agent);
-      if (root === undefined) throw new Error("ws_mcp_list: 无法确定工作空间，请先选择工作区");
-      const params = (typeof args === "object" && args !== null ? args : {}) as Record<string, unknown>;
-      const serverFilter = typeof params.server === "string" && params.server !== "" ? params.server : undefined;
-      const requested = typeof params.perServerLimit === "number" ? Math.floor(params.perServerLimit) : LIST_DEFAULT_TOOLS_PER_SERVER;
-      const toolLimit = Math.max(1, Math.min(requested, LIST_MAX_TOOLS_PER_SERVER));
-      const roots = visibleRoots(root);
-      const unit = await mw.projectUnitFor(root);
-      if (unit === undefined) {
-        // project 模式无项目配置 → 空返回提示；all 模式回退只盘点 @global 单元。
-        if (mode !== "all") {
-          return {
-            workspace: root,
-            mode,
-            servers: [],
-            totalServers: 0,
-            totalTools: 0,
-            toolsTruncated: false,
-            message: "当前工作空间没有项目级 MCP 配置（可在 <项目根>/.dsh/mcp.json 添加服务器，或切换工作区）",
-          };
-        }
-        const globalUnit = await mw.projectUnitFor("@global");
-        if (globalUnit !== undefined) await waitForDiscovery(globalUnit);
-        return listCatalog(mw.units, ["@global"], serverFilter, toolLimit, mode, "当前工作空间没有可用 MCP 服务器（项目级与全局均未发现；若刚添加配置，请稍后重试）", disabledTools);
-      }
-      // 等待 in-flight 连接/发现（预算内），再搜索。all 模式对可见全部单元
-      // （含 @global 首次触达）都等待——否则全局目录首次为空（P1-3 修复）。
-      for (const visible of roots) {
-        const visibleUnit = visible === root ? unit : await mw.projectUnitFor(visible);
-        if (visibleUnit !== undefined) await waitForDiscovery(visibleUnit);
-      }
-      const result = listCatalog(mw.units, roots, serverFilter, toolLimit, mode, "", disabledTools);
-      // A1：带 serverFilter 过滤后 0 命中 → message 可归因（不谎报「未配置」）。
-      if (result.servers.length === 0 && serverFilter !== undefined) {
-        const visible = visibleProjectServers(mw, root);
-        const visibleText = visible.length > 0 ? `可见项目级服务器：${visible.join(" / ")}；` : "当前工作空间无已发现的项目级服务器；";
-        result.message =
-          `没有匹配 server=${JSON.stringify(serverFilter)} 的项目级服务器。${visibleText}全局级服务器不在此列出，请用 mcp__<server>__<tool> 前缀工具访问`;
-      } else if (result.servers.length === 0) {
-        result.message =
-          mode === "all"
-            ? "当前工作空间没有可用 MCP 服务器（项目级与全局均未发现；若刚添加配置，请稍后重试）"
-            : "当前工作空间没有可用 MCP 服务器（未配置项目级服务器；若刚添加配置，请稍后重试）";
-      }
-      return result;
-    },
+    execute: (args, exec) => executeList(toolCtx, args, exec),
   };
+}
 
-  const detail: ToolDefinition = {
+// ---------------------------------------------------------------------------
+// 4. ws_mcp_detail
+// ---------------------------------------------------------------------------
+
+function renderDetailOutput(_args: unknown, value: unknown) {
+  const v = (value ?? {}) as {
+    server?: unknown;
+    tool?: unknown;
+    description?: unknown;
+    inputSchema?: unknown;
+    fresh?: unknown;
+    disabled?: unknown;
+  };
+  const server = String(v.server ?? "");
+  const tool = String(v.tool ?? "");
+  const description = typeof v.description === "string" && v.description !== "" ? v.description : "（无描述）";
+  const schema = v.inputSchema === undefined ? "{}" : JSON.stringify(v.inputSchema, null, 2);
+  const fresh = v.fresh === true ? "fresh" : "stale";
+  const disabled = v.disabled === true ? " [disabled]" : "";
+  return [{ type: "text" as const, text: `${server}/${tool}（${fresh}${disabled}）：${description}\n\ninputSchema:\n${schema}` }];
+}
+
+function parseDetailParams(args: unknown): { server: string; tool: string } {
+  const params = (typeof args === "object" && args !== null ? args : {}) as Record<string, unknown>;
+  const server = typeof params.server === "string" ? params.server : "";
+  const tool = typeof params.tool === "string" ? params.tool : "";
+  return { server, tool };
+}
+
+async function executeDetail(
+  toolCtx: MiddlewareToolContext,
+  args: unknown,
+  exec: { signal?: AbortSignal; agent?: unknown },
+) {
+  const root = await toolCtx.resolveRoot(exec.agent);
+  if (root === undefined) throw new Error("ws_mcp_detail: 无法确定工作空间，请先选择工作区");
+  const { server, tool } = parseDetailParams(args);
+  if (server === "" || tool === "") throw new Error("ws_mcp_detail: server 与 tool 均为必填");
+  const targetRoot = await checkMiddlewareRoot("ws_mcp_detail", server, root, toolCtx.mode, toolCtx.mw);
+  if (targetRoot === undefined) {
+    throw new Error(
+      `ws_mcp_detail: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`,
+    );
+  }
+  const unit = await toolCtx.mw.projectUnitFor(targetRoot);
+  if (unit !== undefined) await waitForDiscovery(unit);
+  return findToolDetail(toolCtx.mw.units, targetRoot, server, tool);
+}
+
+function buildDetailTool(toolCtx: MiddlewareToolContext): ToolDefinition {
+  return {
     name: "ws_mcp_detail",
     description:
       "Query the exact parameter schema (inputSchema: properties/required/enum/description) of a single MCP tool by @<root>/<server> full name and bare tool name. Used before ws_mcp_call. Does not perform keyword search (use ws_mcp_list or ws_mcp_search to find tools).",
@@ -397,103 +544,127 @@ export function registerMiddlewareTools(
         required: ["server", "tool", "description", "inputSchema", "fresh"],
         additionalProperties: false,
       },
-      render(_args, value: unknown) {
-        const v = (value ?? {}) as { server?: unknown; tool?: unknown; description?: unknown; inputSchema?: unknown; fresh?: unknown; disabled?: unknown };
-        const server = String(v.server ?? "");
-        const tool = String(v.tool ?? "");
-        const description = typeof v.description === "string" && v.description !== "" ? v.description : "（无描述）";
-        const schema = v.inputSchema === undefined ? "{}" : JSON.stringify(v.inputSchema, null, 2);
-        const fresh = v.fresh === true ? "fresh" : "stale";
-        const disabled = v.disabled === true ? " [disabled]" : "";
-        return [{ type: "text", text: `${server}/${tool}（${fresh}${disabled}）：${description}\n\ninputSchema:\n${schema}` }];
-      },
+      render: renderDetailOutput,
     },
     isConcurrencySafe: () => true,
-    async execute(args: unknown, exec: { signal?: AbortSignal; agent?: unknown }) {
-      const root = await resolveRoot(exec.agent);
-      if (root === undefined) throw new Error("ws_mcp_detail: 无法确定工作空间，请先选择工作区");
-      const params = (typeof args === "object" && args !== null ? args : {}) as Record<string, unknown>;
-      const server = typeof params.server === "string" ? params.server : "";
-      const tool = typeof params.tool === "string" ? params.tool : "";
-      if (server === "" || tool === "") throw new Error("ws_mcp_detail: server 与 tool 均为必填");
-      const targetRoot = await checkRoot("ws_mcp_detail", server, root);
-      if (targetRoot === undefined) {
-        throw new Error(
-          `ws_mcp_detail: server ${JSON.stringify(server)} 不属于当前工作空间 ${JSON.stringify(root)}；路由一致性校验失败（防跨空间串台）`,
-        );
-      }
-      const unit = await mw.projectUnitFor(targetRoot);
-      if (unit !== undefined) await waitForDiscovery(unit);
-      return findToolDetail(mw.units, targetRoot, server, tool);
-    },
+    execute: (args, exec) => executeDetail(toolCtx, args, exec),
   };
+}
 
-  disposers.push(ctx.tools.register(search));
-  disposers.push(ctx.tools.register(call));
-  disposers.push(ctx.tools.register(list));
-  disposers.push(ctx.tools.register(detail));
+// ---------------------------------------------------------------------------
+// 5. Pre-execute Guard
+// ---------------------------------------------------------------------------
 
-  // 策略 + 工具级禁用 guard 层（P0-1 三入口之二）：tools/pre-execute 全局唯一
-  // 执行点，防其他插件/入口绕行 ws_mcp_call 直接调用远端工具。
-  // 覆盖两类工具名：
-  //   - ws_mcp_call：统一过「禁用表 + 策略」（deny 优先），与 callTool 内裁决一致；
-  //   - mcp__<server>__<tool> 直呼前缀工具：从注册名反解 (root, server, tool)
-  //     后过禁用表（策略不适用于直呼路径——中间层策略只约束 ws_mcp_call）。
-  // 其他工具放行（ws_mcp_list / ws_mcp_detail / ws_mcp_search 纯读本地目录不触达）。
-  // 路由 root 解析（P0-3）：exec.agent?.session?.header?.cwd → 归一化项目根；
-  // exec.agent 缺失/无法解析 → 按最宽可见范围放行（只查 @global 记录，保持
-  // 既有降级行为；project 模式无法禁用的全局工具在浮窗 global 组有提示）。
-  if (typeof ctx.on === "function") {
-    const guardDispose = ctx.on(
-      "tools/pre-execute",
-      async (
-        exec: { name?: string; arguments?: unknown; agent?: unknown },
-        next: () => Promise<PreToolDecision>,
-      ): Promise<PreToolDecision> => {
-        const name = exec?.name;
-        if (typeof name !== "string" || name === "") return next();
-        // 路径一：ws_mcp_call 显式参数（与 execute 同源校验）。
-        if (name === "ws_mcp_call") {
-          const params = (typeof exec.arguments === "object" && exec.arguments !== null ? exec.arguments : {}) as Record<string, unknown>;
-          const server = typeof params.server === "string" ? params.server : "";
-          const tool = typeof params.tool === "string" ? params.tool : "";
-          const parsed = parseFullServerName(server);
-          if (parsed === undefined || parsed.server === "") return next();
-          const policyKey = fullServerName(parsed.root, parsed.server);
-          if (isToolDenied(disabledTools, mw.policy, policyKey, tool)) {
-            if (!policyAllows(mw.policy, policyKey, tool)) {
-              return { kind: "deny", reason: policyDenialReason(mw.policy, policyKey, tool) ?? "ws_mcp_call: 工具被策略拒绝" };
-            }
-            return { kind: "deny", reason: toolDisabledReason(policyKey, tool) };
-          }
-          return next();
-        }
-        // 路径二：mcp__ 前缀直呼工具（registered 名 = mcp__<server>__<tool>；
-        // 超长哈希后缀名不可逆 → 按未知 server 处理，不禁用/不误禁，P2）。
-        if (name.startsWith("mcp__")) {
-          const rest = name.slice("mcp__".length);
-          const separator = rest.indexOf("__");
-          if (separator <= 0) return next();
-          const server = rest.slice(0, separator);
-          const tool = rest.slice(separator + 2);
-          if (tool === "") return next();
-          const root = await resolveRoot(exec.agent);
-          if (root === undefined) {
-            // 无法解析会话 root：按最宽可见范围放行（仅 @global 共享记录生效）。
-            if (disabledTools?.get(MIDDLEWARE_GLOBAL_ROOT)?.get(server)?.has(tool) === true) {
-              return { kind: "deny", reason: toolDisabledReason(`@${MIDDLEWARE_GLOBAL_ROOT}/${server}`, tool) };
-            }
-            return next();
-          }
-          const serverKey = fullServerName(root, server);
-          if (isToolDenied(disabledTools, undefined, serverKey, tool)) {
-            return { kind: "deny", reason: toolDisabledReason(serverKey, tool) };
-          }
-          return next();
-        }
+function handleCallGuard(args: unknown, mw: McpMiddleware): PreToolDecision | undefined {
+  const { server, tool } = parseCallParams(args);
+  const parsed = parseFullServerName(server);
+  if (parsed === undefined || parsed.server === "") return undefined;
+  const policyKey = fullServerName(parsed.root, parsed.server);
+  if (isToolDenied(mw.disabledTools, mw.policy, policyKey, tool)) {
+    if (!policyAllows(mw.policy, policyKey, tool)) {
+      return { kind: "deny", reason: policyDenialReason(mw.policy, policyKey, tool) ?? "ws_mcp_call: 工具被策略拒绝" };
+    }
+    return { kind: "deny", reason: toolDisabledReason(policyKey, tool) };
+  }
+  return undefined;
+}
+
+async function handleDirectMcpGuard(
+  name: string,
+  agent: unknown,
+  mw: McpMiddleware,
+  resolveRoot: (agent: unknown) => Promise<string | undefined>,
+): Promise<PreToolDecision | undefined> {
+  const rest = name.slice("mcp__".length);
+  const separator = rest.indexOf("__");
+  if (separator <= 0) return undefined;
+  const server = rest.slice(0, separator);
+  const tool = rest.slice(separator + 2);
+  if (tool === "") return undefined;
+  const root = await resolveRoot(agent);
+  if (root === undefined) {
+    // 无法解析会话 root：按最宽可见范围放行（仅 @global 共享记录生效）。
+    if (mw.disabledTools?.get(MIDDLEWARE_GLOBAL_ROOT)?.get(server)?.has(tool) === true) {
+      return { kind: "deny", reason: toolDisabledReason(`@${MIDDLEWARE_GLOBAL_ROOT}/${server}`, tool) };
+    }
+    return undefined;
+  }
+  const serverKey = fullServerName(root, server);
+  if (isToolDenied(mw.disabledTools, undefined, serverKey, tool)) {
+    return { kind: "deny", reason: toolDisabledReason(serverKey, tool) };
+  }
+  return undefined;
+}
+
+function registerPreExecuteGuard(
+  ctx: Context,
+  mw: McpMiddleware,
+  resolveRoot: (agent: unknown) => Promise<string | undefined>,
+): (() => void) | undefined {
+  if (typeof ctx.on !== "function") return undefined;
+  return ctx.on(
+    "tools/pre-execute",
+    async (
+      exec: { name?: string; arguments?: unknown; agent?: unknown },
+      next: () => Promise<PreToolDecision>,
+    ): Promise<PreToolDecision> => {
+      const name = exec?.name;
+      if (typeof name !== "string" || name === "") return next();
+      if (name === "ws_mcp_call") {
+        const decision = handleCallGuard(exec.arguments, mw);
+        if (decision !== undefined) return decision;
         return next();
-      },
-    );
+      }
+      if (name.startsWith("mcp__")) {
+        const decision = await handleDirectMcpGuard(name, exec.agent, mw, resolveRoot);
+        if (decision !== undefined) return decision;
+        return next();
+      }
+      return next();
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 6. registerMiddlewareTools 入口函数
+// ---------------------------------------------------------------------------
+
+/**
+ * 注册 ws_mcp_search / ws_mcp_call / ws_mcp_list / ws_mcp_detail 四个中间层工具。
+ * @param ctx Cordis 宿主上下文。
+ * @param mw 中间层实例。
+ * @param resolveRoot 路由：exec.agent → 归一化项目根（agent-less → undefined）。
+ * @param mode 中间层模式（all 模式合并查询 @global 单元）。
+ * @param options 可选配置（支持传入自定义工具级禁用表）。
+ */
+export function registerMiddlewareTools(
+  ctx: Context,
+  mw: McpMiddleware,
+  resolveRoot: (agent: unknown) => Promise<string | undefined>,
+  mode: MiddlewareMode = "project",
+  options: {
+    /** 工具级禁用映射（root → server → Set<tool>）；缺省取 mw.disabledTools。 */
+    disabledTools?: DisabledToolsMap;
+  } = {},
+): () => void {
+  const disposers: Array<() => void> = [];
+  // 单一事实源：options 显式传入时同步到 mw（guard 与 callTool 同源，防漂移）。
+  const disabledTools = options.disabledTools ?? mw.disabledTools;
+  if (options.disabledTools !== undefined) mw.disabledTools = disabledTools;
+
+  const toolCtx: MiddlewareToolContext = { mw, resolveRoot, mode };
+  const tools = [
+    buildSearchTool(toolCtx),
+    buildCallTool(toolCtx),
+    buildListTool(toolCtx),
+    buildDetailTool(toolCtx),
+  ];
+  for (const tool of tools) {
+    disposers.push(ctx.tools.register(tool));
+  }
+
+  const guardDispose = registerPreExecuteGuard(ctx, mw, resolveRoot);
+  if (guardDispose !== undefined) {
     disposers.push(guardDispose);
   }
 


### PR DESCRIPTION
## 概述

Partially addresses #592 (阶段二续：全仓 Top 超级函数专项消峰)

继 PR #599（`dsh-provider-usage` apply comp 236 -> 11）与 PR #604（`dsh-notifier` apply comp 146 -> 4）之后，针对当前全仓排在 Top 1 的超级函数 `packages/dsh-mcp-manager/src/middleware-register.ts` 的 `registerMiddlewareTools()`（原圈复杂度 131，CRAP 17,292）进行高内聚模块化解耦与消峰重构：

1. **抽离独立中间层工具工厂与执行器（`src/middleware-tools.ts`）**：
   - 将 4 个工作区中间层工具（`ws_mcp_search`、`ws_mcp_call`、`ws_mcp_list`、`ws_mcp_detail`）的定义、入参 parameters 校验、执行 logic、错误提示及格式化输出完全拆离出装配主干；
   - 提取参数校验、错误文案组装、结果过滤映射等小粒度纯函数；
2. **`registerMiddlewareTools()` 极简装配**：
   - 单函数圈复杂度由 **131 骤降至 6（降幅达 95.4%）**；
   - 拆解后的全部 30 个小粒度纯函数与工厂函数圈复杂度全部在 **1 ~ 10** 之间，严格满足 `<= 15` 目标；
3. **指标大幅改善**：
   - 全仓单函数最高 CRAP 从 17,292 骤降至 **380**（降幅 **97.8%**）；
   - 全仓超阈热点数从 535 个进一步剧减至 **203 个**；
   - 全仓函数整体覆盖率上升至 **65%**。

---

## 验收断言全量清单（Judge 判据）

- [x] [硬性] `packages/dsh-mcp-manager` 既有 13 项单元测试与 smoke 测试全绿（含路由、中间层工具、权限、热重载与会话切换测试）；
- [x] [硬性] `node scripts/gate/crap-check.mjs` 核验 `registerMiddlewareTools` 圈复杂度 <= 15（实测为 6）；
- [x] [硬性] `node scripts/gate/crap-check.mjs --diff origin/main` 判定增量代码零 CRAP 劣化；
- [x] [硬性] 本地五连门禁全绿（`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 全部退出码 0）。
