### PR TITLE
chore(release): v0.2.3 版本对齐（9 包）

### DIFF
--- a/packages/dsh-codegraph/package.json
+++ b/packages/dsh-codegraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-codegraph",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "codegraph MCP + worktree 开发纪律：探测/引导安装 codegraph CLI，经 mcp-manager 核心服务运行时注册 MCP 服务器，工具层强制「查询前 sync + projectPath」，非 git 仓不启用（#329 阶段2）",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-lan-proxy/package.json
+++ b/packages/dsh-lan-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-lan-proxy",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "局域网访问 dsh web UI：在 0.0.0.0:<port> 监听，把 HTTP/HTTPS 与 WebSocket/wss 转发到回环 web 服务器（默认 127.0.0.1:3080）。重写 Host/Origin 以通过 /api 浏览器信任围栏，仅接受 IP 字面量或 localhost 的 Host 头（DNS 重绑定防护）。HTTPS 默认并存（3443），证书可配置或自动生成自签名。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-mcp-manager/package.json
+++ b/packages/dsh-mcp-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-mcp-manager",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "DSH MCP 管理器：Web 侧边栏「MCP」入口，面板按状态分级展示 MCP 服务器（运行中/连接中/已配置/失败），支持快速接入（stdio / streamable-http 表单）与粘贴 mcpServers JSON 导入。已连接服务器的工具以 mcp__<server>__<tool> 注册给模型直接调用。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-mem0/package.json
+++ b/packages/dsh-mem0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-mem0",
-  "version": "0.1.0",
+  "version": "0.2.3",
   "description": "DSH 长期记忆系统插件：基于 mem0 的本地/轻量持久记忆，原生感知 Git 工作空间，全英文工具契约，中文沉淀与冲突消解，设置页「记忆中心」管理大盘。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-notifier/package.json
+++ b/packages/dsh-notifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-notifier",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "审批/完成/错误事件通知：浏览器 Notification + 系统原生 toast（Windows PowerShell WinRT / macOS osascript / Linux notify-send，均无需额外安装）；提示音可配、每条通知独立显示不互相替换、非安全上下文自动降级横幅",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-plugins-all/package.json
+++ b/packages/dsh-plugins-all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-plugins-all",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "DSH 插件全家桶聚合包：一键安装全部功能插件（notifier / provider-usage / mcp-manager / lan-proxy / verify-isolated / web-file-preview）。装它 = 子包 dependencies 拉齐 + 聚合 cordis patch 激活。dsh-gzip 已退役（压缩合并进 lan-proxy），不再随全家桶分发。",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-provider-usage/package.json
+++ b/packages/dsh-provider-usage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-provider-usage",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "用量统计悬浮框（v2 契约）：胶囊 + 详情面板，宿主端渲染 HTML 注入；用户 mjs 适配器三函数接入任意数据源（fetchData/formatCapsule/formatPanel），宿主注入共享图表工具（utils），密钥配置链注入、按天分片 JSONL 历史、热更新可选；内置 OpenCode Go / DeepSeek 官方 / 智谱 Coding Plan (CN) 适配器",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-verify-isolated/package.json
+++ b/packages/dsh-verify-isolated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-verify-isolated",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "DSH 插件开发的隔离环境浏览器验证 skill：临时 DSH_HOME + 独立 verify_<随机> profile 双重隔离，一键拉起隔离 dsh web（自动构建/挂载/启动/清理），不污染正在使用的 web profile",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/dsh-web-file-preview/package.json
+++ b/packages/dsh-web-file-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wingsky-1/dsh-web-file-preview",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "点击对话中的文件链接在 web 端预览：宿主端按 MIME 服务会话工作区内文件（图片直出/文本 UTF-8 直出 + git diff），客户端拦截文件链接弹出预览 Modal（Markdown/代码高亮/Diff/图片灯箱）",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 概述

v0.2.3 发版准备第二步：9 包版本对齐到 0.2.3（含新增 dsh-mem0，从 0.1.0 对齐到 0.2.3）。

## 变更内容

- `packages/dsh-*/package.json` version 0.2.2 → 0.2.3（9 包：codegraph/lan-proxy/mcp-manager/mem0/notifier/plugins-all/provider-usage/verify-isolated/web-file-preview）
- dsh-mem0 为新增 standalone 插件，本版首次随整体版本对齐发布
- pnpm-lock.yaml 无需变更（workspace 版本不入 lock，frozen 校验已通过）

## 前置

- 依赖 #619（release notes v0.2.3 已合入 main）

## 后续（发版流程）

- 本 PR 合并后推 `v0.2.3` tag，触发 release 流水线（版本校验 → 全量门禁 → publish → GitHub Release）

Refs #618