### PR TITLE
fix(dsh-mcp-manager): 浮窗连接/断开全局 MCP 不再误拆项目级连接单元

### DIFF
--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -591,22 +591,29 @@ export class McpManager {
    * 仅在配置或连接集合实际变化时广播，避免空转 SSE → 客户端 refresh 循环。
    * 变更点驱动（#111）：读取路径不再调用本方法（GET /servers 纯读）；本方法
    * 仅由 fs.watch 变更点与用户操作 API 调用。
+   *
+   * #614 修复：两次 reloadIfChanged 均为 false（配置未变）时直接早退、不再
+   * reconcile——全局 watcher 监听的是整个 `~/.dsh` 目录，插件自身的
+   * user-state 写盘（saveUserState/saveDisabledTools，浮窗连接/断开必写）会
+   * 触发 watcher 事件；此前无配置变化也走 reconcileServers，是「用户操作
+   * 全局服务器 → 项目级单元被误拆」链路的放大器（根因见 start 内注释）。
    */
   async refreshFromDisk(): Promise<void> {
-    let changed = false;
+    let configChanged = false;
     try {
-      changed = (await this.store.reloadIfChanged()) || changed;
+      configChanged = (await this.store.reloadIfChanged()) || configChanged;
     } catch (error) {
       this.logger.warn(`dsh-mcp-manager: reload global config failed: ${String(error)}`);
     }
     if (this.projectStore !== undefined) {
       try {
-        changed = (await this.projectStore.reloadIfChanged()) || changed;
+        configChanged = (await this.projectStore.reloadIfChanged()) || configChanged;
       } catch (error) {
         this.logger.warn(`dsh-mcp-manager: reload project config failed: ${String(error)}`);
       }
     }
-    changed = this.reconcileServers() || changed;
+    if (!configChanged) return;
+    const changed = this.reconcileServers();
     if (changed) this.emitStatus();
   }
 
@@ -648,7 +655,7 @@ export class McpManager {
       }
       for (const [name, want] of desired) {
         if (want.server.enabled === false) continue;
-        // project 模式项目级：由中间层单元管理（touchMiddlewareUnit 惰性重建），
+        // project 模式项目级：由中间层单元管理（ensureMiddlewareServer 幂等触达，#614），
         // 不经 start；all 模式全局照常 start——start 内部下沉接管（触达 @global）。
         if (this.middlewareMode === "project" && want.scope === SCOPE_PROJECT) continue;
         const existing = this.supervisors.get(name);
@@ -701,10 +708,19 @@ export class McpManager {
     // middlewareTakes）。all 模式全局非 runtime 不建 supervisor——杜绝「先建
     // supervisor 再被 reconcile 停掉」的竞态窗口（热更新后 mcp__ 注册残留 →
     // 中间层防双进程探测命中且无重试 → 掉线），改触达 @global 单元惰性连接；
-    // 中间层模式项目级不建 supervisor，拆项目单元惰性重建。startAll / add /
-    // update / reconcile 各入口自动收敛，无需逐处特判。
+    // 中间层模式项目级不建 supervisor，走 ensureMiddlewareServer 幂等触达。
+    // startAll / add / update / reconcile 各入口自动收敛，无需逐处特判。
+    //
+    // #614 根因修复：项目级分支此前是 touchMiddlewareUnit()（teardownUnit 拆毁
+    // 整个当前项目单元）。reconcileServers 对项目级条目（supervisors 恒无）每次
+    // 都会走到 start——浮窗连接/断开任意服务器（saveUserState 写 ~/.dsh → 全局
+    // fs.watch → refreshFromDisk → reconcile）就会把当前项目单元连人带连接整个
+    // 拆掉，且拆后无任何 projectUnitFor 触达，项目级全部显示/实际断开，直到
+    // 切换工作目录（setSession → projectUnitFor）才重建。改为与 touchGlobalUnit
+    // 对称的幂等触达（确保单元存在 + 确保该服务器连接），reconcile 不再有拆毁
+    // 副作用。
     if (this.middlewareTakes(name, scope)) {
-      if (scope === SCOPE_PROJECT) this.touchMiddlewareUnit();
+      if (scope === SCOPE_PROJECT) this.ensureMiddlewareServer(name);
       else this.touchGlobalUnit(name);
       return;
     }
@@ -759,6 +775,37 @@ export class McpManager {
         // #392 遗留⑥：不再静默吞错——projectUnitFor 失败时打 warn 日志，
         // 否则该服务器永不连接且无迹可查（ensureConnected 调用面仍会尝试）。
         this.logger.warn(`dsh-mcp-manager: touchGlobalUnit(${name}) failed: ${String(error)}`);
+      });
+  }
+
+  /**
+   * 幂等触达当前项目单元并确保该服务器连接（#614：start 的中间层项目级接管路径，
+   * 取代旧 touchMiddlewareUnit 的整单元拆毁语义）。
+   * - 单元缺失（宿主重启 / 首次 reconcile）：projectUnitFor 创建 + 惰性连接全部；
+   * - 单元已存在（配置热重载 / 误触发的 reconcile）：保留既有连接，仅对**该**服务器
+   *   ensureConnected（connected/connecting 短路，幂等）；
+   * - entry 已存在但 store 配置已变（手工编辑 mcp.json 热重载）：force 单台重建——
+   *   旧实现的配置生效来自整单元拆毁的副作用，此处改为精确到单台，不殃及同单元
+   *   其他连接。
+   * userDisabled 命中不连（与浮窗断开语义一致）；无活动项目 root 静默返回
+   * （与旧 touchMiddlewareUnit 同口径）。
+   */
+  private ensureMiddlewareServer(name: string): void {
+    const mw = this.middleware;
+    if (mw === undefined || this.projectRoot === undefined) return;
+    void mw.projectUnitFor(this.projectRoot)
+      .then(async (unit) => {
+        if (unit === undefined || unit.userDisabled.has(name)) return;
+        const current = this.projectStore?.find(name);
+        const entry = unit.connections.get(name);
+        if (entry !== undefined && current !== undefined && JSON.stringify(entry.server) !== JSON.stringify(current)) {
+          await mw.ensureConnected(this.projectRoot as string, name, { force: true });
+          return;
+        }
+        await mw.ensureConnected(this.projectRoot as string, name);
+      })
+      .catch((error: unknown) => {
+        this.logger.warn(`dsh-mcp-manager: ensureMiddlewareServer(${name}) failed: ${String(error)}`);
       });
   }
 
@@ -872,10 +919,9 @@ export class McpManager {
     }
     store.upsert(config);
     await store.save();
-    if (this.middlewareMode !== "off" && scope === SCOPE_PROJECT) {
-      // 中间层：拆毁当前 root 单元（下次惰性重建读新配置）。
-      this.touchMiddlewareUnit();
-    }
+    // #614：中间层项目级此前在此 touchMiddlewareUnit() 拆毁整个当前单元——
+    // 新服务器经下方 start → ensureMiddlewareServer 幂等补连即可生效，无需
+    // 拆毁单元殃及既有项目级连接。
     if (config.enabled !== false) this.start(config.name, scope);
     return config;
   }
@@ -910,13 +956,6 @@ export class McpManager {
     }
     store.remove(name);
     await store.save();
-  }
-
-  /** 中间层辅助：拆毁当前 root 单元（配置变更后强制惰性重建）。 */
-  private touchMiddlewareUnit(): void {
-    const mw = this.middleware;
-    if (mw === undefined || this.projectRoot === undefined) return;
-    mw.teardownUnit(this.projectRoot);
   }
 
   async connect(name: string, scope: string = SCOPE_GLOBAL, directConfig?: ServerConfig): Promise<void> {

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -592,7 +592,7 @@ export class McpManager {
    * 变更点驱动（#111）：读取路径不再调用本方法（GET /servers 纯读）；本方法
    * 仅由 fs.watch 变更点与用户操作 API 调用。
    *
-   * #614 修复：两次 reloadIfChanged 均为 false（配置未变）时直接早退、不再
+   * #616 修复：两次 reloadIfChanged 均为 false（配置未变）时直接早退、不再
    * reconcile——全局 watcher 监听的是整个 `~/.dsh` 目录，插件自身的
    * user-state 写盘（saveUserState/saveDisabledTools，浮窗连接/断开必写）会
    * 触发 watcher 事件；此前无配置变化也走 reconcileServers，是「用户操作
@@ -655,7 +655,7 @@ export class McpManager {
       }
       for (const [name, want] of desired) {
         if (want.server.enabled === false) continue;
-        // project 模式项目级：由中间层单元管理（ensureMiddlewareServer 幂等触达，#614），
+        // project 模式项目级：由中间层单元管理（ensureMiddlewareServer 幂等触达，#616），
         // 不经 start；all 模式全局照常 start——start 内部下沉接管（触达 @global）。
         if (this.middlewareMode === "project" && want.scope === SCOPE_PROJECT) continue;
         const existing = this.supervisors.get(name);
@@ -711,7 +711,7 @@ export class McpManager {
     // 中间层模式项目级不建 supervisor，走 ensureMiddlewareServer 幂等触达。
     // startAll / add / update / reconcile 各入口自动收敛，无需逐处特判。
     //
-    // #614 根因修复：项目级分支此前是 touchMiddlewareUnit()（teardownUnit 拆毁
+    // #616 根因修复：项目级分支此前是 touchMiddlewareUnit()（teardownUnit 拆毁
     // 整个当前项目单元）。reconcileServers 对项目级条目（supervisors 恒无）每次
     // 都会走到 start——浮窗连接/断开任意服务器（saveUserState 写 ~/.dsh → 全局
     // fs.watch → refreshFromDisk → reconcile）就会把当前项目单元连人带连接整个
@@ -779,7 +779,7 @@ export class McpManager {
   }
 
   /**
-   * 幂等触达当前项目单元并确保该服务器连接（#614：start 的中间层项目级接管路径，
+   * 幂等触达当前项目单元并确保该服务器连接（#616：start 的中间层项目级接管路径，
    * 取代旧 touchMiddlewareUnit 的整单元拆毁语义）。
    * - 单元缺失（宿主重启 / 首次 reconcile）：projectUnitFor 创建 + 惰性连接全部；
    * - 单元已存在（配置热重载 / 误触发的 reconcile）：保留既有连接，仅对**该**服务器
@@ -793,16 +793,24 @@ export class McpManager {
   private ensureMiddlewareServer(name: string): void {
     const mw = this.middleware;
     if (mw === undefined || this.projectRoot === undefined) return;
-    void mw.projectUnitFor(this.projectRoot)
+    // 入口捕获 root（评审 P2-3）：.then 回调内不再读 this.projectRoot——
+    // setSession 切换后实例字段已变，沿用调用时快照保证 root 与 unit 配套。
+    const root = this.projectRoot;
+    void mw.projectUnitFor(root)
       .then(async (unit) => {
         if (unit === undefined || unit.userDisabled.has(name)) return;
         const current = this.projectStore?.find(name);
         const entry = unit.connections.get(name);
+        // 配置一致性比对（同源 store 实例）：未重载时 entry.server 与 current
+        // 为同一对象引用恒等；真变更必经 reloadIfChanged → load() 整组换新
+        // 对象（键序由 normalizeServer 固定），内容不同则串必不同——假阴性
+        // 不存在；唯一假阳性是用户手排 mcp.json 键序（值不变）触发一次性
+        // force 重连，重建后自愈、不循环。
         if (entry !== undefined && current !== undefined && JSON.stringify(entry.server) !== JSON.stringify(current)) {
-          await mw.ensureConnected(this.projectRoot as string, name, { force: true });
+          await mw.ensureConnected(root, name, { force: true });
           return;
         }
-        await mw.ensureConnected(this.projectRoot as string, name);
+        await mw.ensureConnected(root, name);
       })
       .catch((error: unknown) => {
         this.logger.warn(`dsh-mcp-manager: ensureMiddlewareServer(${name}) failed: ${String(error)}`);
@@ -919,7 +927,7 @@ export class McpManager {
     }
     store.upsert(config);
     await store.save();
-    // #614：中间层项目级此前在此 touchMiddlewareUnit() 拆毁整个当前单元——
+    // #616：中间层项目级此前在此 touchMiddlewareUnit() 拆毁整个当前单元——
     // 新服务器经下方 start → ensureMiddlewareServer 幂等补连即可生效，无需
     // 拆毁单元殃及既有项目级连接。
     if (config.enabled !== false) this.start(config.name, scope);

--- a/packages/dsh-mcp-manager/test/unit-manager2.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-manager2.test.ts
@@ -621,6 +621,87 @@ function rmStatSafe(p) {
   }
 }
 
+// ---- #614：reconcile/refreshFromDisk 不得拆毁中间层项目单元 ----
+
+{
+  console.log("#614 回归：reconcile/start(项目级)/refreshFromDisk 不拆毁中间层项目单元");
+  const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-mgr2x-"));
+  try {
+    const { manager, store } = makeManager(dir);
+    const projRoot = join(dir, "proj");
+    mkdirSync(projRoot, { recursive: true });
+    const projStore = new McpStore(join(projRoot, ".dsh", "mcp.json"));
+    projStore.data = { version: 1, servers: [normalizeServer(quietServer("p1")), normalizeServer(quietServer("p2"))] };
+    manager.projectStores.set(projRoot, projStore);
+    manager.projectRoot = projRoot;
+    manager.projectStore = projStore;
+    manager.middlewareMode = "all";
+
+    // stub 中间层：项目单元已建且 p1/p2 均已 connected（模拟稳定运行态），
+    // teardownUnit 必须零调用（回归红线：reconcile 有任何拆毁即判红）。
+    const teardownRoots = [];
+    const calls614 = [];
+    const mkUnit = (root) => ({
+      root,
+      connections: new Map([
+        ["p1", { server: projStore.find("p1"), client: {}, status: "connected" }],
+        ["p2", { server: projStore.find("p2"), client: {}, status: "connected" }],
+      ]),
+      catalog: new Map(),
+      userDisabled: new Set(),
+      lastTouchedAt: Date.now(),
+      inFlight: new Map(),
+    });
+    const fakeMw = {
+      units: new Map([[projRoot, mkUnit(projRoot)]]),
+      projectUnitFor: async (root) => fakeMw.units.get(root) ?? (() => {
+        const unit = mkUnit(root);
+        fakeMw.units.set(root, unit);
+        return unit;
+      })(),
+      ensureConnected: async (root, name, opts) => {
+        calls614.push(["ensureConnected", root, name, opts]);
+        const unit = fakeMw.units.get(root);
+        if (unit !== undefined && !unit.connections.has(name)) {
+          unit.connections.set(name, { server: projStore.find(name), client: {}, status: "connected" });
+        }
+        return opts;
+      },
+      teardownUnit: (root) => teardownRoots.push(root),
+    };
+    manager.middleware = fakeMw;
+
+    // 全局配置加一台 g1：reconcile 会因 supervisor 集合变化走 start("g1")——
+    // 关键断言：项目单元 connections 保持、teardownUnit 零调用（修复前此处把
+    // 项目单元整个拆毁且无人重建）。
+    store.upsert(normalizeServer(quietServer("g1")));
+    manager.reconcileServers();
+    await pollUntil("all 模式全局 g1 经池接管连接", () => fakeMw.units.get("@global")?.connections.has("g1") === true);
+    assert.equal(teardownRoots.length, 0, "reconcile 零拆毁（#614 回归红线）");
+    assert.equal(fakeMw.units.get(projRoot).connections.get("p1")?.status, "connected", "项目级 p1 连接保持");
+    assert.equal(fakeMw.units.get(projRoot).connections.get("p2")?.status, "connected", "项目级 p2 连接保持");
+
+    // refreshFromDisk 早退：配置无变化时不再 reconcile（消除 user-state 写盘
+    // 误触发 reconcile 的放大器；reconcileBusy 置位可探测是否被调用）。
+    calls614.length = 0;
+    manager.reconcileServers = () => {
+      calls614.push("reconcile");
+      return false;
+    };
+    await manager.refreshFromDisk();
+    assert.equal(calls614.length, 0, "配置无变化 refreshFromDisk 早退、不 reconcile");
+
+    // start(项目级) 幂等触达：不拆单元、对该服务器 ensureConnected（无 force）。
+    calls614.length = 0;
+    manager.start("p1", "project");
+    await pollUntil("start(项目级) 幂等触达完成", () => calls614.some((c) => c[0] === "ensureConnected" && c[1] === projRoot && c[2] === "p1"));
+    assert.equal(teardownRoots.length, 0, "start(项目级) 零拆毁");
+    assert.ok(calls614.every((c) => c[0] !== "ensureConnected" || c[3]?.force !== true), "幂等触达不带 force（connected 短路语义）");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 // ---- #413：all 模式 runtime 注入（toolDefinitions）归一中台 ----
 
 {

--- a/packages/dsh-mcp-manager/test/unit-manager2.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-manager2.test.ts
@@ -621,10 +621,10 @@ function rmStatSafe(p) {
   }
 }
 
-// ---- #614：reconcile/refreshFromDisk 不得拆毁中间层项目单元 ----
+// ---- #616：reconcile/refreshFromDisk 不得拆毁中间层项目单元 ----
 
 {
-  console.log("#614 回归：reconcile/start(项目级)/refreshFromDisk 不拆毁中间层项目单元");
+  console.log("#616 回归：reconcile/start(项目级)/refreshFromDisk 不拆毁中间层项目单元");
   const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-mgr2x-"));
   try {
     const { manager, store } = makeManager(dir);
@@ -654,11 +654,14 @@ function rmStatSafe(p) {
     });
     const fakeMw = {
       units: new Map([[projRoot, mkUnit(projRoot)]]),
-      projectUnitFor: async (root) => fakeMw.units.get(root) ?? (() => {
-        const unit = mkUnit(root);
-        fakeMw.units.set(root, unit);
-        return unit;
-      })(),
+      projectUnitFor: async (root) => {
+        calls614.push(["projectUnitFor", root]);
+        return fakeMw.units.get(root) ?? (() => {
+          const unit = mkUnit(root);
+          fakeMw.units.set(root, unit);
+          return unit;
+        })();
+      },
       ensureConnected: async (root, name, opts) => {
         calls614.push(["ensureConnected", root, name, opts]);
         const unit = fakeMw.units.get(root);
@@ -677,7 +680,7 @@ function rmStatSafe(p) {
     store.upsert(normalizeServer(quietServer("g1")));
     manager.reconcileServers();
     await pollUntil("all 模式全局 g1 经池接管连接", () => fakeMw.units.get("@global")?.connections.has("g1") === true);
-    assert.equal(teardownRoots.length, 0, "reconcile 零拆毁（#614 回归红线）");
+    assert.equal(teardownRoots.length, 0, "reconcile 零拆毁（#616 回归红线）");
     assert.equal(fakeMw.units.get(projRoot).connections.get("p1")?.status, "connected", "项目级 p1 连接保持");
     assert.equal(fakeMw.units.get(projRoot).connections.get("p2")?.status, "connected", "项目级 p2 连接保持");
 
@@ -697,6 +700,23 @@ function rmStatSafe(p) {
     await pollUntil("start(项目级) 幂等触达完成", () => calls614.some((c) => c[0] === "ensureConnected" && c[1] === projRoot && c[2] === "p1"));
     assert.equal(teardownRoots.length, 0, "start(项目级) 零拆毁");
     assert.ok(calls614.every((c) => c[0] !== "ensureConnected" || c[3]?.force !== true), "幂等触达不带 force（connected 短路语义）");
+
+    // start(项目级) 配置漂移：entry.server 与 store 当前配置不一致 → force 单台
+    // 重建（保留手工编辑 mcp.json 热生效语义，评审 P1-2 补测）。
+    calls614.length = 0;
+    projStore.data.servers[0] = normalizeServer(quietServer("p1", { command: "dsh-noop-cmd-v2" }));
+    manager.start("p1", "project");
+    await pollUntil("配置漂移 force 重建完成", () => calls614.some((c) => c[0] === "ensureConnected" && c[2] === "p1" && c[3]?.force === true));
+    assert.equal(teardownRoots.length, 0, "配置漂移 force 重建仍零拆毁（单台重建不殃及单元）");
+
+    // start(项目级) userDisabled 命中：不触发 ensureConnected（浮窗断开语义）。
+    calls614.length = 0;
+    fakeMw.units.get(projRoot).userDisabled.add("p2");
+    manager.start("p2", "project");
+    await pollUntil("projectUnitFor 触达完成", () => calls614.some((c) => c[0] === "projectUnitFor" && c[1] === projRoot));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.ok(!calls614.some((c) => c[0] === "ensureConnected" && c[2] === "p2"), "userDisabled 命中不连接");
+    fakeMw.units.get(projRoot).userDisabled.delete("p2");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #616

## 问题

中间层模式（project / all）下，浮窗对任意**全局** MCP 执行「连接 / 断开」后，**项目级 MCP 全部显示 stopped 且连接被实际拆毁**（stdio 子进程被杀、中间层单元整个消失）；`ws_mcp_*` 调用路径又会惰性重连，表现为「实际没断开但状态显示断开」。切换工作目录再切回（setSession → projectUnitFor）才恢复。

## 根因（隔离环境插桩实证，含完整调用栈）

```
disconnect(name=g1, scope=global)            ← 断开全局（本身正确）
  → saveUserState 写 ~/.dsh/dsh-mcp-user-state.json
  → fs.watch(~/.dsh) 误触发（watcher 监听整个 ~/.dsh 目录）
  → refreshFromDisk → reconcileServers
  → reconcileServers → start(p1, "project")   ← supervisors 恒无项目条目，每次都走 start
  → start → middlewareTakes(project)=true → touchMiddlewareUnit()
  → mw.teardownUnit(当前项目root, connections=1)   ← 项目单元被拆毁
  → 拆后无任何 projectUnitFor 触达 → 永不重建
```

双因子：
1. `start()` 中间层项目级接管分支的 `touchMiddlewareUnit()`（teardownUnit 拆毁整单元）：reconcileServers 对项目级条目每次都会走到 start，任何 reconcile 都拆单元；
2. 全局 watcher 监听整个 `~/.dsh` 目录，插件自身 user-state 写盘（浮窗连接/断开必写）必然误触发 refreshFromDisk → reconcile。

## 修复（`packages/dsh-mcp-manager/src/manager.ts`，+58/−19）

- `start()` 项目级分支改为新增 `ensureMiddlewareServer(name)`：与 `touchGlobalUnit` 对称的幂等触达（`projectUnitFor` 确保单元存在 + `ensureConnected` 确保该服务器连接），reconcile 不再有拆毁副作用；
- entry 配置与 store 当前配置不一致（手工编辑 mcp.json 热重载）→ 仅对该服务器 `force` 重建：保留热生效语义且精确到单台，不殃及同单元其他连接；
- `add()` 移除 `touchMiddlewareUnit()` 调用、方法本体删除（职责已覆盖）；
- `refreshFromDisk` 两次 `reloadIfChanged` 均无变化时早退，消除「user-state 写盘 → reconcile」放大器。

## 验证

- **活体复现**（主实例，操作后已恢复）：断开全局 tavily → 项目级 playwright/chrome-devtools 立即 stopped；POST /resume 恢复——与根因链吻合；
- **隔离环境**（独立 worktree + 临时 DSH_HOME + 假 stdio MCP 服务器 + lib 插桩）：
  - 修复前：all 模式断开全局 g1 → p1 stopped，探针抓到 `teardownUnit(root=/tmp/…, connections=1) <= touchMiddlewareUnit <= start <= reconcileServers`；
  - 修复后：断开/重连全局反复操作 → p1 始终 connected；热切换 project↔all 自动恢复；切目录往返稳定；配置热重载（改 .dsh/mcp.json）生效且连接保持；
- **门禁**：包内 typecheck/build/test；仓库 `pnpm typecheck` / `pnpm build` / `pnpm test` / `pnpm contract` / `pnpm pack:check` 全绿。