### PR TITLE
feat(dsh-mcp-manager): 支持 MCP 调用统计与 debug 模式 (#625)

### DIFF
--- a/packages/dsh-mcp-manager/README.en.md
+++ b/packages/dsh-mcp-manager/README.en.md
@@ -282,6 +282,7 @@ await ctx.mcpManager.registerServer({
   reason carries that semantic note; records live under `<DSH_HOME>/dsh-mcp-user-state.json`
   → `disabledTools` (the `@global` key is shared across workspaces; merged writes never
   overwrite the whole table)
+- **Call stats and debug mode (Metadata-Only)**: Disabled by default; when configured with `dsh-mcp-manager.debug.callStats: true` in `~/.dsh/settings.yaml`, tool call metrics (call count, success/error, average/max duration) and progressive disclosure funnel stats (`ws_mcp_search` query frequencies, `ws_mcp_list` / `ws_mcp_detail` query distributions) are debounced and atomically written to `<DSH_HOME>/mcp-stats.json`, with single-line console debug logs; strictly does not persist user arguments or returned content, avoiding code or privacy leaks
 - The capability catalog injection includes source annotations and a "does not represent current
   connection status" note
 

--- a/packages/dsh-mcp-manager/README.md
+++ b/packages/dsh-mcp-manager/README.md
@@ -236,6 +236,7 @@ await ctx.mcpManager.registerServer({
   跨工作空间共享，合并写盘不整表覆盖）
 - **凭据脱敏**：目录摘要与错误路径经 redactor 把 env/headers/URL 用户信息等
   凭据形状替换为 `[REDACTED]`
+- **调用统计与 Debug 模式（Metadata-Only）**：默认关闭；若在 `~/.dsh/settings.yaml` 中配置 `dsh-mcp-manager.debug.callStats: true`，将把 MCP 调用指标（次数、成功/失败、平均与最大耗时）及渐进式披露漏斗（`ws_mcp_search` 搜索词频次、`ws_mcp_list` 与 `ws_mcp_detail` 查询分布）防抖原子持久化至 `<DSH_HOME>/mcp-stats.json`，且控制台输出单行 debug 跟踪；严格不持久化用户 arguments 与返回 content，杜绝代码与隐私泄漏
 - 能力目录注入含来源标注与"不代表当前连接状态"说明
 
 ## 验证

--- a/packages/dsh-mcp-manager/src/apply-config.ts
+++ b/packages/dsh-mcp-manager/src/apply-config.ts
@@ -15,6 +15,7 @@ import { normalizeMiddlewareMode } from "./middleware.ts";
 import type { McpManager } from "./manager.ts";
 import { uiConfigChangedFrame } from "./routes.ts";
 import { defaultStorePath } from "./store.ts";
+import type { DebugConfig } from "./call-stats-types.ts";
 
 /** apply 顶层解析后的增强/开关配置集合。 */
 export interface ApplyOptions {
@@ -24,6 +25,7 @@ export interface ApplyOptions {
   catalogMaxEntries: number;
   middlewarePolicy: Record<string, unknown>;
   middlewareModeRaw: string | undefined;
+  debug: DebugConfig;
 }
 
 /** 解析 storePath（显式配置优先，回落默认路径）。 */
@@ -31,8 +33,18 @@ export function resolveStorePath(config: Record<string, unknown> | undefined): s
   return typeof config?.storePath === "string" && config.storePath !== "" ? config.storePath : defaultStorePath();
 }
 
+/** 解析 debug 配置。 */
+export function resolveDebugConfig(config: Record<string, unknown> | undefined, settingsSource?: unknown): DebugConfig {
+  const settings = typeof settingsSource === "object" && settingsSource !== null ? (settingsSource as Record<string, unknown>).debug : undefined;
+  const rawDebug = (typeof settings === "object" && settings !== null ? settings : config?.debug) as Record<string, unknown> | undefined;
+  return {
+    callStats: rawDebug?.callStats === true,
+    statsFile: typeof rawDebug?.statsFile === "string" ? rawDebug.statsFile : "",
+  };
+}
+
 /** 解析全部布尔/数值/策略配置（兜底链引用具名常量，单一事实源）。 */
-export function resolveApplyOptions(config: Record<string, unknown> | undefined): ApplyOptions {
+export function resolveApplyOptions(config: Record<string, unknown> | undefined, settingsSource?: unknown): ApplyOptions {
   const announceCatalog = (config?.announceCatalog as boolean | undefined) ?? DEFAULT_ANNOUNCE_CATALOG;
   const catalogMaxEntries = Number.isFinite(config?.catalogMaxEntries) && (config?.catalogMaxEntries as number) > 0
     ? Math.floor(config?.catalogMaxEntries as number)
@@ -44,6 +56,7 @@ export function resolveApplyOptions(config: Record<string, unknown> | undefined)
     catalogMaxEntries,
     middlewarePolicy: (config?.middlewarePolicy as Record<string, unknown> | undefined) ?? {},
     middlewareModeRaw: config?.middleware as string | undefined,
+    debug: resolveDebugConfig(config, settingsSource),
   };
 }
 

--- a/packages/dsh-mcp-manager/src/apply-runtime.ts
+++ b/packages/dsh-mcp-manager/src/apply-runtime.ts
@@ -56,6 +56,7 @@ export function makeMiddlewareHotSwitch(
       const mw = await manager.initMiddleware(next, middlewarePolicy ?? {});
       dispose.current = registerMiddlewareTools(manager.ctx, mw, resolveRoot, next, {
         disabledTools: manager.disabledTools,
+        stats: manager.stats,
       });
     }
     // off ↔ project/all：重注册/卸载中间层工具后 reconcile——all 模式下全局

--- a/packages/dsh-mcp-manager/src/apply.ts
+++ b/packages/dsh-mcp-manager/src/apply.ts
@@ -25,6 +25,7 @@ import {
   injectSettingsSink,
   installConfigSettings,
   resolveApplyOptions,
+  resolveDebugConfig,
   resolveMiddlewareMode,
   resolveStorePath,
 } from "./apply-config.ts";
@@ -66,8 +67,14 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
   // 此同步函数在 settings onChange（运行期变更）与启动兜底（enabled 分支内）
   // 两处调用：前者覆盖运行期变更，后者覆盖启动时 settings 已就绪的场景。
   const syncMiddlewareFromSettings = (): void => {
-    if (typeof manager.setMiddlewareMode !== "function") return;
     const source = manager.uiConfigSource();
+    const debugCfg = resolveDebugConfig(config, source);
+    manager.stats.configure({
+      enabled: debugCfg.callStats,
+      filePath: debugCfg.statsFile || undefined,
+      logger: manager.logger,
+    });
+    if (typeof manager.setMiddlewareMode !== "function") return;
     const persisted = typeof source === "object" && source !== null ? (source as Record<string, unknown>).middleware : undefined;
     if (typeof persisted !== "string") return;
     const next = normalizeMiddlewareMode(persisted);
@@ -76,6 +83,13 @@ export async function apply(ctx: Context, config: Record<string, unknown> | unde
   };
   installConfigSettings(ctx, manager, config, syncMiddlewareFromSettings);
   injectSettingsSink(ctx, manager);
+
+  // 初始化 stats 配置
+  manager.stats.configure({
+    enabled: options.debug.callStats,
+    filePath: options.debug.statsFile || undefined,
+    logger: manager.logger,
+  });
 
   let runtime: EnabledRuntimeDisposers = {
     disposeRoutes: () => {},
@@ -126,6 +140,7 @@ async function assembleEnabledRuntime(
     const mw = await manager.initMiddleware(middlewareMode, options.middlewarePolicy);
     currentMiddlewareDispose = registerMiddlewareTools(ctx, mw, resolveRoot, middlewareMode, {
       disabledTools: manager.disabledTools,
+      stats: manager.stats,
     });
   }
   manager.setMiddlewareMode = makeMiddlewareHotSwitch(manager, options.middlewarePolicy, resolveRoot, middlewareDisposer);

--- a/packages/dsh-mcp-manager/src/call-stats-types.ts
+++ b/packages/dsh-mcp-manager/src/call-stats-types.ts
@@ -1,0 +1,45 @@
+/**
+ * dsh-mcp-manager — MCP 调用统计与渐进式披露指标类型定义。
+ *
+ * 遵循 Metadata-Only 原则：绝不记录用户参数（arguments）与返回值（content），
+ * 仅记录计数、状态、耗时与渐进式披露漏斗元数据。
+ */
+
+export interface ToolCallMetric {
+  calls: number;
+  success: number;
+  errors: number;
+  totalDurationMs: number;
+  avgDurationMs: number;
+  maxDurationMs: number;
+  lastCalledAt?: string;
+  lastError?: string;
+}
+
+export interface ServerStats {
+  totalCalls: number;
+  successCalls: number;
+  failedCalls: number;
+  tools: Record<string, ToolCallMetric>;
+}
+
+export interface ProgressiveDisclosureStats {
+  /** ws_mcp_search 搜索词调用频次（query -> 次数） */
+  searches: Record<string, number>;
+  /** ws_mcp_list 查询频次（serverFilter -> 次数；空串代表全量盘点） */
+  lists: Record<string, number>;
+  /** ws_mcp_detail schema 查询频次（server/tool -> 次数） */
+  details: Record<string, number>;
+}
+
+export interface McpStatsSnapshot {
+  startedAt: string;
+  updatedAt: string;
+  servers: Record<string, ServerStats>;
+  disclosure: ProgressiveDisclosureStats;
+}
+
+export interface DebugConfig {
+  callStats: boolean;
+  statsFile: string;
+}

--- a/packages/dsh-mcp-manager/src/call-stats.ts
+++ b/packages/dsh-mcp-manager/src/call-stats.ts
@@ -1,0 +1,252 @@
+/**
+ * dsh-mcp-manager — MCP 调用统计收集器（纯模块，单例管理）。
+ *
+ * 核心特性：
+ * 1. 内存聚合：按 server/tool 维护聚合指标，同时维护渐进式披露漏斗（search/list/detail）；
+ * 2. 防抖原子写盘（debounce 1000ms）：使用临时文件 + rename 保证落盘不损坏；
+ * 3. 零侵入：未开启时直接短路，零 I/O、零内存分配；
+ * 4. 退出刷新：支持 dispose/flush 同步或异步刷盘；
+ * 5. Metadata-Only：不记录任何业务 arguments 或结果 content，防隐私泄露。
+ */
+
+import { mkdirSync, writeFileSync, renameSync, existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { dshHome } from "../../../shared/dsh-home.js";
+import type {
+  McpStatsSnapshot,
+  ServerStats,
+  ToolCallMetric,
+  ProgressiveDisclosureStats,
+} from "./call-stats-types.ts";
+
+export function defaultStatsPath(): string {
+  return resolve(dshHome(), "mcp-stats.json");
+}
+
+export class McpStatsCollector {
+  private enabled: boolean = false;
+  private filePath: string = defaultStatsPath();
+  private logger?: { info?: (msg: string) => void; debug?: (msg: string) => void };
+  private startedAt: string = new Date().toISOString();
+  private updatedAt: string = new Date().toISOString();
+  private servers: Map<string, {
+    totalCalls: number;
+    successCalls: number;
+    failedCalls: number;
+    tools: Map<string, ToolCallMetric>;
+  }> = new Map();
+  private disclosure: ProgressiveDisclosureStats = {
+    searches: {},
+    lists: {},
+    details: {},
+  };
+  private flushTimer?: NodeJS.Timeout;
+  private isDirty: boolean = false;
+
+  constructor(options?: {
+    enabled?: boolean;
+    filePath?: string;
+    logger?: { info?: (msg: string) => void; debug?: (msg: string) => void };
+  }) {
+    if (options?.enabled !== undefined) this.enabled = options.enabled;
+    if (options?.filePath) this.filePath = resolve(options.filePath);
+    this.logger = options?.logger;
+    if (this.enabled) {
+      this.loadExisting();
+    }
+  }
+
+  /** 更新运行配置（热重载 / 设置同步）。 */
+  configure(options: { enabled?: boolean; filePath?: string; logger?: { info?: (msg: string) => void } }): void {
+    const prevEnabled = this.enabled;
+    if (options.enabled !== undefined) this.enabled = options.enabled;
+    if (options.filePath) this.filePath = resolve(options.filePath);
+    if (options.logger) this.logger = options.logger;
+
+    if (!prevEnabled && this.enabled) {
+      this.loadExisting();
+    } else if (prevEnabled && !this.enabled) {
+      this.flushSync();
+    }
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /** 从现有磁盘文件加载既有计数（避免进程重启后归零）。 */
+  private loadExisting(): void {
+    try {
+      if (!existsSync(this.filePath)) return;
+      const raw = readFileSync(this.filePath, "utf8");
+      const data = JSON.parse(raw) as Partial<McpStatsSnapshot>;
+      if (data && typeof data === "object") {
+        if (data.startedAt) this.startedAt = data.startedAt;
+        if (data.servers && typeof data.servers === "object") {
+          for (const [sName, sVal] of Object.entries(data.servers)) {
+            const toolsMap = new Map<string, ToolCallMetric>();
+            if (sVal.tools && typeof sVal.tools === "object") {
+              for (const [tName, tVal] of Object.entries(sVal.tools)) {
+                toolsMap.set(tName, { ...tVal });
+              }
+            }
+            this.servers.set(sName, {
+              totalCalls: sVal.totalCalls ?? 0,
+              successCalls: sVal.successCalls ?? 0,
+              failedCalls: sVal.failedCalls ?? 0,
+              tools: toolsMap,
+            });
+          }
+        }
+        if (data.disclosure && typeof data.disclosure === "object") {
+          this.disclosure.searches = { ...data.disclosure.searches };
+          this.disclosure.lists = { ...data.disclosure.lists };
+          this.disclosure.details = { ...data.disclosure.details };
+        }
+      }
+    } catch {
+      // 损坏文件忽略，重新开始统计
+    }
+  }
+
+  /** 记录工具调用（ws_mcp_call 或直呼工具）。 */
+  recordCall(server: string, tool: string, durationMs: number, success: boolean, errorMsg?: string): void {
+    if (!this.enabled) return;
+
+    this.updatedAt = new Date().toISOString();
+    let s = this.servers.get(server);
+    if (!s) {
+      s = { totalCalls: 0, successCalls: 0, failedCalls: 0, tools: new Map() };
+      this.servers.set(server, s);
+    }
+    s.totalCalls += 1;
+    if (success) {
+      s.successCalls += 1;
+    } else {
+      s.failedCalls += 1;
+    }
+
+    let t = s.tools.get(tool);
+    if (!t) {
+      t = {
+        calls: 0,
+        success: 0,
+        errors: 0,
+        totalDurationMs: 0,
+        avgDurationMs: 0,
+        maxDurationMs: 0,
+      };
+      s.tools.set(tool, t);
+    }
+    t.calls += 1;
+    if (success) {
+      t.success += 1;
+    } else {
+      t.errors += 1;
+      if (errorMsg) t.lastError = errorMsg.slice(0, 200); // 截断错误，防止溢出
+    }
+    t.totalDurationMs += durationMs;
+    t.avgDurationMs = Math.round(t.totalDurationMs / t.calls);
+    if (durationMs > t.maxDurationMs) t.maxDurationMs = durationMs;
+    t.lastCalledAt = this.updatedAt;
+
+    // debug 控制台单行输出
+    const status = success ? "ok" : "fail";
+    this.logger?.info?.(
+      `[mcp:stats] ${server}/${tool} - ${durationMs}ms - ${status} (total: ${t.calls})`
+    );
+
+    this.scheduleFlush();
+  }
+
+  /** 记录渐进式披露漏斗：ws_mcp_search 搜索词。 */
+  recordSearch(query: string): void {
+    if (!this.enabled) return;
+    const q = query.trim() === "" ? "<empty>" : query.trim().slice(0, 100);
+    this.disclosure.searches[q] = (this.disclosure.searches[q] ?? 0) + 1;
+    this.updatedAt = new Date().toISOString();
+    this.scheduleFlush();
+  }
+
+  /** 记录渐进式披露漏斗：ws_mcp_list 查询过滤项。 */
+  recordList(serverFilter?: string): void {
+    if (!this.enabled) return;
+    const f = (serverFilter ?? "").trim() === "" ? "<all>" : (serverFilter ?? "").trim().slice(0, 100);
+    this.disclosure.lists[f] = (this.disclosure.lists[f] ?? 0) + 1;
+    this.updatedAt = new Date().toISOString();
+    this.scheduleFlush();
+  }
+
+  /** 记录渐进式披露漏斗：ws_mcp_detail 查询。 */
+  recordDetail(server: string, tool: string): void {
+    if (!this.enabled) return;
+    const key = `${server}/${tool}`;
+    this.disclosure.details[key] = (this.disclosure.details[key] ?? 0) + 1;
+    this.updatedAt = new Date().toISOString();
+    this.scheduleFlush();
+  }
+
+  /** 导出当前快照（只读数据对象）。 */
+  snapshot(): McpStatsSnapshot {
+    const serversObj: Record<string, ServerStats> = {};
+    for (const [sName, sVal] of this.servers) {
+      const toolsObj: Record<string, ToolCallMetric> = {};
+      for (const [tName, tVal] of sVal.tools) {
+        toolsObj[tName] = { ...tVal };
+      }
+      serversObj[sName] = {
+        totalCalls: sVal.totalCalls,
+        successCalls: sVal.successCalls,
+        failedCalls: sVal.failedCalls,
+        tools: toolsObj,
+      };
+    }
+    return {
+      startedAt: this.startedAt,
+      updatedAt: this.updatedAt,
+      servers: serversObj,
+      disclosure: {
+        searches: { ...this.disclosure.searches },
+        lists: { ...this.disclosure.lists },
+        details: { ...this.disclosure.details },
+      },
+    };
+  }
+
+  private scheduleFlush(): void {
+    this.isDirty = true;
+    if (this.flushTimer !== undefined) return;
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = undefined;
+      this.flushSync();
+    }, 1000);
+    this.flushTimer.unref?.();
+  }
+
+  /** 同步原子落盘（临时文件 + 重命名）。 */
+  flushSync(): void {
+    if (!this.isDirty || !this.enabled) return;
+    try {
+      const dir = dirname(this.filePath);
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+      }
+      const data = JSON.stringify(this.snapshot(), null, 2);
+      const tmpPath = `${this.filePath}.tmp.${process.pid}.${Date.now()}`;
+      writeFileSync(tmpPath, data, "utf8");
+      renameSync(tmpPath, this.filePath);
+      this.isDirty = false;
+    } catch (err) {
+      this.logger?.info?.(`[mcp:stats] flush to ${this.filePath} failed: ${String(err)}`);
+    }
+  }
+
+  /** 销毁清理。 */
+  dispose(): void {
+    if (this.flushTimer !== undefined) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = undefined;
+    }
+    this.flushSync();
+  }
+}

--- a/packages/dsh-mcp-manager/src/config-schema.ts
+++ b/packages/dsh-mcp-manager/src/config-schema.ts
@@ -22,6 +22,11 @@ export const DEFAULT_UI_CONFIG: UiPlacementConfig = {
   zIndexBase: DEFAULT_Z_INDEX_BASE,
 };
 
+const DebugConfigSchema = z.object({
+  callStats: z.boolean().default(false).description("是否开启 MCP 工具调用统计调试与落盘（默认关闭，仅可通过配置文件开启）"),
+  statsFile: z.string().default("").description("统计落盘路径，留空使用默认 <DSH_HOME>/mcp-stats.json"),
+}).default({ callStats: false, statsFile: "" });
+
 const UI_POSITIONS: UiPlacementConfig["position"][] = ["top-right", "top-left", "bottom-right", "bottom-left"];
 
 const UiConfigSchema = z.object({
@@ -96,6 +101,10 @@ export const Config: z<{
   resultTruncateBytes: number;
   middleware: "off" | "project" | "all";
   middlewarePolicy: Record<string, unknown>;
+  debug: {
+    callStats: boolean;
+    statsFile: string;
+  };
   ui: UiPlacementConfig;
 }> = z.object({
   enabled: z.boolean().default(true).description("是否启用本插件"),
@@ -109,5 +118,6 @@ export const Config: z<{
     .description("MCP 中间层模式：off=直接注册 mcp__ 工具（默认兼容）；project=项目级走 ws_mcp_search/ws_mcp_call（推荐）；all=全部走中间层"),
   middlewarePolicy: z.dict(z.any()).default({})
     .description("中间层策略：{ allowTools: {<server>: [glob]}, denyTools: {<server>: [glob]} }，server 为裸名"),
+  debug: DebugConfigSchema.disabled(true),
   ui: UiConfigSchema,
 });

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -57,6 +57,7 @@ export { panelAnchorForPosition } from "./placement-math.ts";
 
 // 插件契约转发（apply 主流程 + 宣告文本实现于 apply.ts）
 export { apply, MCP_GUIDANCE } from "./apply.ts";
+export { resolveDebugConfig } from "./apply-config.ts";
 
 // 服务器配置归一化（纯函数单一事实源）
 export { SERVER_NAME_PATTERN, normalizeServer } from "./normalize.ts";
@@ -126,6 +127,16 @@ export {
 } from "./catalog.ts";
 // mcpServers JSON 导入
 export { fromClaudeEntry, parseClaudeJson } from "./import.ts";
+// 统计与 Debug
+export { McpStatsCollector, defaultStatsPath } from "./call-stats.ts";
+export type {
+  McpStatsSnapshot,
+  ServerStats,
+  ToolCallMetric,
+  ProgressiveDisclosureStats,
+  DebugConfig,
+} from "./call-stats-types.ts";
+
 // 中间层（工作空间 MCP 路由：连接池 / 目录 / ws_mcp_search / ws_mcp_call /
 // ws_mcp_list / ws_mcp_detail）
 export {

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -36,6 +36,7 @@ import {
   saveDisabledTools,
 } from "./middleware.ts";
 import type { MiddlewareMode, ProjectUnit, DisabledToolsMap } from "./middleware.ts";
+import { McpStatsCollector } from "./call-stats.ts";
 
 /** 中间层 all 模式的全局虚拟 root（全局服务器经中间层访问时的路由 key）。 */
 export const MIDDLEWARE_GLOBAL_ROOT = "@global";
@@ -95,6 +96,8 @@ export class McpManager {
   middleware: McpMiddleware | undefined;
   /** userDisabled 持久化路径。 */
   userStatePath: string;
+  /** MCP 调用统计收集器（可用于 debug 模式量化调用指标与渐进式披露漏斗）。 */
+  stats: McpStatsCollector;
   /** 运行时注册表（内存态，不落盘）：供其他插件经 ctx.mcpManager 注入服务器。
    * 双轨 reconcile：store.data.servers（持久化）+ runtimeRegistry（运行时）。
    * 同名冲突策略：runtime 优先（运行时注入是「当前会话」语义）。 */
@@ -124,6 +127,7 @@ export class McpManager {
     this.middlewareMode = "off";
     this.middleware = undefined;
     this.userStatePath = userStateFile();
+    this.stats = new McpStatsCollector({ logger: ctx.logger });
     this.runtimeRegistry = new Map();
     this.registerQueue = Promise.resolve();
   }
@@ -1171,6 +1175,7 @@ export class McpManager {
       for (const dispose of supervisor.toolDisposers.values()) dispose();
     }
     this.supervisors = new Map();
+    this.stats.dispose();
     if (this.middleware !== undefined) {
       await this.middleware.dispose();
       this.middleware = undefined;

--- a/packages/dsh-mcp-manager/src/middleware-register.ts
+++ b/packages/dsh-mcp-manager/src/middleware-register.ts
@@ -32,12 +32,14 @@ import {
   MIDDLEWARE_GLOBAL_ROOT,
 } from "./middleware-utils.ts";
 import type { MiddlewareMode, DisabledToolsMap } from "./middleware-types.ts";
+import type { McpStatsCollector } from "./call-stats.ts";
 
 /** 工具执行与组装上下文。 */
 interface MiddlewareToolContext {
   mw: McpMiddleware;
   resolveRoot: (agent: unknown) => Promise<string | undefined>;
   mode: MiddlewareMode;
+  stats?: McpStatsCollector;
 }
 
 /** 空 query 搜索无命中时的可归因提示（纯 render 文案，C 项）。 */
@@ -159,6 +161,9 @@ async function executeSearch(
   const root = await toolCtx.resolveRoot(exec.agent);
   if (root === undefined) throw new Error("ws_mcp_search: 无法确定工作空间，请先选择工作区");
   const { query, serverFilter, limit } = parseSearchParams(args);
+  if (toolCtx.stats?.isEnabled()) {
+    toolCtx.stats.recordSearch(query);
+  }
   const roots = visibleMiddlewareRoots(root, toolCtx.mode);
   const unit = await toolCtx.mw.projectUnitFor(root);
   if (unit === undefined) {
@@ -261,7 +266,21 @@ async function executeCall(
   await toolCtx.mw.ensureConnected(targetRoot, parsed.server);
   // #413：透传 exec.agent 给 callTool（封装直呼分支的 execute 依赖
   // agent.session.header.cwd 做 projectPath 补全）。
-  return toolCtx.mw.callTool(server, tool, callArguments, exec.signal, exec.agent);
+  const startTime = Date.now();
+  try {
+    const result = await toolCtx.mw.callTool(server, tool, callArguments, exec.signal, exec.agent);
+    const durationMs = Date.now() - startTime;
+    if (toolCtx.stats?.isEnabled()) {
+      toolCtx.stats.recordCall(parsed.server, tool, durationMs, true);
+    }
+    return result;
+  } catch (error) {
+    const durationMs = Date.now() - startTime;
+    if (toolCtx.stats?.isEnabled()) {
+      toolCtx.stats.recordCall(parsed.server, tool, durationMs, false, error instanceof Error ? error.message : String(error));
+    }
+    throw error;
+  }
 }
 
 function buildCallTool(toolCtx: MiddlewareToolContext): ToolDefinition {
@@ -409,6 +428,9 @@ async function executeList(
   const root = await toolCtx.resolveRoot(exec.agent);
   if (root === undefined) throw new Error("ws_mcp_list: 无法确定工作空间，请先选择工作区");
   const { serverFilter, toolLimit } = parseListParams(args);
+  if (toolCtx.stats?.isEnabled()) {
+    toolCtx.stats.recordList(serverFilter);
+  }
   const roots = visibleMiddlewareRoots(root, toolCtx.mode);
   const unit = await toolCtx.mw.projectUnitFor(root);
   if (unit === undefined) {
@@ -506,6 +528,10 @@ async function executeDetail(
   if (root === undefined) throw new Error("ws_mcp_detail: 无法确定工作空间，请先选择工作区");
   const { server, tool } = parseDetailParams(args);
   if (server === "" || tool === "") throw new Error("ws_mcp_detail: server 与 tool 均为必填");
+  const parsed = parseFullServerName(server);
+  if (toolCtx.stats?.isEnabled()) {
+    toolCtx.stats.recordDetail(parsed?.server ?? server, tool);
+  }
   const targetRoot = await checkMiddlewareRoot("ws_mcp_detail", server, root, toolCtx.mode, toolCtx.mw);
   if (targetRoot === undefined) {
     throw new Error(
@@ -645,6 +671,8 @@ export function registerMiddlewareTools(
   options: {
     /** 工具级禁用映射（root → server → Set<tool>）；缺省取 mw.disabledTools。 */
     disabledTools?: DisabledToolsMap;
+    /** 可选调用统计收集器。 */
+    stats?: McpStatsCollector;
   } = {},
 ): () => void {
   const disposers: Array<() => void> = [];
@@ -652,7 +680,7 @@ export function registerMiddlewareTools(
   const disabledTools = options.disabledTools ?? mw.disabledTools;
   if (options.disabledTools !== undefined) mw.disabledTools = disabledTools;
 
-  const toolCtx: MiddlewareToolContext = { mw, resolveRoot, mode };
+  const toolCtx: MiddlewareToolContext = { mw, resolveRoot, mode, stats: options.stats };
   const tools = [
     buildSearchTool(toolCtx),
     buildCallTool(toolCtx),

--- a/packages/dsh-mcp-manager/src/middleware-types.ts
+++ b/packages/dsh-mcp-manager/src/middleware-types.ts
@@ -9,7 +9,6 @@ import type { Context, LoggerService } from "@deepseek-ai/cordis";
 import type { MCPClient } from "./protocol.ts";
 import type { StdioTransport, HttpTransport } from "./transport.ts";
 import type { ServerConfig } from "./types.ts";
-
 /** 中间层模式：off = 直呼（默认兼容）；project = 项目级走中间层；all = 全部走中间层。 */
 export type MiddlewareMode = "off" | "project" | "all";
 

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -551,6 +551,7 @@ const main = async () => {
     const callDeny = await guard({ name: "ws_mcp_call", arguments: { server: fullServerName("/proj", "ctx"), tool: "use_ctx" } }, async () => ({ kind: "allow" }));
     assert.equal(callDeny.kind, "deny", "ws_mcp_call guard 查禁用表");
     assert.equal(toolDisabledReason(fullServerName("/proj", "ctx"), "use_ctx").includes("mcp-manager 管辖"), true, "禁用原因声明覆盖 mcp__ 与中间层工具（#413）");
+
     // 3) callTool（ws_mcp_call 执行路径）：禁用工具 → 显式抛错（验收 14：三入口一致）。
     const callUnit = {
       root: "/proj",
@@ -569,6 +570,52 @@ const main = async () => {
     // 未禁用工具正常放行到调用。
     const okValue = await mw.callTool(fullServerName("/proj", "ctx"), "other", {}, undefined);
     assert.deepEqual(okValue.content, [], "未禁用工具正常调用");
+
+    // 4) stats：四个原子工具埋点与统计断言
+    const { McpStatsCollector } = await import("../lib/index.js");
+    const testStatsDir = mkdtempSync(join(tmpdir(), "mcp-smoke-stats-"));
+    const testStatsFile = join(testStatsDir, "smoke-stats.json");
+    try {
+      const statsCollector = new McpStatsCollector({ enabled: true, filePath: testStatsFile });
+      // 提取注册的原子工具
+      const statsRegTools: any[] = [];
+      const statsCtx = {
+        tools: { register: (def: any) => { statsRegTools.push(def); return () => {}; } },
+        on: () => () => {},
+      };
+      const statsMwDispose = registerMiddlewareTools(
+        statsCtx as any,
+        mw,
+        async () => "/proj",
+        "project",
+        { stats: statsCollector }
+      );
+
+      const searchTool = statsRegTools.find((t) => t.name === "ws_mcp_search");
+      const listTool = statsRegTools.find((t) => t.name === "ws_mcp_list");
+      const detailTool = statsRegTools.find((t) => t.name === "ws_mcp_detail");
+      const callTool = statsRegTools.find((t) => t.name === "ws_mcp_call");
+
+      assert.ok(searchTool && listTool && detailTool && callTool, "四个原子工具均已注册");
+
+      // 执行四个原子工具
+      await searchTool.execute({ query: "codegraph" }, { agent: { session: { header: { cwd: "/proj" } } } });
+      await listTool.execute({}, { agent: { session: { header: { cwd: "/proj" } } } });
+      await detailTool.execute({ server: fullServerName("/proj", "ctx"), tool: "use_ctx" }, { agent: { session: { header: { cwd: "/proj" } } } });
+      await callTool.execute({ server: fullServerName("/proj", "ctx"), tool: "other" }, { agent: { session: { header: { cwd: "/proj" } } } });
+
+      statsCollector.flushSync();
+      const statsSnap = statsCollector.snapshot();
+      assert.equal(statsSnap.servers.ctx?.totalCalls, 1, "ws_mcp_call 成功记录到 ctx 服务器");
+      assert.equal(statsSnap.servers.ctx?.tools.other?.calls, 1, "other 工具调用成功记录");
+      assert.equal(statsSnap.disclosure.searches["codegraph"], 1, "ws_mcp_search 记录到漏斗");
+      assert.equal(statsSnap.disclosure.lists["<all>"], 1, "ws_mcp_list 记录到漏斗");
+      assert.equal(statsSnap.disclosure.details["ctx/use_ctx"], 1, "ws_mcp_detail 记录到漏斗");
+
+      statsMwDispose();
+    } finally {
+      rmSync(testStatsDir, { recursive: true, force: true });
+    }
     dispose();
   });
   await checkAsync("#362 P1：disabledTools 持久化（合并式写盘 + 重启保留）", async () => {

--- a/packages/dsh-mcp-manager/test/unit-call-stats.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-call-stats.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { McpStatsCollector } from "../src/call-stats.ts";
+import { McpStatsCollector } from "../lib/index.js";
 
 test("McpStatsCollector: 默认关闭时完全无 I/O，不写盘", async () => {
   const dir = mkdtempSync(join(tmpdir(), "mcp-stats-test-"));

--- a/packages/dsh-mcp-manager/test/unit-call-stats.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-call-stats.test.ts
@@ -1,0 +1,127 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { McpStatsCollector } from "../src/call-stats.ts";
+
+test("McpStatsCollector: 默认关闭时完全无 I/O，不写盘", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "mcp-stats-test-"));
+  const statsFile = join(dir, "stats.json");
+  try {
+    const collector = new McpStatsCollector({ enabled: false, filePath: statsFile });
+    assert.equal(collector.isEnabled(), false);
+
+    collector.recordCall("codegraph", "codegraph_search", 150, true);
+    collector.recordSearch("search query");
+    collector.recordList();
+    collector.recordDetail("codegraph", "codegraph_search");
+    collector.flushSync();
+
+    assert.equal(existsSync(statsFile), false, "关闭时不应生成统计文件");
+    const snap = collector.snapshot();
+    assert.equal(Object.keys(snap.servers).length, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("McpStatsCollector: 开启时正确聚合调用与渐进式披露指标并原子落盘", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "mcp-stats-test-"));
+  const statsFile = join(dir, "stats.json");
+  try {
+    const collector = new McpStatsCollector({ enabled: true, filePath: statsFile });
+    assert.equal(collector.isEnabled(), true);
+
+    // 记录工具调用
+    collector.recordCall("codegraph", "codegraph_search", 100, true);
+    collector.recordCall("codegraph", "codegraph_search", 200, true);
+    collector.recordCall("codegraph", "codegraph_explore", 500, false, "timeout error");
+    collector.recordCall("mem0", "memory_search", 50, true);
+
+    // 记录渐进式披露漏斗
+    collector.recordSearch("find symbol");
+    collector.recordSearch("find symbol");
+    collector.recordSearch("");
+    collector.recordList("@global/codegraph");
+    collector.recordList();
+    collector.recordDetail("codegraph", "codegraph_search");
+
+    collector.flushSync();
+
+    assert.equal(existsSync(statsFile), true, "开启后必须生成统计文件");
+    const raw = JSON.parse(readFileSync(statsFile, "utf8"));
+
+    // 断言 servers 聚合数据
+    assert.equal(raw.servers.codegraph.totalCalls, 3);
+    assert.equal(raw.servers.codegraph.successCalls, 2);
+    assert.equal(raw.servers.codegraph.failedCalls, 1);
+
+    const searchTool = raw.servers.codegraph.tools.codegraph_search;
+    assert.equal(searchTool.calls, 2);
+    assert.equal(searchTool.success, 2);
+    assert.equal(searchTool.errors, 0);
+    assert.equal(searchTool.avgDurationMs, 150);
+    assert.equal(searchTool.maxDurationMs, 200);
+
+    const exploreTool = raw.servers.codegraph.tools.codegraph_explore;
+    assert.equal(exploreTool.calls, 1);
+    assert.equal(exploreTool.success, 0);
+    assert.equal(exploreTool.errors, 1);
+    assert.equal(exploreTool.lastError, "timeout error");
+
+    assert.equal(raw.servers.mem0.totalCalls, 1);
+    assert.equal(raw.servers.mem0.tools.memory_search.calls, 1);
+
+    // 断言 disclosure 渐进式披露漏斗
+    assert.equal(raw.disclosure.searches["find symbol"], 2);
+    assert.equal(raw.disclosure.searches["<empty>"], 1);
+    assert.equal(raw.disclosure.lists["@global/codegraph"], 1);
+    assert.equal(raw.disclosure.lists["<all>"], 1);
+    assert.equal(raw.disclosure.details["codegraph/codegraph_search"], 1);
+
+    // 测试重启恢复能力（从已存在的文件加载）
+    const collector2 = new McpStatsCollector({ enabled: true, filePath: statsFile });
+    const snap2 = collector2.snapshot();
+    assert.equal(snap2.servers.codegraph.totalCalls, 3);
+    assert.equal(snap2.disclosure.searches["find symbol"], 2);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("McpManager & routes: 前端 POST /config 不会覆盖抹除已有的 debug 配置", async () => {
+  const { McpManager, McpStore, resolveDebugConfig } = await import("../lib/index.js");
+  const dir = mkdtempSync(join(tmpdir(), "mcp-config-guard-"));
+  try {
+    const store = new McpStore(join(dir, "mcp.json"));
+    const manager = new McpManager({ logger: { info: () => {}, warn: () => {} } } as any, store);
+
+    let persistedSettings: Record<string, unknown> = {
+      ui: { position: "top-right", offset: { x: 8, y: 8, blankY: 40 }, zIndexBase: 10 },
+      debug: { callStats: true, statsFile: "/tmp/custom.json" },
+    };
+
+    manager.uiConfigSource = () => persistedSettings;
+    manager.uiUpdate = async (patch: Record<string, unknown>) => {
+      // 模拟 settings.update 行为：合并 patch，不抹除不在 patch 中的字段
+      persistedSettings = { ...persistedSettings, ...patch };
+      return persistedSettings;
+    };
+
+    // 前端更新 UI（只提交扁平 UI 参数）
+    await manager.updateUiConfig({ position: "bottom-left", offsetX: 10, offsetY: 20 });
+
+    // 验证 debug 没有被抹除
+    assert.equal((persistedSettings.debug as any)?.callStats, true);
+    assert.equal((persistedSettings.debug as any)?.statsFile, "/tmp/custom.json");
+
+    // 验证 debug 解析依然生效
+    const debugCfg = resolveDebugConfig(undefined, persistedSettings);
+    assert.equal(debugCfg.callStats, true);
+    assert.equal(debugCfg.statsFile, "/tmp/custom.json");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+


### PR DESCRIPTION
## 概述

为 `dsh-mcp-manager` 新增 MCP 调用统计与 debug 模式，默认关闭，仅可通过配置文件（`~/.dsh/settings.yaml`）开启，无前端操作界面。
用于量化分析 `codegraph`、`mem0` 等各 MCP 工具的实际调用分布，支撑相关系统提示词优化与渐进式披露方向。

## 详细改动

1. **调用统计与渐进式披露漏斗收集器 (`call-stats.ts`, `call-stats-types.ts`)**：
   - 遵循 **Metadata-Only** 原则：绝不记录用户参数（arguments）与返回值文本（content），杜绝隐私记忆和源码泄露；
   - 支持多维度指标统计：调用次数、成功/失败/超时数、平均与最大耗时；
   - 渐进式披露漏斗支持：记录 `ws_mcp_search` 搜索词频次、`ws_mcp_list` 过滤盘点频次、`ws_mcp_detail` schema 详情查询频次；
   - 1000ms 防抖原子写盘（临时文件 + rename），默认路径 `<DSH_HOME>/mcp-stats.json`；
   - 开启时支持控制台极简 debug 跟踪输出（`[mcp:stats] server/tool - duration - status`）；
   - 默认关闭态直接短路，零 I/O、零额外内存分配。

2. **四个原子工具埋点接入 (`middleware-register.ts`)**：
   - 在 `ws_mcp_search`、`ws_mcp_call`、`ws_mcp_list`、`ws_mcp_detail` 统一挂接统计打点，无侵入且单一事实源。

3. **配置定义与前端防擦除保护 (`config-schema.ts`, `apply-config.ts`, `apply.ts`, `manager.ts`)**：
   - `Config` 中新增 `debug: { callStats, statsFile }` 结构，标记 `.disabled(true)`；
   - 前端设置卡片保存只提交 UI 相关字段，后端严格执行白名单更新，避免覆盖擦除用户在设置文件中手写的 `debug` 配置。

4. **测试与文档**：
   - `test/unit-call-stats.test.ts`：纯单元测试覆盖默认关闭、开启聚合、落盘与恢复、前端保存防抹除；
   - `test/smoke.ts`：集成 smoke 覆盖四个原子工具的实际执行与指标收集；测试文件落盘均隔离至临时目录（遵从 #218 防测试污染纪律）；
   - 更新中英文 README 说明。

## 验证

- `pnpm build` 全包构建通过
- `pnpm test` 全量单元测试与 smoke 测试通过
- `pnpm contract` 契约门禁全绿
- `pnpm pack:check` 打包门禁全绿
- `pnpm typecheck` 类型检查全绿
