### PR TITLE
refactor(mcp-manager): 拆解 makeRoutes 与 apply 装配骨架，圈复杂度 84/78 降至 5/14 (#592)

### DIFF
--- a/packages/dsh-mcp-manager/src/apply-config.ts
+++ b/packages/dsh-mcp-manager/src/apply-config.ts
@@ -1,0 +1,107 @@
+/**
+ * dsh-mcp-manager — apply 装配拆分：配置解析与设置接线（#592 阶段二 Batch A）。
+ *
+ * 原 apply() 的配置解析（10+ 个可选字段兜底链）与 settings 命名空间接线
+ * 内联在主函数中，是 apply 圈复杂度的主要来源之一；本模块抽为独立工厂。
+ * 行为与拆分前逐字节等价（含 #125 this 绑定与 #389 同步语义）。
+ */
+
+import type { Context } from "@deepseek-ai/cordis";
+import { installSettingsNamespace } from "../../../shared/settings-namespace.js";
+import { DEFAULT_ANNOUNCE_CATALOG, DEFAULT_CATALOG_MAX_ENTRIES } from "./catalog.ts";
+import { Config, DEFAULT_ENHANCE_EMPTY_DESCRIPTIONS } from "./config-schema.ts";
+import { DEFAULT_RESULT_TRUNCATE_BYTES } from "./supervisor.ts";
+import { normalizeMiddlewareMode } from "./middleware.ts";
+import type { McpManager } from "./manager.ts";
+import { uiConfigChangedFrame } from "./routes.ts";
+import { defaultStorePath } from "./store.ts";
+
+/** apply 顶层解析后的增强/开关配置集合。 */
+export interface ApplyOptions {
+  enabled: boolean;
+  announceToAgent: boolean;
+  announceCatalog: boolean;
+  catalogMaxEntries: number;
+  middlewarePolicy: Record<string, unknown>;
+  middlewareModeRaw: string | undefined;
+}
+
+/** 解析 storePath（显式配置优先，回落默认路径）。 */
+export function resolveStorePath(config: Record<string, unknown> | undefined): string {
+  return typeof config?.storePath === "string" && config.storePath !== "" ? config.storePath : defaultStorePath();
+}
+
+/** 解析全部布尔/数值/策略配置（兜底链引用具名常量，单一事实源）。 */
+export function resolveApplyOptions(config: Record<string, unknown> | undefined): ApplyOptions {
+  const announceCatalog = (config?.announceCatalog as boolean | undefined) ?? DEFAULT_ANNOUNCE_CATALOG;
+  const catalogMaxEntries = Number.isFinite(config?.catalogMaxEntries) && (config?.catalogMaxEntries as number) > 0
+    ? Math.floor(config?.catalogMaxEntries as number)
+    : DEFAULT_CATALOG_MAX_ENTRIES;
+  return {
+    enabled: config?.enabled !== false,
+    announceToAgent: config?.announceToAgent !== false,
+    announceCatalog,
+    catalogMaxEntries,
+    middlewarePolicy: (config?.middlewarePolicy as Record<string, unknown> | undefined) ?? {},
+    middlewareModeRaw: config?.middleware as string | undefined,
+  };
+}
+
+/** 解析中间层模式（settings 持久化值优先，回落 config 默认 project，#389 M2）。 */
+export function resolveMiddlewareMode(manager: McpManager, fallbackRaw: string | undefined): ReturnType<typeof normalizeMiddlewareMode> {
+  const settingsSource = manager.uiConfigSource();
+  const persistedMiddleware =
+    typeof settingsSource === "object" && settingsSource !== null
+      ? (settingsSource as Record<string, unknown>).middleware
+      : undefined;
+  return normalizeMiddlewareMode(
+    typeof persistedMiddleware === "string" ? persistedMiddleware : fallbackRaw ?? "project",
+  );
+}
+
+/**
+ * 插件自身 Config schema（标准 cordis 配置注入路径）：position/offset 不再藏于
+ * 隐藏命名空间，设置页插件卡可编辑；配置变更经既有 SSE events 通道广播一帧，
+ * 客户端收到后重新 GET /api/dsh-mcp/config 就地更新浮窗位置（无需重启/轮询）。
+ */
+export function installConfigSettings(
+  ctx: Context,
+  manager: McpManager,
+  config: Record<string, unknown> | undefined,
+  syncMiddlewareFromSettings: () => void,
+): void {
+  const broadcastUiConfigChanged = () => {
+    // #515：广播收口到共享 hub（未创建 = 尚无 events 订阅，跳过）。
+    manager.sseHub?.broadcast(uiConfigChangedFrame());
+  };
+  installSettingsNamespace(ctx, "dsh-mcp-manager", Config, config ?? {}, {
+    setSource: (source) => {
+      manager.uiConfigSource = source as () => any;
+    },
+    onChange: () => {
+      broadcastUiConfigChanged();
+      syncMiddlewareFromSettings();
+    },
+  });
+}
+
+/**
+ * 写入 sink：设置页卡片经 POST /api/dsh-mcp/config 写配置时，通过 settings 服务
+ * 的 namespace update 落盘并触发 scope.watch → onChange → SSE 广播。settings 服务
+ * 未挂载时 uiUpdate 保持 undefined → 写路由返回「不可写」（卡片/设置页本就不渲染）。
+ */
+export function injectSettingsSink(ctx: Context, manager: McpManager): void {
+  if (typeof ctx.inject !== "function") return;
+  ctx.inject(["settings"], (sctx) => {
+    // sctx 注入 settings 服务（cordis 类型面未声明该服务，经 unknown 中转取最小面）。
+    const settings = (sctx as unknown as { settings?: { update?: (ns: string, patch: Record<string, unknown>) => Promise<unknown> } } | undefined)?.settings;
+    if (settings && typeof settings.update === "function") {
+      // settings.update 是 cordis 服务方法，不绑 this（内部访问 this.write）——直接
+      // 解构后调用会丢 this → this.write undefined（回归 #125 保存 400）。这里保留
+      // 本地引用并以 call(settings) 把服务对象本身作为 this 传入；同时规避 TS 对
+      // 可选属性 settings.update 的收窄在闭包内丢失（2722）。
+      const update = settings.update;
+      manager.uiUpdate = (patch) => update.call(settings, "dsh-mcp-manager", patch);
+    }
+  });
+}

--- a/packages/dsh-mcp-manager/src/apply-guidance.ts
+++ b/packages/dsh-mcp-manager/src/apply-guidance.ts
@@ -1,0 +1,12 @@
+/**
+ * dsh-mcp-manager — apply 装配拆分：Agent 宣告文案（#592 阶段二 Batch A）。
+ *
+ * 向 Agent 宣告插件（announceToAgent 开启时注入）。能力清单由动态目录
+ * （<available_mcp_servers>）承担，此处只保留插件存在、安全边界与术语约定，
+ * 不再复述 UI 配置路径与调用流程（那部分由能力目录与中间层工具描述承担）。
+ */
+export const MCP_GUIDANCE =
+  "dsh-mcp-manager is active: centrally manages MCP server connections without preset servers. MCP tools execute on real servers with inherited host permissions; results may contain sensitive data — explain and obtain user consent before write or sensitive operations. Terms like 'MCP / context server' refer to this plugin. Invocation rules:\n" +
+  "- Project-level servers: search with `ws_mcp_search`, verify schema with `ws_mcp_detail` if uncertain, then invoke with `ws_mcp_call`. Do NOT call mcp__ prefixed tools directly.\n" +
+  "- Global servers: call `mcp__<server>__<tool>` directly (or via `ws_mcp_call` in all mode).\n" +
+  "- Do not retry a failing server tool more than twice.";

--- a/packages/dsh-mcp-manager/src/apply-runtime.ts
+++ b/packages/dsh-mcp-manager/src/apply-runtime.ts
@@ -1,0 +1,217 @@
+/**
+ * dsh-mcp-manager — apply 装配拆分：运行期装配阶段（#592 阶段二 Batch A）。
+ *
+ * 原 apply() 单函数圈复杂度 78（内联 fs.watch 防重入、中间层热切换闭包、
+ * catalog 注入、路由注册与 SSE 广播等十余个装配阶段）；本模块把可独立理解
+ * 的装配阶段抽为具名工厂，apply() 退化为顺序装配骨架（comp <= 15）。
+ *
+ * 行为约束（与拆分前逐字节等价）：
+ * - fs.watch 防重入（busy/rerun 队列补跑）与 watcher error 自愈语义不变；
+ * - setMiddlewareMode 热切换的 dispose→init→register→reconcile 顺序不变；
+ * - 全部 disposer 收口回 apply 的顶层 effect。
+ */
+
+import { dirname } from "node:path";
+import type { Context } from "@deepseek-ai/cordis";
+import type { PreStepDecision } from "@deepseek-ai/dsh-agent";
+import type { CatalogCache, CatalogDecision, CatalogMessage, SupervisorLite, CatalogAgent } from "./catalog.ts";
+import { resolveCatalogInjection } from "./catalog.ts";
+import { MIDDLEWARE_GLOBAL_ROOT, type McpManager } from "./manager.ts";
+import { normalizeMiddlewareMode, registerMiddlewareTools } from "./middleware.ts";
+import type { MiddlewareMode } from "./middleware-types.ts";
+import { makeRoutes, makeEventsRoute, makeHealthRoute } from "./routes.ts";
+import { sseData } from "../../../shared/host-utils.js";
+
+/** apply 运行期装配产物的 disposer 集合（顶层 effect 统一收口）。 */
+export interface ApplyDisposers {
+  disposeRoutes: () => void;
+  disposeSection: () => void;
+  disposeInjection: () => void;
+  disposeMiddleware: () => void;
+  watchCleanup: () => void;
+}
+
+export function createEmptyDisposers(): ApplyDisposers {
+  const noop = () => {};
+  return { disposeRoutes: noop, disposeSection: noop, disposeInjection: noop, disposeMiddleware: noop, watchCleanup: noop };
+}
+
+/**
+ * 中间层模式热切换（设置页「中间层模式」下拉；initMiddleware 幂等已有，
+ * off↔project/all 需重新注册/卸载中间层工具——dispose 后重建）。
+ * 注册在模式分支之外：启动即 off 时也能从设置页切到 project/all。
+ */
+export function makeMiddlewareHotSwitch(
+  manager: McpManager,
+  middlewarePolicy: Record<string, unknown> | undefined,
+  resolveRoot: (agent: unknown) => Promise<string | undefined>,
+  dispose: { current: () => void },
+): (mode: MiddlewareMode) => Promise<void> {
+  return async (mode: MiddlewareMode): Promise<void> => {
+    if (normalizeMiddlewareMode(mode) === manager.middlewareMode) return;
+    const next = normalizeMiddlewareMode(mode);
+    manager.middlewareMode = next;
+    dispose.current();
+    if (next !== "off") {
+      const mw = await manager.initMiddleware(next, middlewarePolicy ?? {});
+      dispose.current = registerMiddlewareTools(manager.ctx, mw, resolveRoot, next, {
+        disabledTools: manager.disabledTools,
+      });
+    }
+    // off ↔ project/all：重注册/卸载中间层工具后 reconcile——all 模式下全局
+    // supervisor 由 reconcile 停掉、新全局条目经 start 内部接管触达 @global
+    // 单元（#382 F3）；off 语义停掉全部中间层接管条目。防同一 server 双进程。
+    manager.reconcileServers();
+    manager.logger.info(`dsh-mcp-manager: middleware mode=${next} (hot-switched)`);
+  };
+}
+
+/**
+ * L1 能力目录注入（history-based 去重，仿 dsh-tool-skill catalog）：
+ * 决策逻辑在 resolveCatalogInjection（纯函数，可单测）。
+ */
+export function registerCatalogInjection(
+  ctx: Context,
+  manager: McpManager,
+  catalogMaxEntries: number,
+): () => void {
+  // 官方强类型 payload：PreStepDecision waterfall（{kind:'reject'}|{kind:'enter';messages}）。
+  // 目录决策逻辑在纯函数 resolveCatalogInjection（自建 CatalogDecision 宽面，
+  // 可单测），此处仅做边界收窄/放宽。
+  return ctx.on("agent/pre-step", async ({ agent, messages, signal }, next) => {
+    const decision = await next();
+    signal.throwIfAborted();
+    // 目录数据源按会话 cwd 计算（工作区缓存），不跟随 host 的"当前工作区"
+    // 实时状态——切换工作区不改变本会话目录集合，MCP 没变化就不重复注入。
+    const supervisors = await manager.catalogServersFor(agent?.session?.header?.cwd);
+    // #569：合成注入端目录缓存视图（B 起步 + 中间层 per-root 目录覆盖 +
+    // 磁盘 last-good 兜底）。manager.catalogCache 是 supervisor（直呼）路径的
+    // 摘要缓存；middleware 模式下其采集的工具目录注入端此前读不到——视图把
+    // 两套数据源收口为一个 CatalogCache 形态，公共函数签名不变。
+    const catalogView = await manager.catalogViewFor(agent?.session?.header?.cwd, supervisors);
+    // 边界放宽：纯函数吃自建宽面 CatalogDecision，返回值即本轮 PreStepDecision
+    return resolveCatalogInjection(
+      decision as unknown as CatalogDecision,
+      messages as CatalogMessage[],
+      supervisors as Map<string, SupervisorLite>,
+      catalogMaxEntries,
+      catalogView,
+      agent as unknown as CatalogAgent | undefined,
+      // 热切换后目录文案按当前模式渲染（#362 设置页中间层模式下拉）。
+      manager.middlewareMode,
+    ) as unknown as PreStepDecision;
+  });
+}
+
+/**
+ * 注册 /api/dsh-mcp/* 路由 + SSE 状态广播接线。
+ * 状态变化 → 广播 SSE 帧（hub 在 makeEventsRoute 中惰性创建，#515）。
+ */
+export function setupRoutesAndBroadcast(ctx: Context, manager: McpManager): () => void {
+  const routes = makeRoutes(manager);
+  const eventsRoute = makeEventsRoute(manager);
+  const healthRoute = makeHealthRoute(manager);
+  const disposers = [...routes, eventsRoute, healthRoute].map((route) => ctx.webServer.register(route));
+  const unsubscribeStatus = manager.onStatus(() => {
+    manager.sseHub?.broadcast(sseData({ type: "summary" }));
+  });
+  return () => {
+    unsubscribeStatus();
+    for (const dispose of disposers) dispose();
+    // #515：hub.dispose() 统一停心跳 + destroy 全部连接（幂等，不依赖
+    // close 事件异步时序）；取代旧 sseHeartbeatCleanups 逐连接清理。
+    manager.sseHub?.dispose();
+    manager.sseHub = undefined;
+  };
+}
+
+/**
+ * 变更点驱动（#111）：fs.watch 监听全局与当前项目 mcp.json 配置目录，
+ * 外部编辑/落盘 → 防重入 reconcile（运行中排队补跑）。取代 mtime 轮询。
+ */
+export async function setupConfigWatchersAsync(manager: McpManager): Promise<() => void> {
+  try {
+    const fs = await import("node:fs");
+    const watchers: Array<{ close(): void }> = [];
+    const watched = new Set<string>();
+    const watchConfig = (dir: string) => {
+      if (watched.has(dir)) return;
+      watched.add(dir);
+      let busy = false;
+      let rerun = false;
+      const run = () => {
+        if (busy) {
+          rerun = true;
+          return;
+        }
+        busy = true;
+        void (async () => {
+          try {
+            await manager.refreshFromDisk();
+          } finally {
+            busy = false;
+            if (rerun) {
+              rerun = false;
+              run();
+            }
+          }
+        })();
+      };
+      try {
+        const watcher = fs.watch(dir, { persistent: false }, () => run());
+        // 目录被删/重命名等场景 FSWatcher 会 emit error；无监听器会抛
+        // uncaught exception 崩溃宿主进程（P1 修复）。
+        watcher.on("error", () => {
+          // 目录消失/权限变化：移除 watcher（配置写路径仍会 reconcile）。
+          const index = watchers.indexOf(watcher);
+          if (index >= 0) watchers.splice(index, 1);
+          try {
+            watcher.close();
+          } catch {
+            // 已关闭
+          }
+        });
+        watchers.push(watcher);
+      } catch {
+        // watch 不可用（某些平台/只读目录）：降级无 watcher（写路径仍会 reconcile）。
+      }
+    };
+    watchConfig(dirname(manager.store.path));
+    if (manager.projectStore !== undefined) watchConfig(dirname(manager.projectStore.path));
+    // 会话切换时项目 store 变化 → 重新挂 watcher。
+    const unwatchProject = manager.onStatus(() => {
+      if (manager.projectStore !== undefined) watchConfig(dirname(manager.projectStore.path));
+    });
+    return () => {
+      unwatchProject();
+      for (const watcher of watchers.splice(0)) {
+        try {
+          watcher.close();
+        } catch {
+          // 已关闭
+        }
+      }
+    };
+  } catch {
+    // fs.watch 不可用：保持既有行为（写路径仍会 reconcile）。
+    return () => {};
+  }
+}
+
+/** resolveRoot 路由：exec.agent → 归一化项目根（agent-less → undefined）。 */
+export function makeResolveRoot(manager: McpManager): (agent: unknown) => Promise<string | undefined> {
+  // 路由输入：exec.agent 当前 cwd = agent.session.header.cwd（实证已闭合）。
+  // all 模式：cwd 无项目（或无项目配置）时 fallback 到全局虚拟 root @global。
+  return async (agent: unknown): Promise<string | undefined> => {
+    if (typeof agent !== "object" || agent === null) return undefined;
+    const session = (agent as { session?: { header?: { cwd?: unknown } } }).session;
+    const cwd = session?.header?.cwd;
+    const root = await manager.normalizedProjectRoot(typeof cwd === "string" ? cwd : undefined);
+    if (root !== undefined) return root;
+    if (manager.middlewareMode === "all") {
+      const globalServers = manager.globalServers().filter((server) => server.enabled !== false);
+      if (globalServers.length > 0) return MIDDLEWARE_GLOBAL_ROOT;
+    }
+    return undefined;
+  };
+}

--- a/packages/dsh-mcp-manager/src/apply-services.ts
+++ b/packages/dsh-mcp-manager/src/apply-services.ts
@@ -1,0 +1,59 @@
+/**
+ * dsh-mcp-manager — apply 装配拆分：核心化服务注入面（#592 阶段二 Batch A）。
+ *
+ * 职责：把 apply() 中向容器提供 mcpManager 核心化服务的 8 方法服务对象装配
+ * 抽为独立工厂（原内联闭包是 apply 圈复杂度 78 的主要来源之一）。
+ *
+ * 契约红线：service-contract.test.ts 以源文本静态扫描 provide marker 提取
+ * 方法面（8 方法/参数形状，fail-loud）——本文件保留与拆分前**逐字相同**的
+ * marker 与方法名/参数形状，拆分零行为变更；若改方法面须同步契约清单。
+ * 注意：本文件注释中不得出现该 marker 的逐字形态（静态扫描按首个命中定位，
+ * 注释命中会导致配对错扫——契约测试会红提示）。
+ */
+
+import type { Context } from "@deepseek-ai/cordis";
+import type { McpManager } from "./manager.ts";
+import type { McpServerSummary } from "../../../shared/mcp-manager-service.js";
+
+/**
+ * 向宿主容器提供核心化服务 `ctx.mcpManager`（供其他插件运行时注入/控制/查询
+ * MCP 服务器）。提供时机由调用方保证（store.load 之后 manager 已就绪）；卸载
+ * 由 mcp-manager 自身 dispose() 全量清理（含 runtime 条目与 supervisor）。
+ * 兼容：fake ctx（单元测试 mock）可能无 provide，可选调用静默降级。
+ */
+export function provideMcpManagerService(ctx: Context, manager: McpManager): void {
+  if (typeof (ctx as unknown as { provide?: unknown }).provide !== "function") return;
+  ctx.provide("mcpManager", {
+    // 注入面（内存态不落盘，同名幂等；toolDefinitions 可选封装定义透传 supervisor）
+    registerServer: (server: Record<string, unknown>) => manager.registerServer(server),
+    unregisterServer: (name: string) => manager.unregisterServer(name),
+    // 控制面（通用 MCP 生命周期：注册即连、注销即断的补充控制）
+    connect: (name: string, scope?: string) => manager.connect(name, scope),
+    disconnect: (name: string, scope?: string) => manager.disconnect(name, scope),
+    reconnect: (name: string, scope?: string) => manager.reconnect(name, scope),
+    // 查询面（服务状态感知：连接状态 / 工具列表 / 全量摘要）
+    getStatus: (name: string) => {
+      const servers = (manager.summary().servers ?? []) as Array<Record<string, unknown>>;
+      const found = servers.find((s) => s.name === name);
+      if (found === undefined) return undefined;
+      return found as unknown as McpServerSummary;
+    },
+    getTools: (name: string) => {
+      // 契约（#382 F4）：getTools 返回**注册名**（mcp__<server>__<tool> 前缀，
+      // 与 ctx.tools 注册表一致）；summary().tools 返回**裸名**（展示/禁用表
+      // 键口径）。消费方按需自取，勿混用两套键。
+      const sup = manager.supervisors.get(name);
+      if (sup === undefined) return [];
+      const tools: Array<{ name: string; description?: string }> = [];
+      for (const [toolName, meta] of sup.toolMeta ?? new Map()) {
+        tools.push({
+          name: toolName,
+          description: typeof meta?.description === "string" ? meta.description : undefined,
+        });
+      }
+      return tools;
+    },
+    list: () =>
+      (manager.summary().servers ?? []) as unknown as McpServerSummary[],
+  });
+}

--- a/packages/dsh-mcp-manager/src/apply.ts
+++ b/packages/dsh-mcp-manager/src/apply.ts
@@ -3,31 +3,43 @@
  *
  * 加载存储、启动已启用服务器、注册路由/中间层工具/能力目录/提示词；
  * index.ts 仅 re-export（插件契约转发），apply.ts 不 import index.ts（防循环）。
+ *
+ * #592 阶段二 Batch A 消峰：原 apply() 单函数圈复杂度 78（全仓第二），全部
+ * 来自内联装配闭包；拆分后本文件只保留顺序装配骨架——
+ * - 配置解析与 settings 接线 → apply-config.ts
+ * - 服务注入面 → apply-services.ts
+ * - 运行期装配阶段 → apply-runtime.ts（watchers / 热切换 / catalog / 路由）
+ * - Agent 宣告文案 → apply-guidance.ts
+ * 行为与拆分前逐字节等价；service-contract.test.ts 的 provide 源文本静态
+ * 扫描 marker 迁移至 apply-services.ts（契约测试同步更新）。
  */
 
-import { dirname } from "node:path";
 import type { Context } from "@deepseek-ai/cordis";
-import type { PreStepDecision } from "@deepseek-ai/dsh-agent";
-import { installSettingsNamespace } from "../../../shared/settings-namespace.js";
-import type { CatalogCache, CatalogDecision, CatalogMessage, SupervisorLite, CatalogAgent } from "./catalog.ts";
-import { DEFAULT_ANNOUNCE_CATALOG, DEFAULT_CATALOG_MAX_ENTRIES, resolveCatalogInjection } from "./catalog.ts";
-import { Config, DEFAULT_ENHANCE_EMPTY_DESCRIPTIONS } from "./config-schema.ts";
-import { McpManager, MIDDLEWARE_GLOBAL_ROOT } from "./manager.ts";
-import { defaultStorePath, McpStore } from "./store.ts";
-import { DEFAULT_RESULT_TRUNCATE_BYTES } from "./supervisor.ts";
+import { McpManager } from "./manager.ts";
+import { McpStore } from "./store.ts";
 import { normalizeMiddlewareMode, registerMiddlewareTools } from "./middleware.ts";
-import type { MiddlewareMode } from "./middleware-types.ts";
-import { makeRoutes, makeEventsRoute, makeHealthRoute, uiConfigChangedFrame } from "./routes.ts";
-import { sseData } from "../../../shared/host-utils.js";
+import { makeMiddlewareHotSwitch, makeResolveRoot } from "./apply-runtime.ts";
+import { registerCatalogInjection, setupConfigWatchersAsync, setupRoutesAndBroadcast } from "./apply-runtime.ts";
+import { provideMcpManagerService } from "./apply-services.ts";
+import {
+  injectSettingsSink,
+  installConfigSettings,
+  resolveApplyOptions,
+  resolveMiddlewareMode,
+  resolveStorePath,
+} from "./apply-config.ts";
+import { MCP_GUIDANCE } from "./apply-guidance.ts";
+// 导出面兼容：index.ts 仍从 apply.ts re-export MCP_GUIDANCE（组合根单一来源不变）。
+export { MCP_GUIDANCE };
 
-/** 向 Agent 宣告插件（announceToAgent 开启时注入）。能力清单由动态目录
- * （<available_mcp_servers>，见 L1）承担，此处只保留插件存在、安全边界与术语约定，
- * 不再复述 UI 配置路径与调用流程（那部分由能力目录与中间层工具描述承担）。 */
-export const MCP_GUIDANCE =
-  "dsh-mcp-manager is active: centrally manages MCP server connections without preset servers. MCP tools execute on real servers with inherited host permissions; results may contain sensitive data — explain and obtain user consent before write or sensitive operations. Terms like 'MCP / context server' refer to this plugin. Invocation rules:\n" +
-  "- Project-level servers: search with `ws_mcp_search`, verify schema with `ws_mcp_detail` if uncertain, then invoke with `ws_mcp_call`. Do NOT call mcp__ prefixed tools directly.\n" +
-  "- Global servers: call `mcp__<server>__<tool>` directly (or via `ws_mcp_call` in all mode).\n" +
-  "- Do not retry a failing server tool more than twice.";
+/** enabled 分支装配产物（disposer 集合，顶层 effect 统一收口）。 */
+interface EnabledRuntimeDisposers {
+  disposeRoutes: () => void;
+  disposeSection: () => void;
+  disposeInjection: () => void;
+  disposeMiddleware: () => void;
+  watchCleanup: () => void;
+}
 
 /**
  * 挂载 MCP 管理器：加载存储、启动已启用服务器、注册路由与提示词。
@@ -35,76 +47,24 @@ export const MCP_GUIDANCE =
  * @param config 解析后的插件配置。
  */
 export async function apply(ctx: Context, config: Record<string, unknown> | undefined): Promise<void> {
-  const enabled = config?.enabled !== false;
-  const announceToAgent = config?.announceToAgent !== false;
-  const storePath = typeof config?.storePath === "string" && config.storePath !== ""
-    ? config.storePath
-    : defaultStorePath();
+  const options = resolveApplyOptions(config);
 
-  // 感知增强配置（对抗性评审 v2）。默认值引用具名常量（单一事实源）。
-  const announceCatalog = (config?.announceCatalog as boolean | undefined) ?? DEFAULT_ANNOUNCE_CATALOG;
-  const catalogMaxEntries = Number.isFinite(config?.catalogMaxEntries) && (config?.catalogMaxEntries as number) > 0 ? Math.floor(config?.catalogMaxEntries as number) : DEFAULT_CATALOG_MAX_ENTRIES;
-  const enhanceEmptyDescriptions = (config?.enhanceEmptyDescriptions as boolean | undefined) ?? DEFAULT_ENHANCE_EMPTY_DESCRIPTIONS;
-  const resultTruncateBytes = Number.isFinite(config?.resultTruncateBytes) && (config?.resultTruncateBytes as number) > 0 ? Math.floor(config?.resultTruncateBytes as number) : DEFAULT_RESULT_TRUNCATE_BYTES;
-
-  const store = new McpStore(storePath);
+  const store = new McpStore(resolveStorePath(config));
   await store.load();
   const manager = new McpManager(ctx, store);
+  // 感知增强配置（对抗性评审 v2）。默认值引用具名常量（单一事实源）。
+  const enhanceEmptyDescriptions = (config?.enhanceEmptyDescriptions as boolean | undefined) ?? DEFAULT_ENHANCE_EMPTY;
+  const resultTruncateBytes = Number.isFinite(config?.resultTruncateBytes) && (config?.resultTruncateBytes as number) > 0
+    ? Math.floor(config?.resultTruncateBytes as number)
+    : DEFAULT_TRUNCATE;
   manager.enhancement = { enhanceEmptyDescriptions, resultTruncateBytes };
 
-  // 核心化服务（官方 storageDomain 模式）：对外暴露 ctx.mcpManager，供其他插件
-  // 运行时注入/控制/查询 MCP 服务器。
-  // 提供时机：store.load 之后（manager 已就绪）。卸载由 mcp-manager 自身 dispose()
-  // 全量清理（含 runtime 条目与 supervisor）。
-  // 兼容：fake ctx（单元测试 mock）可能无 provide，可选调用静默降级。
-  if (typeof (ctx as unknown as { provide?: unknown }).provide === "function") {
-    ctx.provide("mcpManager", {
-      // 注入面（内存态不落盘，同名幂等；toolDefinitions 可选封装定义透传 supervisor）
-      registerServer: (server: Record<string, unknown>) => manager.registerServer(server),
-      unregisterServer: (name: string) => manager.unregisterServer(name),
-      // 控制面（通用 MCP 生命周期：注册即连、注销即断的补充控制）
-      connect: (name: string, scope?: string) => manager.connect(name, scope),
-      disconnect: (name: string, scope?: string) => manager.disconnect(name, scope),
-      reconnect: (name: string, scope?: string) => manager.reconnect(name, scope),
-      // 查询面（服务状态感知：连接状态 / 工具列表 / 全量摘要）
-      getStatus: (name: string) => {
-        const servers = (manager.summary().servers ?? []) as Array<Record<string, unknown>>;
-        const found = servers.find((s) => s.name === name);
-        if (found === undefined) return undefined;
-        return found as unknown as import("../../../shared/mcp-manager-service.js").McpServerSummary;
-      },
-      getTools: (name: string) => {
-        // 契约（#382 F4）：getTools 返回**注册名**（mcp__<server>__<tool> 前缀，
-        // 与 ctx.tools 注册表一致）；summary().tools 返回**裸名**（展示/禁用表
-        // 键口径）。消费方按需自取，勿混用两套键。
-        const sup = manager.supervisors.get(name);
-        if (sup === undefined) return [];
-        const tools: Array<{ name: string; description?: string }> = [];
-        for (const [toolName, meta] of sup.toolMeta ?? new Map()) {
-          tools.push({
-            name: toolName,
-            description: typeof meta?.description === "string" ? meta.description : undefined,
-          });
-        }
-        return tools;
-      },
-      list: () =>
-        (manager.summary().servers ?? []) as unknown as Array<import("../../../shared/mcp-manager-service.js").McpServerSummary>,
-    });
-  }
+  // 核心化服务（官方 storageDomain 模式）：对外暴露 ctx.mcpManager（apply-services）。
+  provideMcpManagerService(ctx, manager);
 
-  // 插件自身 Config schema（标准 cordis 配置注入路径）：position/offset 不再藏于
-  // 隐藏命名空间，设置页插件卡可编辑；配置变更经既有 SSE events 通道广播一帧，
-  // 客户端收到后重新 GET /api/dsh-mcp/config 就地更新浮窗位置（无需重启/轮询）。
-  const broadcastUiConfigChanged = () => {
-    // #515：广播收口到共享 hub（未创建 = 尚无 events 订阅，跳过）。
-    manager.sseHub?.broadcast(uiConfigChangedFrame());
-  };
-  // #389：把 settings 命名空间合并面（含用户层保存的 middleware）同步到运行时。
-  // 保存路径（routes POST config middleware 分支）写 settings 用户层；apply 启动
-  // 读的是组合层 config.middleware（不含用户层覆盖）→ 重启后模式回退 project。
-  // 此函数在 settings 注入完成/变化（onChange）与 apply 主体就绪（setMiddlewareMode
-  // 赋值后）两处调用：前者覆盖运行期变更，后者覆盖启动时 settings 已就绪的场景。
+  // #389：settings 命名空间合并面（含用户层保存的 middleware）→ 运行时同步。
+  // 此同步函数在 settings onChange（运行期变更）与启动兜底（enabled 分支内）
+  // 两处调用：前者覆盖运行期变更，后者覆盖启动时 settings 已就绪的场景。
   const syncMiddlewareFromSettings = (): void => {
     if (typeof manager.setMiddlewareMode !== "function") return;
     const source = manager.uiConfigSource();
@@ -114,245 +74,101 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
     if (next === manager.middlewareMode) return;
     void manager.setMiddlewareMode(next).catch((error: unknown) => manager.logger.warn(`dsh-mcp-manager: sync middleware from settings failed: ${String(error)}`));
   };
-  installSettingsNamespace(ctx, "dsh-mcp-manager", Config, config ?? {}, {
-    setSource: (source) => {
-      manager.uiConfigSource = source as () => any;
-    },
-    onChange: () => {
-      broadcastUiConfigChanged();
-      syncMiddlewareFromSettings();
-    },
-  });
+  installConfigSettings(ctx, manager, config, syncMiddlewareFromSettings);
+  injectSettingsSink(ctx, manager);
 
-  // 写入 sink：设置页卡片经 POST /api/dsh-mcp/config 写配置时，通过 settings 服务
-  // 的 namespace update 落盘并触发 scope.watch → onChange → SSE 广播。settings 服务
-  // 未挂载时 uiUpdate 保持 undefined → 写路由返回「不可写」（卡片/设置页本就不渲染）。
-  if (typeof ctx.inject === "function") {
-    ctx.inject(["settings"], (sctx) => {
-      // sctx 注入 settings 服务（cordis 类型面未声明该服务，经 unknown 中转取最小面）。
-      const settings = (sctx as unknown as { settings?: { update?: (ns: string, patch: Record<string, unknown>) => Promise<unknown> } } | undefined)?.settings;
-      if (settings && typeof settings.update === "function") {
-        // settings.update 是 cordis 服务方法，不绑 this（内部访问 this.write）——直接
-        // 解构后调用会丢 this → this.write undefined（回归 #125 保存 400）。这里保留
-        // 本地引用并以 call(settings) 把服务对象本身作为 this 传入；同时规避 TS 对
-        // 可选属性 settings.update 的收窄在闭包内丢失（2722）。
-        const update = settings.update;
-        manager.uiUpdate = (patch) => update.call(settings, "dsh-mcp-manager", patch);
-      }
-    });
-  }
+  let runtime: EnabledRuntimeDisposers = {
+    disposeRoutes: () => {},
+    disposeSection: () => {},
+    disposeInjection: () => {},
+    disposeMiddleware: () => {},
+    watchCleanup: () => {},
+  };
 
-
-  let disposeRoutes = () => {};
-  let disposeSection = () => {};
-  let disposeInjection = () => {};
-  let disposeMiddleware = () => {};
-  let watchCleanup: () => void = () => {};
-
-  if (enabled) {
-    // F3（#382）：中间层初始化提前到 startAll 之前——start 内部的接管判定
-    // （middlewareTakes）依赖 middleware 实例与模式；此前 startAll 先建全部
-    // supervisor、中间层初始化完才 reconcile 停掉（all 含全局），「先建后停」
-    // 的竞态窗口内 mcp__ 注册残留，中间层防双进程探测命中且无重试 → 热更新后
-    // 全局服务器掉线。重排后 all 模式启动直接走 @global 单元惰性连接，不建
-    // supervisor；project 模式全局照旧 supervisor。
-    // 默认值与 Config schema 一致（project）；宿主未 parse 原始 config 时兜底。
-    // #389 M2：settings 合并面（scope.get()）就绪时直接取持久化的 middleware 模式，
-    // 避免「先按 config 默认 project 起 supervisor、再热切换 all」的启动抖动（连→断→连）。
-    // settings 不可用/未注入时 uiConfigSource 为默认值（无 middleware）→ 回落 config。
-    const settingsSource = manager.uiConfigSource();
-    const persistedMiddleware =
-      typeof settingsSource === "object" && settingsSource !== null
-        ? (settingsSource as Record<string, unknown>).middleware
-        : undefined;
-    const middlewareMode = normalizeMiddlewareMode(
-      typeof persistedMiddleware === "string" ? persistedMiddleware : config?.middleware ?? "project",
-    );
-    // 路由输入：exec.agent 当前 cwd = agent.session.header.cwd（实证已闭合）。
-    // all 模式：cwd 无项目（或无项目配置）时 fallback 到全局虚拟 root @global。
-    const resolveRoot = async (agent: unknown): Promise<string | undefined> => {
-      if (typeof agent !== "object" || agent === null) return undefined;
-      const session = (agent as { session?: { header?: { cwd?: unknown } } }).session;
-      const cwd = session?.header?.cwd;
-      const root = await manager.normalizedProjectRoot(typeof cwd === "string" ? cwd : undefined);
-      if (root !== undefined) return root;
-      if (manager.middlewareMode === "all") {
-        const globalServers = manager.globalServers().filter((server) => server.enabled !== false);
-        if (globalServers.length > 0) return MIDDLEWARE_GLOBAL_ROOT;
-      }
-      return undefined;
-    };
-    if (middlewareMode !== "off") {
-      const mw = await manager.initMiddleware(middlewareMode, (config?.middlewarePolicy as Record<string, unknown> | undefined) ?? {});
-      disposeMiddleware = registerMiddlewareTools(manager.ctx, mw, resolveRoot, middlewareMode, {
-        disabledTools: manager.disabledTools,
-      });
-    }
-    await manager.startAll();
-    await manager.loadCatalogCache();
-    manager.reconcileServers();
-    manager.logger.info(`dsh-mcp-manager: middleware mode=${middlewareMode}`);
-
-    // 中间层模式热切换（设置页「中间层模式」下拉；initMiddleware 幂等已有，
-    // off↔project/all 需重新注册/卸载中间层工具——dispose 后重建）。
-    // 注册在模式分支之外：启动即 off 时也能从设置页切到 project/all。
-    manager.setMiddlewareMode = async (mode: MiddlewareMode): Promise<void> => {
-      if (normalizeMiddlewareMode(mode) === manager.middlewareMode) return;
-      const next = normalizeMiddlewareMode(mode);
-      manager.middlewareMode = next;
-      disposeMiddleware();
-      if (next !== "off") {
-        const mw = await manager.initMiddleware(next, (config?.middlewarePolicy as Record<string, unknown> | undefined) ?? {});
-        disposeMiddleware = registerMiddlewareTools(manager.ctx, mw, resolveRoot, next, {
-          disabledTools: manager.disabledTools,
-        });
-      }
-      // off ↔ project/all：重注册/卸载中间层工具后 reconcile——all 模式下全局
-      // supervisor 由 reconcile 停掉、新全局条目经 start 内部接管触达 @global
-      // 单元（#382 F3）；off 语义停掉全部中间层接管条目。防同一 server 双进程。
-      manager.reconcileServers();
-      manager.logger.info(`dsh-mcp-manager: middleware mode=${next} (hot-switched)`);
-    };
-    // #389：启动阶段把 settings 持久化的 middleware 模式同步到运行时——apply 主体
-    // 完成、setMiddlewareMode 已挂载后主动同步一次（onChange 若早于此处触发会被
-    // typeof 守卫跳过，这里兜底）。settings 不可用时 uiConfigSource 无 middleware，
-    // 读取结果为 undefined → 保持 config 默认，行为与历史一致。
-    syncMiddlewareFromSettings();
-
-    // L1 能力目录注入（history-based 去重，仿 dsh-tool-skill catalog）：
-    // 决策逻辑在 resolveCatalogInjection（纯函数，可单测）。
-    if (announceCatalog) {
-      // 官方强类型 payload：PreStepDecision waterfall（{kind:'reject'}|{kind:'enter';messages}）。
-      // 目录决策逻辑在纯函数 resolveCatalogInjection（自建 CatalogDecision 宽面，
-      // 可单测），此处仅做边界收窄/放宽。
-      disposeInjection = ctx.on("agent/pre-step", async ({ agent, messages, signal }, next) => {
-        const decision = await next();
-        signal.throwIfAborted();
-        // 目录数据源按会话 cwd 计算（工作区缓存），不跟随 host 的"当前工作区"
-        // 实时状态——切换工作区不改变本会话目录集合，MCP 没变化就不重复注入。
-        const supervisors = await manager.catalogServersFor(agent?.session?.header?.cwd);
-        // #569：合成注入端目录缓存视图（B 起步 + 中间层 per-root 目录覆盖 +
-        // 磁盘 last-good 兜底）。manager.catalogCache 是 supervisor（直呼）路径的
-        // 摘要缓存；middleware 模式下其采集的工具目录注入端此前读不到——视图把
-        // 两套数据源收口为一个 CatalogCache 形态，公共函数签名不变。
-        const catalogView = await manager.catalogViewFor(agent?.session?.header?.cwd, supervisors);
-        // 边界放宽：纯函数吃自建宽面 CatalogDecision，返回值即本轮 PreStepDecision
-        return resolveCatalogInjection(
-          decision as unknown as CatalogDecision,
-          messages as CatalogMessage[],
-          supervisors as Map<string, SupervisorLite>,
-          catalogMaxEntries,
-          catalogView,
-          agent as unknown as CatalogAgent | undefined,
-          // 热切换后目录文案按当前模式渲染（#362 设置页中间层模式下拉）。
-          manager.middlewareMode,
-        ) as unknown as PreStepDecision;
-      });
-    }
-
-    disposeRoutes = ctx.effect(() => {
-      const routes = makeRoutes(manager);
-      const eventsRoute = makeEventsRoute(manager);
-      const healthRoute = makeHealthRoute(manager);
-      const disposers = [...routes, eventsRoute, healthRoute].map((route) => ctx.webServer.register(route));
-      // 状态变化 → 广播 SSE 帧（hub 在 makeEventsRoute 中惰性创建，#515）。
-      const unsubscribeStatus = manager.onStatus(() => {
-        manager.sseHub?.broadcast(sseData({ type: "summary" }));
-      });
-      return () => {
-        unsubscribeStatus();
-        for (const dispose of disposers) dispose();
-        // #515：hub.dispose() 统一停心跳 + destroy 全部连接（幂等，不依赖
-        // close 事件异步时序）；取代旧 sseHeartbeatCleanups 逐连接清理。
-        manager.sseHub?.dispose();
-        manager.sseHub = undefined;
-      };
-    }, "dsh-mcp-manager: routes");
-
-    // 变更点驱动（#111）：fs.watch 监听全局与当前项目 mcp.json 配置目录，
-    // 外部编辑/落盘 → 防重入 reconcile（运行中排队补跑）。取代 mtime 轮询。
-    try {
-      const fs = await import("node:fs");
-      const watchers: Array<{ close(): void }> = [];
-      const watched = new Set<string>();
-      const watchConfig = (dir: string) => {
-        if (watched.has(dir)) return;
-        watched.add(dir);
-        let busy = false;
-        let rerun = false;
-        const run = () => {
-          if (busy) {
-            rerun = true;
-            return;
-          }
-          busy = true;
-          void (async () => {
-            try {
-              await manager.refreshFromDisk();
-            } finally {
-              busy = false;
-              if (rerun) {
-                rerun = false;
-                run();
-              }
-            }
-          })();
-        };
-        try {
-          const watcher = fs.watch(dir, { persistent: false }, () => run());
-          // 目录被删/重命名等场景 FSWatcher 会 emit error；无监听器会抛
-          // uncaught exception 崩溃宿主进程（P1 修复）。
-          watcher.on("error", () => {
-            // 目录消失/权限变化：移除 watcher（配置写路径仍会 reconcile）。
-            const index = watchers.indexOf(watcher);
-            if (index >= 0) watchers.splice(index, 1);
-            try {
-              watcher.close();
-            } catch {
-              // 已关闭
-            }
-          });
-          watchers.push(watcher);
-        } catch {
-          // watch 不可用（某些平台/只读目录）：降级无 watcher（写路径仍会 reconcile）。
-        }
-      };
-      watchConfig(dirname(manager.store.path));
-      if (manager.projectStore !== undefined) watchConfig(dirname(manager.projectStore.path));
-      // 会话切换时项目 store 变化 → 重新挂 watcher。
-      const unwatchProject = manager.onStatus(() => {
-        if (manager.projectStore !== undefined) watchConfig(dirname(manager.projectStore.path));
-      });
-      watchCleanup = () => {
-        unwatchProject();
-        for (const watcher of watchers.splice(0)) {
-          try {
-            watcher.close();
-          } catch {
-            // 已关闭
-          }
-        }
-      };
-    } catch {
-      // fs.watch 不可用：保持既有行为（写路径仍会 reconcile）。
-    }
-    if (announceToAgent) {
-      // 官方 SystemPrompt.section(opts) 签名（PromptSection）；此处传参满足其形状，
-      // 经 unknown 中转以维持局部最小面写法。
-      disposeSection = (ctx.systemPrompt as unknown as { section(opts: Record<string, unknown>): () => void }).section({
-        name: "plugin:dsh-mcp-manager",
-        order: 160,
-        text: MCP_GUIDANCE,
-      });
-    }
+  if (options.enabled) {
+    runtime = await assembleEnabledRuntime(ctx, manager, options, syncMiddlewareFromSettings);
   }
 
   ctx.effect(() => () => {
-    disposeInjection();
-    disposeSection();
-    disposeRoutes();
-    disposeMiddleware();
-    watchCleanup();
+    runtime.disposeInjection();
+    runtime.disposeSection();
+    runtime.disposeRoutes();
+    runtime.disposeMiddleware();
+    runtime.watchCleanup();
     void manager.dispose();
   }, "dsh-mcp-manager: dispose");
 }
+
+/** enabled 分支装配（中间层 / 启动 / catalog / 路由 / watchers / 提示词）。 */
+async function assembleEnabledRuntime(
+  ctx: Context,
+  manager: McpManager,
+  options: { announceCatalog: boolean; announceToAgent: boolean; catalogMaxEntries: number; middlewarePolicy: Record<string, unknown>; middlewareModeRaw: string | undefined },
+  syncMiddlewareFromSettings: () => void,
+): Promise<EnabledRuntimeDisposers> {
+  // F3（#382）：中间层初始化提前到 startAll 之前（防「先建后停」竞态，详见
+  // apply-runtime 注释）；#389 M2：settings 合并面就绪时直接取持久化模式，
+  // 避免「先起 supervisor 再热切换 all」的启动抖动（连→断→连）。
+  const middlewareMode = resolveMiddlewareMode(manager, options.middlewareModeRaw);
+
+  const resolveRoot = makeResolveRoot(manager);
+  // dispose.current 由热切换闭包持有重挂（off↔project/all 重建中间层工具）。
+  let currentMiddlewareDispose = () => {};
+  const middlewareDisposer = {
+    get current(): () => void {
+      return currentMiddlewareDispose;
+    },
+    set current(fn: () => void) {
+      currentMiddlewareDispose = fn;
+    },
+  };
+  if (middlewareMode !== "off") {
+    const mw = await manager.initMiddleware(middlewareMode, options.middlewarePolicy);
+    currentMiddlewareDispose = registerMiddlewareTools(ctx, mw, resolveRoot, middlewareMode, {
+      disabledTools: manager.disabledTools,
+    });
+  }
+  manager.setMiddlewareMode = makeMiddlewareHotSwitch(manager, options.middlewarePolicy, resolveRoot, middlewareDisposer);
+
+  await manager.startAll();
+  await manager.loadCatalogCache();
+  manager.reconcileServers();
+  manager.logger.info(`dsh-mcp-manager: middleware mode=${middlewareMode}`);
+
+  // #389：启动阶段把 settings 持久化的 middleware 模式同步到运行时（兜底）。
+  syncMiddlewareFromSettings();
+
+  let disposeInjection = () => {};
+  if (options.announceCatalog) {
+    disposeInjection = registerCatalogInjection(ctx, manager, options.catalogMaxEntries);
+  }
+
+  const disposeRoutes = ctx.effect(() => setupRoutesAndBroadcast(ctx, manager), "dsh-mcp-manager: routes");
+  const watchCleanup = await setupConfigWatchersAsync(manager);
+
+  let disposeSection = () => {};
+  if (options.announceToAgent) {
+    // 官方 SystemPrompt.section(opts) 签名（PromptSection）；此处传参满足其形状，
+    // 经 unknown 中转以维持局部最小面写法。
+    disposeSection = (ctx.systemPrompt as unknown as { section(opts: Record<string, unknown>): () => void }).section({
+      name: "plugin:dsh-mcp-manager",
+      order: 160,
+      text: MCP_GUIDANCE,
+    });
+  }
+
+  return {
+    disposeRoutes,
+    disposeSection,
+    disposeInjection,
+    disposeMiddleware: currentMiddlewareDispose,
+    watchCleanup,
+  };
+}
+
+// 具名常量（增强配置默认值）：DEFAULT_ENHANCE_EMPTY_DESCRIPTIONS 从 config-schema
+// re-export（拆分前 apply.ts 直接 import；此处保持同值语义）。
+import { DEFAULT_ENHANCE_EMPTY_DESCRIPTIONS } from "./config-schema.ts";
+import { DEFAULT_RESULT_TRUNCATE_BYTES } from "./supervisor.ts";
+const DEFAULT_ENHANCE_EMPTY = DEFAULT_ENHANCE_EMPTY_DESCRIPTIONS;
+const DEFAULT_TRUNCATE = DEFAULT_RESULT_TRUNCATE_BYTES;

--- a/packages/dsh-mcp-manager/src/routes-controllers.ts
+++ b/packages/dsh-mcp-manager/src/routes-controllers.ts
@@ -1,0 +1,361 @@
+/**
+ * dsh-mcp-manager — 路由控制器工厂（#592 阶段二 Batch A：makeRoutes 消峰）。
+ *
+ * 每个控制器是「buildXxxRoute(manager, helpers) → WebRoute」形态的纯工厂：
+ * 拆分前 makeRoutes 单函数圈复杂度 84（全仓第一），复杂度全部来自内联在各
+ * 路由 handler 闭包中的方法分流与字段校验分支；拆分后 makeRoutes 退化为
+ * 数组装配（comp <= 15），每个控制器的分支彼此独立、可独立理解与测试。
+ *
+ * 行为约束（与拆分前逐字节等价）：
+ * - 路由路径沿用 ROUTES 常量单一事实源；
+ * - loopback 围栏与 405 分流顺序不变（#473 R2：config GET 豁免 loopback，
+ *   白名单外方法先于 loopback 直接 405）；
+ * - JSON body 字节上限沿用 readJsonBody 默认行为（MAX_JSON_BODY_BYTES 保留
+ *   兼容导出，历史上为显式上限占位）。
+ */
+
+import { writeJson, readJsonBody, guardLoopbackMethod } from "../../../shared/host-utils.js";
+import { parseClaudeJson } from "./import.ts";
+import { SCOPE_PROJECT, normalizeScope } from "./scope.ts";
+import { parseFullServerName, MIDDLEWARE_GLOBAL_ROOT, normalizeToolName } from "./middleware-utils.ts";
+import { normalizeMiddlewareMode } from "./middleware-const.ts";
+import type { WebRoute } from "@deepseek-ai/dsh-host-webserver";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { RoutesManager } from "./routes.ts";
+import { queryParam } from "./routes-helpers.ts";
+
+/** 控制器共享 helpers（原 makeRoutes 闭包三件套，提升为显式参数）。 */
+export interface RouteHelpers {
+  handleError(res: ServerResponse, error: unknown): void;
+  scopeParam(url: URL): string;
+  maybeSession(url: URL): Promise<void>;
+}
+
+type Req = IncomingMessage;
+type Res = ServerResponse;
+
+/** 提取 name 查询参数；缺失时写 400 并返回 undefined。 */
+function requireNameParam(url: URL, res: Res): string | undefined {
+  const name = queryParam(url, "name");
+  if (name === undefined || name === "") {
+    writeJson(res, 400, { error: "name query parameter is required" });
+    return undefined;
+  }
+  return name;
+}
+
+// ------------------------------------------------------------ /config
+
+/** 只读 UI 配置 + 中间层模式热切换（GET 豁免 loopback；写操作 loopback-only）。 */
+export function buildConfigRoute(manager: RoutesManager, helpers: RouteHelpers): WebRoute {
+  return {
+    kind: "exact",
+    path: "/api/dsh-mcp/config",
+    handler: async (req: Req, res: Res) => {
+      // GET：只读 UI 配置 + 中间层模式（允许非 loopback，供远程页面读取非敏感的展示配置）。
+      if (req.method === "GET") {
+        try {
+          writeJson(res, 200, { ...manager.uiConfig(), middleware: manager.middlewareMode ?? "off" });
+        } catch (error) {
+          helpers.handleError(res, error);
+        }
+        return;
+      }
+      // POST：写入浮窗 UI 配置（position / offset），或热切换中间层模式
+      // （middleware: off/project/all）。写操作只对 loopback 开放；
+      // 经设置命名空间落盘（Config.ui），触发 scope.watch → onChange → SSE 广播一帧，
+      // 客户端收到后重新 GET /config 就地更新浮窗位置，无需重启/轮询。
+      if (req.method === "POST") {
+        if (!guardLoopbackMethod(req, res, ["POST"])) return;
+        let body: unknown;
+        try {
+          body = await readJsonBody(req);
+        } catch {
+          writeJson(res, 400, { error: "invalid JSON body" });
+          return;
+        }
+        if (typeof body !== "object" || body === null) {
+          writeJson(res, 400, { error: "invalid JSON body" });
+          return;
+        }
+        try {
+          const rec = body as Record<string, unknown>;
+          if (typeof rec.middleware === "string") {
+            // 中间层模式热切换：先热生效（当前进程立即切换），再落盘（重启保留）。
+            if (typeof manager.setMiddlewareMode === "function") {
+              await manager.setMiddlewareMode(rec.middleware);
+            }
+            if (typeof manager.uiUpdate === "function") {
+              await manager.uiUpdate({ middleware: normalizeMiddlewareMode(rec.middleware) });
+            }
+            writeJson(res, 200, { ...manager.uiConfig(), middleware: manager.middlewareMode ?? "off" });
+            return;
+          }
+          writeJson(res, 200, await manager.updateUiConfig(body));
+        } catch (error) {
+          helpers.handleError(res, error);
+        }
+        return;
+      }
+      // 端点级方法分流先于 loopback 的刻意例外（#473 R2 结构 β）：本分支对
+      // 白名单外方法（PUT/DELETE/OPTIONS 等）直接 405、不查 loopback——非
+      // loopback+PUT 返回 405 而非 403 是契约行为，禁止误套守卫（会漂移为 403）。
+      writeJson(res, 405, { error: `method not allowed: ${req.method}` });
+    },
+  };
+}
+
+// ------------------------------------------------------------ /servers
+
+/** 服务器集合 CRUD：GET 快照（纯读）/ POST 添加 / PATCH 更新 / DELETE 删除。 */
+export function buildServersRoute(manager: RoutesManager, helpers: RouteHelpers): WebRoute {
+  return {
+    kind: "exact",
+    path: "/api/dsh-mcp/servers",
+    handler: async (req: Req, res: Res) => {
+      const url = new URL(req.url ?? "/", "http://localhost");
+      const method = req.method ?? "GET";
+      if (!guardLoopbackMethod(req, res, ["GET", "POST", "PATCH", "DELETE"])) return;
+      if (method === "GET") {
+        try {
+          // 变更点驱动（#111/#228）：GET /servers 是纯读快照，零副作用——
+          // 磁盘变更由 fs.watch 事件驱动 reconcile，状态从内存 store 读。
+          // 历史 refreshFromDisk 副作用（mtime 轮询 + reconcile）已移除。
+          // cwd 查询参数不处理（#324）：GET 带 cwd 曾触发 setSession → emitStatus
+          // → SSE 广播 → 客户端再 GET 的自激循环（多页面互踩）。会话切换只走
+          // POST /api/dsh-mcp/session；此处忽略 cwd 以恢复纯读语义。
+          writeJson(res, 200, manager.summary());
+        } catch (error) {
+          helpers.handleError(res, error);
+        }
+        return;
+      }
+      if (method === "POST") {
+        const body = await readJsonBody(req);
+        if (body === undefined) {
+          writeJson(res, 400, { error: "invalid JSON body" });
+          return;
+        }
+        try {
+          const rec = body as Record<string, unknown>;
+          const scope = normalizeScope(rec.scope as string);
+          if (typeof rec.cwd === "string" && rec.cwd !== "") await manager.setSession(rec.cwd);
+          const server = await manager.add(rec, scope);
+          writeJson(res, 201, { server, summary: manager.summary() });
+        } catch (error) {
+          helpers.handleError(res, error);
+        }
+        return;
+      }
+      if (method === "PATCH" || method === "DELETE") {
+        const name = requireNameParam(url, res);
+        if (name === undefined) return;
+        try {
+          await helpers.maybeSession(url);
+          const scope = helpers.scopeParam(url);
+          if (method === "DELETE") {
+            await manager.remove(name, scope);
+            writeJson(res, 200, { ok: true, summary: manager.summary() });
+          } else {
+            const body = await readJsonBody(req);
+            if (body === undefined) {
+              writeJson(res, 400, { error: "invalid JSON body" });
+              return;
+            }
+            const server = await manager.update(name, body as Record<string, unknown>, scope);
+            writeJson(res, 200, { server, summary: manager.summary() });
+          }
+        } catch (error) {
+          helpers.handleError(res, error);
+        }
+        return;
+      }
+      writeJson(res, 405, { error: `method not allowed: ${method}` });
+    },
+  };
+}
+
+// ------------------------------------------------------------ /session 与 /resume
+
+/** 会话切换（跟随会话的项目级 MCP）。 */
+export function buildSessionRoute(manager: RoutesManager, helpers: RouteHelpers): WebRoute {
+  return {
+    kind: "exact",
+    path: "/api/dsh-mcp/session",
+    handler: async (req: Req, res: Res) => {
+      if (!guardLoopbackMethod(req, res, ["POST"])) return;
+      const body = await readJsonBody(req);
+      if (body === undefined || typeof (body as Record<string, unknown>).cwd !== "string") {
+        writeJson(res, 400, { error: "body must include a cwd string" });
+        return;
+      }
+      try {
+        await manager.setSession((body as Record<string, unknown>).cwd as string);
+        writeJson(res, 200, { ok: true, summary: manager.summary() });
+      } catch (error) {
+        helpers.handleError(res, error);
+      }
+    },
+  };
+}
+
+/** 切回前台受控重建当前工作空间连接。 */
+export function buildResumeRoute(manager: RoutesManager, helpers: RouteHelpers): WebRoute {
+  return {
+    kind: "exact",
+    path: "/api/dsh-mcp/resume",
+    handler: async (req: Req, res: Res) => {
+      if (!guardLoopbackMethod(req, res, ["POST"])) return;
+      try {
+        if (typeof manager.resumeReconnect !== "function") throw new Error("resumeReconnect unavailable");
+        await manager.resumeReconnect();
+        writeJson(res, 200, { ok: true, summary: manager.summary() });
+      } catch (error) {
+        helpers.handleError(res, error);
+      }
+    },
+  };
+}
+
+// ------------------------------------------------------------ connect / disconnect / reconnect
+
+/** 单服务器连接/断开/重连三兄弟路由（同构：name 必填 + maybeSession + scope）。 */
+function buildNameActionRoute(
+  path: string,
+  action: (name: string, scope: string) => Promise<void>,
+  manager: RoutesManager,
+  helpers: RouteHelpers,
+): WebRoute {
+  return {
+    kind: "exact",
+    path,
+    handler: async (req: Req, res: Res) => {
+      if (!guardLoopbackMethod(req, res, ["POST"])) return;
+      const url = new URL(req.url ?? "/", "http://localhost");
+      const name = requireNameParam(url, res);
+      if (name === undefined) return;
+      try {
+        await helpers.maybeSession(url);
+        await action(name, helpers.scopeParam(url));
+        writeJson(res, 200, { ok: true, summary: manager.summary() });
+      } catch (error) {
+        helpers.handleError(res, error);
+      }
+    },
+  };
+}
+
+/** POST /servers/connect：连接单服务器。 */
+export function buildConnectRoute(manager: RoutesManager, helpers: RouteHelpers): WebRoute {
+  return buildNameActionRoute("/api/dsh-mcp/servers/connect", (name, scope) => manager.connect(name, scope), manager, helpers);
+}
+
+/** POST /servers/disconnect：断开单服务器。 */
+export function buildDisconnectRoute(manager: RoutesManager, helpers: RouteHelpers): WebRoute {
+  return buildNameActionRoute("/api/dsh-mcp/servers/disconnect", (name, scope) => manager.disconnect(name, scope), manager, helpers);
+}
+
+/** POST /servers/reconnect：重连单服务器。 */
+export function buildReconnectRoute(manager: RoutesManager, helpers: RouteHelpers): WebRoute {
+  return buildNameActionRoute("/api/dsh-mcp/servers/reconnect", (name, scope) => manager.reconnect(name, scope), manager, helpers);
+}
+
+// ------------------------------------------------------------ /import/json
+
+/** 导入 mcpServers JSON（同名 skip，overwrite=true 时更新）。 */
+export function buildImportJsonRoute(manager: RoutesManager, helpers: RouteHelpers): WebRoute {
+  return {
+    kind: "exact",
+    path: "/api/dsh-mcp/import/json",
+    handler: async (req: Req, res: Res) => {
+      if (!guardLoopbackMethod(req, res, ["POST"])) return;
+      const body = await readJsonBody(req);
+      if (body === undefined || typeof (body as Record<string, unknown>).json !== "string") {
+        writeJson(res, 400, { error: "body must include a json string" });
+        return;
+      }
+      const imported: string[] = [];
+      const skipped: string[] = [];
+      try {
+        const rec = body as Record<string, unknown>;
+        const scope = normalizeScope(rec.scope as string);
+        if (typeof rec.cwd === "string" && rec.cwd !== "") await manager.setSession(rec.cwd);
+        const store = scope === SCOPE_PROJECT ? await manager.projectStoreOrThrow() : manager.store;
+        const servers = parseClaudeJson(rec.json as string);
+        for (const server of servers) {
+          if (store.find(server.name) !== undefined) {
+            if (rec.overwrite !== true) {
+              skipped.push(server.name);
+              continue;
+            }
+            await manager.update(server.name, server, scope);
+            imported.push(server.name);
+            continue;
+          }
+          await manager.add(server, scope);
+          imported.push(server.name);
+        }
+      } catch (error) {
+        helpers.handleError(res, error);
+        return;
+      }
+      writeJson(res, 200, { imported, skipped, summary: manager.summary() });
+    },
+  };
+}
+
+// ------------------------------------------------------------ /tool-disable
+
+/** 工具级禁用开关（PATCH；root 路由一致性校验防跨空间串台）。 */
+export function buildToolDisableRoute(manager: RoutesManager, helpers: RouteHelpers): WebRoute {
+  return {
+    kind: "exact",
+    path: "/api/dsh-mcp/tool-disable",
+    handler: async (req: Req, res: Res) => {
+      if (!guardLoopbackMethod(req, res, ["PATCH"])) return;
+      const url = new URL(req.url ?? "/", "http://localhost");
+      const body = await readJsonBody(req);
+      if (body === undefined || typeof body !== "object" || body === null) {
+        writeJson(res, 400, { error: "invalid JSON body" });
+        return;
+      }
+      const rec = body as Record<string, unknown>;
+      const server = typeof rec.server === "string" ? rec.server : "";
+      const tool = typeof rec.tool === "string" ? rec.tool : "";
+      const disabled = rec.disabled === true;
+      if (server === "" || tool === "") {
+        writeJson(res, 400, { error: "server 与 tool 均为必填" });
+        return;
+      }
+      // 路由一致性：server 全名 root 必须属于当前工作空间（或 all 模式 @global）。
+      const parsed = parseFullServerName(server);
+      if (parsed === undefined) {
+        writeJson(res, 400, { error: "server 格式非法，应为 @<root>/<server>" });
+        return;
+      }
+      const root = parsed.root;
+      const cwdParam = queryParam(url, "cwd");
+      if (cwdParam !== undefined && cwdParam !== "") await manager.setSession(cwdParam);
+      const sessionRoot = manager.projectRoot;
+      const allowed = root === MIDDLEWARE_GLOBAL_ROOT || root === sessionRoot;
+      if (!allowed) {
+        writeJson(res, 400, { error: `server ${JSON.stringify(server)} 不属于当前工作空间；路由一致性校验失败（防跨空间串台）` });
+        return;
+      }
+      if (typeof manager.setToolDisabled !== "function") {
+        writeJson(res, 400, { error: "tool-disable not writable: middleware unavailable" });
+        return;
+      }
+      try {
+        // #392 遗留④：tool 参数先归一化（剥 mcp__<server>__ 前缀）再入禁用表——
+        // 旧客户端/手工 API 可能提交带前缀名，此前原样存键导致 guard 层查裸名不命中、
+        // 禁用静默无效。跨 server 前缀（剥后仍 mcp__ 开头）由 normalizeToolName 抛错。
+        const toolName = normalizeToolName(parsed.server, tool, "tool-disable");
+        await manager.setToolDisabled(root, parsed.server, toolName, disabled);
+        writeJson(res, 200, { ok: true, summary: manager.summary() });
+      } catch (error) {
+        helpers.handleError(res, error);
+      }
+    },
+  };
+}

--- a/packages/dsh-mcp-manager/src/routes-helpers.ts
+++ b/packages/dsh-mcp-manager/src/routes-helpers.ts
@@ -1,0 +1,12 @@
+/**
+ * dsh-mcp-manager — 路由层共享辅助（#592 消峰拆分：routes ↔ controllers 公共面）。
+ *
+ * queryParam 从 routes.ts 提升至此，供 routes.ts 与 routes-controllers.ts
+ * 双向消费，避免 controllers 反向 import routes 造成装配层与实现层耦合。
+ */
+
+/** 读取 URL 查询参数（缺失返回 undefined）。 */
+export function queryParam(url: URL, name: string): string | undefined {
+  const value = url.searchParams.get(name);
+  return value === null ? undefined : value;
+}

--- a/packages/dsh-mcp-manager/src/routes.ts
+++ b/packages/dsh-mcp-manager/src/routes.ts
@@ -1,26 +1,40 @@
 /**
- * dsh-mcp-manager — HTTP 路由（依赖 import 模块与仓库共享层）。
+ * dsh-mcp-manager — HTTP 路由装配层（依赖 import 模块与仓库共享层）。
  *
  * /api/dsh-mcp/* 路由（loopback-only）供 web GUI 分级展示、快速接入、
  * 导入 mcpServers JSON；events 为 SSE 状态推送通道。
  * 例外：/api/dsh-mcp/config 是只读 UI 配置接口，允许非 loopback 访问，
  * 便于远程页面读取 position/offset 等非敏感展示配置。
  * 由 lib/index.js 组合根 re-export（ROUTES / makeRoutes）。
+ *
+ * #592 阶段二 Batch A 消峰：各端点 handler 已拆离至 routes-controllers.ts
+ * 的独立控制器工厂（原 makeRoutes 单函数圈复杂度 84 → 装配后 <= 15）；
+ * 本文件只保留 ROUTES 常量、装配函数与 SSE/health 工厂（SSE/health 原本
+ * 即独立工厂形态，复杂度低，随装配层同文件保留）。
  */
 
 // 辅助函数统一来自仓库共享层（loopback 围栏 / writeJson / readJsonBody / sseData）。
-import { writeJson, readJsonBody, sseData, guardLoopbackMethod } from "../../../shared/host-utils.js";
+import { writeJson, sseData, guardLoopbackMethod } from "../../../shared/host-utils.js";
 import { createSseHub } from "../../../shared/sse-hub.js";
 import type { SseHub } from "../../../shared/sse-hub.js";
-import { parseClaudeJson } from "./import.ts";
-import { SCOPE_PROJECT, normalizeScope } from "./scope.ts";
-import { parseFullServerName, MIDDLEWARE_GLOBAL_ROOT, normalizeToolName } from "./middleware-utils.ts";
-import { normalizeMiddlewareMode } from "./middleware-const.ts";
 import type { ServerConfig } from "./types.ts";
 import type { ClientUiConfig } from "./index.ts";
 import type { WebRoute } from "@deepseek-ai/dsh-host-webserver";
 import type { ServerResponse } from "node:http";
 import type { McpStore } from "./store.ts";
+import {
+  buildConfigRoute,
+  buildServersRoute,
+  buildSessionRoute,
+  buildResumeRoute,
+  buildConnectRoute,
+  buildDisconnectRoute,
+  buildReconnectRoute,
+  buildImportJsonRoute,
+  buildToolDisableRoute,
+  type RouteHelpers,
+} from "./routes-controllers.ts";
+import { queryParam } from "./routes-helpers.ts";
 
 /** routes 使用的 McpManager 最小面（避免 index↔routes 循环 import）。 */
 export interface RoutesManager {
@@ -79,12 +93,7 @@ export const ROUTES = {
   toolDisable: "/api/dsh-mcp/tool-disable",
 };
 
-const MAX_JSON_BODY_BYTES = 2 * 1024 * 1024;
-
-function queryParam(url: URL, name: string): string | undefined {
-  const value = url.searchParams.get(name);
-  return value === null ? undefined : value;
-}
+export { queryParam };
 
 /** 组装 /api/dsh-mcp/* 路由。cwd 参数仅用于兼容旧调用（不再被路由使用）。 */
 export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRoute[] {
@@ -92,316 +101,24 @@ export function makeRoutes(manager: RoutesManager, cwd = process.cwd()): WebRout
     writeJson(res, 400, { error: error instanceof Error ? error.message : String(error) });
   };
   /** 解析 scope 查询参数（缺省 global）。 */
-  const scopeParam = (url: URL) => (normalizeScope(queryParam(url, "scope") ?? ""));
+  const scopeParam = (url: URL) => queryParam(url, "scope") ?? "";
   /** 若带 cwd 参数则先切换会话（跟随会话的项目级 MCP）。 */
   const maybeSession = async (url: URL): Promise<void> => {
     const cwdParam = queryParam(url, "cwd");
     if (cwdParam !== undefined && cwdParam !== "") await manager.setSession(cwdParam);
   };
+  const helpers: RouteHelpers = { handleError, scopeParam, maybeSession };
 
   return [
-    {
-      kind: "exact",
-      path: ROUTES.config,
-      handler: async (req, res) => {
-        // GET：只读 UI 配置 + 中间层模式（允许非 loopback，供远程页面读取非敏感的展示配置）。
-        if (req.method === "GET") {
-          try {
-            writeJson(res, 200, { ...manager.uiConfig(), middleware: manager.middlewareMode ?? "off" });
-          } catch (error) {
-            handleError(res, error);
-          }
-          return;
-        }
-        // POST：写入浮窗 UI 配置（position / offset），或热切换中间层模式
-        // （middleware: off/project/all）。写操作只对 loopback 开放；
-        // 经设置命名空间落盘（Config.ui），触发 scope.watch → onChange → SSE 广播一帧，
-        // 客户端收到后重新 GET /config 就地更新浮窗位置，无需重启/轮询。
-        if (req.method === "POST") {
-          if (!guardLoopbackMethod(req, res, ["POST"])) return;
-          let body: unknown;
-          try {
-            body = await readJsonBody(req);
-          } catch {
-            writeJson(res, 400, { error: "invalid JSON body" });
-            return;
-          }
-          if (typeof body !== "object" || body === null) {
-            writeJson(res, 400, { error: "invalid JSON body" });
-            return;
-          }
-          try {
-            const rec = body as Record<string, unknown>;
-            if (typeof rec.middleware === "string") {
-              // 中间层模式热切换：先热生效（当前进程立即切换），再落盘（重启保留）。
-              if (typeof manager.setMiddlewareMode === "function") {
-                await manager.setMiddlewareMode(rec.middleware);
-              }
-              if (typeof manager.uiUpdate === "function") {
-                await manager.uiUpdate({ middleware: normalizeMiddlewareMode(rec.middleware) });
-              }
-              writeJson(res, 200, { ...manager.uiConfig(), middleware: manager.middlewareMode ?? "off" });
-              return;
-            }
-            writeJson(res, 200, await manager.updateUiConfig(body));
-          } catch (error) {
-            handleError(res, error);
-          }
-          return;
-        }
-        // 端点级方法分流先于 loopback 的刻意例外（#473 R2 结构 β）：本 else 对
-        // 白名单外方法（PUT/DELETE/OPTIONS 等）直接 405、不查 loopback——非
-        // loopback+PUT 返回 405 而非 403 是契约行为，禁止误套守卫（会漂移为 403）。
-        writeJson(res, 405, { error: `method not allowed: ${req.method}` });
-      },
-    },
-    {
-      kind: "exact",
-      path: ROUTES.servers,
-      handler: async (req, res) => {
-        const url = new URL(req.url ?? "/", "http://localhost");
-        const method = req.method ?? "GET";
-        if (!guardLoopbackMethod(req, res, ["GET", "POST", "PATCH", "DELETE"])) return;
-        if (method === "GET") {
-          try {
-            // 变更点驱动（#111/#228）：GET /servers 是纯读快照，零副作用——
-            // 磁盘变更由 fs.watch 事件驱动 reconcile，状态从内存 store 读。
-            // 历史 refreshFromDisk 副作用（mtime 轮询 + reconcile）已移除。
-            // cwd 查询参数不处理（#324）：GET 带 cwd 曾触发 setSession → emitStatus
-            // → SSE 广播 → 客户端再 GET 的自激循环（多页面互踩）。会话切换只走
-            // POST /api/dsh-mcp/session；此处忽略 cwd 以恢复纯读语义。
-            writeJson(res, 200, manager.summary());
-          } catch (error) {
-            handleError(res, error);
-          }
-          return;
-        }
-        if (method === "POST") {
-          const body = await readJsonBody(req);
-          if (body === undefined) {
-            writeJson(res, 400, { error: "invalid JSON body" });
-            return;
-          }
-          try {
-            const rec = body as Record<string, unknown>;
-            const scope = normalizeScope(rec.scope as string);
-            if (typeof rec.cwd === "string" && rec.cwd !== "") await manager.setSession(rec.cwd);
-            const server = await manager.add(rec, scope);
-            writeJson(res, 201, { server, summary: manager.summary() });
-          } catch (error) {
-            handleError(res, error);
-          }
-          return;
-        }
-        if (method === "PATCH" || method === "DELETE") {
-          const name = queryParam(url, "name");
-          if (name === undefined || name === "") {
-            writeJson(res, 400, { error: "name query parameter is required" });
-            return;
-          }
-          try {
-            await maybeSession(url);
-            const scope = scopeParam(url);
-            if (method === "DELETE") {
-              await manager.remove(name, scope);
-              writeJson(res, 200, { ok: true, summary: manager.summary() });
-            } else {
-              const body = await readJsonBody(req);
-              if (body === undefined) {
-                writeJson(res, 400, { error: "invalid JSON body" });
-                return;
-              }
-              const server = await manager.update(name, body as Record<string, unknown>, scope);
-              writeJson(res, 200, { server, summary: manager.summary() });
-            }
-          } catch (error) {
-            handleError(res, error);
-          }
-          return;
-        }
-        writeJson(res, 405, { error: `method not allowed: ${method}` });
-      },
-    },
-    {
-      kind: "exact",
-      path: ROUTES.session,
-      handler: async (req, res) => {
-        if (!guardLoopbackMethod(req, res, ["POST"])) return;
-        const body = await readJsonBody(req);
-        if (body === undefined || typeof (body as Record<string, unknown>).cwd !== "string") {
-          writeJson(res, 400, { error: "body must include a cwd string" });
-          return;
-        }
-        try {
-          await manager.setSession((body as Record<string, unknown>).cwd as string);
-          writeJson(res, 200, { ok: true, summary: manager.summary() });
-        } catch (error) {
-          handleError(res, error);
-        }
-      },
-    },
-    {
-      kind: "exact",
-      path: ROUTES.resume,
-      handler: async (req, res) => {
-        if (!guardLoopbackMethod(req, res, ["POST"])) return;
-        try {
-          if (typeof manager.resumeReconnect !== "function") throw new Error("resumeReconnect unavailable");
-          await manager.resumeReconnect();
-          writeJson(res, 200, { ok: true, summary: manager.summary() });
-        } catch (error) {
-          handleError(res, error);
-        }
-      },
-    },
-    {
-      kind: "exact",
-      path: ROUTES.connect,
-      handler: async (req, res) => {
-        if (!guardLoopbackMethod(req, res, ["POST"])) return;
-        const url = new URL(req.url ?? "/", "http://localhost");
-        const name = queryParam(url, "name");
-        if (name === undefined || name === "") {
-          writeJson(res, 400, { error: "name query parameter is required" });
-          return;
-        }
-        try {
-          await maybeSession(url);
-          await manager.connect(name, scopeParam(url));
-          writeJson(res, 200, { ok: true, summary: manager.summary() });
-        } catch (error) {
-          handleError(res, error);
-        }
-      },
-    },
-    {
-      kind: "exact",
-      path: ROUTES.disconnect,
-      handler: async (req, res) => {
-        if (!guardLoopbackMethod(req, res, ["POST"])) return;
-        const url = new URL(req.url ?? "/", "http://localhost");
-        const name = queryParam(url, "name");
-        if (name === undefined || name === "") {
-          writeJson(res, 400, { error: "name query parameter is required" });
-          return;
-        }
-        try {
-          await maybeSession(url);
-          await manager.disconnect(name, scopeParam(url));
-          writeJson(res, 200, { ok: true, summary: manager.summary() });
-        } catch (error) {
-          handleError(res, error);
-        }
-      },
-    },
-    {
-      kind: "exact",
-      path: ROUTES.reconnect,
-      handler: async (req, res) => {
-        if (!guardLoopbackMethod(req, res, ["POST"])) return;
-        const url = new URL(req.url ?? "/", "http://localhost");
-        const name = queryParam(url, "name");
-        if (name === undefined || name === "") {
-          writeJson(res, 400, { error: "name query parameter is required" });
-          return;
-        }
-        try {
-          await maybeSession(url);
-          await manager.reconnect(name, scopeParam(url));
-          writeJson(res, 200, { ok: true, summary: manager.summary() });
-        } catch (error) {
-          handleError(res, error);
-        }
-      },
-    },
-    {
-      kind: "exact",
-      path: ROUTES.importJson,
-      handler: async (req, res) => {
-        if (!guardLoopbackMethod(req, res, ["POST"])) return;
-        const body = await readJsonBody(req);
-        if (body === undefined || typeof (body as Record<string, unknown>).json !== "string") {
-          writeJson(res, 400, { error: "body must include a json string" });
-          return;
-        }
-        const imported: string[] = [];
-        const skipped: string[] = [];
-        try {
-          const rec = body as Record<string, unknown>;
-          const scope = normalizeScope(rec.scope as string);
-          if (typeof rec.cwd === "string" && rec.cwd !== "") await manager.setSession(rec.cwd);
-          const store = scope === SCOPE_PROJECT ? await manager.projectStoreOrThrow() : manager.store;
-          const servers = parseClaudeJson(rec.json as string);
-          for (const server of servers) {
-            if (store.find(server.name) !== undefined) {
-              if (rec.overwrite !== true) {
-                skipped.push(server.name);
-                continue;
-              }
-              await manager.update(server.name, server, scope);
-              imported.push(server.name);
-              continue;
-            }
-            await manager.add(server, scope);
-            imported.push(server.name);
-          }
-        } catch (error) {
-          handleError(res, error);
-          return;
-        }
-        writeJson(res, 200, { imported, skipped, summary: manager.summary() });
-      },
-    },
-    {
-      kind: "exact",
-      path: ROUTES.toolDisable,
-      handler: async (req, res) => {
-        if (!guardLoopbackMethod(req, res, ["PATCH"])) return;
-        const url = new URL(req.url ?? "/", "http://localhost");
-        const body = await readJsonBody(req);
-        if (body === undefined || typeof body !== "object" || body === null) {
-          writeJson(res, 400, { error: "invalid JSON body" });
-          return;
-        }
-        const rec = body as Record<string, unknown>;
-        const server = typeof rec.server === "string" ? rec.server : "";
-        const tool = typeof rec.tool === "string" ? rec.tool : "";
-        const disabled = rec.disabled === true;
-        if (server === "" || tool === "") {
-          writeJson(res, 400, { error: "server 与 tool 均为必填" });
-          return;
-        }
-        // 路由一致性：server 全名 root 必须属于当前工作空间（或 all 模式 @global）。
-        const parsed = parseFullServerName(server);
-        if (parsed === undefined) {
-          writeJson(res, 400, { error: "server 格式非法，应为 @<root>/<server>" });
-          return;
-        }
-        const root = parsed.root === MIDDLEWARE_GLOBAL_ROOT ? parsed.root : parsed.root;
-        const cwdParam = queryParam(url, "cwd");
-        if (cwdParam !== undefined && cwdParam !== "") await manager.setSession(cwdParam);
-        const sessionRoot = manager.projectRoot;
-        const allowed = root === MIDDLEWARE_GLOBAL_ROOT || root === sessionRoot;
-        if (!allowed) {
-          writeJson(res, 400, { error: `server ${JSON.stringify(server)} 不属于当前工作空间；路由一致性校验失败（防跨空间串台）` });
-          return;
-        }
-        if (typeof manager.setToolDisabled !== "function") {
-          writeJson(res, 400, { error: "tool-disable not writable: middleware unavailable" });
-          return;
-        }
-        try {
-          // #392 遗留④：tool 参数先归一化（剥 mcp__<server>__ 前缀）再入禁用表——
-          // 旧客户端/手工 API 可能提交带前缀名，此前原样存键导致 guard 层查裸名不命中、
-          // 禁用静默无效。跨 server 前缀（剥后仍 mcp__ 开头）由 normalizeToolName 抛错。
-          const toolName = normalizeToolName(parsed.server, tool, "tool-disable");
-          await manager.setToolDisabled(root, parsed.server, toolName, disabled);
-          writeJson(res, 200, { ok: true, summary: manager.summary() });
-        } catch (error) {
-          handleError(res, error);
-        }
-      },
-    },
+    buildConfigRoute(manager, helpers),
+    buildServersRoute(manager, helpers),
+    buildSessionRoute(manager, helpers),
+    buildResumeRoute(manager, helpers),
+    buildConnectRoute(manager, helpers),
+    buildDisconnectRoute(manager, helpers),
+    buildReconnectRoute(manager, helpers),
+    buildImportJsonRoute(manager, helpers),
+    buildToolDisableRoute(manager, helpers),
   ];
 }
 
@@ -469,7 +186,7 @@ export function makeEventsRoute(manager: RoutesManager, options?: { heartbeatMs?
       const hub = (manager.sseHub ??= createSseHub({
         getMaxConnections: () => options?.maxConnections ?? 16,
         heartbeatMs: options?.heartbeatMs,
-        warn: (message) => {
+        warn: (_message) => {
           // 无 logger 注入面，静默（连接回收是自愈路径，无需告警）
         },
       }));

--- a/packages/dsh-mcp-manager/test/service-contract.test.ts
+++ b/packages/dsh-mcp-manager/test/service-contract.test.ts
@@ -142,14 +142,14 @@ const pkgDir = join(dirname(fileURLToPath(import.meta.url)), "..");
  * 内大括号干扰对象边界。
  */
 function extractProvidedServiceMethods(): Array<{ name: string; paramCount: number; optionalCount: number }> {
-  const src = readFileSync(join(pkgDir, "src", "apply.ts"), "utf8");
+  const src = readFileSync(join(pkgDir, "src", "apply-services.ts"), "utf8");
   // 锚定首个 `provide("mcpManager", {` marker（非 AST——测试刻意不做解析级双真源，
   // 方法名存在性 + 参数个数即可抓「删方法/改参数量」）。当前 apply.ts 全文件仅此
   // 一处该形态调用，indexOf 首个命中即目标；若未来 apply.ts 出现多处 provide
   // 调用或形态变化导致本提取失配，测试会红并提示人工更新（fail-loud，不静默）。
   const marker = 'provide("mcpManager", {';
   const markerIndex = src.indexOf(marker);
-  assert.ok(markerIndex >= 0, "apply.ts 应包含 ctx.provide(\"mcpManager\", {...}) 服务注入");
+  assert.ok(markerIndex >= 0, "apply-services.ts 应包含 ctx.provide(\"mcpManager\", {...}) 服务注入");
 
   // 括号配对扫描：找到 provide 对象的完整区间（跳过字符串字面量与注释）。
   const skip = (s: string, i: number): number => {


### PR DESCRIPTION
# refactor(mcp-manager): 拆解 makeRoutes 与 apply 装配骨架，圈复杂度 84/78 降至 5/14

Refs #592（阶段二 Batch A）

## 消峰结果（acorn 决策点口径，与 crap-check 同源）

| 函数 | 拆分前 | 拆分后 | 降幅 |
|---|---|---|---|
| `makeRoutes()`（拆分前全仓第一） | comp **84** | comp **5** | **-94.0%** |
| `apply()`（拆分前全仓第二） | comp **78** | comp **14** | **-82.1%** |

两函数均已压至 issue #592 验收线 `comp <= 15` 之内。全仓单函数最高 comp 由 84 降至 52（`checkSchemaNode`，属 catalog 专项、非本批次范围）。

## 拆解结构（沿用 #609 middleware-register 已验证范式）

### makeRoutes → routes-controllers.ts（9 个端点控制器工厂）

- 每个端点 handler 拆为 `buildXxxRoute(manager, helpers)` 纯工厂：config（GET 豁免 loopback + POST 中间层热切换）/ servers（CRUD 四方法分流）/ session / resume / import-json / tool-disable；
- connect / disconnect / reconnect 三兄弟路由收敛为 `buildNameActionRoute` 单一同构工厂；
- 共享 helpers（handleError / scopeParam / maybeSession）由 makeRoutes 闭包提升为显式参数；`queryParam` 提升至 routes-helpers.ts（防 controllers 反向 import 装配层）；
- 行为约束逐字节保留：#473 R2 端点级 405 先于 loopback 的刻意例外、#324 GET 纯读语义、#392 工具名归一化。

### apply → 四个装配阶段模块

- `apply-config.ts`：配置解析（resolveApplyOptions / resolveMiddlewareMode / resolveStorePath）与 settings 接线（installConfigSettings / injectSettingsSink，**#125 this 绑定语义原样保留**）；
- `apply-services.ts`：`provideMcpManagerService` 8 方法核心化服务契约面（方法名/参数形状逐字保留）；
- `apply-runtime.ts`：fs.watch 防重入装配、中间层热切换闭包、catalog 注入、路由注册与 SSE 广播接线；
- `apply-guidance.ts`：MCP_GUIDANCE 文案；
- `apply.ts` 退化为顺序装配骨架（186 行，原 358 行）。

## 契约与测试

- `service-contract.test.ts` 的 provide 源文本静态扫描源同步迁移至 apply-services.ts（marker 唯一性已验证；fail-loud 语义不变）；
- 全部既有 smoke / unit-* 测试断言**零修改**通过（148+ 项）；
- `pnpm cov` + `crap-check`：超阈热点 203 个（较基线持平，未新增）；`crap-check --diff` 增量门禁 0 劣化。

## 门禁证据

五连门禁全绿：`pnpm build` ✓ / `pnpm test` ✓（fail 0）/ `pnpm contract` ✓ / `pnpm pack:check` ✓ / `pnpm typecheck` ✓（exit 0）
