### PR TITLE
chore(release): v0.2.3 release notes

### DIFF
--- a/docs/release-notes/v0.2.3.md
+++ b/docs/release-notes/v0.2.3.md
@@ -1,0 +1,169 @@
+# dsh-plugin-hub v0.2.3 Release Notes
+
+> **[中文](#user-content-zh)** · **[English](#user-content-en)**
+
+> **锚定声明：v0.2.3 继续适配 `dsh 0.1.2-rc.1`**（cordis `4.0.2`）——官方类型层 catalog 与全部插件 peer 保持 v0.2.2 的 `0.1.2-rc.1` 锚定不变，本版无 dsh 侧破坏性变更，**无需升级 dsh 本体**。本插件集**只适配 dsh rc 版本，不对 alpha 版本适配**；安装/更新时若 dsh 版本不匹配，npm/pnpm 会给出 peer 提示。
+
+> **Anchor statement: v0.2.3 keeps targeting `dsh 0.1.2-rc.1`** (cordis `4.0.2`) — the official type-layer catalog and all plugin peers stay pinned to `0.1.2-rc.1` as in v0.2.2, with no dsh-side breaking changes. **No dsh CLI upgrade is required for this release.** This plugin set only adapts to dsh **rc** releases; **alpha versions are not supported**. npm/pnpm will surface a peer mismatch if your dsh version does not match.
+
+<a id="zh"></a><a id="user-content-zh"></a>
+## 中文
+
+### 概述
+
+v0.2.3 是 0.2 线的第三个补丁版本，主线为「**mem0 长期记忆插件落地 + 圈复杂度专项消峰 + 用量趋势与文件预览体验完善**」。功能面：**新增 `dsh-mem0` 独立插件**（#570 系列）——mem0 长期记忆系统最小 MVP（#573）、记忆中心双区改版与全面配置化及本地向量落地（#578）、环境探测 / 虚拟环境自愈 / 前端一键安装（#582）、设置页 LLM 复用 DSH 提供商模型与向量模型本地化精简（#610）；provider-usage 使用趋势「日/周/月」视图改版（#566）；web-file-preview HTML 预览支持交互式预览（opt-in 脚本执行 + 独立短 TTL token + 按模式 CSP）（#558）。工程治理面，圈复杂度专项（#592）把 provider-usage / notifier / mcp-manager 的 apply 超级函数与路由处理器拆解消峰（236→11、146→4、131→≤15 与 84/78→5/14），并新增 crap-check `--diff` 增量防劣化判定（#596）与 B5 homedir 门禁（#548）。修复面覆盖 mcp-manager 浮窗断开不再误拆项目级连接单元（#617）、notifier webhook 空串字段保存必 400（#614）与审批通知 waterfall 链头化（#560）、lan-proxy WS 保活与压缩解耦（#561）及 schemastery 移入 devDependencies（#594）、mem0 服务未就绪与路由注册签名修复（#613/#603）、provider-usage 趋势 Y 域桶堆叠合计口径（#591）与报告周期语义（#601）、web-file-preview serve 围栏子资源 403（#553）等。工程化面完成客户端 TSX 语法支持与 SettingsCard 试点迁移（#584/#597/#605）、CI 调度脚本下沉 ci-matrix.mjs（#586）、变异测试基线 Orphan 分支化（#572），并沉淀工业级变异测试优化指南（#607）。
+
+### 升级指南
+
+**1. dsh 本体**：本版继续锚定 `dsh 0.1.2-rc.1`，无需升级；若当前 dsh 低于该版本请先升级：
+
+```sh
+npm i -g @deepseek-ai/dsh@0.1.2-rc.1
+dsh --version   # 应显示 0.1.2-rc.1
+```
+
+**2. 升级插件到 0.2.3**（升级后需**重启一次** `dsh web`，bundle 层只在启动时组合）：
+
+```sh
+# 全家桶（聚合包 + 其拉齐的子包）升到 0.2.3
+dsh plugin --profile web update @wingsky-1/dsh-plugins-all@0.2.3
+
+# 或逐个插件指定版本（示例，按需替换包名）
+dsh plugin --profile web update @wingsky-1/dsh-notifier@0.2.3
+dsh plugin --profile web update @wingsky-1/dsh-mcp-manager@0.2.3
+```
+
+**3. 新插件 dsh-mem0**（独立分发，不在聚合包内；按需显式安装）：
+
+```sh
+dsh plugin --profile web install @wingsky-1/dsh-mem0@0.2.3
+```
+
+> 未全局安装 `dsh` 时，将上述 `dsh plugin ...` 换成 `npx @deepseek-ai/dsh plugin ...` 即可。
+
+### 新功能
+
+- **[dsh-mem0]** 新插件：mem0 长期记忆系统最小 MVP（#570，#573）
+- **[dsh-mem0]** 记忆中心双区改版、全面配置化与本地向量落地（#570 阶段二，#578）
+- **[dsh-mem0]** 环境探测、虚拟环境自愈与前端一键安装机制（#570 阶段二补充，#582）
+- **[dsh-mem0]** 设置页 LLM 复用 DSH 提供商模型 + 向量模型本地化精简（#610）
+- **[dsh-provider-usage]** 使用趋势「日/周/月」视图改版（#503 M2.1，#566）
+- **[dsh-web-file-preview]** HTML 预览支持交互式预览——opt-in 脚本执行，独立短 TTL token + 按模式 CSP（#507，#558）
+- **[gate]** crap-check 增加 `--diff` 增量防劣化判定与单测覆盖（#592，#596）
+- **[gate]** B5 homedir 门禁——`forbid-homedir-src.mjs` AST 扫描 src 禁直连 HOME 来源 API（#548）
+
+### 修复
+
+- **[dsh-mcp-manager]** 浮窗连接/断开全局 MCP 不再误拆项目级连接单元（#616，#617）
+- **[dsh-mcp-manager]** 能力目录接入 middleware per-root 目录摘要（#569，#574）
+- **[dsh-notifier]** webhook 新增实例空串字段致保存必 400——客户端初始化不预置可选键 + 提交面空串剥除（#614）
+- **[dsh-notifier]** 审批通知 waterfall 链头化——prepend 修复宿主 answerer 短路致 approval/request 不可达（#559，#560）
+- **[dsh-mem0]** 修复 inject 缺 llm 声明导致的服务未就绪 + 记忆中心体验重构（#612，#613）
+- **[dsh-mem0]** 修复路由注册签名不匹配与前端诊断异常静默（#602，#603）
+- **[dsh-provider-usage]** 用量报告统一按已闭环上一周期统计 + 提示词语义块升级（#600，#601）
+- **[dsh-provider-usage]** 趋势图 Y 域口径改按桶堆叠合计——单段最大值致多段桶堆叠顶溢出轴顶（#589，#591）
+- **[dsh-provider-usage]** 趋势图 Y 轴刻度动态化——按数据最大值推导 1/2/2.5/5×10^k 步长与刻度序列（#571）
+- **[dsh-lan-proxy]** WS 保活与压缩解耦——wsBridgeEnabled 全桥接基座，清空白名单不再丢保活（#552，#561）
+- **[dsh-lan-proxy]** schemastery 移入 devDependencies——维持零运行时依赖（#583，#594）
+- **[dsh-web-file-preview]** serve 围栏放宽跨站 no-cors 子资源——修复多文件 HTML 静态预览失效（#549，#553）
+- **[dsh-web-file-preview]** 交互式预览 iframe 充满面板 + el() attrs 装配恢复 tab 高亮（#563，#564，#565）
+- **[ci]** 修复 overlay-baseline.mjs 缺失 mkdtempSync 导入错误（#579）
+
+### 维护与工程化
+
+- **[refactor]** provider-usage 拆解 apply 超级函数与路由处理器——圈复杂度从 236 降至 11（#592，#599）
+- **[refactor]** notifier 拆解 apply 超级函数与事件处理器——圈复杂度从 146 降至 4（#592，#604）
+- **[refactor]** mcp-manager 拆解中间层工具定义与执行器——圈复杂度从 131 降至 ≤15（#592，#609）
+- **[refactor]** mcp-manager 拆解 makeRoutes 与 apply 装配骨架——圈复杂度 84/78 降至 5/14（#592，#611）
+- **[refactor]** 客户端构建支持 TSX 语法与轻量 JSX 类型垫片（#584，#597）
+- **[refactor]** 存量 SettingsCard 组件试点迁移为原生 TSX（#584，#605）
+- **[refactor]** CI 复杂调度与路径解析脚本下沉至 scripts/ci/ci-matrix.mjs（#586，#606）
+- **[refactor]** 变异测试基线改走 Orphan 孤立分支——剥离 main 代码树巨型 JSON（#572）
+- **[refactor]** codegraph 与 mcp-manager 提示词优化为全英文并改系统提示词注入（#577）
+- **[docs]** 沉淀工业级变异测试全链路优化与落地指南（#607）
+- **[docs]** 消除架构文档中硬编码代码行号引用与规范冗余去重（#585，#595）
+- **[docs]** AGENTS.md 增补 PR 贴图纪律——相对路径按 main 解析必破图，commit-pin raw URL 保长期有效（#566 实证，#567）
+- **[docs]** README 插件描述对齐各包当前功能面 + 核心优势补通知中心与用量趋势条目（#551，#555，#557）
+- **[test]** provider-usage 客户端产物路由字面量与 ROUTES 全集对比断言（#524，#593）
+- **[ci]** 增量变异基线例行快照（#562，#568）
+
+<a id="en"></a><a id="user-content-en"></a>
+## English
+
+### Overview
+
+v0.2.3 is the third patch release on the 0.2 line, centered on **the dsh-mem0 long-term memory plugin + cyclomatic-complexity reduction + usage-trend and file-preview polish**. Features: a new standalone **`dsh-mem0`** plugin (#570 series) — minimal MVP of the mem0 long-term memory system (#573), a redesigned two-zone memory hub with full configuration and local vector persistence (#578), environment detection / virtualenv self-healing / one-click install from the UI (#582), and settings-page LLM reuse of DSH provider models with a leaner local vector model (#610); provider-usage day/week/month usage-trend views (#566); web-file-preview interactive HTML preview (opt-in script execution with per-mode CSP and dedicated short-TTL tokens) (#558). On the engineering side, the complexity drive (#592) decomposes the apply super-functions and route handlers in provider-usage / notifier / mcp-manager (236→11, 146→4, 131→≤15 and 84/78→5/14), and adds a crap-check `--diff` incremental anti-regression gate (#596) and the B5 homedir gate (#548). Fixes cover mcp-manager no longer tearing down project-level connection units when toggling global MCP from the floating window (#617), notifier webhook empty-string fields causing a guaranteed 400 on save (#614) and approval-notification waterfall chain-heading (#560), lan-proxy WS keep-alive/compression decoupling (#561) and schemastery moved to devDependencies (#594), mem0 service-not-ready and route-registration-signature fixes (#613/#603), provider-usage trend Y-domain stacked-total accounting (#591) and report-period semantics (#601), and web-file-preview serve-fence no-cors subresources (#553). The toolchain also lands client TSX syntax support with a SettingsCard pilot migration (#584/#597/#605), CI scheduling scripts consolidated into ci-matrix.mjs (#586), the mutation-testing baseline moved to an orphan branch (#572), and an industrial-grade mutation-testing optimization guide (#607).
+
+### Upgrade Guide
+
+**1. dsh CLI**: this release keeps targeting `dsh 0.1.2-rc.1` — no upgrade is required. If your dsh is older, upgrade first:
+
+```sh
+npm i -g @deepseek-ai/dsh@0.1.2-rc.1
+dsh --version   # should print 0.1.2-rc.1
+```
+
+**2. Upgrade plugins to 0.2.3** (restart `dsh web` once afterwards — the bundle layer composes only at startup):
+
+```sh
+# Bundle (aggregate + the sub-packages it pulls in) to 0.2.3
+dsh plugin --profile web update @wingsky-1/dsh-plugins-all@0.2.3
+
+# Or pin per-plugin versions (examples — replace with the packages you use)
+dsh plugin --profile web update @wingsky-1/dsh-notifier@0.2.3
+dsh plugin --profile web update @wingsky-1/dsh-mcp-manager@0.2.3
+```
+
+**3. New plugin dsh-mem0** (distributed standalone, not part of the aggregate; install it explicitly if you want it):
+
+```sh
+dsh plugin --profile web install @wingsky-1/dsh-mem0@0.2.3
+```
+
+> If `dsh` is not installed globally, replace `dsh plugin ...` with `npx @deepseek-ai/dsh plugin ...`.
+
+### Features
+
+- **[dsh-mem0]** New plugin: minimal MVP of the mem0 long-term memory system (#570, #573)
+- **[dsh-mem0]** Redesigned two-zone memory hub, full configuration and local vector persistence (#570 phase 2, #578)
+- **[dsh-mem0]** Environment detection, virtualenv self-healing and one-click install from the UI (#570 phase 2 follow-up, #582)
+- **[dsh-mem0]** Settings page reuses DSH provider models for the LLM + leaner local vector model (#610)
+- **[dsh-provider-usage]** Day/week/month usage-trend views (#503 M2.1, #566)
+- **[dsh-web-file-preview]** Interactive HTML preview — opt-in script execution with per-mode CSP and dedicated short-TTL tokens (#507, #558)
+- **[gate]** crap-check gains a `--diff` incremental anti-regression gate with unit tests (#592, #596)
+- **[gate]** B5 homedir gate — `forbid-homedir-src.mjs` AST scan forbids direct HOME-derived APIs in src (#548)
+
+### Bug Fixes
+
+- **[dsh-mcp-manager]** Toggling global MCP from the floating window no longer tears down project-level connection units (#616, #617)
+- **[dsh-mcp-manager]** Capability catalog consumes middleware per-root directory summaries (#569, #574)
+- **[dsh-notifier]** Webhook empty-string fields caused a guaranteed 400 on save — client init no longer pre-seeds optional keys + submission strips empty strings (#614)
+- **[dsh-notifier]** Approval notifications waterfall chain-heading — prepend fixes host answerer short-circuit making approval/request unreachable (#559, #560)
+- **[dsh-mem0]** Fixes service-not-ready caused by a missing llm declaration in inject + memory-hub experience refactor (#612, #613)
+- **[dsh-mem0]** Fixes route-registration signature mismatch and silently-swallowed frontend diagnostics (#602, #603)
+- **[dsh-provider-usage]** Usage reports uniformly count the closed previous period + upgraded prompt semantic blocks (#600, #601)
+- **[dsh-provider-usage]** Trend Y-domain switches to bucket-stacked totals — single-segment maximum made stacked bars overflow the axis top (#589, #591)
+- **[dsh-provider-usage]** Trend Y-axis ticks become dynamic — 1/2/2.5/5×10^k steps derived from the data maximum (#571)
+- **[dsh-lan-proxy]** WS keep-alive decoupled from compression — wsBridgeEnabled as the all-bridging base; clearing the whitelist no longer drops keep-alive (#552, #561)
+- **[dsh-lan-proxy]** schemastery moved to devDependencies — keeps zero runtime dependencies (#583, #594)
+- **[dsh-web-file-preview]** Serve fence relaxes cross-site no-cors subresources — fixes multi-file HTML static preview (#549, #553)
+- **[dsh-web-file-preview]** Interactive preview iframe fills the panel + el() attrs assembly restores tab highlighting (#563, #564, #565)
+- **[ci]** Fixes missing mkdtempSync import in overlay-baseline.mjs (#579)
+
+### Maintenance
+
+- **[refactor]** provider-usage apply super-function and route handlers decomposed — complexity 236 → 11 (#592, #599)
+- **[refactor]** notifier apply super-function and event handlers decomposed — complexity 146 → 4 (#592, #604)
+- **[refactor]** mcp-manager middleware tool definitions and executor decomposed — complexity 131 → ≤15 (#592, #609)
+- **[refactor]** mcp-manager makeRoutes and apply assembly skeleton decomposed — complexity 84/78 → 5/14 (#592, #611)
+- **[refactor]** Client build supports TSX syntax with a lightweight JSX type shim (#584, #597)
+- **[refactor]** Existing SettingsCard components pilot-migrate to native TSX (#584, #605)
+- **[refactor]** CI scheduling and path-resolution scripts consolidated into scripts/ci/ci-matrix.mjs (#586, #606)
+- **[refactor]** Mutation-testing baseline moved to an orphan branch — giant JSON removed from the main tree (#572)
+- **[refactor]** codegraph and mcp-manager prompts optimized to full English and injected as system prompts (#577)
+- **[docs]** Industrial-grade mutation-testing full-chain optimization and landing guide (#607)
+- **[docs]** Hardcoded code-line references removed from architecture docs + spec redundancy dedup (#585, #595)
+- **[docs]** AGENTS.md gains PR image-attachment discipline — relative paths resolve against main and break; commit-pin raw URLs stay valid (#566 evidence, #567)
+- **[docs]** README plugin descriptions aligned to each package's current surface + core-advantage entries for the notification center and usage trends (#551, #555, #557)
+- **[test]** provider-usage client artifact route literals asserted against the full ROUTES set (#524, #593)
+- **[ci]** Routine incremental mutation baseline snapshots (#562, #568)


### PR DESCRIPTION
## 概述

v0.2.3 发版准备的 release notes（对应 issue #618）。

## 变更内容

- 新增 `docs/release-notes/v0.2.3.md`：从 `v0.2.2..HEAD` 的 40 个常规提交生成
  - 中文与英文各自成节（不逐条混排）
  - 文件头语言跳转导航 + 分节双锚补位（`user-content-` 前缀，GitHub / 第三方渲染器均可跳转）
  - 适配锚定声明：继续锚定 `dsh 0.1.2-rc.1`（catalog/peer 与 v0.2.2 一致，无需升级 dsh 本体）
  - 升级指南含全家桶与逐个指定版本两种形态 + 新插件 dsh-mem0 独立安装命令（standalone，不入聚合包）
  - 无 emoji

## 核验情况

- reviewer 子 agent 事实核验：PASS——40/40 提交全覆盖、无遗漏无多余；引用 issue/PR 号全部真实；锚定声明与仓库 catalog/peer/README 一致；格式与 v0.2.2 模板一致
- 覆盖率审计：新功能 8 条 / 修复 14 条 / 维护工程化 15 条（中英一一对应）

## 非范围（另走发布流程）

- 9 包版本对齐到 0.2.3（发版 tag 时由 release 流程处理）
- 推 v0.2.3 tag 触发 npm publish（由维护者执行）

Closes #618