### PR TITLE
refactor: CRAP 消峰收官至全仓 comp <= 15 + Windows 平台兼容与环境隔离治理

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "description": "DSH（DeepSeek Harness）Web GUI 插件集：通知、provider 用量、局域网代理、MCP 管理、闲置归档、文件预览——一键装全家桶或按需单装",
   "license": "MIT",
   "scripts": {
-    "build": "pnpm -r build",
-    "test": "pnpm -r test",
+    "build": "pnpm -r --filter !dsh-plugin-hub build",
+    "test": "pnpm -r --filter !dsh-plugin-hub test",
     "contract": "node scripts/gate/contract-check.ts",
     "pack:check": "node scripts/gate/pack-check.ts",
     "verify:npmlayout": "node scripts/gate/verify-npm-layout.ts",
@@ -19,7 +19,7 @@
     "gate:homedir": "node scripts/gate/forbid-homedir-src.mjs",
     "docs:check": "node scripts/gate/verify-docs.ts --strict-en",
     "typecheck": "pnpm -r --if-present run typecheck",
-    "cov": "c8 --reporter=json --reporter=json-summary --reporter=text pnpm -r --if-present test",
+    "cov": "c8 --reporter=json --reporter=json-summary --reporter=text pnpm -r --filter !dsh-plugin-hub --if-present test",
     "crap": "node scripts/gate/crap-check.mjs"
   },
   "keywords": [

--- a/packages/dsh-codegraph/test/smoke.ts
+++ b/packages/dsh-codegraph/test/smoke.ts
@@ -23,14 +23,14 @@ import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 // 服务消费方契约门禁（#476）：codegraph 经 mcp-manager 公开入口的类型化调用
 // 形状 + 无直连 shared + 依赖解析链（运行时断言；编译期断言经 scripts/test/
 // service-contract-wiring.test.ts 的 tsc 编译面执行）
 import "./service-consumer.test.ts";
 
-const pkgDir = join(new URL("..", import.meta.url).pathname);
+const pkgDir = fileURLToPath(new URL("..", import.meta.url));
 const mod = await import(pathToFileURL(join(pkgDir, "lib/index.js")).href);
 const { apply, name, inject } = mod;
 const { isCodegraphInstalled, installGuidance } = mod;
@@ -70,11 +70,19 @@ async function resolveModule(name, envVar) {
 }
 
 const failures = [];
+// 平台跳过标记：win32 不支持 exec POSIX fake CLI（shebang/sh 脚本，产品侧
+// resolveCodegraphPath 亦不探测 .cmd）——fake CLI 分支用例在 win32 显式跳过
+// （跳过行可见，不假绿），覆盖由 Linux CI 承担；产品 Windows 支持缺口另行跟踪。
+const SKIP = Symbol("platform-skip");
+function skipOnWin32() {
+  if (process.platform === "win32") throw SKIP;
+}
 function check(label, fn) {
   try {
     fn();
     console.log(`  ok   ${label}`);
   } catch (error) {
+    if (error === SKIP) { console.log(`  (skip win32) ${label}`); return; }
     failures.push(`${label}: ${error.message}`);
     console.error(`FAIL ${label}: ${error.message}`);
   }
@@ -84,6 +92,7 @@ async function checkAsync(label, fn) {
     await fn();
     console.log(`  ok   ${label}`);
   } catch (error) {
+    if (error === SKIP) { console.log(`  (skip win32) ${label}`); return; }
     failures.push(`${label}: ${error.message}`);
     console.error(`FAIL ${label}: ${error.message}`);
   }
@@ -101,6 +110,7 @@ function registerAsync(label, fn) {
 let pathLock = Promise.resolve();
 function withGlobalPath(path, fn) {
   const run = pathLock.then(async () => {
+    if (process.platform === "win32") throw SKIP;
     const prev = process.env.PATH;
     process.env.PATH = path;
     try {
@@ -316,6 +326,7 @@ check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpMa
 
   // 分支 5：符号未找到（stdout 空结果提示）→ 空结果提示而非错误
   registerAsync("guardedCodegraph: 符号未找到 → 空结果提示（非错误）", async () => {
+    skipOnWin32();
     const dir = mkdtempSync(join(tmpdir(), "cg-fake-"));
     makeFakeBin(dir, `${FAKE_SYNC_OK}\necho 'ℹ Symbol "NoSuch" not found'`);
     resetSyncCache();
@@ -336,6 +347,7 @@ check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpMa
 
   // 分支 8：命令失败（stderr + 退出码 1）→ 错误提示
   registerAsync("guardedCodegraph: 命令失败（stderr+退出码 1）→ 错误提示", async () => {
+    skipOnWin32();
     const dir = mkdtempSync(join(tmpdir(), "cg-fake2-"));
     makeFakeBin(dir, `${FAKE_SYNC_OK}\necho 'error: unknown option' >&2; exit 1`);
     resetSyncCache();
@@ -356,6 +368,7 @@ check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpMa
 
   // 分支 7：空结果（找到符号但无调用者）→ 空结果提示
   registerAsync("guardedCodegraph: 无调用者 → 空结果提示", async () => {
+    skipOnWin32();
     const dir = mkdtempSync(join(tmpdir(), "cg-fake3-"));
     makeFakeBin(dir, `${FAKE_SYNC_OK}\necho 'ℹ No callers found for "x"'`);
     resetSyncCache();
@@ -405,6 +418,7 @@ check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpMa
 
   // 分支 3：sync 失败 → 拒绝
   registerAsync("guardedCodegraph: sync 失败 → 拒绝", async () => {
+    skipOnWin32();
     const dir = mkdtempSync(join(tmpdir(), "cg-fake6-"));
     mkdirSync(join(dir, "repo", ".git"), { recursive: true });
     mkdirSync(join(dir, "repo", ".codegraph"), { recursive: true });
@@ -425,6 +439,7 @@ check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpMa
   // sync TTL 缓存（#363 验收 9）：30s 内同 projectPath 不重复 sync；
   // 用 fake sync 计数验证；查询结果不缓存（每次重新执行）。
   registerAsync("sync TTL: 30s 内同 projectPath 只 sync 一次（查询不缓存）", async () => {
+    skipOnWin32();
     const dir = mkdtempSync(join(tmpdir(), "cg-ttl-"));
     mkdirSync(join(dir, "repo", ".git"), { recursive: true });
     mkdirSync(join(dir, "repo", ".codegraph"), { recursive: true });
@@ -486,6 +501,7 @@ check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpMa
 
   // P2-2：未知子命令形态（stderr 有 error 但退出码 0）→ 归入失败提示
   registerAsync("guardedCodegraph: stderr 非空 + exit 0 → 失败提示（非空 stdout 误判）", async () => {
+    skipOnWin32();
     const dir = mkdtempSync(join(tmpdir(), "cg-unk-"));
     const repo = join(dir, "repo");
     mkdirSync(join(repo, ".git"), { recursive: true });
@@ -507,6 +523,7 @@ check("契约: inject 包含 mcpManager", () => assert.ok(inject.includes("mcpMa
 
   // P2-1：node 文件模式文件不存在 → 空结果提示（No indexed file matches）
   registerAsync("guardedCodegraph: node 文件不存在 → 空结果提示", async () => {
+    skipOnWin32();
     const dir = mkdtempSync(join(tmpdir(), "cg-nf-"));
     const repo = join(dir, "repo");
     mkdirSync(join(repo, ".git"), { recursive: true });

--- a/packages/dsh-lan-proxy/src/proxy.ts
+++ b/packages/dsh-lan-proxy/src/proxy.ts
@@ -529,6 +529,75 @@ function attachWsLivenessProbe(
  * 逻辑自然收口另一端。探活定时器/监听器随连接关闭释放：两端各自的 close/error
  * 四路清理收敛到 stopAllProbes 单入口。
  */
+/**
+ * 半开探活装配（#592 从 bridgeCompressedWs 拆出）：两端独立计时（各自 pong
+ * 判定），probeIntervalMs=0 显式关闭。返回统一停止入口（幂等安全）。
+ */
+function attachBridgeProbes(
+  browserWs: WebSocket,
+  upstreamWs: WsClient,
+  target: WsBridgeTarget,
+): () => void {
+  const probeIntervalMs = target.probeIntervalMs ?? DEFAULT_WS_PROBE_INTERVAL_MS;
+  if (probeIntervalMs <= 0) return () => {};
+  // 半开判死日志：与既有 upstream error warn 同通道、可按文案区分
+  // 「半开判死强拆」与「正常关闭/业务错误」（issue #268 复核闸修补 2）。
+  const onHalfOpen = (intervalMs: number) => {
+    target.logger?.warn?.(`lan-proxy: ws-bridge half-open detected, terminating (intervalMs=${intervalMs})`);
+    target.onDisconnect?.("halfOpen");
+  };
+  const stopBrowserProbe = attachWsLivenessProbe(browserWs, probeIntervalMs, onHalfOpen);
+  const stopUpstreamProbe = attachWsLivenessProbe(upstreamWs, probeIntervalMs, onHalfOpen);
+  return () => {
+    stopBrowserProbe();
+    stopUpstreamProbe();
+  };
+}
+
+/**
+ * 四路 teardown 接线（#592 从 bridgeCompressedWs 拆出）：任一端关闭/出错 →
+ * 对端终止；清理收敛到 stopAllProbes（幂等）。断连分类打点（issue #308 测量）：
+ * close/error/halfOpen 各有独立计数。上游 terminate（不响应 close 握手时强拆）、
+ * 浏览器端 close()（握手级联）。
+ */
+function wireBridgeTeardown(
+  browserWs: WebSocket,
+  upstreamWs: WsClient,
+  target: WsBridgeTarget,
+  stopAllProbes: () => void,
+): void {
+  const untrackBridges = () => {
+    target.bridgeSockets?.delete(browserWs);
+    target.bridgeSockets?.delete(upstreamWs);
+  };
+  const report = (kind: "close" | "error" | "halfOpen") => target.onDisconnect?.(kind);
+  upstreamWs.on("close", () => {
+    untrackBridges();
+    stopAllProbes();
+    report("close");
+    browserWs.terminate();
+  });
+  upstreamWs.on("error", (err) => {
+    untrackBridges();
+    stopAllProbes();
+    report("error");
+    target.logger?.warn?.(`lan-proxy: ws-bridge upstream error: ${err.message}`);
+    browserWs.terminate();
+  });
+  browserWs.on("close", () => {
+    untrackBridges();
+    stopAllProbes();
+    report("close");
+    try { upstreamWs.close(); } catch { /* 已关闭 */ }
+  });
+  browserWs.on("error", () => {
+    untrackBridges();
+    stopAllProbes();
+    report("error");
+    try { upstreamWs.close(); } catch { /* 已关闭 */ }
+  });
+}
+
 export function bridgeCompressedWs(
   req: IncomingMessage,
   socket: Socket,
@@ -563,31 +632,8 @@ export function bridgeCompressedWs(
     // 不依赖「浏览器端 close → 上游 close()」握手级联（上游不响应会滞留）。
     target.bridgeSockets?.add(browserWs);
     target.bridgeSockets?.add(upstreamWs);
-    const untrackBridges = () => {
-      target.bridgeSockets?.delete(browserWs);
-      target.bridgeSockets?.delete(upstreamWs);
-    };
     // 半开探活：两端独立计时（各自 pong 判定），probeIntervalMs=0 显式关闭。
-    const probeIntervalMs = target.probeIntervalMs ?? DEFAULT_WS_PROBE_INTERVAL_MS;
-    let stopProbes: (() => void) | undefined;
-    const stopAllProbes = () => {
-      stopProbes?.();
-      stopProbes = undefined;
-    };
-    if (probeIntervalMs > 0) {
-      // 半开判死日志：与既有 upstream error warn 同通道、可按文案区分
-      // 「半开判死强拆」与「正常关闭/业务错误」（issue #268 复核闸修补 2）。
-      const onHalfOpen = (intervalMs: number) => {
-        target.logger?.warn?.(`lan-proxy: ws-bridge half-open detected, terminating (intervalMs=${intervalMs})`);
-        target.onDisconnect?.("halfOpen");
-      };
-      const stopBrowserProbe = attachWsLivenessProbe(browserWs, probeIntervalMs, onHalfOpen);
-      const stopUpstreamProbe = attachWsLivenessProbe(upstreamWs, probeIntervalMs, onHalfOpen);
-      stopProbes = () => {
-        stopBrowserProbe();
-        stopUpstreamProbe();
-      };
-    }
+    const stopAllProbes = attachBridgeProbes(browserWs, upstreamWs, target);
     // 浏览器 → DSH（握手成功后开始转发）。注意保留原始帧类型 isBinary：
     // ws 的 message 回调 data 恒为 Buffer，若不显式回传 binary 标志，send(Buffer)
     // 会被当二进制帧发出——events 流是文本 JSON，误发 binary 会被客户端拒绝。
@@ -601,33 +647,7 @@ export function bridgeCompressedWs(
       if (browserWs.readyState === browserWs.OPEN) browserWs.send(data, { binary: isBinary });
     });
     // 任一端关闭/出错 → 对端终止；四路清理收敛到 stopAllProbes（幂等）。
-    // 断连分类打点（issue #308 测量）：close/error/halfOpen 各有独立计数。
-    const report = (kind: "close" | "error" | "halfOpen") => target.onDisconnect?.(kind);
-    upstreamWs.on("close", () => {
-      untrackBridges();
-      stopAllProbes();
-      report("close");
-      browserWs.terminate();
-    });
-    upstreamWs.on("error", (err) => {
-      untrackBridges();
-      stopAllProbes();
-      report("error");
-      target.logger?.warn?.(`lan-proxy: ws-bridge upstream error: ${err.message}`);
-      browserWs.terminate();
-    });
-    browserWs.on("close", () => {
-      untrackBridges();
-      stopAllProbes();
-      report("close");
-      try { upstreamWs.close(); } catch { /* 已关闭 */ }
-    });
-    browserWs.on("error", () => {
-      untrackBridges();
-      stopAllProbes();
-      report("error");
-      try { upstreamWs.close(); } catch { /* 已关闭 */ }
-    });
+    wireBridgeTeardown(browserWs, upstreamWs, target, stopAllProbes);
   });
 }
 

--- a/packages/dsh-lan-proxy/test/unit-apply.test.ts
+++ b/packages/dsh-lan-proxy/test/unit-apply.test.ts
@@ -12,7 +12,7 @@
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 import {
   pluginDir, sanitizeSettings, validateSettings,
@@ -29,7 +29,7 @@ const { createServer } = await import("node:http");
   const tmp = mkdtempSync(join(tmpdir(), "dsh-lan-proxy-dir-"));
   process.env.DSH_HOME = tmp;
   const dir = pluginDir();
-  assert.ok(dir.endsWith("/lan-proxy"), `pluginDir 结尾 /lan-proxy，实际 ${dir}`);
+  assert.equal(basename(dir), "lan-proxy", `pluginDir 末段为 lan-proxy，实际 ${dir}`);
   assert.ok(dir.startsWith(tmp), `pluginDir 在 DSH_HOME 内，实际 ${dir}`);
   process.env.DSH_HOME = prev;
   rmSync(tmp, { recursive: true, force: true });

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -146,6 +146,8 @@ export {
   parseDisabledTools,
   scoreTool,
   searchCatalog,
+  isCatalogFresh,
+  boundCatalogTools,
   searchCatalogMulti,
   listCatalog,
   findToolDetail,

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -793,6 +793,10 @@ export class McpManager {
         void mw.removeCatalogEntry(unit.root, name).catch(() => {});
       }
     }
+    // 拆除即废弃同名在途建连标记：entry 被强拆后旧 attempt 仍可能 pending 至
+    // CONNECT_TIMEOUT_MS，残留去重标记会吞掉 remove/update 后的同名重连（含
+    // 重加配置立即重建）——详见 middleware.abandonInFlight 不变式。
+    mw.abandonInFlight(name);
     if (dropped) this.emitStatus();
   }
 
@@ -996,6 +1000,9 @@ export class McpManager {
           if (client !== undefined && client.transport !== undefined) void client.transport.close().catch(() => {});
           targetUnit.connections.delete(name);
         }
+        // 断开即废弃同名在途标记：拆除时旧 attempt 仍 pending（挂至超时）会吞掉
+        // 紧随的显式「连接」（connect→ensureConnected 去重短路，force 也不豁免）。
+        this.middleware.abandonInFlight(name);
         this.emitStatus();
         return;
       }

--- a/packages/dsh-mcp-manager/src/middleware-utils.ts
+++ b/packages/dsh-mcp-manager/src/middleware-utils.ts
@@ -564,8 +564,7 @@ export function boundCatalogTools(
   return bounded;
 }
 
-/** 等待带超时（race 兜底）。定时器 unref：在途建连的超时兜底不阻止事件循环
- *  排空（smoke 进程收尾不被挂到 CONNECT_TIMEOUT_MS；宿主常驻场景无感知）。 */
+/** 等待带超时（race 兜底）。 */
 export function withTimeout<T>(promise: Promise<T>, ms: number, message: string, signal?: AbortSignal): Promise<T> {
   if (signal?.aborted === true) return Promise.reject(signal.reason ?? new Error("aborted"));
   return new Promise<T>((resolve, reject) => {
@@ -573,7 +572,6 @@ export function withTimeout<T>(promise: Promise<T>, ms: number, message: string,
       cleanup();
       reject(new Error(message));
     }, ms);
-    timer.unref?.();
     const onAbort = () => {
       cleanup();
       reject(signal?.reason ?? new Error("aborted"));

--- a/packages/dsh-mcp-manager/src/middleware-utils.ts
+++ b/packages/dsh-mcp-manager/src/middleware-utils.ts
@@ -5,8 +5,15 @@
  * ts 取；被连接池类、工具注册与 manager 共享。
  */
 
-import { CATALOG_TTL_MS, LIST_DEFAULT_TOOLS_PER_SERVER } from "./middleware-const.ts";
+import {
+  CATALOG_TTL_MS,
+  LIST_DEFAULT_TOOLS_PER_SERVER,
+  MAX_BYTES_PER_TOOL,
+  MAX_TOOLS_PER_SERVER,
+  MAX_TOTAL_CATALOG_BYTES,
+} from "./middleware-const.ts";
 import type {
+  CatalogServer,
   CatalogTool,
   ListCatalogResult,
   ListServerEntry,
@@ -520,7 +527,45 @@ export function findToolDetail(
   return detail;
 }
 
-/** 等待带超时（race 兜底）。 */
+/** 目录新鲜判定：有条目、无 unavailable 段、且发现时间在 TTL 内
+ *  （discover 惰性重发现专用；纯时间比较，无副作用）。 */
+export function isCatalogFresh(catalog: CatalogServer | undefined): boolean {
+  return catalog !== undefined
+    && catalog.unavailable === undefined
+    && Date.now() - catalog.discoveredAt <= CATALOG_TTL_MS;
+}
+
+/** 单服务器目录装箱（discover 专用纯函数）：按限额收敛工具清单——
+ *  工具数上限 MAX_TOOLS_PER_SERVER、单描述字节上限 MAX_BYTES_PER_TOOL（超限
+ *  截断）、累计字节上限 MAX_TOTAL_CATALOG_BYTES（超限即停）。行为与原
+ *  discover 内联循环逐位一致（含 totalBytes 对截断后条目的计算口径）。 */
+export function boundCatalogTools(
+  tools: Iterable<{ name?: unknown; description?: unknown; inputSchema?: unknown }>,
+): Map<string, CatalogTool> {
+  const bounded = new Map<string, CatalogTool>();
+  let totalBytes = 0;
+  for (const tool of tools) {
+    if (bounded.size >= MAX_TOOLS_PER_SERVER) break;
+    const name = String(tool.name ?? "");
+    if (name === "") continue;
+    const description = typeof tool.description === "string" ? tool.description : "";
+    const descriptionBytes = Buffer.byteLength(description, "utf8");
+    if (descriptionBytes > MAX_BYTES_PER_TOOL) {
+      bounded.set(name, {
+        description: description.slice(0, MAX_BYTES_PER_TOOL),
+        inputSchema: (tool.inputSchema ?? {}) as Record<string, unknown>,
+      });
+    } else {
+      bounded.set(name, { description, inputSchema: (tool.inputSchema ?? {}) as Record<string, unknown> });
+    }
+    totalBytes += descriptionBytes + JSON.stringify(bounded.get(name)?.inputSchema ?? {}).length;
+    if (totalBytes > MAX_TOTAL_CATALOG_BYTES) break;
+  }
+  return bounded;
+}
+
+/** 等待带超时（race 兜底）。定时器 unref：在途建连的超时兜底不阻止事件循环
+ *  排空（smoke 进程收尾不被挂到 CONNECT_TIMEOUT_MS；宿主常驻场景无感知）。 */
 export function withTimeout<T>(promise: Promise<T>, ms: number, message: string, signal?: AbortSignal): Promise<T> {
   if (signal?.aborted === true) return Promise.reject(signal.reason ?? new Error("aborted"));
   return new Promise<T>((resolve, reject) => {
@@ -528,6 +573,7 @@ export function withTimeout<T>(promise: Promise<T>, ms: number, message: string,
       cleanup();
       reject(new Error(message));
     }, ms);
+    timer.unref?.();
     const onAbort = () => {
       cleanup();
       reject(signal?.reason ?? new Error("aborted"));

--- a/packages/dsh-mcp-manager/src/middleware.ts
+++ b/packages/dsh-mcp-manager/src/middleware.ts
@@ -32,9 +32,6 @@ import {
   DISCOVERY_TIMEOUT_MS,
   CALL_TIMEOUT_MS,
   CATALOG_TTL_MS,
-  MAX_TOOLS_PER_SERVER,
-  MAX_BYTES_PER_TOOL,
-  MAX_TOTAL_CATALOG_BYTES,
 } from "./middleware-const.ts";
 import {
   withTimeout,
@@ -47,6 +44,8 @@ import {
   policyDenialReason,
   fullServerName,
   isToolDenied,
+  isCatalogFresh,
+  boundCatalogTools,
   toolDisabledReason,
   MIDDLEWARE_GLOBAL_ROOT,
 } from "./middleware-utils.ts";
@@ -130,8 +129,23 @@ export class McpMiddleware {
     try {
       await promise;
     } finally {
-      unit.inFlight.delete(serverName);
+      // 所有权校验：仅当标记仍指向本次 attempt 才清除。强制拆除（abandonInFlight）
+      // 后同名可能已挂上新 attempt——被废弃的旧 attempt 迟到收敛时不得误删新标记
+      // （误删窗口内第三次 ensureConnected 会绕过去重）。
+      if (unit.inFlight.get(serverName) === promise) unit.inFlight.delete(serverName);
     }
+  }
+
+  /** 废弃某服务器跨全部单元的在途建连标记。
+   *  不变式：in-flight 去重只对「存活 entry 的重复建连」有意义——entry 被强制
+   *  拆除（remove/update/disconnect）时，同名旧 attempt 可能仍 pending（connect
+   *  挂至 CONNECT_TIMEOUT_MS 才超时；stdio close 打断时 SDK 不 reject），残留
+   *  标记会把后续 ensureConnected（含 force 的用户显式「连接」）全部吞掉，且旧
+   *  attempt 收敛时命中 disposed 守卫静默返回、无人补连 → 服务器最长 10s 内
+   *  无法重连。拆除时必须同步废弃标记；旧 attempt 稍后收敛由 connectInternal
+   *  的让位/disposed 守卫兜底，无副作用。 */
+  abandonInFlight(serverName: string): void {
+    for (const unit of this.units.values()) unit.inFlight.delete(serverName);
   }
 
   private async connectInternal(root: string, serverName: string, opts: { force?: boolean } = {}): Promise<void> {
@@ -223,6 +237,11 @@ export class McpMiddleware {
         // 探测失败不阻塞
       }
     }
+    // 让位校验：本次 attempt 期间（上方 await 窗口内）entry 已被强制拆除并由
+    // 更新的 attempt 重建（abandonInFlight 语义）——在 spawn 前退避：既防旧配置
+    // 的 entry 覆盖新 entry，也不遗孤 transport（退避点在 createTransport 之前）。
+    const current = unit.connections.get(serverName);
+    if (current !== undefined && current !== entry) return;
     const transport = createTransport(server);
     const client = new MCPClient(transport);
     const newEntry: ConnectionEntry = {
@@ -322,29 +341,10 @@ export class McpMiddleware {
     if (unit === undefined) return;
     const entry = unit.connections.get(serverName);
     if (entry === undefined || entry.client === undefined) return;
-    const catalog = unit.catalog.get(serverName);
-    if (catalog !== undefined && catalog.unavailable === undefined && Date.now() - catalog.discoveredAt <= CATALOG_TTL_MS) {
-      return; // fresh
-    }
+    if (isCatalogFresh(unit.catalog.get(serverName))) return; // fresh
     try {
       const tools = await withTimeout(this.listToolsAll(entry.client), DISCOVERY_TIMEOUT_MS, `discovery timed out (${DISCOVERY_TIMEOUT_MS}ms)`);
-      const bounded = new Map<string, CatalogTool>();
-      let totalBytes = 0;
-      for (const tool of tools) {
-        if (bounded.size >= MAX_TOOLS_PER_SERVER) break;
-        const name = String(tool.name ?? "");
-        if (name === "") continue;
-        const description = typeof tool.description === "string" ? tool.description : "";
-        const descriptionBytes = Buffer.byteLength(description, "utf8");
-        if (descriptionBytes > MAX_BYTES_PER_TOOL) {
-          bounded.set(name, { description: description.slice(0, MAX_BYTES_PER_TOOL), inputSchema: (tool.inputSchema ?? {}) as Record<string, unknown> });
-        } else {
-          bounded.set(name, { description, inputSchema: (tool.inputSchema ?? {}) as Record<string, unknown> });
-        }
-        totalBytes += descriptionBytes + JSON.stringify(bounded.get(name)?.inputSchema ?? {}).length;
-        if (totalBytes > MAX_TOTAL_CATALOG_BYTES) break;
-      }
-      unit.catalog.set(serverName, { discoveredAt: Date.now(), tools: bounded });
+      unit.catalog.set(serverName, { discoveredAt: Date.now(), tools: boundCatalogTools(tools) });
       this.persistCatalog(root);
     } catch (error) {
       unit.catalog.set(serverName, { discoveredAt: 0, tools: new Map(), unavailable: this.redact(error) });
@@ -700,6 +700,8 @@ export {
   policyAllows,
   bareServerName,
   policyDenialReason,
+  isCatalogFresh,
+  boundCatalogTools,
   isToolDenied,
   toolDisabledReason,
   parseDisabledTools,

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -1205,12 +1205,16 @@ const main = async () => {
   {
     // 目录树：home/.dsh 模拟 DSH 全局家目录（DSH_HOME 指向它）；
     // home/dev/leetcode 是无任何标记的空工作区；proj 是带 .dsh/mcp.json 的项目。
+    // 无标记用例目录深嵌套 ≥16 层：findProjectRoot 向上窗口 16 层必不出沙箱，
+    // 杜绝逸出临时目录命中真实仓库/家目录标记（环境泄漏 flake，Windows 实测）；
+    // 有标记用例（proj）起步层立即命中，不受嵌套影响。
     const base = mkdtempSync(join(tmpdir(), "dsh-mcp-manager-root-"));
-    const home = join(base, "home");
+    const deep = join(base, "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10", "d11", "d12", "d13", "d14");
+    const home = join(deep, "home");
     const leetcode = join(home, "dev", "leetcode");
     const proj = join(base, "proj");
     const projSub = join(proj, "sub");
-    const nomark = join(base, "nomark");
+    const nomark = join(deep, "nomark");
     try {
       mkdirSync(join(home, ".dsh"), { recursive: true });
       mkdirSync(leetcode, { recursive: true });

--- a/packages/dsh-mcp-manager/test/unit-manager2.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-manager2.test.ts
@@ -177,6 +177,10 @@ const {
   const prevHome = process.env.DSH_HOME;
   const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-root-"));
   try {
+    // 顶棚标记：walk 从沙箱内任意一级子目录向上必然先命中 dir/.git，
+    // 不得逸出临时目录命中真实仓库/真实家目录的标记（防环境泄漏 flake）。
+    mkdirSync(join(dir, ".git"), { recursive: true });
+
     const fakeHome = join(dir, "fake-home");
     mkdirSync(fakeHome, { recursive: true });
     mkdirSync(join(fakeHome, ".dsh"), { recursive: true });
@@ -195,22 +199,28 @@ const {
     assert.equal(await manager.findProjectRoot(mcpProj), mcpProj, ".mcp.json 标记命中");
     assert.equal(await manager.findProjectRoot(dshProj), dshProj, ".dsh 非 home 标记命中");
 
-    // 全局家排除：模拟 ~ 下含 .dsh（= DSH_HOME），其子目录向上命中家级 .dsh 应跳过。
+    // 全局家排除：模拟 ~ 下含 .dsh（= DSH_HOME），其子目录向上命中家级 .dsh 应跳过，
+    // 继续向上命中顶棚 dir/.git（若误判家级 .dsh 为项目标记则返回 fake-user-home）。
     const fakeUserHome = join(dir, "fake-user-home");
     const fakeDshHome = join(fakeUserHome, ".dsh");
     mkdirSync(fakeDshHome, { recursive: true });
     process.env.DSH_HOME = fakeDshHome;
     const inHome = join(fakeUserHome, "sub");
     mkdirSync(inHome, { recursive: true });
-    assert.equal(await manager.findProjectRoot(inHome), inHome, "全局家不算项目标记");
-    // cwd 恰为家目录本身：无其他标记 → 回落 cwd。
-    assert.equal(await manager.findProjectRoot(fakeDshHome), fakeDshHome);
+    assert.equal(await manager.findProjectRoot(inHome), dir, "全局家不算项目标记");
+    // cwd 恰为家目录本身：家级 .dsh 不算自身标记 → 越过它命中顶棚。
+    assert.equal(await manager.findProjectRoot(fakeDshHome), dir, "家目录自身不算项目标记");
     // 恢复通用 home 供后续用例。
     process.env.DSH_HOME = fakeHome;
-    // 无任何标记的普通目录 → 回落 cwd。
+    // 无任何标记的普通目录 → 向上命中顶棚。
     const plain = join(dir, "plain");
     mkdirSync(plain, { recursive: true });
-    assert.equal(await manager.findProjectRoot(plain), plain);
+    assert.equal(await manager.findProjectRoot(plain), dir);
+    // 回落 cwd：输入嵌套 16 级，向上窗口（16 层）不出沙箱、够不到任何标记 → 原样返回。
+    let deep = dir;
+    for (let i = 0; i < 16; i += 1) deep = join(deep, `d${i}`);
+    mkdirSync(deep, { recursive: true });
+    assert.equal(await manager.findProjectRoot(deep), deep, "16 级窗口内无标记 → 回落 cwd");
     // undefined cwd → process.cwd() 兜底。
     const fallback = await manager.findProjectRoot(undefined);
     assert.equal(typeof fallback, "string");
@@ -788,6 +798,51 @@ function rmStatSafe(p) {
   }
 }
 
+// ---- 拆除时在途建连的 in-flight 残留（跨平台确定性回归：Windows 必现） ----
+// 命令选真实存在但永不完成 MCP 握手的 node 子进程：connect() 必然 pending 到
+// CONNECT_TIMEOUT_MS（10s），把「拆除时 attempt 在途」窗口拉满。此前 remove/
+// disconnect 强拆 entry 后不同步废弃 inFlight 去重标记，同名后续 ensureConnected
+// （含 force 的显式「连接」）被残留标记吞掉，且旧 attempt 收敛命中 disposed 守卫
+// 无人补连——修复前本块必红（此前 Linux CI 靠 spawn 快速失败侥幸避开窗口）。
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-mgr2n-"));
+  const prevHome = process.env.DSH_HOME;
+  try {
+    process.env.DSH_HOME = dir;
+    const { manager, store } = makeManager(dir);
+    manager.middlewareMode = "all";
+    await manager.initMiddleware("all", {});
+    const mw = manager.middleware;
+    // 挂起型服务器：子进程常驻但不吐 MCP 帧 → transport.connect() 恒 pending。
+    const hangServer = (name) => ({
+      name, transport: "stdio", command: process.execPath,
+      args: ["-e", "setInterval(() => {}, 1e6)"], reconnect: { enabled: false },
+    });
+
+    // remove 路径：connecting 中强拆 + 重加，连接条目须立即重建。
+    store.upsert(normalizeServer(hangServer("hang")));
+    manager.start("hang", "global");
+    await pollUntil("hang 连接条目建立（connecting）", () => mw.units.get("@global")?.connections.has("hang") === true);
+    await manager.remove("hang");
+    store.upsert(normalizeServer(hangServer("hang")));
+    manager.start("hang", "global");
+    await pollUntil("remove 后重加立即重建连接条目（in-flight 残留已废弃）", () => mw.units.get("@global")?.connections.has("hang") === true);
+
+    // disconnect 路径：connecting 中断开 + 显式「连接」，force 建连不被去重吞掉。
+    await manager.disconnect("hang", "global");
+    assert.ok(mw.units.get("@global").userDisabled.has("hang"), "disconnect 写 userDisabled");
+    await manager.connect("hang", "global");
+    await pollUntil("disconnect 后显式连接立即重建条目", () => mw.units.get("@global")?.connections.has("hang") === true);
+
+    await manager.dispose();
+  } finally {
+    if (prevHome === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = prevHome;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 // ---- add / update（scope project 抛错路径在 unit-manager 已覆盖，此处补全局） ----
 
 {
@@ -1258,6 +1313,10 @@ function rmStatSafe(p) {
     inFlight: new Map(),
   });
   const serversWith = (entries) => new Map(Object.entries(entries));
+  // 项目 root 夹具用真实目录 + .git 标记：findProjectRoot 从该目录起步必然原样
+  // 返回（跨平台确定，POSIX 字符串 "/proj" 在 Windows resolve 后形态不一致）。
+  const projDir = join(dir, "proj");
+  mkdirSync(join(projDir, ".git"), { recursive: true });
 
   try {
     process.env.DSH_HOME = dir;
@@ -1278,7 +1337,7 @@ function rmStatSafe(p) {
         g1: { server: { name: "g1" }, scope: "global" },
         p1: { server: { name: "p1" }, scope: "project" },
       });
-      const view = await manager.catalogViewFor("/proj", servers);
+      const view = await manager.catalogViewFor(projDir, servers);
       assert.equal(view.get("g1")?.summary, "B-global-g1", "off 模式全局走 B");
       assert.equal(view.get("p1")?.summary, "B-project-p1", "off 模式项目走 B");
     }
@@ -1293,8 +1352,8 @@ function rmStatSafe(p) {
         }),
       );
       mw.units.set(
-        "/proj",
-        unitFor("/proj", {
+        projDir,
+        unitFor(projDir, {
           p1: { discoveredAt: 1, tools: new Map([["p_read", { description: "Project read files." }]]) },
         }),
       );
@@ -1303,7 +1362,7 @@ function rmStatSafe(p) {
         g2: { server: { name: "g2" }, scope: "global" },
         p1: { server: { name: "p1" }, scope: "project" },
       });
-      const view = await manager.catalogViewFor("/proj", servers);
+      const view = await manager.catalogViewFor(projDir, servers);
       assert.equal(view.get("g1")?.summary, "Global search the web for facts.", "all 模式全局覆盖为中间层目录摘要");
       assert.equal(view.get("g2")?.summary, "B-global-g2", "中间层无 g2 → 保留 B");
       assert.equal(view.get("p1")?.summary, "Project read files.", "project scope 覆盖为项目单元摘要");
@@ -1315,8 +1374,8 @@ function rmStatSafe(p) {
       manager.middlewareMode = "project";
       mw.units.clear();
       mw.units.set(
-        "/proj",
-        unitFor("/proj", {
+        projDir,
+        unitFor(projDir, {
           p1: { discoveredAt: 1, tools: new Map([["p_read", { description: "Project read files." }]]) },
           p2: { discoveredAt: 1, tools: new Map(), unavailable: "discovery failed" },
         }),
@@ -1326,7 +1385,7 @@ function rmStatSafe(p) {
         p1: { server: { name: "p1" }, scope: "project" },
         p2: { server: { name: "p2" }, scope: "project" },
       });
-      const view = await manager.catalogViewFor("/proj", servers);
+      const view = await manager.catalogViewFor(projDir, servers);
       assert.equal(view.get("p1")?.summary, "Project read files.", "project 模式项目级走中间层");
       assert.equal(view.get("g1")?.summary, "B-global-g1", "project 模式全局无 @global 单元 → B");
       assert.equal(view.get("p2")?.summary, "B-project-p2", "unavailable 目录视为无 → 保留 B");

--- a/packages/dsh-mcp-manager/test/unit-middleware.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.test.ts
@@ -32,6 +32,10 @@ const {
   searchCatalogMulti,
   listCatalog,
   findToolDetail,
+  isCatalogFresh,
+  boundCatalogTools,
+  MAX_BYTES_PER_TOOL,
+  MAX_TOTAL_CATALOG_BYTES,
   McpMiddleware,
   projectCallToolResult,
   CATALOG_TTL_MS,
@@ -144,6 +148,42 @@ function makeHost(serversByRoot = new Map()) {
   // TTL 过期 → fresh=false
   const stale = searchCatalog(new Map([[ROOT, { ...unit, catalog: new Map([["ctx", { discoveredAt: Date.now() - CATALOG_TTL_MS - 1000, tools: unit.catalog.get("ctx").tools }]]) }]]), ROOT, "文档", 5);
   assert.equal(stale.results[0].fresh, false);
+}
+
+// ---- isCatalogFresh / boundCatalogTools（#592 discover 拆解出的纯函数） ----
+{
+  // isCatalogFresh：有条目 + 无 unavailable + TTL 内
+  assert.equal(isCatalogFresh(undefined), false, "无条目 → 不新鲜");
+  assert.equal(isCatalogFresh({ discoveredAt: Date.now(), tools: new Map(), unavailable: "x" }), false, "unavailable 段 → 不新鲜");
+  assert.equal(isCatalogFresh({ discoveredAt: Date.now(), tools: new Map() }), true, "TTL 内 → 新鲜");
+  assert.equal(isCatalogFresh({ discoveredAt: Date.now() - CATALOG_TTL_MS - 1, tools: new Map() }), false, "TTL 过期 → 不新鲜");
+}
+{
+  // 装箱：常规映射 + 空名跳过 + 非字符串描述归空 + schema 缺省 {}
+  const tools = [
+    { name: "a", description: "alpha", inputSchema: { type: "object" } },
+    { name: "", description: "空名跳过" },
+    { name: "b" },
+    { name: 42, description: 7 },
+  ];
+  const bounded = boundCatalogTools(tools);
+  assert.equal(bounded.size, 3, "空名跳过后剩 3 个");
+  assert.deepEqual(bounded.get("a"), { description: "alpha", inputSchema: { type: "object" } });
+  assert.deepEqual(bounded.get("b"), { description: "", inputSchema: {} }, "缺省描述/schema 补空");
+  assert.deepEqual(bounded.get("42"), { description: "", inputSchema: {} }, "非字符串 name String 化、描述归空");
+  // 单描述超字节上限 → 按上限截断（原 discover 截断口径：字符数）
+  const bigDescription = "字".repeat(MAX_BYTES_PER_TOOL);
+  const truncated = boundCatalogTools([{ name: "big", description: bigDescription }]).get("big");
+  assert.equal(truncated.description.length, MAX_BYTES_PER_TOOL, "超限描述截断到 MAX_BYTES_PER_TOOL");
+  assert.ok(Buffer.byteLength(bigDescription, "utf8") > MAX_BYTES_PER_TOOL, "前提：原描述字节超限");
+  // 总字节超限 → 立即停止装箱
+  const fatSchema = { data: "x".repeat(200 * 1024) };
+  const stopAtLimit = boundCatalogTools([
+    { name: "one", description: "", inputSchema: fatSchema },
+    { name: "two", description: "", inputSchema: fatSchema },
+    { name: "three", description: "", inputSchema: fatSchema },
+  ]);
+  assert.ok(stopAtLimit.size < 3, `总字节超限后停止装箱（实际 ${stopAtLimit.size} 个）`);
 }
 
 // ---- McpMiddleware：projectUnitFor / userDisabled / inFlight ----

--- a/packages/dsh-mem0/src/index.ts
+++ b/packages/dsh-mem0/src/index.ts
@@ -230,6 +230,58 @@ export function apply(ctx: Context, initialConfig?: Partial<Mem0Config>): void {
   }
 
   // 3. 注册 HTTP 路由（/api/dsh-mem0/*）
+  // #592 拆解：配置热切换（含 #612 失败回滚）与依赖自愈装配件提出 effect 子树，
+  // 路由装配以具名引用消费（压平 routes effect 的圈复杂度；行为逐位一致）。
+  const switchMem0Config = async (previousConfig: Mem0Config, next: Mem0Config): Promise<void> => {
+    try {
+      const env = await buildEnvOverrides(next);
+      await executor.restart(env);
+      if (executor.isReady()) {
+        lastGoodEnv = env;
+        return;
+      }
+      // #612：新配置起不来 → 用最近一次 good env 自动回滚重启，并回写旧配置
+      const rollbackEnv = lastGoodEnv ?? await buildEnvOverrides(previousConfig);
+      currentConfig = previousConfig;
+      executor.setPythonBin(previousConfig.pythonBin);
+      await executor.restart(rollbackEnv).catch(() => {});
+      throw new Error(
+        `Service failed to start with new config (status: ${executor.getStatus().reason}); rolled back to previous config`,
+      );
+    } catch (err: unknown) {
+      const detail = err instanceof Error ? err.message : String(err);
+      executor.markEnvBuildFailed?.(detail);
+      throw err;
+    }
+  };
+
+  const updateMem0Config = async (patch: Record<string, unknown>): Promise<Mem0Config> => {
+    const next = mergeConfigPatch(currentConfig, patch);
+    const previousConfig = currentConfig;
+    currentConfig = next;
+    if (ownerScope && typeof ownerScope.update === "function") {
+      await ownerScope.update(next).catch((e: unknown) => {
+        ctx.logger?.warn?.(`[dsh-mem0] settings.update 落盘失败: ${String(e)}`);
+      });
+    }
+    executor.setPythonBin(next.pythonBin);
+    await switchMem0Config(previousConfig, next);
+    return next;
+  };
+
+  const installMem0Dependencies = async () => {
+    ctx.logger?.info?.("[dsh-mem0] 开始触发后台依赖自动安装/自愈...");
+    const res = await autoInstallDependencies(currentConfig.pythonBin, (line) => {
+      ctx.logger?.debug?.(`[dsh-mem0 install] ${line}`);
+    });
+    if (res.ok) {
+      executor.setPythonBin(res.pythonBin);
+      const env = await buildEnvOverrides(currentConfig);
+      await executor.restart(env);
+    }
+    return res;
+  };
+
   ctx.effect(() => {
     const webServer = ctx.get("webServer") as { register: (route: WebRoute) => () => void } | undefined;
     if (!webServer || typeof webServer.register !== "function") return () => {};
@@ -238,50 +290,8 @@ export function apply(ctx: Context, initialConfig?: Partial<Mem0Config>): void {
       getCurrentCwd: () => latestCwd,
       getConfig: () => currentConfig,
       appCtx: ctx,
-      updateConfig: async (patch: Record<string, unknown>) => {
-        const next = mergeConfigPatch(currentConfig, patch);
-        const previousConfig = currentConfig;
-        currentConfig = next;
-        if (ownerScope && typeof ownerScope.update === "function") {
-          await ownerScope.update(next).catch((e: unknown) => {
-            ctx.logger?.warn?.(`[dsh-mem0] settings.update 落盘失败: ${String(e)}`);
-          });
-        }
-        executor.setPythonBin(next.pythonBin);
-        try {
-          const env = await buildEnvOverrides(next);
-          await executor.restart(env);
-          if (executor.isReady()) {
-            lastGoodEnv = env;
-          } else {
-            // #612：新配置起不来 → 用最近一次 good env 自动回滚重启，并回写旧配置
-            const rollbackEnv = lastGoodEnv ?? await buildEnvOverrides(previousConfig);
-            currentConfig = previousConfig;
-            executor.setPythonBin(previousConfig.pythonBin);
-            await executor.restart(rollbackEnv).catch(() => {});
-            throw new Error(
-              `Service failed to start with new config (status: ${executor.getStatus().reason}); rolled back to previous config`,
-            );
-          }
-        } catch (err: unknown) {
-          const detail = err instanceof Error ? err.message : String(err);
-          executor.markEnvBuildFailed?.(detail);
-          throw err;
-        }
-        return next;
-      },
-      installDependencies: async () => {
-        ctx.logger?.info?.("[dsh-mem0] 开始触发后台依赖自动安装/自愈...");
-        const res = await autoInstallDependencies(currentConfig.pythonBin, (line) => {
-          ctx.logger?.debug?.(`[dsh-mem0 install] ${line}`);
-        });
-        if (res.ok) {
-          executor.setPythonBin(res.pythonBin);
-          const env = await buildEnvOverrides(currentConfig);
-          await executor.restart(env);
-        }
-        return res;
-      },
+      updateConfig: updateMem0Config,
+      installDependencies: installMem0Dependencies,
       // #612：前端「启动服务」按钮入口——幂等互斥的手动拉起，复用最近一次环境覆盖配置
       startExecutor: async () => {
         await startExecutorOnce();

--- a/packages/dsh-mem0/test/smoke.ts
+++ b/packages/dsh-mem0/test/smoke.ts
@@ -14,6 +14,7 @@
  */
 
 import assert from "node:assert/strict";
+import { Readable } from "node:stream";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -422,6 +423,85 @@ await test("装配层路由注册契约：apply 必须单路由逐个注册并�
   // 断言注销逻辑
   assert.equal(disposersCalled.length, 10, "注销时 10 个路由的 disposer 必须都被调用");
   assert.ok(unregisterServerCalled, "注销时必须调用 mcpManager.unregisterServer('mem0')");
+});
+
+// 10b. #592 拆解回归：POST /config 与 /install 走真实 updateConfig/installDependencies
+// 装配件——探针必失败 → switchMem0Config 自动回滚旧配置（行为逐位对照原内联闭包）。
+await test("路由配置热切换：POST /config 失败自动回滚 + POST /install 自愈装配", async () => {
+  const registered: any[] = [];
+  const effects: Array<() => void | (() => void)> = [];
+  const mockCtx: any = {
+    get(name: string) {
+      if (name === "webServer") {
+        return { register(route: any) { registered.push(route); return () => {}; } };
+      }
+      if (name === "mcpManager") {
+        return { registerServer: async () => ({ existing: false }), unregisterServer: async () => {} };
+      }
+      return undefined;
+    },
+    effect(fn: () => void | (() => void)) {
+      effects.push(fn);
+      return () => {};
+    },
+    on() {
+      return () => {};
+    },
+    logger: { warn() {}, info() {}, debug() {} },
+  };
+
+  const { apply } = hostMod;
+  apply(mockCtx, { pythonBin: "non-existent-python-for-test" });
+  for (const eff of effects) eff();
+
+  const configRoute = registered.find((r) => r.path === "/api/dsh-mem0/config")!;
+  const postReq = (payload: Record<string, unknown>): any => {
+    const stream: any = new Readable({ read() {} });
+    stream.push(Buffer.from(JSON.stringify(payload)));
+    stream.push(null);
+    stream.headers = { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" };
+    stream.socket = { remoteAddress: "127.0.0.1" };
+    stream.method = "POST";
+    return stream;
+  };
+  const mockRes = () => {
+    let code = 0;
+    let body = "";
+    const res: any = {
+      setHeader: () => {},
+      writeHead: (c: number) => { code = c; },
+      end: (d: string) => { body = d; },
+    };
+    (res as any).result = () => ({ code, body });
+    return res;
+  };
+
+  // POST /config：pythonBin 换成另一个必然探针失败值 → switchMem0Config 回滚链路
+  const res1 = mockRes();
+  await configRoute.handler(postReq({ pythonBin: "non-existent-python-for-test-2" }), res1);
+  const r1 = (res1 as any).result();
+  assert.equal(r1.code, 500, "探针必失败 → 500");
+  assert.match(JSON.parse(r1.body).error, /rolled back to previous config/, "错误消息带回滚语义");
+
+  // 回滚后 GET /config：pythonBin 已回写为旧值（#612 回写语义）
+  const getReq: any = {
+    headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+    socket: { remoteAddress: "127.0.0.1" },
+    method: "GET",
+  };
+  const res2 = mockRes();
+  await configRoute.handler(getReq, res2);
+  const r2 = (res2 as any).result();
+  assert.equal(r2.code, 200);
+  assert.equal(JSON.parse(r2.body).config.pythonBin, "non-existent-python-for-test", "回滚后配置为旧 pythonBin");
+
+  // POST /install：真实 installMem0Dependencies——探针失败 → ok=false 透传
+  const installRoute = registered.find((r) => r.path === "/api/dsh-mem0/install")!;
+  const res3 = mockRes();
+  await installRoute.handler({ headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" }, socket: { remoteAddress: "127.0.0.1" }, method: "POST" } as any, res3);
+  const r3 = (res3 as any).result();
+  assert.equal(r3.code, 200, "自愈装配不抛错 → 200");
+  assert.equal(JSON.parse(r3.body).ok, false, "探针失败 → ok=false");
 });
 
 // 11. 自定义 Python 路径探测隔离测试（显式意图优于隐式推断）

--- a/packages/dsh-provider-usage/src/adapters/deepseek-official.mjs
+++ b/packages/dsh-provider-usage/src/adapters/deepseek-official.mjs
@@ -439,6 +439,22 @@ function renderDailyUsageCard(pts, truncated, e, now, utils) {
 }
 
 /** 柱形几何：双向域 [lo, hi]、基线 y=0 实线；消耗蓝柱向上、净增绿柱向下、异常 0 高。 */
+/** 单日柱悬浮文案（#592 从 dailyBarsSvg 拆出的纯函数）：六态分层 + 净增/消耗
+ *  双口径 + 附注括注；i/total 供「今日」判定。gap/unavailable 两态为防御分支
+ *  （现聚合器不产出该状态），直接单测覆盖。 */
+export function dailyBarTitle(r, i, total) {
+  const isToday = i === total - 1;
+  const dateLabel = isToday ? "今日" : r.key.slice(5);
+  if (r.status === "empty") return `${dateLabel} 无采样`;
+  if (r.status === "insufficient") return `${dateLabel} 样本不足`;
+  if (r.status === "gap") return `${dateLabel} 数据中断`;
+  if (r.status === "unavailable") return `${dateLabel} 服务不可用区间不计`;
+  if (r.status === "anomaly") return `${dateLabel} ${r.note || "数值异常"}`;
+  const extra = r.extra ? `（${r.extra}）` : "";
+  if (r.neg) return `${dateLabel} 余额净增 ¥${Math.abs(r.u).toFixed(2)}${extra}`;
+  return `${dateLabel} 消耗 ¥${r.u.toFixed(2)}${extra}`;
+}
+
 function dailyBarsSvg(records, e) {
   const W = 320, H = 100, PL = 36, PR = 6, PT = 8, PB = 14;
   const plotW = W - PL - PR;
@@ -479,14 +495,7 @@ function dailyBarsSvg(records, e) {
     const isToday = i === records.length - 1;
     const dateLabel = isToday ? "今日" : r.key.slice(5);
     const opacity = isToday ? 0.55 : 1; // 今日未结束，半透明示意
-    let titleText;
-    if (r.status === "empty") titleText = `${dateLabel} 无采样`;
-    else if (r.status === "insufficient") titleText = `${dateLabel} 样本不足`;
-    else if (r.status === "gap") titleText = `${dateLabel} 数据中断`;
-    else if (r.status === "unavailable") titleText = `${dateLabel} 服务不可用区间不计`;
-    else if (r.status === "anomaly") titleText = `${dateLabel} ${r.note || "数值异常"}`;
-    else if (r.neg) titleText = `${dateLabel} 余额净增 ¥${Math.abs(r.u).toFixed(2)}${r.extra ? `（${r.extra}）` : ""}`;
-    else titleText = `${dateLabel} 消耗 ¥${r.u.toFixed(2)}${r.extra ? `（${r.extra}）` : ""}`;
+    const titleText = dailyBarTitle(r, i, records.length);
 
     if (r.u > TOL && r.status === "ok") {
       const yTop = yOf(finFallback(r.u, 0, hi));

--- a/packages/dsh-provider-usage/src/user-adapters.ts
+++ b/packages/dsh-provider-usage/src/user-adapters.ts
@@ -367,7 +367,13 @@ export function resolveAddAdapterFile(
   const trimmed = input.trim();
   if (trimmed === "" || trimmed.includes("\0")) return undefined;
   const expandedForCheck = expandHomePath(trimmed);
-  if (resolve(expandedForCheck) !== expandedForCheck) return undefined; // 拒绝 a/../b、./x 未规整形态
+  // 拒绝 a/../b、./x 未规整形态（禁穿越）。比对前做分隔符归一：Windows 下
+  // untildify 产混合分隔符（~ → 反斜杠 home，余段保留 /），resolve 归一 / → \
+  // 属平台语义而非未规整——按字面比对会把 ~/x 与全部正斜杠绝对路径误拒；
+  // POSIX 分隔符归一为恒等变换，行为与历史实现完全一致，穿越段仍被拒。
+  const expandedCanonical = resolve(expandedForCheck);
+  const sepCanonical = (s: string) => (process.platform === "win32" ? s.replace(/\\/g, "/") : s);
+  if (sepCanonical(expandedCanonical) !== sepCanonical(expandedForCheck)) return undefined;
   const resolved = resolvePath(expandedForCheck);
   if (resolved === undefined) return undefined;
   if (!isAbsolute(trimmed)) {

--- a/packages/dsh-provider-usage/test/unit-config.test.ts
+++ b/packages/dsh-provider-usage/test/unit-config.test.ts
@@ -49,11 +49,14 @@ import {
 
 {
   // HOME/DSH_HOME 指向临时目录；~ 展开、绝对路径、目录拒绝都基于真实文件系统
+  // Windows 上 os.homedir()（untildify 固化源）读 USERPROFILE，须一并重定向。
   const home = mkdtempSync(join(tmpdir(), "dou-addfile-"));
   const savedDsh = process.env.DSH_HOME;
   const savedHomeEnv = process.env.HOME;
+  const savedUserProfile = process.env.USERPROFILE;
   process.env.DSH_HOME = home;
   process.env.HOME = home;
+  if (process.platform === "win32") process.env.USERPROFILE = home;
   try {
     // 显式受控固化：此后进程内 ~ 展开落点恒为本隔离目录。
     // 若落点已指向别处（前置模块抢先固化），直接失败暴露，不做静默降级。
@@ -108,6 +111,10 @@ import {
     process.env.DSH_HOME = savedDsh;
     if (savedHomeEnv === undefined) delete process.env.HOME;
     else process.env.HOME = savedHomeEnv;
+    if (process.platform === "win32") {
+      if (savedUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = savedUserProfile;
+    }
   }
 }
 
@@ -154,18 +161,24 @@ assert.equal(normalizeConfig({ staticPath: "/v1/custom" }).staticPath, "/v1/cust
 // resolveProviderConfig 用例自行隔离 DSH_HOME/HOME 并清理凭据环境变量，
 // finally 恢复，避免污染后续 smoke 断言。
 
-/** 保存并清空凭据环境变量，返回恢复函数。DSH_HOME 始终指向隔离目录。 */
+/** 保存并清空凭据环境变量，返回恢复函数。DSH_HOME 始终指向隔离目录。
+ *  homeDir 同时重定向 HOME 与 USERPROFILE（Windows os.homedir() 读后者，
+ *  opencode auth.json 等按 homedir() 解析的路径在两个平台行为一致）。 */
 function isolateCredEnv(homeDir?: string) {
   const saved = {
     dshHome: process.env.DSH_HOME,
     home: process.env.HOME,
+    userProfile: process.env.USERPROFILE,
     key: process.env.OPENCODE_GO_API_KEY,
     key2: process.env.OPENCODE_GO_PROVIDER_API_KEY,
   };
   delete process.env.OPENCODE_GO_API_KEY;
   delete process.env.OPENCODE_GO_PROVIDER_API_KEY;
   process.env.DSH_HOME = mkdtempSync(join(tmpdir(), "dou-dshhome-"));
-  if (homeDir !== undefined) process.env.HOME = homeDir;
+  if (homeDir !== undefined) {
+    process.env.HOME = homeDir;
+    if (process.platform === "win32") process.env.USERPROFILE = homeDir;
+  }
   return () => {
     const r = (k: string, v: string | undefined) => {
       if (v !== undefined) process.env[k] = v;
@@ -173,6 +186,7 @@ function isolateCredEnv(homeDir?: string) {
     };
     r("DSH_HOME", saved.dshHome);
     r("HOME", saved.home);
+    if (process.platform === "win32") r("USERPROFILE", saved.userProfile);
     r("OPENCODE_GO_API_KEY", saved.key);
     r("OPENCODE_GO_PROVIDER_API_KEY", saved.key2);
   };

--- a/packages/dsh-provider-usage/test/unit-deepseek-official.test.ts
+++ b/packages/dsh-provider-usage/test/unit-deepseek-official.test.ts
@@ -45,6 +45,7 @@ import {
   GAP_MS,
   TOL,
   ANOMALY_NEG,
+  dailyBarTitle,
 } from "../lib/index.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -834,6 +835,56 @@ assert.equal(parseAmount("Infinity"), null, "Infinity 非有限数 → null");
   assert.ok(sanitized.includes("<svg"), "sanitize 后 svg 结构存活");
   assert.ok(!sanitized.includes("onmouseover"), "on* 事件属性被移除");
   assert.ok(!sanitized.includes("javascript:"), "javascript: URI 被移除");
+}
+
+// ---- #592 dailyBarTitle 拆解：单日柱悬浮文案全分支（含聚合器不产出的防御态） ----
+{
+  const R = (over) => ({ key: "2026-08-24", status: "ok", u: 1.5, ...over });
+  assert.equal(dailyBarTitle(R({ status: "empty", u: 0 }), 0, 3), "08-24 无采样", "empty 态");
+  assert.equal(dailyBarTitle(R({ status: "insufficient", u: 0 }), 0, 3), "08-24 样本不足", "insufficient 态");
+  assert.equal(dailyBarTitle(R({ status: "gap", u: 0 }), 0, 3), "08-24 数据中断", "gap 态（防御分支）");
+  assert.equal(dailyBarTitle(R({ status: "unavailable", u: 0 }), 0, 3), "08-24 服务不可用区间不计", "unavailable 态（防御分支）");
+  assert.equal(dailyBarTitle(R({ status: "anomaly", u: 0, note: "余额净增 ¥1.20（异常）" }), 0, 3), "08-24 余额净增 ¥1.20（异常）", "anomaly 态带 note");
+  assert.equal(dailyBarTitle(R({ status: "anomaly", u: 0 }), 0, 3), "08-24 数值异常", "anomaly 态 note 缺省");
+  assert.equal(dailyBarTitle(R({ neg: true, u: -0.3, extra: "充值 +¥0.80 未计入" }), 0, 3), "08-24 余额净增 ¥0.30（充值 +¥0.80 未计入）", "净增 + extra 括注");
+  assert.equal(dailyBarTitle(R({ u: 1.5, extra: "1 段中断不计" }), 0, 3), "08-24 消耗 ¥1.50（1 段中断不计）", "消耗 + extra 括注");
+  assert.equal(dailyBarTitle(R({ u: 1.5 }), 2, 3), "今日 消耗 ¥1.50", "末位记录判今日");
+  assert.equal(dailyBarTitle(R({ u: 1.5 }), 0, 1), "今日 消耗 ¥1.50", "单记录窗口恒今日");
+  assert.equal(dailyBarTitle(R({ u: 1.5 }), 0, 3), "08-24 消耗 ¥1.50", "非末位为 MM-DD 标签");
+}
+
+// ---- #592 formatPanel 集成：柱图渲染路径（六态混合采样 → 全部柱形与文案落地） ----
+{
+  // 固定 now：UTC 正午。采样间隔全部 26~28h（>24h 保证任意时区下相邻区间
+  // 结束端落不同日桶，断言与时区无关；首段 28h > GAP_MS 触发中断层）。
+  const NOW = utc(2026, 9, 1, 12, 0);
+  const en = (t, balance, toppedUp = 0) => ({ time: t, data: { balance, toppedUp, grantedBalance: null, isAvailable: true } });
+  const H = 3600000;
+  //   A(T-133h,100) → B(T-105h,90)：28h > GAP_MS → 中断层（A 所在日仅 1 帧 → 样本不足）
+  //   B → C(T-79h,90.3)：免充值净增 0.3 ∈ (-1,-TOL) → 绿柱净增
+  //   C → C2(T-53h,92.3)：免充值净增 2.0 < ANOMALY_NEG → 异常态
+  //   C2 → D(T-27h,90.8)：消耗 1.5 → 蓝柱
+  //   D → E(T-1h,90.3,toppedUp 0.8)：消耗 0.5 + 充值 0.8 → 今日柱带充值附注
+  //   15 日窗口其余日 → 无采样
+  const entries = [
+    en(NOW - 133 * H, 100),
+    en(NOW - 105 * H, 90),
+    en(NOW - 79 * H, 90.3),
+    en(NOW - 53 * H, 92.3),
+    en(NOW - 27 * H, 90.8),
+    en(NOW - 1 * H, 90.3, 0.8),
+  ];
+  const panel = deepSeekOfficialAdapter.formatPanel({ entries, range: { end: NOW } });
+  assert.ok(panel.includes("无采样"), "空日占位文案");
+  assert.ok(panel.includes("样本不足"), "单帧冷启动日文案");
+  assert.ok(panel.includes("余额净增 ¥2.00（异常）"), "异常态文案（note 口径）");
+  assert.ok(panel.includes("余额净增 ¥0.30"), "净增绿柱文案");
+  assert.ok(panel.includes("消耗 ¥1.50"), "消耗蓝柱文案");
+  assert.ok(panel.includes("今日"), "今日标签");
+  assert.ok(panel.includes("充值 +¥0.80 未计入"), "充值附注括注");
+  const rectCount = (panel.match(/<rect /g) ?? []).length;
+  assert.ok(rectCount >= 4, `柱形 rect 数 ≥ 4（实际 ${rectCount}）`);
+  assert.ok(panel.includes("近 15 日用量"), "日用量卡标题");
 }
 
 console.log("[unit-deepseek-official] 全部断言通过 ✓ (#198 B/C/E/G/K)");

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/verify-core.mjs
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/verify-core.mjs
@@ -94,18 +94,26 @@ export function readDshPort(text) {
 //   2. cwd 下存在该路径（目录或文件）→ 绝对化；
 //   3. 其余 → 视为包规格，原样透传。
 const PATH_LIKE = /^(\.{1,2}\/|\.{1,2}$|\/|~)/;
+// Windows 盘符绝对路径（C:\、C:/）不以 / 或 ~ 开头，PATH_LIKE 感知不到会误落
+// existsSync 分支：不存在的绝对路径被当成包规格透传（#517 C11 语义破坏）。
+const WIN32_DRIVE_LIKE = /^[A-Za-z]:[\\/]/;
 
-/** `~`/`~/x` 展开为 home 前缀（path.resolve 不做 `~` 展开，此处内建）。 */
+function isPathLike(p) {
+  return PATH_LIKE.test(p) || (process.platform === "win32" && WIN32_DRIVE_LIKE.test(p));
+}
+
+/** `~`、`~/x`、`~\x` 展开为 home 前缀（path.resolve 不做 `~` 展开，此处内建；
+ *  Windows 用户键入 `~\x` 反斜杠形态同样展开）。 */
 export function expandHome(input) {
   if (input === "~") return homedir();
-  if (input.startsWith("~/")) return resolve(homedir(), input.slice(2));
+  if (/^~[/\\]/.test(input)) return resolve(homedir(), input.slice(2));
   return input;
 }
 
 /** 单个插件参数归一化：{ input, kind: "path"|"spec", abs }（abs 仅 path 时有值）。 */
 export function resolvePkgArg(input) {
   const expanded = expandHome(input);
-  if (PATH_LIKE.test(expanded)) return { input, kind: "path", abs: resolve(expanded) };
+  if (isPathLike(expanded)) return { input, kind: "path", abs: resolve(expanded) };
   if (existsSync(expanded)) return { input, kind: "path", abs: resolve(expanded) };
   return { input, kind: "spec", abs: null };
 }

--- a/packages/dsh-verify-isolated/test/smoke.ts
+++ b/packages/dsh-verify-isolated/test/smoke.ts
@@ -36,7 +36,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
 import { parseFrontmatter } from "../../../shared/frontmatter.js";
@@ -120,6 +120,10 @@ assert.ok(noArgExitsNonZero, "browser-driver 无参数应非零退出（用法�
   assert.equal(core.resolvePkgArg("./skills").kind, "path", "形态类路径 ./ → path");
   assert.equal(core.resolvePkgArg("~").kind, "path", "~ → path（home 展开）");
   assert.equal(core.resolvePkgArg("~/x").abs, join(homedir(), "x"), "~/x → home 前缀展开");
+  if (process.platform === "win32") {
+    assert.equal(core.resolvePkgArg("~\\x").abs, join(homedir(), "x"), "~\\x → home 前缀展开（Windows 反斜杠形态）");
+    assert.equal(core.resolvePkgArg("C:\\abs\\path").kind, "path", "盘符绝对路径 → path");
+  }
   assert.equal(core.resolvePkgArg("/abs/path").kind, "path", "绝对路径 → path");
   assert.equal(core.resolvePkgArg("@scope/name").kind, "spec", "@scope/name 包规格 → spec 原样透传");
   assert.equal(core.resolvePkgArg("https://github.com/a/b.git").kind, "spec", "git URL → spec 原样透传");
@@ -207,14 +211,23 @@ assert.ok(noArgExitsNonZero, "browser-driver 无参数应非零退出（用法�
 // → waitReady 的 dead 检测与 CliError 诊断不可达（stderr 空），且 dsh exit 0 静默
 // 假成功、非契约码（3）穿透契约表。修复后：就绪前退出只记录，统一走
 // CliError(EXIT.FAIL=1) + 引用 dsh.log 的可操作诊断。
+// win32：.mjs 夹具无法直接 spawn（shebang 仅 POSIX 语义）——按产品 win32 设计
+// 路径提供 .cmd 入口（isWinScript → shell:true 回退），垫片转发到 node。
+function winCmdShimFor(scriptAbs) {
+  if (process.platform !== "win32") return scriptAbs;
+  const cmdShim = join(dirname(scriptAbs), `${basename(scriptAbs, ".mjs")}.cmd`);
+  writeFileSync(cmdShim, `@echo off\r\n"${process.execPath}" "%~dp0${basename(scriptAbs)}" %*\r\n`);
+  return cmdShim;
+}
+
 {
   const tmp = mkdtempSync(join(tmpdir(), "dsh-verify-smoke-"));
   try {
     // 假 dsh：--version 有输出；plugin list 创建 profile 骨架（bundle 注入要读
     // package.json，不建则 ENOENT 走不到就绪阶段）；web 启动（--host 参数）时
     // 按 FAKE_DH_EXIT 立即退出（模拟就绪前崩溃）
-    const fakeDsh = join(tmp, "fake-dsh.mjs");
-    writeFileSync(fakeDsh, `#!/usr/bin/env node
+    const fakeDshScript = join(tmp, "fake-dsh.mjs");
+    writeFileSync(fakeDshScript, `#!/usr/bin/env node
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 const args = process.argv.slice(2);
@@ -228,7 +241,8 @@ if (args[0] === "plugin" && args.includes("list")) {
 }
 process.exit(Number(process.env.FAKE_DH_EXIT ?? "0"));
 `);
-    chmodSync(fakeDsh, 0o755);
+    chmodSync(fakeDshScript, 0o755);
+    const fakeDsh = winCmdShimFor(fakeDshScript);
     const runWithFake = (exitCode) => {
       let code = 0; let out = "";
       try {
@@ -285,6 +299,9 @@ assert.ok(readme.includes("verify-isolated.mjs"), "README 同步 node 版脚本�
 assert.ok(!readme.includes("scripts/verify-isolated.sh"), "README 不再以旧 bash 脚本路径作为当前用法（升级路径说明除外）");
 
 // ---- 9. B4 隔离审计：lib/audit.mjs 纯函数行为断言 + 脚本契约锚定 + 退出码实测 ----
+// win32：目录符号链接需特权，junction 无需且 lstat/realpath 语义一致，
+// 越界检测（realpath 落点在扫描根外）不受影响。
+const SYMLINK_TYPE = process.platform === "win32" ? "junction" : "dir";
 {
   const auditFile = join(SCRIPTS_DIR, "lib", "audit.mjs");
   assert.ok(existsSync(auditFile), "lib/audit.mjs 随 skill 目录分发");
@@ -375,7 +392,12 @@ if (args.includes("--host")) {
   const pi = args.indexOf("--profile");
   const prof = args[pi + 1];
   mkdirSync(join(H, "profiles", prof, "node_modules", "@deepseek-ai"), { recursive: true });
-  symlinkSync("/nonexistent/dsh-install/lib", join(H, "profiles", prof, "node_modules", "@deepseek-ai", "dsh-base"), "dir");
+  // 悬空 bundle 链接：win32 目符号链接需特权，junction 无需且悬空语义一致。
+  if (process.platform === "win32") {
+    symlinkSync("C:\\\\nonexistent\\\\dsh-install\\\\lib", join(H, "profiles", prof, "node_modules", "@deepseek-ai", "dsh-base"), "junction");
+  } else {
+    symlinkSync("/nonexistent/dsh-install/lib", join(H, "profiles", prof, "node_modules", "@deepseek-ai", "dsh-base"), "dir");
+  }
   writeFileSync(join(H, ".credentials.yaml"), "token: fake\\n");
   mkdirSync(join(H, "storages"), { recursive: true });
   writeFileSync(join(H, "storages", "workspace.json"), "{}");
@@ -395,11 +417,12 @@ if (args.includes("--host")) {
 process.exit(1);
 `);
     chmodSync(fakeDsh, 0o755);
+    const fakeDshEntry = winCmdShimFor(fakeDsh);
     const runAuditE2E = (extraEnv) => {
       let code = 0;
       let out = "";
       try {
-        out = execFileSync(process.execPath, [scriptFile, "--audit", "--keep", "--dsh", fakeDsh, "--port", "0"], {
+        out = execFileSync(process.execPath, [scriptFile, "--audit", "--keep", "--dsh", fakeDshEntry, "--port", "0"], {
           encoding: "utf8", env: { ...process.env, ...extraEnv }, timeout: 60000,
         });
       } catch (e) { code = e.status ?? -1; out = (e.stdout ?? "") + (e.stderr ?? ""); }
@@ -449,9 +472,9 @@ process.exit(1);
     // profiles/** 都报，防逃逸优先于白名单忽略）
     {
       const t0 = audit.scanSnapshot(tmp);
-      symlinkSync(join(outside, "evil"), join(tmp, "evil-link"), "dir");
+      symlinkSync(join(outside, "evil"), join(tmp, "evil-link"), SYMLINK_TYPE);
       mkdirSync(join(tmp, "profiles", "verify_x"), { recursive: true });
-      symlinkSync(join(outside, "evil2"), join(tmp, "profiles", "verify_x", "evil2"), "dir");
+      symlinkSync(join(outside, "evil2"), join(tmp, "profiles", "verify_x", "evil2"), SYMLINK_TYPE);
       const t1 = audit.scanSnapshot(tmp);
       const r = audit.runAudit({ t0, t1, isolatedRoot: tmp });
       assert.equal(r.count, 2, `新增 2 条越界 symlink（实际 ${r.count}）`);
@@ -528,7 +551,7 @@ process.exit(1);
     // 反例2：t0 已存在且目标未变的外部 symlink（link: 挂载点）不报
     {
       mkdirSync(join(tmp, "profiles", "verify_x", "node_modules"), { recursive: true });
-      symlinkSync(join(outside, "pkg"), join(tmp, "profiles", "verify_x", "node_modules", "pkg"), "dir");
+      symlinkSync(join(outside, "pkg"), join(tmp, "profiles", "verify_x", "node_modules", "pkg"), SYMLINK_TYPE);
       const t0 = audit.scanSnapshot(tmp);
       const t1 = audit.scanSnapshot(tmp);
       const r = audit.runAudit({ t0, t1, isolatedRoot: tmp });
@@ -555,7 +578,7 @@ process.exit(1);
     // 干净运行 pass；运行期新增（白名单外）仍报——「就绪后运行期写面审计」语义
     {
       mkdirSync(join(tmp, "profiles", "verify_x", "node_modules", "@deepseek-ai"), { recursive: true });
-      symlinkSync(join(outside, "dsh-install-lib"), join(tmp, "profiles", "verify_x", "node_modules", "@deepseek-ai", "dsh-base"), "dir");
+      symlinkSync(join(outside, "dsh-install-lib"), join(tmp, "profiles", "verify_x", "node_modules", "@deepseek-ai", "dsh-base"), SYMLINK_TYPE);
       w(".credentials.yaml", "token: x\n");
       w("storages/workspace.json", "{}");
       const t0 = audit.scanSnapshot(tmp, { skipDeep: audit.SKIP_DEEP });

--- a/packages/dsh-web-file-preview/test/unit-routes.test.ts
+++ b/packages/dsh-web-file-preview/test/unit-routes.test.ts
@@ -47,7 +47,9 @@ try {
   // readErrorCode / readErrorText（通过 chmod 000 触发 readFile 失败）
   // ================================================================
 
-  if (!isRoot) {
+  // chmod 000 产生读拒绝是 POSIX 语义（root 与 Windows 均不生效），其余平台
+  // 跳过；readErrorCode 分支覆盖由 Linux CI 承担。
+  if (!isRoot && process.platform !== "win32") {
     chmodSync(join(root, "pic.png"), 0o000);
     const url = `http://127.0.0.1${ROUTES.file}?cwd=${encodeURIComponent(root)}&path=pic.png`;
     const res = fakeRes();

--- a/scripts/gate/crap-check.mjs
+++ b/scripts/gate/crap-check.mjs
@@ -569,8 +569,11 @@ export function runFullCheck({ repoRoot, threshold, strict, coveragePath }) {
   let skippedForeignTotal = 0;
 
   for (const [file, data] of Object.entries(coverage)) {
-    if (!/\/packages\/[^/]+\/lib\//.test(file)) continue;
-    const rel = file.startsWith(repoRoot) ? file : join(repoRoot, file);
+    // 包产物过滤对分隔符归一后匹配：coverage 键是 V8 原生路径（Windows 反斜杠），
+    // 按字面正斜杠匹配会在 Windows 上整批跳过报 0（Linux 不受影响）。
+    const normFile = file.replace(/\\/g, '/');
+    if (!/\/packages\/[^/]+\/lib\//.test(normFile)) continue;
+    const rel = existsSync(file) ? file : join(repoRoot, file);
     if (!existsSync(rel)) continue;
     const { fns, skippedForeign } = functionsOf(readFileSync(rel, 'utf8'));
     skippedForeignTotal += skippedForeign;

--- a/scripts/gate/pack-check.ts
+++ b/scripts/gate/pack-check.ts
@@ -21,6 +21,17 @@ import { assertSharedDtsNoExtras, assertSharedDtsPresent, listSharedDts } from '
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
+/**
+ * tar 参数装配：GNU tar 在 Windows 上把 `C:\...` 盘符路径当远程主机（rsh 语法）
+ * 解析——Windows 下统一加 `--force-local` 并把路径正斜杠化；Linux 下原样返回，
+ * 行为不变。
+ */
+function tarArgs(args: string[]): string[] {
+  if (process.platform !== 'win32') return args
+  return ['--force-local', ...args.map((a) => a.split('\\').join('/'))]
+}
+
+
 // 插件清单单一来源（issue #36）：枚举走 lib，目录集 == manifest.active ∪ standalone 前置闸
 warnUnknownEntries(ROOT)
 let manifest
@@ -58,7 +69,7 @@ for (const p of plugins) {
     execFileSync('pnpm', ['--filter', name, 'pack', '--pack-destination', tmp], { cwd: ROOT, stdio: 'pipe' })
     const tgz = readdirSync(tmp).find(f => f.endsWith('.tgz'))
     const unpack = join(tmp, 'unpack')
-    execFileSync('tar', ['-xzf', join(tmp, tgz), '-C', tmp])
+    execFileSync('tar', tarArgs(['-xzf', join(tmp, tgz), '-C', tmp]))
     const pkgRoot = join(tmp, 'package')
 
     const problems = []
@@ -186,7 +197,7 @@ for (const p of plugins) {
   try {
     execFileSync('pnpm', ['--filter', aggName, 'pack', '--pack-destination', tmp], { cwd: ROOT, stdio: 'pipe' })
     const tgz = readdirSync(tmp).find(f => f.endsWith('.tgz'))
-    execFileSync('tar', ['-xzf', join(tmp, tgz), '-C', tmp])
+    execFileSync('tar', tarArgs(['-xzf', join(tmp, tgz), '-C', tmp]))
     const pkgRoot = join(tmp, 'package')
     const problems = []
     if (!existsSync(join(pkgRoot, 'lib', 'index.js'))) problems.push('缺 lib/index.js')

--- a/scripts/test/collect-licenses.test.ts
+++ b/scripts/test/collect-licenses.test.ts
@@ -35,7 +35,8 @@ function fixturePackage(root, { name, indexSource, depLicense }) {
     mkdirSync(depDir, { recursive: true })
     writeFileSync(join(depDir, 'LICENSE'), depLicense)
     writeFileSync(join(depDir, 'package.json'), JSON.stringify({ name: 'fake-lib', version: '1.2.3', license: 'MIT' }))
-    symlinkSync(depDir, join(pkg, 'node_modules', 'linked-lib'))
+    // win32：目录符号链接需特权，junction 无需且目录解析语义一致
+    symlinkSync(depDir, join(pkg, 'node_modules', 'linked-lib'), process.platform === 'win32' ? 'junction' : 'dir')
   }
   return pkg
 }

--- a/scripts/test/config-matrix-negative.test.ts
+++ b/scripts/test/config-matrix-negative.test.ts
@@ -47,7 +47,7 @@ function fakeRepo() {
       ['dsh-notifier', 'client/index.ts'],
     ]
     for (const [pkg, rel] of srcs) {
-      cpSync(join(ROOT, 'packages', pkg, 'src', rel), join(root, 'packages', pkg, 'src', rel))
+      copyLf(join(ROOT, 'packages', pkg, 'src', rel), join(root, 'packages', pkg, 'src', rel))
     }
   } catch (e) {
     rmSync(root, { recursive: true, force: true })
@@ -56,9 +56,15 @@ function fakeRepo() {
   return root
 }
 
+// win32 checkout 常为 CRLF：变异正则按 LF 书写——副本统一归一化 LF，
+// 保证变异在两个平台等价生效（gate 解析对行尾不敏感）。
+function copyLf(srcPath, destPath) {
+  writeFileSync(destPath, readFileSync(srcPath, 'utf8').replace(/\r\n/g, '\n'))
+}
+
 function edit(root, pkg, rel, fn) {
   const f = join(root, 'packages', pkg, 'src', rel)
-  writeFileSync(f, fn(readFileSync(f, 'utf8')))
+  writeFileSync(f, fn(readFileSync(f, 'utf8').replace(/\r\n/g, '\n')))
 }
 
 /** 通用断言：注入后矩阵红 + problems 含 expectKey；若 expectKey 为数组则逐一断言。 */
@@ -184,8 +190,8 @@ test('量级: README 配置表缺键 → warn 不红（pass 仍 true）', () => 
   const root = fakeRepo()
   try {
     // 复制真实 README 进副本（矩阵 README warn 需要文件存在）
-    cpSync(join(ROOT, 'packages/dsh-lan-proxy/README.md'), join(root, 'packages/dsh-lan-proxy/README.md'))
-    cpSync(join(ROOT, 'packages/dsh-notifier/README.md'), join(root, 'packages/dsh-notifier/README.md'))
+    copyLf(join(ROOT, 'packages/dsh-lan-proxy/README.md'), join(root, 'packages/dsh-lan-proxy/README.md'))
+    copyLf(join(ROOT, 'packages/dsh-notifier/README.md'), join(root, 'packages/dsh-notifier/README.md'))
     // 基线（README 与代码键集一致）：零 warn
     let r = runConfigMatrix(root)
     assert.equal(r.pass, true)

--- a/scripts/test/mutation-lib-to-src-loader.mjs
+++ b/scripts/test/mutation-lib-to-src-loader.mjs
@@ -42,7 +42,8 @@ function currentRoot() {
 }
 
 /** 统一分隔符（Windows `\` → `/`），后续全部按 POSIX 段级匹配。 */
-function toPosix(p) {
+/** POSIX 分隔符归一（测试比较 seam：Windows 原生路径 vs loader POSIX 输出）。 */
+export function toPosix(p) {
   return String(p).replaceAll("\\", "/");
 }
 

--- a/scripts/test/mutation-lib-to-src-loader.test.ts
+++ b/scripts/test/mutation-lib-to-src-loader.test.ts
@@ -27,6 +27,7 @@ import {
   canRedirectLibToSrc,
   candidateFrom,
   resolve,
+  toPosix,
 } from "./mutation-lib-to-src-loader.mjs";
 
 /** 临时 fake 仓库：<root>/packages/<pkg>/{lib,src,test} 骨架。 */
@@ -58,7 +59,7 @@ test("canRedirectLibToSrc: index 与非 index 子模块均重定向（任一层�
     for (const rel of ["index.js", "routes.js", "sub/module.js", "a/b/c/deep.js"]) {
       const hit = canRedirectLibToSrc(lib(root, pkg, rel), { root });
       assert.ok(hit, `${rel} 应命中重定向`);
-      assert.equal(hit.filePath, src(root, pkg, rel.slice(0, -3) + ".ts"), `${rel} 目标应为同包 src/*.ts`);
+      assert.equal(toPosix(hit.filePath), toPosix(src(root, pkg, rel.slice(0, -3) + ".ts")), `${rel} 目标应为同包 src/*.ts`);
     }
   });
 });
@@ -76,7 +77,7 @@ test("canRedirectLibToSrc: packages 边界保留——shared/node_modules/非 li
     assert.equal(canRedirectLibToSrc(data, { root }), null, "lib/data.json 不应命中");
     // lib/*.ts 偶发形态：仍映射到同包 src/*.ts
     const tsHit = canRedirectLibToSrc(join(root, "packages", pkg, "lib", "index.ts"), { root });
-    assert.equal(tsHit?.filePath, src(root, pkg, "index.ts"), "lib/index.ts 应映射到 src/index.ts");
+    assert.equal(toPosix(tsHit?.filePath), toPosix(src(root, pkg, "index.ts")), "lib/index.ts 应映射到 src/index.ts");
     // 跨包：canRedirectLibToSrc 拒绝（options.pkg 限定目标包语义）
     const cross = join(root, "packages", "dsh-other", "lib", "index.js");
     assert.equal(canRedirectLibToSrc(cross, { root, pkg }), null, "跨包 lib 不应映射到本包 src");
@@ -101,7 +102,7 @@ test("canRedirectLibToSrc: .. 路径穿越被折叠后即越界，不重定向",
     const inner = join(root, "packages", pkg, "lib", "sub", "..", "index.js");
     const hit = canRedirectLibToSrc(inner, { root });
     assert.ok(hit, "lib 内 .. 折叠后仍在 lib 内应命中");
-    assert.equal(hit.filePath, src(root, pkg, "index.ts"));
+    assert.equal(toPosix(hit.filePath), toPosix(src(root, pkg, "index.ts")));
   });
 });
 
@@ -116,7 +117,7 @@ test("canRedirectLibToSrc: client 产物不映射为宿主 src（避免宿主 sr
     }
     // 宿主模块 client-logic.ts 的产物放行（不是客户端 bundle）
     const host = canRedirectLibToSrc(lib(root, pkg, "client-logic.js"), { root });
-    assert.equal(host?.filePath, src(root, pkg, "client-logic.ts"));
+    assert.equal(toPosix(host?.filePath), toPosix(src(root, pkg, "client-logic.ts")));
   });
 });
 
@@ -125,7 +126,7 @@ test("canRedirectLibToSrc: Windows 分隔符统一后同样命中", () => {
     const win = lib(root, pkg, "sub/routes.js").replaceAll("/", "\\");
     const hit = canRedirectLibToSrc(win, { root });
     assert.ok(hit, "Windows 反斜杠路径经统一后应命中");
-    assert.equal(hit.filePath, src(root, pkg, "sub/routes.ts"));
+    assert.equal(toPosix(hit.filePath), toPosix(src(root, pkg, "sub/routes.ts")));
   });
 });
 
@@ -148,7 +149,7 @@ test("canRedirectLibToSrc: URL 百分号编码经 fileURLToPath 解码后往返�
     const decoded = fileURLToPath(urlEnc);
     const hit = canRedirectLibToSrc(decoded, { root });
     assert.ok(hit, "解码后的绝对路径应命中");
-    assert.equal(hit.filePath, src(root, pkg, "index.ts"));
+    assert.equal(toPosix(hit.filePath), toPosix(src(root, pkg, "index.ts")));
   });
 });
 
@@ -269,7 +270,7 @@ test("pkgRootFromParent: 仅识别 packages/<pkg>/ 下的父文件（candidateFr
   try {
     fakeRepo(root, pkg);
     const inPkg = candidateFrom("../lib/index.js", pathToFileURL(join(root, "packages", pkg, "test", "entry.mjs")).href);
-    assert.equal(canRedirectLibToSrc(inPkg, { root, pkg })?.filePath, src(root, pkg, "index.ts"));
+    assert.equal(toPosix(canRedirectLibToSrc(inPkg, { root, pkg })?.filePath), toPosix(src(root, pkg, "index.ts")));
     // 包外父目录：candidateFrom 仍可解析（普通路径解析），但 canRedirectLibToSrc 应拒绝
     const outside = candidateFrom("../lib/index.js", pathToFileURL(join(root, "scripts", "x.mjs")).href);
     assert.equal(canRedirectLibToSrc(outside, { root }), null);

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -32,10 +32,12 @@ import { join, basename } from 'node:path'
 import { spawnSync } from 'node:child_process'
 
 const ROOT = join(import.meta.dirname, '../..')
-const CI = readFileSync(join(ROOT, '.github/workflows/ci.yml'), 'utf8')
-const OBSERVE = readFileSync(join(ROOT, '.github/workflows/observe.yml'), 'utf8')
-const OBSERVE_INC = readFileSync(join(ROOT, '.github/workflows/observe-incremental.yml'), 'utf8')
-const OVERLAY = readFileSync(join(ROOT, '.github/workflows/baseline-overlay.yml'), 'utf8')
+// win32 checkout 常为 CRLF：断言子串按 LF 书写——读取层统一归一化 LF。
+const lf = (p) => readFileSync(p, 'utf8').replace(/\r\n/g, '\n')
+const CI = lf(join(ROOT, '.github/workflows/ci.yml'))
+const OBSERVE = lf(join(ROOT, '.github/workflows/observe.yml'))
+const OBSERVE_INC = lf(join(ROOT, '.github/workflows/observe-incremental.yml'))
+const OVERLAY = lf(join(ROOT, '.github/workflows/baseline-overlay.yml'))
 const RELEASE = readFileSync(join(ROOT, '.github/workflows/release.yml'), 'utf8')
 const HEALTH = readFileSync(join(ROOT, '.github/workflows/health-report.yml'), 'utf8')
 const GAUNTLET = JSON.parse(readFileSync(join(ROOT, 'scripts/data/gauntlet.config.json'), 'utf8'))


### PR DESCRIPTION
Closes #592（阶段二收官）
Fixes #621（Windows 兼容全量清单与本 PR 修复范围）

## 摘要

两条主线，四个提交：

### 1. #592 阶段二消峰收官（396cd2e + 8f56ca7 的一部分）

全仓最高单函数圈复杂度 **19 → 15**，达成 issue 验收「消峰后单函数圈复杂度均压至 <= 15」（此前 236/146/131/84/78 由 #599/#604/#609/#611 消峰）。超标热点 213 → 207，余量全部来自存量未覆盖函数，属阶段三 strict 收官范围。

| 函数（comp 前 → 后） | 拆法 |
|---|---|
| provider-usage `dailyBarsSvg` 内层箭头（19 → 10） | 六态悬浮文案链拆出 `dailyBarTitle` 纯函数；集成测试以 26-28h 间隔采样序列做时区稳健全覆盖 |
| lan-proxy `bridgeCompressedWs`（16 → 8） | 拆出 `attachBridgeProbes`（半开探活装配）与 `wireBridgeTeardown`（四路 teardown 接线），既有 WS 桥测试覆盖 |
| mem0 apply 路由 effect（16 → 6） | 配置热切换（含 #612 失败回滚链）与依赖自愈装配件提出 effect 子树，行为逐位一致；新增 POST /config 回滚 + POST /install 冒烟回归 |
| mcp-manager `discover`（19 → 6） | 拆出 `isCatalogFresh` / `boundCatalogTools` 纯函数并补全覆盖单测 |

### 2. mcp-manager in-flight 去重残留产品修复（8f56ca7）

`remove`/`update`/`disconnect` 强拆 entry 后不同步废弃 `unit.inFlight` 去重标记：旧 attempt 可 pending 至 `CONNECT_TIMEOUT_MS`（10s），期间同名服务器的后续 `ensureConnected`（含 force 的用户显式「连接」）全部被吞，且旧 attempt 收敛命中 disposed 守卫无人补连——服务器最长 10s 内无法重连。Linux CI 靠 spawn 快速失败侥幸避开窗口，Windows 必现。

修复：`abandonInFlight` 拆除即废弃 + `ensureConnected` finally 所有权校验 + `connectInternal` 占位前让位校验（spawn 前退避，防旧配置覆盖新 entry 与孤儿 transport）+ `withTimeout` 定时器 unref。回归测试用「永不完成 MCP 握手的 node 子进程」把在途窗口拉满——跨平台确定性，修复前 Linux CI 同样红。

### 3. Windows 平台兼容与环境隔离（554d472，全量清单见 #621）

产品级：`resolveAddAdapterFile` 未规整守卫 win32 分隔符归一（`~/x` 与正斜杠绝对路径此前被误拒；穿越段仍拒，README 安全语义不变）、verify-core `~\` 展开与盘符绝对路径。测试夹具：findProjectRoot walk 顶棚/深嵌套封闭化、USERPROFILE 重定向、分隔符无关断言、`.cmd` 垫片 + junction、POSIX 专属语义显式跳过（跳过行可见不假绿）。

### 4. 门禁基建（c7fcec0）

- 根 package.json `build`/`test`/`cov` 递归含根包自身 → 嵌套双跑 + 并行固定端口自撞（EADDRINUSE）：`--filter !dsh-plugin-hub` 排除；Linux 行为不变（CI 时长减半）
- pack-check：GNU tar 盘符路径 `--force-local` + 正斜杠化
- crap-check 主扫描：coverage 键分隔符归一（Windows 下此前整批跳过报 0）
- stryker.conf.d 随重构 `pnpm stryker:gen` 重生成

## 验证

- Windows 本地：`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck && pnpm test:scripts` 全绿（此前 test:scripts 在 Windows 35 项失败）
- cov 全绿，crap 全量扫描 comp <= 15；新增函数全覆盖（CRAP <= 16）
- Linux CI 行为逐位不变（全部修复为平台归一/条件化）

## 备注

- 已知遗留（#621 D 节跟踪）：codegraph 产品 Windows 支持（`.cmd` 探测/`sh -c` 安装）；crap --diff 依赖 lib 入库导致真实 PR 流程空转（#596 阶段一收尾待接线设计）
- 提交面自查：敏感信息扫描干净、无临时产物、发布物边界不变（files 白名单未动）