### PR TITLE
fix(dsh-notifier): 新增 webhook 实例空串认证字段致保存必 400——客户端初始化不预置可选键 + 提交面空串剥除 (#614)

### DIFF
--- a/packages/dsh-notifier/src/client/index.ts
+++ b/packages/dsh-notifier/src/client/index.ts
@@ -60,10 +60,38 @@ function diffSettingsPayload(settings: Record<string, any>, baseLine: Record<str
     if (!Object.prototype.hasOwnProperty.call(settings, key)) continue;
     var cur = settings[key];
     var base = baseLine[key];
-    var same = JSON.stringify(cur) === JSON.stringify(base);
-    if (!same) payload[key] = cur;
+    // #614：channels 整组提交前对实例做空串可选字段剥除——存量配置（0.2.2 保存
+    // 失败前/手改 yaml/旧版本）可能残留 token:"" 等空串形态，UI 编辑任一字段都会
+    // 触发整组提交把残留一起带走 → 400 死锁。剥除与读面 normalize（空串按未配置
+    // 剥除）同语义，纯读不改草稿，用户后续输入仍经 assignChannelFields 正常写。
+    var value = key === "channels" && Array.isArray(cur) ? cur.map(stripChannelEmpties) : cur;
+    var same = JSON.stringify(value) === JSON.stringify(base);
+    if (!same) payload[key] = value;
   }
   return payload;
+}
+
+/**
+ * 单个频道实例的空串可选字段剥除（issue #614）：对实例浅拷贝后删除值为空串的
+ * 可选字段。必填字段（id/type/url/baseUrl/deviceKey/enabled/auth）不在清单内——
+ * 它们缺失/为空由服务端写面校验 400（语义正确：必填不允许空）。只处理 string
+ * 值，number/boolean/对象字段不触碰；非对象输入原样返回（防御数组/null）。
+ * 模块级纯函数（apply 挂载 + vm 直测），对齐 diffSettingsPayload 先例。
+ */
+/** 空串即「未配置」的可选 string 字段清单（bark/webhook 实例合集，#614）。
+ *  必填键（id/type/url/baseUrl/deviceKey/enabled/auth）不在清单内——为空由服务端
+ *  写面校验 400 拦截（必填不允许空，语义正确）；非 string 值（number/boolean/
+ *  levels 对象）不触碰。 */
+const CHANNEL_OPTIONAL_STRING_KEYS: readonly string[] = ["name", "token", "username", "password", "headerName", "headerValue", "template", "sound", "group", "icon", "url"];
+
+function stripChannelEmpties(ch: unknown): unknown {
+  if (typeof ch !== "object" || ch === null || Array.isArray(ch)) return ch;
+  var out = Object.assign({}, ch as Record<string, unknown>);
+  for (var i = 0; i < CHANNEL_OPTIONAL_STRING_KEYS.length; i++) {
+    var key = CHANNEL_OPTIONAL_STRING_KEYS[i];
+    if (typeof out[key] === "string" && (out[key] as string).length === 0) delete out[key];
+  }
+  return out;
 }
 
 /**
@@ -95,6 +123,26 @@ function domainPayload(diff: Record<string, any>, entry: string): Record<string,
     return { channels: diff.channels };
   }
   return {};
+}
+
+/**
+ * 频道实例字段合并（issue #614）：part 中**空串/undefined 值从 target 删除该键**，
+ * 其余浅覆盖。空串在服务端写面校验中是「非法值」而非「未配置」——token/username/
+ * password/headerValue 要求非空（length > 0）、headerName 过头名正则、name 要求
+ * 非空，读面 normalize 却把空串剥除（等价未配置）。若把清空输入回写成 "" 提交，
+ * 实例会带着空串残留被整组 400（「填了又删空」死锁，#614 必现根因之一）——空串
+ * 删键后提交面与读面同语义（键不存在 = 未配置）。单点收敛在 chPatch（bark/webhook
+ * 实例所有字段写回共用此函数）。模块级纯函数（apply 挂载 + vm 直测），
+ * 对齐 diffSettingsPayload 先例。
+ */
+function assignChannelFields(target: Record<string, any>, part: Record<string, any>): Record<string, any> {
+  var out = Object.assign({}, target);
+  Object.keys(part).forEach(function (key: string) {
+    var value = part[key];
+    if (value === "" || value === undefined) delete out[key];
+    else out[key] = value;
+  });
+  return out;
 }
 
 /**
@@ -1022,11 +1070,12 @@ function createSaveGuard(): { tryBegin(entry: string): boolean; isBusy(): boolea
 
     // ---- M2 频道编辑（settings.channels 不可变操作；deviceKey 掩码语义见服务端）----
 
-    /** 更新第 idx 个频道实例（浅合并 patch；函数式基于最新 channels，防后写覆盖）。 */
+    /** 更新第 idx 个频道实例（字段经 assignChannelFields 合并——空串/undefined
+     *  删键，#614；函数式基于最新 channels，防后写覆盖）。 */
     function chPatch(idx: number, part: Record<string, any>) {
       patch(function (prev: any) {
         var list = (prev.channels || []).slice();
-        list[idx] = Object.assign({}, list[idx], part);
+        list[idx] = assignChannelFields(list[idx] || {}, part);
         return Object.assign({}, prev, { channels: list });
       });
     }
@@ -1057,8 +1106,12 @@ function createSaveGuard(): { tryBegin(entry: string): boolean; isBusy(): boolea
     }
 
     /** 新增频道实例（#508 M2：kind = "bark" | "webhook"）——自动分配未占用的 id
-     *  （bark-1… / webhook-1…），默认禁用（出站授权显式授予；webhook 凭据/模板字段
-     *  空白起步，超时缺省 10s 由服务端 normalize 兜底）。 */
+     *  （bark-1… / webhook-1…），默认禁用（出站授权显式授予）。#614：可选认证/
+     *  凭据/模板字段一律**不预置键**——空串形态会被服务端写面校验整组 400（token/
+     *  username/password/headerValue 要求非空、headerName 过头名正则），未填写 =
+     *  键不存在；输入清空经 assignChannelFields 同步删键。url/baseUrl 为必填占位，
+     *  未填保存由服务端 400 拦（url 非法即整组拒绝，语义正确）。超时缺省 10s 由
+     *  服务端 normalize 兜底。 */
     function chAdd(kind: string) {
       patch(function (prev: any) {
         var list = prev.channels || [];
@@ -1073,12 +1126,6 @@ function createSaveGuard(): { tryBegin(entry: string): boolean; isBusy(): boolea
               type: "webhook",
               url: "",
               auth: "none",
-              token: "",
-              username: "",
-              password: "",
-              headerName: "",
-              headerValue: "",
-              template: "",
               timeoutSec: 10,
               enabled: false,
             }
@@ -1087,7 +1134,6 @@ function createSaveGuard(): { tryBegin(entry: string): boolean; isBusy(): boolea
               name: t("chNewBarkName") + " " + seq,
               type: "bark",
               baseUrl: "",
-              deviceKey: "",
               enabled: false,
             };
         return Object.assign({}, prev, { channels: list.concat([base]) });
@@ -2097,11 +2143,14 @@ function createSaveGuard(): { tryBegin(entry: string): boolean; isBusy(): boolea
 export function apply(ctx: any) {
     // 测试直测挂载面（#470 复核 P1-2 / #405）：diffSettingsPayload 与
     // createSaveGuard 是模块级纯函数，经 apply 暴露给 smoke 测试引用——
-    // 保证「测试即产品实现」而非手写近似。
+    // 保证「测试即产品实现」而非手写近似。#614 新增 assignChannelFields /
+    // stripChannelEmpties（频道实例字段合并与空串剥除）。
     (apply as any).diffSettingsPayload = diffSettingsPayload;
     (apply as any).createSaveGuard = createSaveGuard;
     (apply as any).domainPayload = domainPayload;
     (apply as any).rebaseSettings = rebaseSettings;
+    (apply as any).assignChannelFields = assignChannelFields;
+    (apply as any).stripChannelEmpties = stripChannelEmpties;
     try {
       ensureStyle({ id: STYLE_ID, cssText: STYLE, version: CSS_VERSION });
 

--- a/packages/dsh-notifier/test/client-contract.test.ts
+++ b/packages/dsh-notifier/test/client-contract.test.ts
@@ -468,6 +468,54 @@ const pkgDir = fileURLToPath(new URL("..", import.meta.url));
 
   // baseline 为 null（加载未完成）→ 空 payload（不误存）
   assert.deepEqual(JSON.parse(JSON.stringify(diffFn(settingsView, null))), {}, "#470 P1-2：baseline null → 空 payload");
+
+  // ---- issue #614：channels 提交面空串可选字段剥除（真产物直测）----
+
+  // 存量 0.2.2 空串残留形态：UI 改 enabled 一字段 → 整组提交被 strip 成合法形态
+  // （否则 token:"" 等残留随组提交 → 服务端 400，UI 无法解锁修复）
+  const legacy = {
+    notifyTaskDone: true,
+    channels: [
+      { id: "webhook-1", type: "webhook", url: "https://ntfy.sh/t", auth: "bearer", token: "tk614", enabled: false, username: "", password: "", headerName: "", headerValue: "", template: "" },
+      { id: "bark-1", type: "bark", baseUrl: "https://api.day.app", deviceKey: "k614", enabled: false, sound: "", group: "" },
+    ],
+  };
+  const edited = JSON.parse(JSON.stringify(legacy));
+  edited.channels[0].enabled = true;
+  const stripped = diffFn(edited, legacy);
+  assert.ok(stripped.channels !== undefined, "#614：channels 变更整组入 diff");
+  assert.equal(JSON.stringify(stripped.channels), JSON.stringify([
+    { id: "webhook-1", type: "webhook", url: "https://ntfy.sh/t", auth: "bearer", token: "tk614", enabled: true },
+    { id: "bark-1", type: "bark", baseUrl: "https://api.day.app", deviceKey: "k614", enabled: false },
+  ]), "#614：空串可选字段剥除、非空值与必填字段保留");
+
+  // 无空串的常规 diff 不受影响（strip 幂等，非空全保留）
+  const clean = { channels: [{ id: "webhook-1", type: "webhook", url: "https://ntfy.sh/t", auth: "none", enabled: false }] };
+  const cleanEdited = JSON.parse(JSON.stringify(clean));
+  cleanEdited.channels[0].enabled = true;
+  assert.equal(JSON.stringify(diffFn(cleanEdited, clean).channels), JSON.stringify(cleanEdited.channels), "#614：无空串形态 diff 原样通过");
+
+  // 防御：channels 含非对象成员（null/字符串）不炸、原样透传（服务端校验兜底）
+  const junk = { channels: [null, "x"] };
+  const junkEdited = JSON.parse(JSON.stringify(junk));
+  junkEdited.channels[1] = "y";
+  assert.equal(JSON.stringify(diffFn(junkEdited, junk).channels), JSON.stringify([null, "y"]), "#614：非对象成员原样透传不炸");
+
+  // #614 纯函数直测：assignChannelFields（空串/undefined 删键）与 stripChannelEmpties
+  const assignFn = mod.apply.assignChannelFields;
+  const stripFn = mod.apply.stripChannelEmpties;
+  assert.equal(typeof assignFn, "function", "#614：apply 挂载 assignChannelFields");
+  assert.equal(typeof stripFn, "function", "#614：apply 挂载 stripChannelEmpties");
+  // 空串输入 → 删键（清空 token 输入框 = 回到未配置态）
+  assert.equal("token" in assignFn({ id: "w", token: "old" }, { token: "" }), false, "#614：空串输入删键");
+  // undefined 输入 → 删键（bark level 清除路径传 undefined）
+  assert.equal("level" in assignFn({ id: "b", level: "critical" }, { level: undefined }), false, "#614：undefined 输入删键");
+  // 非空值正常覆盖；无关键不新增
+  const assigned = assignFn({ id: "w", token: "old", auth: "none" }, { token: "new", url: "" });
+  assert.equal(JSON.stringify(assigned), JSON.stringify({ id: "w", token: "new", auth: "none" }), "#614：非空覆盖 + 空串 url 删键（不存在则不新增）");
+  // stripChannelEmpties：剥空串可选键（url 属 bark 可选位），非对象原样
+  assert.equal(JSON.stringify(stripFn({ id: "w", url: "", token: "", name: "n", enabled: false })), JSON.stringify({ id: "w", name: "n", enabled: false }), "#614：strip 剥可选空串（含 url）");
+  assert.equal(stripFn(null), null, "#614：strip 非对象输入原样返回");
 }
 
 // ---- issue #405 PR2/PR3：客户端保存模型演进源码级契约锚点 ----

--- a/packages/dsh-notifier/test/routes.test.ts
+++ b/packages/dsh-notifier/test/routes.test.ts
@@ -582,6 +582,19 @@ try {
     await configRoute.handler(bodyReq({ patch: { channels: [{ id: "webhook-new", type: "webhook", url: "https://ntfy.sh/dsh-y", enabled: false, token: "********" }] } }), putW3.res);
     assert.equal(putW3.rec.status, 400, "新 webhook 实例带掩码 400 拒绝");
     assert.ok(JSON.parse(putW3.rec.text).error.hint.includes("掩码"), "400 hint 指引真实 token");
+
+    // #614：客户端修复后「空白起步」形态回归——chAdd 不预置可选键，用户填 url/token
+    // 后提交（无任何空串键）→ 200；此前该形态必 400（保存失败: channels）
+    const putW4 = makeRes();
+    await configRoute.handler(bodyReq({ patch: { channels: [{ id: "webhook-2", type: "webhook", url: "https://ntfy.sh/dsh-z", enabled: false, auth: "bearer", token: WH_SECRET, preset: "ntfy", timeoutSec: 10 }] } }), putW4.res);
+    assert.equal(putW4.rec.status, 200, "#614：无空串键形态（客户端 strip 产物）PUT 成功");
+
+    // #614：存量「空串残留」payload 仍 400（写面契约锁定——空串 ≠ 未配置，
+    // 语义由客户端 assignChannelFields/stripChannelEmpties 剥除承接，服务端不放宽）
+    const putW5 = makeRes();
+    await configRoute.handler(bodyReq({ patch: { channels: [{ id: "webhook-3", type: "webhook", url: "https://ntfy.sh/dsh-b", enabled: false, auth: "bearer", token: "tk614", username: "", password: "", headerName: "", headerValue: "" }] } }), putW5.res);
+    assert.equal(putW5.rec.status, 400, "#614：空串认证字段仍整组 400（写面口径不变）");
+    assert.equal(JSON.parse(putW5.rec.text).error.error, "配置校验失败: channels", "#614：报错键仍为 channels");
   }
 
   // ===== M2：/test 收敛 service 管线 + /status + /kinds（issue #366）=====


### PR DESCRIPTION
## 问题

#614：UI 新增 webhook 通知实例后保存必定失败——「保存失败：配置校验失败: channels」，前端完全无法配置；curl 直写后端正常。

## 根因

客户端 `chAdd` 把 `token/username/password/headerName/headerValue` 全部初始化为空字符串，而服务端写面校验要求这些字段非空（`headerName` 过头名正则）、`validateSettings` 只跳过 `undefined`/`null`——任一空串残留即整组 400。ntfy/gotify 预设只覆写 `auth`/`template`，其余空串原样随组提交，故 **bearer 场景必现**；curl 不带空串字段所以成功。定位与八场景实证详见 [issue 根因评论](https://github.com/wingsky-1/dsh-plugin-hub/issues/614#issuecomment-5558557724)。

## 修复（方案 1：客户端根治，服务端契约不变）

- **`chAdd` 不预置可选键**：webhook 去掉 `token/username/password/headerName/headerValue/template`，bark 去掉 `deviceKey: ""`；未填写 = 键不存在（必填 `url`/`baseUrl` 占位保留，未填保存仍由服务端 400 合理拦截）
- **`chPatch` 单点改走 `assignChannelFields`**：空串/`undefined` 输入删除该键（清空输入框 = 回到未配置态，防「填了又删空」回写死锁）；bark/webhook 卡全字段写回共用此函数
- **`diffSettingsPayload` 提交面 `stripChannelEmpties`**：`channels` 整组提交前剥除空串可选字段，解锁存量 0.2.2 残留草稿/手改 yaml 的死锁形态（与读面 `normalizeWebhookChannel` 空串按未配置剥除同语义）；非对象成员原样透传，服务端校验兜底

服务端写面口径**不变**（空串仍 400，测试锁定）：空串语义由客户端剥除承接；「服务端按未配置放行」的口径统一（方案 2）留待 issue 内另行评审。

## 测试

- `routes.test.ts`：#614 双向断言——无空串键形态（客户端 strip 产物）PUT 200；空串认证字段仍 400（写面契约锁定）
- `client-contract.test.ts`：真产物直测（apply 挂载面）——存量空串残留形态整组 strip 后与合法值全等、无空串形态原样通过、非对象成员不炸、`assignChannelFields`/`stripChannelEmpties` 边界（空串删键/undefined 删键/非空覆盖/必填不剥）
- 本地全量门禁：`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 全绿

## 备注

- draft PR：等报告人（issue 内两问确认）与维护者对方案的反馈后转 ready
- issue 保持 OPEN：待报告人交叉验证确认后按流程关闭
