### PR TITLE
feat(dsh-provider-usage): 用量统计 cwd 维度数据链路与兼容割接（分片 a）

### DIFF
--- a/packages/dsh-provider-usage/src/apply.ts
+++ b/packages/dsh-provider-usage/src/apply.ts
@@ -287,6 +287,17 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
     root: join(historyRoot, "trend"),
     retentionDays: config.trendRetentionDays,
     warn: (msg) => console.warn(`[dsh-provider-usage] trend: ${sanitizeDiagnostic(msg)}`),
+    // #633 A1：目录归属主源 = 官方 store 的会话创建元数据（SessionHeader.cwd）。
+    // SessionId 为官方品牌类型（string & BRAND），裸 string 经 get 参数位断言桥接
+    // （brandString 桥接需新增 @deepseek-ai/dsh-brand 依赖，不引入）；store 无该
+    // session / cwd 缺失 / 抛错 → undefined，collector 侧归未识别桶（不静默丢弃）。
+    resolveCwd: (session) => {
+      try {
+        return ctx.sessions.get(session as Parameters<typeof ctx.sessions.get>[0])?.header.cwd;
+      } catch {
+        return undefined;
+      }
+    },
   });
   const trendDisposers: Array<() => void> = [];
   trendDisposers.push(ctx.on("session/event", (session, event) => trend.handleEvent(session, event)));

--- a/packages/dsh-provider-usage/src/index.ts
+++ b/packages/dsh-provider-usage/src/index.ts
@@ -71,12 +71,12 @@ export { TrendTracker } from "./trend/index.ts";
 export type { TrendTrackerOptions } from "./trend/index.ts";
 export { TrendCollector, TREND_FOLD_TTL_MS, TREND_DONE_MAX } from "./trend/collector.ts";
 export type { TrendCallRecord, TrendCorrectRecord, TrendCounterRecord, TrendEmit } from "./trend/collector.ts";
-export { TrendAggregator, metricValue, weekStartKey, lastNWeekKeys, lastNMonthKeys, monthRange, weekRange, mergeAggRows } from "./trend/aggregator.ts";
+export { TrendAggregator, metricValue, weekStartKey, lastNWeekKeys, lastNMonthKeys, monthRange, weekRange, mergeAggRows, mergeDirRows } from "./trend/aggregator.ts";
 export type { TrendMetric, TrendGranularity, TrendStackPart, TrendStackPoint, TrendWindowSummary } from "./trend/aggregator.ts";
 export { TrendStore } from "./trend/store.ts";
 // isValidShardRow/safeToken/safeId：分片行校验与防御提取纯函数（单测从 lib/index.js 导入）
 export { TREND_ROW_VERSION, TREND_UNIDENTIFIED, sumToken, isValidShardRow, safeToken, safeId } from "./trend/types.ts";
-export type { TrendAttribution, TrendTokens, TrendDetailRow, TrendCounterRow, TrendAggRow, TrendCell } from "./trend/types.ts";
+export type { TrendAttribution, TrendTokens, TrendDetailRow, TrendCounterRow, TrendAggRow, TrendDirRow, TrendCell } from "./trend/types.ts";
 // #503 会话用量报告（M3 接线）：report 模块公共面（测试/外部消费者从 lib/index.js 导入）
 export { candidateWindow, pendingReports, presetLastRunForNewlyEnabled, previousClosedWindow, deriveLastRun, isClosedWindowRecord, LAST_RUN_SCHEMA } from "./report/schedule.ts";
 export type { DueReport, LastRunRecord } from "./report/schedule.ts";

--- a/packages/dsh-provider-usage/src/report/generate.ts
+++ b/packages/dsh-provider-usage/src/report/generate.ts
@@ -26,7 +26,7 @@ import type {
   TokenUsage,
 } from "@deepseek-ai/dsh-llm";
 import { metricValue } from "../trend/aggregator.ts";
-import { sumToken, type TrendCell } from "../trend/types.ts";
+import { sumToken, type TrendCell, type TrendDirRow } from "../trend/types.ts";
 import type { ReportPeriod } from "./config.ts";
 
 /** 报告生成所用 llm 服务面（LlmRuntime 最小结构面——只依赖实际用到的三个方法）。 */
@@ -130,6 +130,10 @@ export interface ReportStatsSnapshot {
   byProvider: Array<{ provider: string; model: string | null; calls: number; total: number | null }>;
   /** 上一同等长度窗口的指标总量（环比基准；接线层经 windowSummary 取得）。 */
   prevTotal: number | null;
+  /** 按目录聚合（calls 降序，口径与 byProvider 一致；#633 分片 a 数据面——未识别桶
+   * dir=TREND_UNIDENTIFIED；dir 键为净化 basename 或未识别桶键，非完整路径；旧数据
+   * 无 dir 事实 → 空数组，不补造）。 */
+  byDirectory: Array<{ dir: string; calls: number; total: number | null }>;
   // ---------------------------------------------------------------- #532 年报派生维度
   // 全部为快照内单遍派生的聚合数值，注入面收敛承诺不变（仍无路径/会话明细）。
   /** 峰值日（byDay 内 total 最大的一天；空窗口 null）。 */
@@ -260,8 +264,9 @@ export async function generateReport(opts: GenerateReportOptions): Promise<Repor
 
 /**
  * 报告统计快照（纯计算）：从 tracker.buckets() 快照聚合窗口内数据。
- * 注入面收敛（方案 §八7）：只含聚合数值，不含会话明细与路径——
- * sanitizePaths 配置约束未来注入面扩展，v1 统计面无路径可脱敏。
+ * 注入面收敛（方案 §八7）：只含聚合数值与目录 basename（#633 增量：dir 键为
+ * 净化后 basename 或未识别桶键，非完整路径，进快照前剥控制字符 + 截断），
+ * 不含会话明细与路径——sanitizePaths 配置约束未来注入面扩展。
  */
 export function buildStatsSnapshot(input: {
   period: ReportPeriod;
@@ -269,6 +274,11 @@ export function buildStatsSnapshot(input: {
   endDay: string;
   /** tracker.buckets() 快照（day 升序；day×provider×model×cell）。 */
   buckets: Array<{ day: string; providers: Array<{ provider: string; model: string | null; cell: TrendCell }> }>;
+  /**
+   * 目录维度日汇总行快照（#633 分片 a：store.readAggDayShard 产物 filter kind:"dir"，
+   * 可选；缺省 = 旧数据无目录事实，不补造桶（A2「旧格式零变化」口径）。
+   */
+  dirRows?: TrendDirRow[];
   /** 上一同等长度窗口的指标总量（环比基准；接线层经 windowSummary 取得）。 */
   prevTotal: number | null;
 }): ReportStatsSnapshot {
@@ -310,6 +320,21 @@ export function buildStatsSnapshot(input: {
   }
   const byProvider = [...byKey.values()].sort((a, b) => b.calls - a.calls);
 
+  // ---- #633 分片 a：目录维度聚合（dir 行 → byDirectory，口径与 byProvider 一致）----
+  // 同 dir 键跨日 null-aware 累加；窗口过滤与 buckets 同口径（day 字典序闭区间）。
+  const byDir = new Map<string, { dir: string; calls: number; total: number | null }>();
+  for (const row of input.dirRows ?? []) {
+    if (row.day < input.startDay || row.day > input.endDay) continue;
+    const total = metricValue(row, "total");
+    const cur = byDir.get(row.dir);
+    if (cur === undefined) byDir.set(row.dir, { dir: row.dir, calls: row.calls, total });
+    else {
+      cur.calls += row.calls;
+      cur.total = sumToken(cur.total, total);
+    }
+  }
+  const byDirectory = [...byDir.values()].sort((a, b) => b.calls - a.calls);
+
   // ---- #532 年报派生维度（快照内单遍 O(n)，全部聚合数值，注入面收敛不变） ----
   // 注入文本防御：provider/model 名为 adapter/上游可影响文本，进快照前截断 80 字符
   // 并剥离控制字符（prompt 注入面收紧；快照数值维度不受影响）。
@@ -318,6 +343,10 @@ export function buildStatsSnapshot(input: {
   for (const row of byProvider) {
     row.provider = safeName(row.provider.replace(/[\u0000-\u001f\u007f]/g, ""));
     if (row.model !== null) row.model = safeName(row.model.replace(/[\u0000-\u001f\u007f]/g, ""));
+  }
+  // dir 键同防（collector.dirOf 落盘前已净化，快照侧防御性复算同一口径）
+  for (const row of byDirectory) {
+    row.dir = safeName(row.dir.replace(/[\u0000-\u001f\u007f]/g, ""));
   }
   // 峰值日：byDay（升序）内 total 最大；并列取最早一天
   let peakDay: { day: string; total: number | null } | null = null;
@@ -359,6 +388,7 @@ export function buildStatsSnapshot(input: {
     totals,
     byDay,
     byProvider,
+    byDirectory,
     prevTotal: input.prevTotal,
     peakDay,
     activeDays,

--- a/packages/dsh-provider-usage/src/trend/aggregator.ts
+++ b/packages/dsh-provider-usage/src/trend/aggregator.ts
@@ -120,6 +120,7 @@ export class TrendAggregator {
       retry: r.retry,
       provider: r.provider,
       model: r.model,
+      dir: r.dir, // #633 A1：目录归属落盘（collector.dirOf 已保证 sanitize 后 basename 或未识别桶，不重复净化）
       input: r.tokens?.input ?? null,
       output: r.tokens?.output ?? null,
       cacheRead: r.tokens?.cacheRead ?? null,
@@ -174,6 +175,7 @@ export class TrendAggregator {
       session: r.session,
       provider: r.provider,
       model: r.model,
+      dir: r.dir, // #633 A1：目录归属落盘（同 detail 行约定）
       turns: r.turns,
       toolCalls: r.toolCalls,
     };

--- a/packages/dsh-provider-usage/src/trend/aggregator.ts
+++ b/packages/dsh-provider-usage/src/trend/aggregator.ts
@@ -17,10 +17,12 @@ import { dayKey, lastNDayKeys } from "../charts.ts";
 import {
   sumToken,
   TREND_ROW_VERSION,
+  TREND_UNIDENTIFIED,
   type TrendAggRow,
   type TrendCell,
   type TrendCounterRow,
   type TrendDetailRow,
+  type TrendDirRow,
   type TrendTokens,
 } from "./types.ts";
 import type { TrendCallRecord, TrendCorrectRecord, TrendCounterRecord, TrendEmit } from "./collector.ts";
@@ -79,6 +81,8 @@ function emptyCell(): TrendCell {
 export class TrendAggregator {
   /** day → provider → model(null 允许) → cell。 */
   private days = new Map<string, Map<string, Map<string | null, TrendCell>>>();
+  /** #633 A3：day → dir → cell（目录维度日汇总内存态，生命周期与 days 同步）。 */
+  private dirDays = new Map<string, Map<string, TrendCell>>();
   /** 未压实明细/计数行（跨日可能：时钟回拨把旧日事件记进对应日分片）。 */
   private pending: PendingEntry[] = [];
 
@@ -99,16 +103,21 @@ export class TrendAggregator {
     }
   }
 
+  /** call 量累加进 cell（applyCall / rebuild 明细行共用，cells 与 dirCells 同构复用）。 */
+  private addCall(cell: TrendCell, tokens: TrendTokens | null): void {
+    cell.calls += 1;
+    if (tokens !== null) {
+      cell.input = sumToken(cell.input, tokens.input);
+      cell.output = sumToken(cell.output, tokens.output);
+      cell.cacheRead = sumToken(cell.cacheRead, tokens.cacheRead);
+      cell.cacheWrite = sumToken(cell.cacheWrite, tokens.cacheWrite);
+    }
+  }
+
   private applyCall(r: TrendCallRecord): void {
     const day = dayKey(r.time);
-    const cell = this.cellOf(day, r.provider, r.model);
-    cell.calls += 1;
-    if (r.tokens !== null) {
-      cell.input = sumToken(cell.input, r.tokens.input);
-      cell.output = sumToken(cell.output, r.tokens.output);
-      cell.cacheRead = sumToken(cell.cacheRead, r.tokens.cacheRead);
-      cell.cacheWrite = sumToken(cell.cacheWrite, r.tokens.cacheWrite);
-    }
+    this.addCall(this.cellOf(day, r.provider, r.model), r.tokens);
+    this.addCall(this.dirCellOf(day, r.dir), r.tokens); // #633 A3：目录维度平行累加（同 record 不二次 emit）
     const row: TrendDetailRow = {
       v: TREND_ROW_VERSION,
       kind: "detail",
@@ -153,7 +162,14 @@ export class TrendAggregator {
     /* 未找到（已压实/重启后迟到）：校正窗口已关闭，按口径不追溯 */
   }
 
-  /** 明细行 token 变更的 cell 增量修正。 */
+  /**
+   * 明细行 token 变更的 cell 增量修正。
+   * 注意：只修 cells、不同步 dirDays——pending 行的 token 是否在 dir 桶取决于
+   * 行来源（apply 产 = 在；重建产 = 不在，#633 图纸 detail 分支不进 dir 累加），
+   * 无法从行本身区分，无差别修正会给重建行凭空虚增。dirDays 是未压实窗口的
+   * 实时视图（压实即消费、当前无查询面消费），漂移窗口短暂且自愈；持久层
+   * dir 行从 pending 行折算（applyCorrect 已就地改行值），权威数据无漂移。
+   */
   private retokenCell(row: TrendDetailRow, next: TrendTokens): void {
     const cell = this.cellOf(row.day, row.provider, row.model);
     cell.input = sumToken(cell.input, sub(row.input, next.input));
@@ -162,11 +178,16 @@ export class TrendAggregator {
     cell.cacheWrite = sumToken(cell.cacheWrite, sub(row.cacheWrite, next.cacheWrite));
   }
 
+  /** counter 量累加进 cell（applyCounter / rebuild 计数行共用）。 */
+  private addCounter(cell: TrendCell, turns: number, toolCalls: number): void {
+    cell.turns += turns;
+    cell.toolCalls += toolCalls;
+  }
+
   private applyCounter(r: TrendCounterRecord): void {
     const day = dayKey(r.time);
-    const cell = this.cellOf(day, r.provider, r.model);
-    cell.turns += r.turns;
-    cell.toolCalls += r.toolCalls;
+    this.addCounter(this.cellOf(day, r.provider, r.model), r.turns, r.toolCalls);
+    this.addCounter(this.dirCellOf(day, r.dir), r.turns, r.toolCalls); // #633 A3：目录维度平行累加
     const row: TrendCounterRow = {
       v: TREND_ROW_VERSION,
       kind: "counter",
@@ -189,24 +210,28 @@ export class TrendAggregator {
    * @param rows 校验过的分片行（agg 权威行 + 当日明细/计数行）
    * @param persistedRows 这些行是否已落盘（agg 行无意义；明细/计数行来自分片 = true）
    */
-  rebuild(rows: Array<TrendAggRow | TrendDetailRow | TrendCounterRow>, persistedRows: boolean): void {
+  rebuild(rows: Array<TrendAggRow | TrendDetailRow | TrendCounterRow | TrendDirRow>, persistedRows: boolean): void {
     for (const row of rows) {
       if (row.kind === "agg") {
         const cell = this.cellOf(row.day, row.provider, row.model);
         mergeCell(cell, row);
         continue;
       }
+      // #633 A3：dir 汇总行重建 → 只进目录维度桶（cells 累加只发生在事件路径与
+      // detail/counter 行重建，防双重计数）
+      if (row.kind === "dir") {
+        mergeCell(this.dirCellOf(row.day, row.dir), row);
+        continue;
+      }
       if (row.kind === "detail") {
-        const cell = this.cellOf(row.day, row.provider, row.model);
-        cell.calls += 1;
-        cell.input = sumToken(cell.input, row.input);
-        cell.output = sumToken(cell.output, row.output);
-        cell.cacheRead = sumToken(cell.cacheRead, row.cacheRead);
-        cell.cacheWrite = sumToken(cell.cacheWrite, row.cacheWrite);
+        this.addCall(this.cellOf(row.day, row.provider, row.model), {
+          input: row.input,
+          output: row.output,
+          cacheRead: row.cacheRead,
+          cacheWrite: row.cacheWrite,
+        });
       } else {
-        const cell = this.cellOf(row.day, row.provider, row.model);
-        cell.turns += row.turns;
-        cell.toolCalls += row.toolCalls;
+        this.addCounter(this.cellOf(row.day, row.provider, row.model), row.turns, row.toolCalls);
       }
       this.pending.push({ row, persisted: persistedRows });
     }
@@ -246,6 +271,39 @@ export class TrendAggregator {
   /** 精确标记快照条目已持久化（append 成功后调用；只翻转快照内的对象）。 */
   markPersisted(entries: PendingEntry[]): void {
     for (const p of entries) p.persisted = true;
+  }
+
+  /**
+   * 取走给定日的目录维度未压实行快照（#633 A4 压实素材，纯读不消费）。
+   * flush 压实两步式安全序：纯计算行 → IO → 成功后才 dropPending(day)（联动消费）。
+   * 同源折算：与 rollupRowsOf 遍历同一批 pending 行，按 row.dir 分桶；dir 键缺失的
+   * 行（旧格式/无归属）不产 dir 行——目录维度为加性可选键，缺键 = 无 dir 事实可
+   * 折叠（未识别桶由 collector 显式归桶产生，不在折算侧补造；旧格式日压实产物
+   * 与 #633 前形态一致，A2「旧格式零变化」口径）。
+   */
+  takeDirUnpersisted(day: string): TrendDirRow[] {
+    const byDir = new Map<string, TrendDirRow>();
+    for (const p of this.pending) {
+      if (p.row.day !== day) continue;
+      if (p.row.dir === undefined) continue;
+      const dir = p.row.dir;
+      let agg = byDir.get(dir);
+      if (agg === undefined) {
+        agg = { v: TREND_ROW_VERSION, kind: "dir", day, dir, input: null, output: null, cacheRead: null, cacheWrite: null, calls: 0, turns: 0, toolCalls: 0 };
+        byDir.set(dir, agg);
+      }
+      if (p.row.kind === "detail") {
+        agg.calls += 1;
+        agg.input = sumToken(agg.input, p.row.input);
+        agg.output = sumToken(agg.output, p.row.output);
+        agg.cacheRead = sumToken(agg.cacheRead, p.row.cacheRead);
+        agg.cacheWrite = sumToken(agg.cacheWrite, p.row.cacheWrite);
+      } else {
+        agg.turns += p.row.turns;
+        agg.toolCalls += p.row.toolCalls;
+      }
+    }
+    return [...byDir.values()];
   }
 
   /**
@@ -294,6 +352,7 @@ export class TrendAggregator {
   /** 消费给定日的 pending 行（压实 IO 全部成功后调用；cells 不动）。 */
   dropPending(day: string): void {
     this.pending = this.pending.filter((p) => p.row.day !== day);
+    this.dirDays.delete(day); // #633 A4：dir 内存桶随 pending 同步消费（生命周期一致，防过期双算）
   }
 
   /** 裁剪内存日桶（prune 同步收缩，长期运行不重启时 days 有界；cells 随桶整体丢弃）。 */
@@ -312,11 +371,13 @@ export class TrendAggregator {
    * 日切压实（一步式）：折叠为聚合行返回并从 pending 移除。
    * 仅供启动自愈等「无并发 IO 失败窗口」的同步场景使用；flush 压实路径
    * 一律走 rollupRowsOf + dropPending 两步式（IO 失败内存行保留，防丢数）。
+   * #633 A4：返回混存行——agg 行在前、dir 行在后（writeAggDay 写入约定）。
    */
-  rollupDay(day: string): TrendAggRow[] {
+  rollupDay(day: string): Array<TrendAggRow | TrendDirRow> {
     const rows = this.rollupRowsOf(day);
+    const dirRows = this.takeDirUnpersisted(day);
     this.dropPending(day);
-    return rows;
+    return [...rows, ...dirRows];
   }
 
   /** 从内存 pending 移除给定日已全部落盘的登记（重启自愈删除明细分片后同步内存视图）。 */
@@ -564,6 +625,21 @@ export class TrendAggregator {
     }
     return cell;
   }
+
+  /** dir 维度日桶定位（仿 cellOf；day → dir → cell，缺桶逐级补建；#633 A3）。 */
+  private dirCellOf(day: string, dir: string): TrendCell {
+    let dirs = this.dirDays.get(day);
+    if (dirs === undefined) {
+      dirs = new Map();
+      this.dirDays.set(day, dirs);
+    }
+    let cell = dirs.get(dir);
+    if (cell === undefined) {
+      cell = emptyCell();
+      dirs.set(dir, cell);
+    }
+    return cell;
+  }
 }
 
 // ---------------------------------------------------------------- 纯函数
@@ -585,8 +661,8 @@ function firstDayKeyOf(days: Map<string, unknown>): string | null {
   return first;
 }
 
-/** 聚合行并入 cell（重建用；null-aware）。 */
-function mergeCell(cell: TrendCell, row: TrendAggRow): void {
+/** 聚合行并入 cell（重建用；null-aware。agg 与 dir 汇总行十数值字段同构，同函数复用）。 */
+function mergeCell(cell: TrendCell, row: TrendAggRow | TrendDirRow): void {
   cell.calls += row.calls;
   cell.turns += row.turns;
   cell.toolCalls += row.toolCalls;
@@ -625,6 +701,30 @@ export function mergeAggRows(base: TrendAggRow[], add: TrendAggRow[]): TrendAggR
     const cur = byKey.get(key);
     if (cur === undefined) {
       byKey.set(key, { ...r });
+      continue;
+    }
+    cur.calls += r.calls;
+    cur.turns += r.turns;
+    cur.toolCalls += r.toolCalls;
+    cur.input = sumToken(cur.input, r.input);
+    cur.output = sumToken(cur.output, r.output);
+    cur.cacheRead = sumToken(cur.cacheRead, r.cacheRead);
+    cur.cacheWrite = sumToken(cur.cacheWrite, r.cacheWrite);
+  }
+  return [...byKey.values()];
+}
+
+/**
+ * dir 汇总行合并（#633 A4 flush 压实写盘前与既有聚合分片内的 dir 行合并——
+ * 迟到旧日行场景防覆盖丢数；十数值字段与 mergeAggRows 完全同构，null-aware
+ * 求和，同 dir 键累加。输出保持输入相对顺序：base 在前（dir 行位于分片尾段））。
+ */
+export function mergeDirRows(base: TrendDirRow[], add: TrendDirRow[]): TrendDirRow[] {
+  const byKey = new Map<string, TrendDirRow>();
+  for (const r of [...base, ...add]) {
+    const cur = byKey.get(r.dir);
+    if (cur === undefined) {
+      byKey.set(r.dir, { ...r });
       continue;
     }
     cur.calls += r.calls;

--- a/packages/dsh-provider-usage/src/trend/aggregator.ts
+++ b/packages/dsh-provider-usage/src/trend/aggregator.ts
@@ -81,7 +81,12 @@ function emptyCell(): TrendCell {
 export class TrendAggregator {
   /** day → provider → model(null 允许) → cell。 */
   private days = new Map<string, Map<string, Map<string | null, TrendCell>>>();
-  /** #633 A3：day → dir → cell（目录维度日汇总内存态，生命周期与 days 同步）。 */
+  /**
+   * #633 A3：day → dir → cell（目录维度日汇总内存态）。
+   * 生命周期与 days 同步（复核 M1 统一口径）：apply 实时累加 → rollup 压实消费
+   * 当日（dropPending 联动删除）→ 重启经混存分片 dir 行 rebuild 读回恢复（M1：
+   * rebuildFromDisk 走 readAggDayShard）→ prune 同步收缩（pruneDays 联动删除）。
+   */
   private dirDays = new Map<string, Map<string, TrendCell>>();
   /** 未压实明细/计数行（跨日可能：时钟回拨把旧日事件记进对应日分片）。 */
   private pending: PendingEntry[] = [];
@@ -164,11 +169,13 @@ export class TrendAggregator {
 
   /**
    * 明细行 token 变更的 cell 增量修正。
-   * 注意：只修 cells、不同步 dirDays——pending 行的 token 是否在 dir 桶取决于
-   * 行来源（apply 产 = 在；重建产 = 不在，#633 图纸 detail 分支不进 dir 累加），
-   * 无法从行本身区分，无差别修正会给重建行凭空虚增。dirDays 是未压实窗口的
-   * 实时视图（压实即消费、当前无查询面消费），漂移窗口短暂且自愈；持久层
-   * dir 行从 pending 行折算（applyCorrect 已就地改行值），权威数据无漂移。
+   * 注意：只修 cells、不同步 dirDays。行来源其实可区分（复核 L1 纠正旧论证）：
+   * pending 登记的 persisted 字段即判别——apply 产行（false）已由 applyCall/
+   * applyCounter 累加进 dirDays，重建产行（true）不进 dirDays（#633 图纸），
+   * 技术上可按 persisted 精确同步。裁定仍为不同步：dirDays 当前无查询面消费
+   * （分片 b 接线时再定同步策略），统一走「内存 dir 桶单向流入（apply 累加 /
+   * rebuild 读回写入，压实与 prune 删除）、权威数据只从 pending 行折算」的简单
+   * 口径；applyCorrect 已就地改 pending 行值（折算取新值），持久层 dir 行无漂移。
    */
   private retokenCell(row: TrendDetailRow, next: TrendTokens): void {
     const cell = this.cellOf(row.day, row.provider, row.model);
@@ -355,7 +362,11 @@ export class TrendAggregator {
     this.dirDays.delete(day); // #633 A4：dir 内存桶随 pending 同步消费（生命周期一致，防过期双算）
   }
 
-  /** 裁剪内存日桶（prune 同步收缩，长期运行不重启时 days 有界；cells 随桶整体丢弃）。 */
+  /**
+   * 裁剪内存日桶（prune 同步收缩，长期运行不重启时 days 有界；cells 随桶整体丢弃）。
+   * #633 复核 M1：dirDays 联动删除（与 dropPending 对称，生命周期与 days 一致；
+   * 独立遍历不依赖 days 键集，纯 dir 日桶（无 agg 行的防御形态）也能清）。
+   */
   pruneDays(beforeDay: string): number {
     let removed = 0;
     for (const day of [...this.days.keys()]) {
@@ -363,6 +374,9 @@ export class TrendAggregator {
         this.days.delete(day);
         removed += 1;
       }
+    }
+    for (const day of [...this.dirDays.keys()]) {
+      if (day < beforeDay) this.dirDays.delete(day);
     }
     return removed;
   }

--- a/packages/dsh-provider-usage/src/trend/collector.ts
+++ b/packages/dsh-provider-usage/src/trend/collector.ts
@@ -24,6 +24,7 @@ import {
   TREND_UNIDENTIFIED,
   safeId,
   safeToken,
+  sanitizeDirName,
   type TrendAttribution,
   type TrendTokens,
 } from "./types.ts";
@@ -50,6 +51,12 @@ export interface TrendCallRecord {
   provider: string;
   /** 归属 model（未识别/缺失时 null）。 */
   model: string | null;
+  /**
+   * 目录归属（#633 A1：cwd 经 sanitizeDirName 归一化的 basename；
+   * store 无 session / header.cwd 缺失 / 获取抛错时为 TREND_UNIDENTIFIED——
+   * 不静默丢弃，沿用 provider 维度未识别桶约定）。
+   */
+  dir: string;
   /** token 计量（补记且 usage 缺失时 null——调用照计）。 */
   tokens: TrendTokens | null;
   interrupted?: true;
@@ -70,6 +77,8 @@ export interface TrendCounterRecord {
   session: string;
   provider: string;
   model: string | null;
+  /** 目录归属（同 TrendCallRecord.dir；#633 A1）。 */
+  dir: string;
   turns: 0 | 1;
   toolCalls: 0 | 1;
 }
@@ -82,6 +91,13 @@ export type TrendEmit =
 /** 单会话折叠状态。 */
 interface SessionFoldState {
   attribution: TrendAttribution | null;
+  /**
+   * 目录归属缓存（#633 A1）：值三态——string = 已解析（净化 basename 或
+   * TREND_UNIDENTIFIED）；null = 已查询但 store 无该 session / cwd 缺失 / 抛错
+   * （缓存未识别结果，防同 session 重复查询）；undefined = 尚未查询。
+   * 同 session 生命周期内至多发起一次 store.get（A1 硬性约束；TTL 回收随会话状态）。
+   */
+  dir: string | null | undefined;
   /** 进行中 fold 缓冲，key = `${turn}:${step}`。 */
   folds: Map<string, { retry: number; finalized: boolean }>;
   /**
@@ -109,6 +125,12 @@ export interface TrendCollectorOptions {
   emit: (e: TrendEmit) => void;
   /** 归属异常告警出口（P2-6：主源与 message.source 副源不一致等；只告警不纠数）。 */
   onAnomaly?: (msg: string) => void;
+  /**
+   * 目录归属解析器（#633 A1，可选）：输入 session id，返回 cwd 原始值或 undefined。
+   * 接入 ctx.sessions.get(id)?.header.cwd（官方类型层）；抛错由本模块捕获归未识别。
+   * 缺省 = 不接 store（纯离线/测试），目录恒归未识别桶。
+   */
+  resolveCwd?: (session: string) => string | undefined;
 }
 
 /**
@@ -151,19 +173,21 @@ export class TrendCollector {
   private readonly now: () => number;
   private readonly emit: (e: TrendEmit) => void;
   private readonly onAnomaly: ((msg: string) => void) | null;
+  private readonly resolveCwd: ((session: string) => string | undefined) | null;
   private lastSweep = 0;
 
   constructor(opts: TrendCollectorOptions) {
     this.now = opts.now ?? Date.now;
     this.emit = opts.emit;
     this.onAnomaly = opts.onAnomaly ?? null;
+    this.resolveCwd = opts.resolveCwd ?? null;
   }
 
   /** 会话状态（惰性建）。 */
   private stateOf(session: string): SessionFoldState {
     let s = this.sessions.get(session);
     if (s === undefined) {
-      s = { attribution: null, folds: new Map(), headerSeen: false, done: new Map<string, number>(), lastTouch: this.now(), lastFoldTouch: this.now() };
+      s = { attribution: null, dir: undefined, folds: new Map(), headerSeen: false, done: new Map<string, number>(), lastTouch: this.now(), lastFoldTouch: this.now() };
       this.sessions.set(session, s);
     }
     return s;
@@ -174,6 +198,26 @@ export class TrendCollector {
     const a = s.attribution;
     if (a === null) return { provider: TREND_UNIDENTIFIED, model: null };
     return { provider: a.provider, model: a.model };
+  }
+
+  /**
+   * 目录归属解析（#633 A1）：per-session 惰性单查——首次需要归属时经 resolveCwd
+   * 查一次（结果缓存进会话状态，后续定稿直接命中缓存）；store 无该 session /
+   * cwd 缺失 / sanitize 失败 / resolveCwd 抛错 → 缓存 null（未识别），同样只查一次。
+   */
+  private dirOf(s: SessionFoldState, session: string): string {
+    if (s.dir !== undefined) return s.dir ?? TREND_UNIDENTIFIED;
+    let dir: string | null = null;
+    if (this.resolveCwd !== null) {
+      try {
+        const raw = this.resolveCwd(session);
+        dir = raw === undefined ? null : sanitizeDirName(raw);
+      } catch {
+        dir = null; // 获取抛错 → 未识别（缓存，不重复查询）
+      }
+    }
+    s.dir = dir;
+    return dir ?? TREND_UNIDENTIFIED;
   }
 
   /**
@@ -281,9 +325,10 @@ export class TrendCollector {
     state.lastFoldTouch = nowMs;
     rememberDone(state.done, key, fold.retry);
     const { provider, model } = this.providerOf(state);
+    const dir = this.dirOf(state, session);
     this.emit({
       type: "call",
-      record: { time, session, turn, step, retry: fold.retry, provider, model, tokens },
+      record: { time, session, turn, step, retry: fold.retry, provider, model, dir, tokens },
     });
   }
 
@@ -341,6 +386,7 @@ export class TrendCollector {
     rememberDone(state.done, key, retry);
     const time = typeof event.time === "number" && Number.isFinite(event.time) ? event.time : this.now();
     const { provider, model } = this.providerOf(state);
+    const dir = this.dirOf(state, session);
     this.emit({
       type: "call",
       record: {
@@ -351,6 +397,7 @@ export class TrendCollector {
         retry,
         provider,
         model,
+        dir,
         tokens,
         ...(d.interrupted === true ? { interrupted: true as const } : {}),
       },
@@ -369,14 +416,16 @@ export class TrendCollector {
     // counter 记账时间取事件 time（P2-1：防时钟回拨时 counter 落错日桶），非有限数回落 now
     const time = typeof event.time === "number" && Number.isFinite(event.time) ? event.time : this.now();
     const { provider, model } = this.providerOf(state);
-    this.emit({ type: "counter", record: { time, session, provider, model, turns: 1, toolCalls: 0 } });
+    const dir = this.dirOf(state, session);
+    this.emit({ type: "counter", record: { time, session, provider, model, dir, turns: 1, toolCalls: 0 } });
   }
 
   private onToolCall(state: SessionFoldState, session: string, event: SessionEvent & { type: "tool/call" }): void {
     // 同 onTurnEnd：counter 记账时间取事件 time，非有限数回落 now（口径与 onMessage 一致）
     const time = typeof event.time === "number" && Number.isFinite(event.time) ? event.time : this.now();
     const { provider, model } = this.providerOf(state);
-    this.emit({ type: "counter", record: { time, session, provider, model, turns: 0, toolCalls: 1 } });
+    const dir = this.dirOf(state, session);
+    this.emit({ type: "counter", record: { time, session, provider, model, dir, turns: 0, toolCalls: 1 } });
   }
 
   private foldKey(turn: unknown, step: unknown): string {

--- a/packages/dsh-provider-usage/src/trend/index.ts
+++ b/packages/dsh-provider-usage/src/trend/index.ts
@@ -25,6 +25,12 @@ export interface TrendTrackerOptions {
   now?: () => number;
   /** 诊断出口（默认 console.warn）。 */
   warn?: (msg: string) => void;
+  /**
+   * 目录归属解析器（#633 A1 官方契约接入，可选）：输入 session id，返回 cwd 原始值
+   * 或 undefined（store 无该 session / header.cwd 缺失）。抛错由 collector 捕获归
+   * 未识别桶；缺省 = 不接 store（纯离线/测试），目录恒归未识别桶。
+   */
+  resolveCwd?: (session: string) => string | undefined;
 }
 
 export class TrendTracker {
@@ -46,6 +52,7 @@ export class TrendTracker {
       flushDebounceMs: number;
       now: () => number;
       warn: (msg: string) => void;
+      resolveCwd?: (session: string) => string | undefined;
     },
     store: TrendStore,
   ) {
@@ -57,6 +64,7 @@ export class TrendTracker {
     this.aggregator = new TrendAggregator();
     this.collector = new TrendCollector({
       now: resolved.now,
+      resolveCwd: resolved.resolveCwd, // #633 A1：目录归属透传（collector 侧 per-session 惰性单查）
       emit: (e) => {
         this.aggregator.apply(e);
         this.markDirty();
@@ -73,6 +81,7 @@ export class TrendTracker {
       flushDebounceMs: opts.flushDebounceMs ?? 4000,
       now: opts.now ?? Date.now,
       warn: opts.warn ?? ((msg: string) => console.warn(`[dsh-provider-usage] trend: ${msg}`)),
+      resolveCwd: opts.resolveCwd,
     };
     const tracker = new TrendTracker(resolved, new TrendStore({ root: opts.root, warn: resolved.warn }));
     await tracker.rebuildFromDisk();

--- a/packages/dsh-provider-usage/src/trend/index.ts
+++ b/packages/dsh-provider-usage/src/trend/index.ts
@@ -3,7 +3,8 @@
  *
  * collector（事件折叠）→ aggregator（内存聚合）→ store（按天分片 JSONL）的组合：
  * - 刷盘三挂点（方案定稿）：3~5s 防抖 + `session/flush` 官方排空点 + dispose await；
- * - 启动重建：聚合分片（权威）+ 当日明细分片 → 内存聚合；过去日明细分片自愈压实；
+ * - 启动重建：聚合分片（权威，agg+dir 混存全量读回，dir 行进内存目录视图）+
+ *   当日明细分片 → 内存聚合；过去日明细分片自愈压实；
  * - 崩溃安全：压实先原子写聚合分片再删明细分片；同日并存时聚合权威（见 store）；
  * - 已知边界（文档化口径）：kill -9 丢防抖窗口数据（事件路线无重扫兜底）；
  *   统计自挂载时点起算。
@@ -101,7 +102,11 @@ export class TrendTracker {
   private async rebuildFromDisk(): Promise<void> {
     const today = dayKey(this.now());
     for (const day of await this.store.listAggDays()) {
-      this.aggregator.rebuild(await this.store.readAggShard(day), false);
+      // #633 复核 M1：混存分片全量读回（agg+dir）——dir 行经 rebuild 的 dir 分支
+      // mergeCell 进 dirDays（重启后内存目录视图恢复，分片 b 视图假设成立）；
+      // agg 行照旧进 cells。dir 行不进 cells/pending（rebuild 内 continue），
+      // 防双计语义与读回前一致。
+      this.aggregator.rebuild(await this.store.readAggDayShard(day), false);
     }
     for (const day of await this.store.listDetailDays()) {
       const rows = await this.store.readDetailShard(day);

--- a/packages/dsh-provider-usage/src/trend/index.ts
+++ b/packages/dsh-provider-usage/src/trend/index.ts
@@ -9,9 +9,18 @@
  *   统计自挂载时点起算。
  */
 import { dayKey } from "../charts.ts";
-import { TrendAggregator, mergeAggRows, type TrendGranularity, type TrendMetric, type TrendStackPoint, type TrendWindowSummary } from "./aggregator.ts";
+import {
+  TrendAggregator,
+  mergeAggRows,
+  mergeDirRows,
+  type TrendGranularity,
+  type TrendMetric,
+  type TrendStackPoint,
+  type TrendWindowSummary,
+} from "./aggregator.ts";
 import { TrendCollector } from "./collector.ts";
 import { TrendStore } from "./store.ts";
+import type { TrendAggRow, TrendDirRow } from "./types.ts";
 import { safeId } from "./types.ts";
 
 export interface TrendTrackerOptions {
@@ -181,8 +190,20 @@ export class TrendTracker {
       if (this.aggregator.hasUnpersisted(day)) continue; // 上一步失败：留到下轮
       try {
         const pendingAgg = this.aggregator.rollupRowsOf(day);
-        const existing = await this.store.readAggShard(day);
-        await this.store.writeAggDay(day, mergeAggRows(existing, pendingAgg));
+        const pendingDir = this.aggregator.takeDirUnpersisted(day); // #633 A4：dir 汇总行同源折算
+        // #633 A4：既有聚合分片全量取回（agg+dir 混存）——若仍走 readAggShard（只取
+        // agg 行），整日原子重写会把分片内既有 dir 行抹掉；dir 行必须与 pendingDir
+        // 合并后一起重写（迟到旧日行二次压实防丢防重）。
+        const existing = await this.store.readAggDayShard(day);
+        const aggRows = mergeAggRows(
+          existing.filter((r): r is TrendAggRow => r.kind === "agg"),
+          pendingAgg,
+        );
+        const dirRows = mergeDirRows(
+          existing.filter((r): r is TrendDirRow => r.kind === "dir"),
+          pendingDir,
+        );
+        await this.store.writeAggDay(day, [...aggRows, ...dirRows]); // agg 行在前、dir 行在后（写入约定）
         await this.store.deleteDetailShard(day);
         this.aggregator.dropPending(day);
       } catch (e: unknown) {

--- a/packages/dsh-provider-usage/src/trend/store.ts
+++ b/packages/dsh-provider-usage/src/trend/store.ts
@@ -20,9 +20,10 @@ import {
   type TrendAggRow,
   type TrendCounterRow,
   type TrendDetailRow,
+  type TrendDirRow,
 } from "./types.ts";
 
-export type TrendShardRow = TrendDetailRow | TrendCounterRow | TrendAggRow;
+export type TrendShardRow = TrendDetailRow | TrendCounterRow | TrendAggRow | TrendDirRow;
 
 export class TrendStore {
   private readonly root: string;

--- a/packages/dsh-provider-usage/src/trend/store.ts
+++ b/packages/dsh-provider-usage/src/trend/store.ts
@@ -140,7 +140,8 @@ export class TrendStore {
   /**
    * 读聚合分片全量行（agg + dir 混存，#633 A4）：flush 压实的「既有聚合合并」
    * 必须连 dir 行一起取回重写，否则二次压实会把混存分片里的 dir 行抹掉。
-   * 重建路径仍走 readAggShard（filter kind:"agg"）——dir 行进 dirCellOf 桶，不进 cells。
+   * #633 复核 M1：重启重建也走本方法——dir 行进 aggregator 的 dirDays 目录
+   * 内存桶（不进 cells），分片内 dir 权威行经 rebuild 读回内存视图。
    */
   async readAggDayShard(day: string): Promise<Array<TrendAggRow | TrendDirRow>> {
     return this.readShard(this.aggFile(day), (r): r is TrendAggRow | TrendDirRow => r.kind === "agg" || r.kind === "dir");

--- a/packages/dsh-provider-usage/src/trend/store.ts
+++ b/packages/dsh-provider-usage/src/trend/store.ts
@@ -91,10 +91,13 @@ export class TrendStore {
   // ---------------------------------------------------------------- 聚合压实
 
   /**
-   * 整日聚合行原子重写（tmp+rename，0600）。空行数组 = 删除该日聚合分片（防御）。
+   * 整日聚合分片原子重写（tmp+rename，0600）。空行数组 = 删除该日聚合分片（防御）。
    * 这是「聚合分片权威」约定的写入侧：成功返回后该日聚合事实已完整落盘。
+   * #633 A4：rows 为 agg+dir 混存行（调用方约定 agg 行在前、dir 行在后）——
+   * 分片行自带 kind 判别，读侧 readAggShard（filter kind:"agg"）与 readAggDayShard
+   * （agg+dir）各自取所需，互不干扰。
    */
-  async writeAggDay(day: string, rows: TrendAggRow[]): Promise<void> {
+  async writeAggDay(day: string, rows: Array<TrendAggRow | TrendDirRow>): Promise<void> {
     await mkdir(this.aggDir(), { recursive: true });
     if (rows.length === 0) {
       await rm(this.aggFile(day), { force: true });
@@ -132,6 +135,15 @@ export class TrendStore {
   /** 读聚合分片（同上）。 */
   async readAggShard(day: string): Promise<TrendAggRow[]> {
     return this.readShard(this.aggFile(day), (r): r is TrendAggRow => r.kind === "agg");
+  }
+
+  /**
+   * 读聚合分片全量行（agg + dir 混存，#633 A4）：flush 压实的「既有聚合合并」
+   * 必须连 dir 行一起取回重写，否则二次压实会把混存分片里的 dir 行抹掉。
+   * 重建路径仍走 readAggShard（filter kind:"agg"）——dir 行进 dirCellOf 桶，不进 cells。
+   */
+  async readAggDayShard(day: string): Promise<Array<TrendAggRow | TrendDirRow>> {
+    return this.readShard(this.aggFile(day), (r): r is TrendAggRow | TrendDirRow => r.kind === "agg" || r.kind === "dir");
   }
 
   private async readShard<T extends TrendShardRow>(file: string, filter: (r: TrendShardRow) => r is T): Promise<T[]> {

--- a/packages/dsh-provider-usage/src/trend/types.ts
+++ b/packages/dsh-provider-usage/src/trend/types.ts
@@ -17,6 +17,11 @@
 
 /** 分片行 schema 版本：字段语义破坏性变更时递增（载入只认当前版本，其余跳过）。 */
 export const TREND_ROW_VERSION = 1;
+/**
+ * #633 A1/A2：目录维度（cwd basename 净化值）为**加性可选键**，不递增版本——
+ * 旧格式行（无 dir 键）必须原样读回（round-trip 不丢行、不因缺键拒绝），
+ * 重建时目录维度归「未识别」桶（TREND_UNIDENTIFIED，不静默丢弃）。
+ */
 
 /** 未识别归属桶键（provider/model 缺失显式入此桶，不静默丢弃）。 */
 export const TREND_UNIDENTIFIED = "(unidentified)";
@@ -33,6 +38,35 @@ export interface TrendTokens {
   output: number | null;
   cacheRead: number | null;
   cacheWrite: number | null;
+}
+
+/** 目录键防御校验上限（POSIX NAME_MAX=255 兜底；伪造超长行按坏行跳过）。 */
+const TREND_DIR_MAX = 256;
+
+/** 分片行 dir 键防御校验：非空字符串且不超上限（旧格式行无该键，天然通过）。 */
+function isValidDirKey(v: unknown): boolean {
+  return typeof v === "string" && v.length > 0 && v.length <= TREND_DIR_MAX;
+}
+
+/**
+ * cwd → 目录键归一化（#633 A1/C2 数据层约定：dir 字段落盘即存 basename 净化值）：
+ * 剥控制字符（C0/C1）→ POSIX basename（取最后一个 '/' 后段，尾斜杠取前段）。
+ * 无效输入（非字符串/空白/根路径/剥后为空）返回 null → 归「未识别」桶。
+ * 注意：不在数据层截断长度——截断属展示出口（C2），数据层截断会把不同目录
+ * 暗中合并为同桶（违反 B1 可区分性）。
+ */
+export function sanitizeDirName(cwd: unknown): string | null {
+  if (typeof cwd !== "string") return null;
+  let cleaned = "";
+  for (const ch of cwd) {
+    const c = ch.codePointAt(0) as number;
+    if (c < 0x20 || (c >= 0x7f && c <= 0x9f)) continue; // C0 + DEL + C1 控制字符剥除
+    cleaned += ch;
+  }
+  if (cleaned.endsWith("/")) cleaned = cleaned.slice(0, -1);
+  const base = cleaned.slice(cleaned.lastIndexOf("/") + 1);
+  if (base.length === 0 || base.trim().length === 0) return null; // 根路径/空段/纯空白 → 未识别
+  return base;
 }
 
 /** 当日 per-step 明细行（分片 kind:"detail"；每次定稿调用一行）。 */
@@ -52,6 +86,8 @@ export interface TrendDetailRow {
   provider: string;
   /** 归属 model（缺失时 null；未识别桶 model 记 null）。 */
   model: string | null;
+  /** 目录归属（cwd basename 净化值；#633 新行必有，旧格式行无此键 → 重建归未识别）。 */
+  dir?: string;
   input: number | null;
   output: number | null;
   cacheRead: number | null;
@@ -73,6 +109,8 @@ export interface TrendCounterRow {
   turns: 0 | 1;
   /** tool/call 计 1，否则 0。 */
   toolCalls: 0 | 1;
+  /** 目录归属（同 detail 行约定；#633 新行必有，旧格式行无此键）。 */
+  dir?: string;
 }
 
 /** 日切压实后的 day×provider(×model) 聚合行（分片 kind:"agg"；append 后整日原子重写）。 */
@@ -91,7 +129,28 @@ export interface TrendAggRow {
   toolCalls: number;
 }
 
-export type TrendRow = TrendDetailRow | TrendCounterRow | TrendAggRow;
+/**
+ * 日级目录汇总行（分片 kind:"dir"；#633 A4 落盘形态：会话归属为 session 级
+ * 内存映射（per-session 缓存），日切时由明细/计数行折算为 day×dir 汇总行，
+ * 与 kind:"agg" 同生命周期、整日原子重写）。
+ * dir 为 TREND_UNIDENTIFIED 时即「未识别目录」桶（不静默丢弃约定）。
+ */
+export interface TrendDirRow {
+  v: number;
+  kind: "dir";
+  day: string;
+  /** 目录键（sanitizeDirName 净化 basename 或 TREND_UNIDENTIFIED）。 */
+  dir: string;
+  input: number | null;
+  output: number | null;
+  cacheRead: number | null;
+  cacheWrite: number | null;
+  calls: number;
+  turns: number;
+  toolCalls: number;
+}
+
+export type TrendRow = TrendDetailRow | TrendCounterRow | TrendAggRow | TrendDirRow;
 
 /** 内存聚合桶（day×provider×model 单元）。null token 语义：桶内无任何有效数字则保持 null。 */
 export interface TrendCell {
@@ -135,8 +194,11 @@ function isStrOrNull(v: unknown): boolean {
   return v === null || typeof v === "string";
 }
 
-/** 判定明细/计数行是否完整可收（载入重建的防御校验；坏行跳过）。 */
-export function isValidShardRow(row: unknown): row is TrendDetailRow | TrendCounterRow | TrendAggRow {
+/** 判定明细/计数/聚合/目录汇总行是否完整可收（载入重建的防御校验；坏行跳过）。
+ *  #633 A2：detail/counter 的 dir 为加性可选键——旧格式行（无 dir）不因缺键拒绝。 */
+export function isValidShardRow(
+  row: unknown,
+): row is TrendDetailRow | TrendCounterRow | TrendAggRow | TrendDirRow {
   if (typeof row !== "object" || row === null) return false;
   const r = row as Record<string, unknown>;
   if (r.v !== TREND_ROW_VERSION) return false;
@@ -155,7 +217,8 @@ export function isValidShardRow(row: unknown): row is TrendDetailRow | TrendCoun
       isNumOrNull(r.output) &&
       isNumOrNull(r.cacheRead) &&
       isNumOrNull(r.cacheWrite) &&
-      isStrOrNull(r.model)
+      isStrOrNull(r.model) &&
+      (r.dir === undefined || isValidDirKey(r.dir))
     );
   }
   if (r.kind === "counter") {
@@ -167,7 +230,8 @@ export function isValidShardRow(row: unknown): row is TrendDetailRow | TrendCoun
       typeof r.provider === "string" &&
       isStrOrNull(r.model) &&
       (r.turns === 0 || r.turns === 1) &&
-      (r.toolCalls === 0 || r.toolCalls === 1)
+      (r.toolCalls === 0 || r.toolCalls === 1) &&
+      (r.dir === undefined || isValidDirKey(r.dir))
     );
   }
   if (r.kind === "agg") {
@@ -176,6 +240,20 @@ export function isValidShardRow(row: unknown): row is TrendDetailRow | TrendCoun
       TREND_DAY_RE.test(r.day) &&
       typeof r.provider === "string" &&
       isStrOrNull(r.model) &&
+      isNumOrNull(r.input) &&
+      isNumOrNull(r.output) &&
+      isNumOrNull(r.cacheRead) &&
+      isNumOrNull(r.cacheWrite) &&
+      typeof r.calls === "number" &&
+      typeof r.turns === "number" &&
+      typeof r.toolCalls === "number"
+    );
+  }
+  if (r.kind === "dir") {
+    return (
+      typeof r.day === "string" &&
+      TREND_DAY_RE.test(r.day) &&
+      isValidDirKey(r.dir) &&
       isNumOrNull(r.input) &&
       isNumOrNull(r.output) &&
       isNumOrNull(r.cacheRead) &&

--- a/packages/dsh-provider-usage/src/trend/types.ts
+++ b/packages/dsh-provider-usage/src/trend/types.ts
@@ -40,7 +40,9 @@ export interface TrendTokens {
   cacheWrite: number | null;
 }
 
-/** 目录键防御校验上限（POSIX NAME_MAX=255 兜底；伪造超长行按坏行跳过）。 */
+/** 目录键防御校验上限（复核 L4：POSIX NAME_MAX=255 以字节计，JS 字符串按 UTF-16
+ * 码元计长——255 字节至多 255 个字符（多字节字符只会更短），255 < 256，取 256 与
+ * safeId 上限同口径留 1 字符安全余量；超长伪造行按坏行跳过）。 */
 const TREND_DIR_MAX = 256;
 
 /** 分片行 dir 键防御校验：非空字符串且不超上限（旧格式行无该键，天然通过）。 */

--- a/packages/dsh-provider-usage/test/unit-report.test.ts
+++ b/packages/dsh-provider-usage/test/unit-report.test.ts
@@ -14,6 +14,9 @@
  *   接线层 smoke 另以 emitEvent 计数显式断言「生成不产生 session 事件→不入统计」。
  * - scheduler（M3 接线补）：lastRun 读写 roundtrip / 单飞互斥（busy 期 tick 跳过）/
  *   失败不推进 lastRun（下轮重试同窗）/ 成功推进 / dispose 停 tick
+ * - #633 分片 a D1：旧格式 trend 分片（无 cwd/dir 键）→ 启动重建 + buildStatsSnapshot
+ *   报告链路不抛错；byDirectory 未识别桶数值正确；byProvider/byDay/派生维度与无 dir
+ *   维度时完全一致（零回归）
  */
 import { mkdtempSync, existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync, renameSync, utimesSync } from "node:fs";
 import { join } from "node:path";
@@ -59,6 +62,10 @@ import {
   __clearReportIndexCacheForTests,
   __reportIndexCacheStatsForTests,
   handleReportStatus,
+  TrendTracker,
+  dayKey,
+  TREND_ROW_VERSION,
+  TREND_UNIDENTIFIED,
 } from "../lib/index.js";
 
 // ---------------------------------------------------------------- 工具
@@ -899,6 +906,78 @@ const GEN = (over = {}) => ({
   );
   assert.equal(payload2.status, "done", "非复用任务 status done");
   assert.equal(payload2.reused, undefined, "非复用任务不携带 reused（新生成语义不变）");
+}
+
+// ---------------------------------------------------------------- #633 分片 a D1：旧格式（无 cwd/dir 键）报告生成链路回归
+
+{
+  // D1 spec：构造升级前格式（无 cwd/dir 键）分片 fixture，断言启动重建、统计/趋势查询、
+  // 报告生成三条链路均不抛错且未识别桶计入正确数值。前两条链路由 unit-trend A2 用例
+  // 覆盖；本块补报告生成链路：旧格式分片经真实 TrendTracker.start 重建（启动链路）→
+  // buckets()（统计/趋势查询面）→ buildStatsSnapshot + generateReport（报告链路）逐级
+  // 不抛错；byDirectory 未识别桶数值正确；既有维度与无 dir 维度时零回归。
+  const root = mkdtempSync(join(tmpdir(), "dou-report-d1-legacy-"));
+  const aggDir = join(root, "agg");
+  const detDir = join(root, "details");
+  mkdirSync(aggDir, { recursive: true });
+  mkdirSync(detDir, { recursive: true });
+  const today = dayKey(T0); // 2026-09-04
+  // 旧格式行（无 dir 键；形态同 unit-trend A2 fixture）：过去日 agg 权威行 + 当日明细/计数行
+  const legacyAgg = { v: TREND_ROW_VERSION, kind: "agg", day: "2026-09-03", provider: "deepseek", model: "deepseek-chat", input: 5000, output: 800, cacheRead: 120, cacheWrite: 10, calls: 30, turns: 12, toolCalls: 40 };
+  const legacyDetail = { v: TREND_ROW_VERSION, kind: "detail", time: T0 - HOUR, day: today, session: "旧会话-甲", turn: 3, step: 2, retry: 1, provider: "deepseek", model: "deepseek-chat", input: 1200, output: 300, cacheRead: 45, cacheWrite: 6, calls: 1 };
+  const legacyCounter = { v: TREND_ROW_VERSION, kind: "counter", time: T0 - HOUR, day: today, session: "旧会话-甲", provider: "deepseek", model: "deepseek-chat", turns: 1, toolCalls: 1 };
+  writeFileSync(join(aggDir, "2026-09-03.jsonl"), `${JSON.stringify(legacyAgg)}\n`);
+  writeFileSync(join(detDir, `${today}.jsonl`), `${JSON.stringify(legacyDetail)}\n${JSON.stringify(legacyCounter)}\n`);
+  // 链路 1/2（启动重建 + 统计/趋势查询面）：不抛错、两日全量入内存
+  const tracker = await TrendTracker.start({ root, now: () => T0, flushDebounceMs: 60000 });
+  const buckets = tracker.buckets();
+  assert.equal(buckets.length, 2, "旧格式分片重建：过去日 agg 权威行 + 当日明细两日全量入内存（不抛错）");
+  // 链路 3（报告生成）：窗口覆盖两日（weekly 形态）——历史输出不缺失
+  // dirRows 为升级后 A4 dir 行形态（store.readAggDayShard filter kind:"dir" 的输入面）：
+  // 未识别桶由 collector 显式归桶产生（升级后无 cwd 会话），旧格式日无 dir 事实不补造。
+  const dirRows = [
+    { v: TREND_ROW_VERSION, kind: "dir", day: today, dir: TREND_UNIDENTIFIED, input: 22, output: 11, cacheRead: null, cacheWrite: null, calls: 1, turns: 1, toolCalls: 0 },
+    { v: TREND_ROW_VERSION, kind: "dir", day: "2026-09-10", dir: "窗口外", input: 999, output: 999, cacheRead: null, cacheWrite: null, calls: 9, turns: 9, toolCalls: 9 },
+  ];
+  const s = buildStatsSnapshot({ period: "weekly", startDay: "2026-09-03", endDay: today, buckets, dirRows, prevTotal: null });
+  assert.deepEqual(
+    s.byDirectory,
+    [{ dir: TREND_UNIDENTIFIED, calls: 1, total: 33 }],
+    "byDirectory 未识别桶计入正确数值（窗口外 dir 行不计；旧格式日 09-03 无 dir 事实不补造）",
+  );
+  assert.equal(s.totals.calls, 31, "历史输出不缺失：calls 与升级前一致（30+1）");
+  assert.equal(s.totals.total, 7481, "历史 token 总量不缺失（5930+1551，四项 null-aware 之和）");
+  assert.deepEqual(
+    s.byDay,
+    [{ day: "2026-09-03", total: 5930 }, { day: today, total: 1551 }],
+    "byDay 旧数据完整（两日总量一致）",
+  );
+  // 零回归：同 buckets 无 dir 维度（dirRows 缺省）时既有字段逐字段完全一致
+  const s0 = buildStatsSnapshot({ period: "weekly", startDay: "2026-09-03", endDay: today, buckets, prevTotal: null });
+  assert.deepEqual(s0.byDirectory, [], "无 dir 行 → byDirectory 空数组（加性可选维度，不补造）");
+  const strip = (snap) => {
+    const clone = { ...snap };
+    delete clone.byDirectory;
+    return clone;
+  };
+  assert.deepEqual(strip(s), strip(s0), "byProvider/byDay/totals/派生维度与无 dir 维度时完全一致（零回归）");
+  // {stats} 注入 → generateReport（fake llm）不抛错且成功，byDirectory 进注入面
+  const { llm, seen } = fakeLlm();
+  const r = await generateReport(GEN({ llm, period: "weekly", key: "2026-09-03", startDay: "2026-09-03", endDay: today, statsJson: JSON.stringify(s) }));
+  assert.equal(r.meta.ok, true, "旧格式数据报告生成不抛错且成功");
+  assert.ok(seen.options.messages[0].content[0].text.includes(JSON.stringify(s.byDirectory[0])), "{stats} 注入面含未识别目录桶（dir=TREND_UNIDENTIFIED）");
+  await tracker.dispose();
+  // dir 键防御（与 provider/model 名同口径）：控制字符剥离 + 80 字符截断
+  const hostile = buildStatsSnapshot({
+    period: "daily",
+    startDay: today,
+    endDay: today,
+    buckets: [],
+    dirRows: [{ v: TREND_ROW_VERSION, kind: "dir", day: today, dir: `a\nb${"x".repeat(100)}`, input: 1, output: null, cacheRead: null, cacheWrite: null, calls: 1, turns: 0, toolCalls: 0 }],
+    prevTotal: null,
+  });
+  assert.ok(!hostile.byDirectory[0].dir.includes("\n"), "dir 控制字符进快照前已剥离");
+  assert.equal(hostile.byDirectory[0].dir.length, 80, "dir 截断至 80 字符（与 byProvider 同口径）");
 }
 
 console.log("unit-report: all assertions passed");

--- a/packages/dsh-provider-usage/test/unit-trend.test.ts
+++ b/packages/dsh-provider-usage/test/unit-trend.test.ts
@@ -33,6 +33,7 @@ import {
   dayKey,
   sumToken,
   mergeAggRows,
+  mergeDirRows,
   metricValue,
   TREND_ROW_VERSION,
   TREND_UNIDENTIFIED,
@@ -1242,6 +1243,245 @@ const A2_LEGACY_AGG = {
   assert.equal(rows.length, 1, "空串/非字符串 dir 按坏行拒绝（A1 值域防线不回退）");
   assert.equal(rows[0].session, "旧会话-甲", "保留的是合法行");
   assert.equal(warns.length, 2, "两个非法 dir 行均告警");
+}
+
+// ---------------------------------------------------------------- #633 A3/A4：dir 维度归并内存态与日汇总行生成
+
+{
+  // A3(a)：内存态归并（tracker 全链路）——apply 平行累加后压实产物 dir 行：
+  // 双 session 同 cwd → 恰 1 条 calls 为和；不同 cwd 独立行；resolveCwd 缺失 →
+  // 未识别桶独立成行。dir 行位于 agg 行之后（writeAggDay 写入顺序约定）。
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-a3-merge-"));
+  let nowMs = T0;
+  const tracker = await TrendTracker.start({
+    root,
+    now: () => nowMs,
+    flushDebounceMs: 60000,
+    resolveCwd: (session) => (session === "s1" || session === "s2" ? "/home/u/shared" : session === "s3" ? "/home/u/other" : undefined),
+  });
+  tracker.handleEvent({ id: "s1" }, ev("request/header", HEADER(), T0, 1));
+  tracker.handleEvent({ id: "s1" }, ev("assistant/chunk", USAGE(10, 5), T0, 2));
+  tracker.handleEvent({ id: "s1" }, ev("turn/end", { turn: 1, reason: { kind: "completed" } }, T0, 3));
+  tracker.handleEvent({ id: "s2" }, ev("request/header", HEADER(), T0, 4));
+  tracker.handleEvent({ id: "s2" }, ev("assistant/chunk", USAGE(7, 7), T0, 5));
+  tracker.handleEvent({ id: "s3" }, ev("request/header", HEADER(), T0, 6));
+  tracker.handleEvent({ id: "s3" }, ev("assistant/chunk", USAGE(3, 3), T0, 7));
+  tracker.handleEvent({ id: "s4" }, ev("request/header", HEADER(), T0, 8));
+  tracker.handleEvent({ id: "s4" }, ev("assistant/chunk", USAGE(2, 2), T0, 9));
+  nowMs = T0 + 24 * HOUR; // 日切：DAY0 成过去日
+  await tracker.flushNow();
+  const shard = await new TrendStore({ root }).readAggDayShard(DAY0);
+  assert.deepEqual(
+    shard.map((r) => r.kind),
+    ["agg", "dir", "dir", "dir"],
+    "混存分片：agg 行在前、dir 行在后",
+  );
+  assert.deepEqual(
+    shard.filter((r) => r.kind === "dir"),
+    [
+      { v: TREND_ROW_VERSION, kind: "dir", day: DAY0, dir: "shared", input: 17, output: 12, cacheRead: 0, cacheWrite: 0, calls: 2, turns: 1, toolCalls: 0 },
+      { v: TREND_ROW_VERSION, kind: "dir", day: DAY0, dir: "other", input: 3, output: 3, cacheRead: 0, cacheWrite: 0, calls: 1, turns: 0, toolCalls: 0 },
+      { v: TREND_ROW_VERSION, kind: "dir", day: DAY0, dir: TREND_UNIDENTIFIED, input: 2, output: 2, cacheRead: 0, cacheWrite: 0, calls: 1, turns: 0, toolCalls: 0 },
+    ],
+    "同 cwd 双 session 归并为恰 1 条（calls 为和）；不同 cwd/未识别桶独立行",
+  );
+  assert.deepEqual(
+    shard.filter((r) => r.kind === "agg").map((r) => ({ input: r.input, output: r.output, calls: r.calls, turns: r.turns })),
+    [{ input: 22, output: 17, calls: 4, turns: 1 }],
+    "agg 行（provider 维度）不受 dir 平行累加影响",
+  );
+  assert.equal(existsSync(join(root, "details", `${DAY0}.jsonl`)), false, "明细分片压实后删除");
+  await tracker.dispose();
+}
+
+{
+  // A3(b)：rebuild 混存行——agg 行 + dir 行 + 当日 detail/counter 行重放：dir 行
+  // 只进目录维度桶（dirDays），不进 cells（防双计）、不进 pending（不二次落盘）。
+  const agg = new TrendAggregator();
+  agg.rebuild(
+    [
+      { v: 1, kind: "agg", day: DAY0, provider: "deepseek", model: "chat", input: 100, output: 50, cacheRead: null, cacheWrite: null, calls: 2, turns: 1, toolCalls: 3 },
+      { v: 1, kind: "dir", day: DAY0, dir: "proj", input: 100, output: 50, cacheRead: null, cacheWrite: null, calls: 2, turns: 1, toolCalls: 3 },
+      { v: 1, kind: "detail", time: T0, day: DAY0, session: "s9", turn: 9, step: 1, retry: 1, provider: "deepseek", model: "chat", dir: "proj", input: 7, output: 7, cacheRead: null, cacheWrite: null, calls: 1 },
+      { v: 1, kind: "counter", time: T0, day: DAY0, session: "s9", provider: "deepseek", model: "chat", dir: "proj", turns: 1, toolCalls: 0 },
+    ],
+    true,
+  );
+  const cell = cellTotals(agg, DAY0);
+  assert.deepEqual(
+    { input: cell.input, output: cell.output, cacheRead: cell.cacheRead, cacheWrite: cell.cacheWrite, calls: cell.calls, turns: cell.turns, toolCalls: cell.toolCalls },
+    { input: 107, output: 57, cacheRead: null, cacheWrite: null, calls: 3, turns: 2, toolCalls: 3 },
+    "rebuild：agg + detail/counter 进 cells；dir 行不进（calls=2+1 而非 +dir 的 2）",
+  );
+  assert.equal(agg.stats().pendingRows, 2, "dir 行不进 pending（不二次落盘）");
+}
+
+{
+  // A4(c)：rollup 产物字段值 deepEqual——rollupDay 返回 [...aggRows, ...dirRows]，
+  // dir 行十字段（v/kind/day/dir/input/output/cacheRead/cacheWrite/calls/turns/toolCalls）
+  // 值与 pending 折算一致；tokens null 的行 null-aware 归并；消费后不重复产出。
+  const agg = new TrendAggregator();
+  agg.apply({ type: "call", record: { time: T0, session: "s1", turn: 1, step: 1, retry: 1, provider: "deepseek", model: "chat", dir: "proj", tokens: { input: 100, output: 50, cacheRead: 10, cacheWrite: 5 } } });
+  agg.apply({ type: "counter", record: { time: T0, session: "s1", provider: "deepseek", model: "chat", dir: "proj", turns: 1, toolCalls: 2 } });
+  agg.apply({ type: "call", record: { time: T0 + HOUR, session: "s2", turn: 1, step: 1, retry: 1, provider: "deepseek", model: "chat", dir: "proj", tokens: null } });
+  const rows = agg.rollupDay(DAY0);
+  assert.deepEqual(
+    rows,
+    [
+      { v: TREND_ROW_VERSION, kind: "agg", day: DAY0, provider: "deepseek", model: "chat", input: 100, output: 50, cacheRead: 10, cacheWrite: 5, calls: 2, turns: 1, toolCalls: 2 },
+      { v: TREND_ROW_VERSION, kind: "dir", day: DAY0, dir: "proj", input: 100, output: 50, cacheRead: 10, cacheWrite: 5, calls: 2, turns: 1, toolCalls: 2 },
+    ],
+    "rollupDay 产物 agg+dir 行逐字段 deepEqual（null token 不污染、calls 独立累计）",
+  );
+  assert.deepEqual(agg.rollupDay(DAY0), [], "消费后二次 rollup 不重复产出（pending/dir 素材同源消费）");
+}
+
+{
+  // A4(d)：mergeDirRows 纯函数——同 dir 键累加（null-aware）、异 dir 独立、
+  // 输出保序（base 在前：对应分片内既有 dir 行位置约定）。
+  const merged = mergeDirRows(
+    [
+      { v: 1, kind: "dir", day: DAY0, dir: "a", input: null, output: null, cacheRead: null, cacheWrite: null, calls: 1, turns: 0, toolCalls: 0 },
+      { v: 1, kind: "dir", day: DAY0, dir: "b", input: 7, output: null, cacheRead: null, cacheWrite: null, calls: 2, turns: 1, toolCalls: 1 },
+    ],
+    [{ v: 1, kind: "dir", day: DAY0, dir: "a", input: 5, output: 3, cacheRead: null, cacheWrite: null, calls: 2, turns: 0, toolCalls: 0 }],
+  );
+  assert.deepEqual(
+    merged,
+    [
+      { v: 1, kind: "dir", day: DAY0, dir: "a", input: 5, output: 3, cacheRead: null, cacheWrite: null, calls: 3, turns: 0, toolCalls: 0 },
+      { v: 1, kind: "dir", day: DAY0, dir: "b", input: 7, output: null, cacheRead: null, cacheWrite: null, calls: 2, turns: 1, toolCalls: 1 },
+    ],
+    "mergeDirRows 同键累加、null-aware、保序",
+  );
+}
+
+{
+  // A4(e)：混存 round-trip——压实（混存落盘）→ 重启重建（不丢不重，dir 行不双算
+  // 进 cells）→ 迟到旧日行二次压实（既有 dir 行经 readAggDayShard 全量取回合并，
+  // 不被整日重写抹掉）→ 再重启（分片不再被改写）。
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-a4-roundtrip-"));
+  let nowMs = T0;
+  let tracker = await TrendTracker.start({
+    root,
+    now: () => nowMs,
+    flushDebounceMs: 60000,
+    resolveCwd: (session) => (session === "s1" ? "/home/u/alpha" : "/home/u/beta"),
+  });
+  tracker.handleEvent({ id: "s1" }, ev("request/header", HEADER(), T0, 1));
+  tracker.handleEvent({ id: "s1" }, ev("assistant/chunk", USAGE(10, 5), T0, 2));
+  tracker.handleEvent({ id: "s1" }, ev("turn/end", { turn: 1, reason: { kind: "completed" } }, T0, 3));
+  tracker.handleEvent({ id: "s2" }, ev("request/header", HEADER(), T0, 4));
+  tracker.handleEvent({ id: "s2" }, ev("tool/call", { turn: 1, step: 1, callId: "c", name: "bash", arguments: "{}" }, T0, 5));
+  tracker.handleEvent({ id: "s2" }, ev("assistant/chunk", USAGE(7, 7), T0, 6));
+  nowMs = T0 + 24 * HOUR;
+  await tracker.flushNow(); // 第一次压实：agg + dir 混存落盘
+  const store = new TrendStore({ root });
+  const round1 = await store.readAggDayShard(DAY0);
+  assert.deepEqual(
+    round1.map((r) => r.kind),
+    ["agg", "dir", "dir"],
+    "首次压实混存形态",
+  );
+  const dirRows1 = round1.filter((r) => r.kind === "dir");
+  assert.equal(existsSync(join(root, "details", `${DAY0}.jsonl`)), false, "明细分片已删（压实收尾）");
+  await tracker.dispose();
+  tracker = await TrendTracker.start({ root, now: () => nowMs, flushDebounceMs: 60000, resolveCwd: () => "/home/u/alpha" });
+  const cellR1 = tracker.buckets().find((d) => d.day === DAY0).providers.find((p) => p.provider === "deepseek").cell;
+  assert.deepEqual(
+    { input: cellR1.input, output: cellR1.output, cacheRead: cellR1.cacheRead, cacheWrite: cellR1.cacheWrite, calls: cellR1.calls, turns: cellR1.turns, toolCalls: cellR1.toolCalls },
+    { input: 17, output: 12, cacheRead: 0, cacheWrite: 0, calls: 2, turns: 1, toolCalls: 1 },
+    "重启重建：agg 行权威进 cells，dir 行不双算（calls=2 而非 4）",
+  );
+  // 迟到旧日行（时钟回拨）：s1 turn2 usage 落 DAY0 → 二次压实合并
+  tracker.handleEvent({ id: "s1" }, ev("request/header", HEADER(), T0 + HOUR, 7));
+  tracker.handleEvent({ id: "s1" }, ev("assistant/chunk", { turn: 2, step: 1, chunk: { type: "usage", usage: { inputTokens: 3, outputTokens: 3, cacheReadTokens: 0, cacheWriteTokens: 0 } } }, T0 + HOUR, 8));
+  await tracker.flushNow();
+  const round2 = await store.readAggDayShard(DAY0);
+  assert.deepEqual(
+    round2.map((r) => r.kind),
+    ["agg", "dir", "dir"],
+    "二次压实后行数不增（既有 dir 行未被整日重写抹掉）",
+  );
+  assert.deepEqual(
+    round2.filter((r) => r.kind === "dir"),
+    [
+      { v: TREND_ROW_VERSION, kind: "dir", day: DAY0, dir: "alpha", input: 13, output: 8, cacheRead: 0, cacheWrite: 0, calls: 2, turns: 1, toolCalls: 0 },
+      { v: TREND_ROW_VERSION, kind: "dir", day: DAY0, dir: "beta", input: 7, output: 7, cacheRead: 0, cacheWrite: 0, calls: 1, turns: 0, toolCalls: 1 },
+    ],
+    "迟到行并入 dir 行（alpha calls=1+1、input 10+3）且 beta 不受连坐",
+  );
+  await tracker.dispose();
+  tracker = await TrendTracker.start({ root, now: () => nowMs, flushDebounceMs: 60000, resolveCwd: () => "/home/u/alpha" });
+  const cellR2 = tracker.buckets().find((d) => d.day === DAY0).providers.find((p) => p.provider === "deepseek").cell;
+  assert.equal(cellR2.calls, 3, "再重启重建 calls=2+1（迟到行已并入 agg 行，不丢不重）");
+  assert.deepEqual(
+    (await store.readAggDayShard(DAY0)).map((r) => r.kind),
+    ["agg", "dir", "dir"],
+    "再重启后分片形态稳定（persisted 行 flush 不重写）",
+  );
+  await tracker.dispose();
+}
+
+{
+  // A4(f)：查询面零变化——含 dir 记账 + dir 行 rebuild 后，buckets()/seriesDays()
+  // 与固定 fixture 全等（dir 不出现在 provider 查询面，cells 数值不受平行累加影响）。
+  const agg = new TrendAggregator();
+  agg.apply({ type: "call", record: { time: T0, session: "s1", turn: 1, step: 1, retry: 1, provider: "deepseek", model: "chat", dir: "x", tokens: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 } } });
+  agg.apply({ type: "call", record: { time: T0 + HOUR, session: "s2", turn: 1, step: 1, retry: 1, provider: "deepseek", model: "chat", tokens: { input: 3, output: 4, cacheRead: null, cacheWrite: null } } });
+  agg.rebuild(
+    [
+      { v: 1, kind: "agg", day: DAY0, provider: "other", model: null, input: 5, output: 5, cacheRead: null, cacheWrite: null, calls: 1, turns: 1, toolCalls: 1 },
+      { v: 1, kind: "dir", day: DAY0, dir: "x", input: 1, output: 2, cacheRead: 0, cacheWrite: 0, calls: 1, turns: 0, toolCalls: 0 },
+    ],
+    false,
+  );
+  assert.deepEqual(
+    agg.buckets(),
+    [
+      {
+        day: DAY0,
+        providers: [
+          { provider: "deepseek", model: "chat", cell: { input: 4, output: 6, cacheRead: 0, cacheWrite: 0, calls: 2, turns: 0, toolCalls: 0 } },
+          { provider: "other", model: null, cell: { input: 5, output: 5, cacheRead: null, cacheWrite: null, calls: 1, turns: 1, toolCalls: 1 } },
+        ],
+      },
+    ],
+    "buckets() 固定 fixture 全等（dir 行 rebuild 不进 cells、apply 平行累加不污染）",
+  );
+  assert.deepEqual(
+    agg.seriesDays(2, T0 + HOUR, "input").map((d) => d.value),
+    [null, 9],
+    "seriesDays 零变化（空日 null 语义保持；input=4+5 跨 provider 求和）",
+  );
+}
+
+{
+  // A4(g)：量级留痕——1000 事件 / 5 session：resolveCwd 恰 5 次（per-session 惰性
+  // 单查缓存，与事件量无关）；start+dispose 耗时基线 stderr 一行注明取数时点。
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-a4-scale-"));
+  let cwdCalls = 0;
+  const startAt = Date.now();
+  const tracker = await TrendTracker.start({ root, now: () => T0, flushDebounceMs: 60000, resolveCwd: () => { cwdCalls += 1; return "/home/u/scale"; } });
+  const startMs = Date.now() - startAt;
+  let seq = 0;
+  for (let s = 1; s <= 5; s += 1) {
+    const sid = `s${s}`;
+    tracker.handleEvent({ id: sid }, ev("request/header", HEADER(), T0, (seq += 1)));
+    for (let k = 0; k < 199; k += 1) {
+      tracker.handleEvent({ id: sid }, ev("assistant/chunk", { turn: k + 1, step: 1, chunk: { type: "usage", usage: { inputTokens: 10, outputTokens: 5, cacheReadTokens: 0, cacheWriteTokens: 0 } } }, T0, (seq += 1)));
+    }
+  }
+  const cell = tracker.buckets().find((d) => d.day === DAY0).providers[0].cell;
+  assert.equal(cell.calls, 995, "1000 事件（5 header + 995 usage）全量记账进 cells");
+  const disposeAt = Date.now();
+  await tracker.dispose();
+  const disposeMs = Date.now() - disposeAt;
+  assert.equal(cwdCalls, 5, "resolveCwd 调用数恰 5（每 session 惰性单查）");
+  const rows = readFileSync(join(root, "details", `${DAY0}.jsonl`), "utf8").trimEnd().split("\n").map((l) => JSON.parse(l));
+  assert.equal(rows.length, 995, "995 条明细行全量落盘");
+  assert.ok(rows.filter((r) => r.session === "s1").every((r) => r.dir === "scale"), "dir 落盘值逐行正确（抽查 s1 全量）");
+  console.error(`[#633 A4 量级基线] 1000 事件/5 session：start=${startMs}ms dispose=${disposeMs}ms（resolveCwd=5，995 行落盘）；取数时点 ${new Date().toISOString()} node ${process.version}`);
 }
 
 assert.equal(sumToken(null, 5), 5, "sumToken null+数字");

--- a/packages/dsh-provider-usage/test/unit-trend.test.ts
+++ b/packages/dsh-provider-usage/test/unit-trend.test.ts
@@ -1040,6 +1040,210 @@ function writeAggShardLine(row) {
   await tracker.dispose();
 }
 
+// ---------------------------------------------------------------- #633 A2 兼容割接：存量分片（无 cwd/dir 键）升级后首次启动重建
+
+// A2 前提（图纸第 1 步已验证）：isValidShardRow 按 kind 校验必填键，无键白名单遍历
+// ——未知键不拒绝；detail/counter 的 dir 为加性可选键（dir === undefined 放行）。
+// 本节全部离线 mkdtempSync：手工构造旧格式分片文件（无 dir 键），零 src 改动断言实际行为。
+
+/** 旧格式 detail 行（无 dir 键；含中文归属桶与中文目录语义无关的会话 id）。 */
+const A2_LEGACY_DETAIL = {
+  v: TREND_ROW_VERSION,
+  kind: "detail",
+  time: T0 - 24 * HOUR, // 2026-09-03 12:00（过去日）
+  day: "2026-09-03",
+  session: "旧会话-甲",
+  turn: 3,
+  step: 2,
+  retry: 1,
+  provider: "deepseek",
+  model: "deepseek-chat",
+  input: 1200,
+  output: 300,
+  cacheRead: 45,
+  cacheWrite: 6,
+  calls: 1,
+};
+/** 旧格式 counter 行（无 dir 键）。 */
+const A2_LEGACY_COUNTER = {
+  v: TREND_ROW_VERSION,
+  kind: "counter",
+  time: T0 - 24 * HOUR,
+  day: "2026-09-03",
+  session: "旧会话-甲",
+  provider: "deepseek",
+  model: "deepseek-chat",
+  turns: 1,
+  toolCalls: 1,
+};
+/** 旧格式聚合行（agg 行本就无 dir 键，升级前后形态一致）。 */
+const A2_LEGACY_AGG = {
+  v: TREND_ROW_VERSION,
+  kind: "agg",
+  day: "2026-09-03",
+  provider: "deepseek",
+  model: "deepseek-chat",
+  input: 5000,
+  output: 800,
+  cacheRead: 120,
+  cacheWrite: 10,
+  calls: 30,
+  turns: 12,
+  toolCalls: 40,
+};
+
+{
+  // A2(a)：旧格式 fixture 重建（真实升级场景）——过去日聚合分片（权威）+ 当日旧版
+  // 明细分片（无 dir 键的 detail/counter 行）：升级后首次启动不抛错；两日内存聚合
+  // 数值与写入值一致；当日旧 detail 分片逐字节不变（rebuild 不重写 = round-trip
+  // 结构性安全；dispose 最终刷盘同样不触碰 persisted 行）。过去日同日并存的残留
+  // 明细分片（聚合分片 + 残留明细）走聚合权威自愈删除，残留行不双算——一并覆盖。
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-a2-rebuild-"));
+  const aggDir = join(root, "agg");
+  const detDir = join(root, "details");
+  mkdirSync(aggDir, { recursive: true });
+  mkdirSync(detDir, { recursive: true });
+  const today = dayKey(T0); // 2026-09-04
+  const detFile = join(detDir, `${today}.jsonl`);
+  const aggFile = join(aggDir, "2026-09-03.jsonl");
+  const todayDetail = { ...A2_LEGACY_DETAIL, time: T0 - HOUR, day: today };
+  const todayCounter = { ...A2_LEGACY_COUNTER, time: T0 - HOUR, day: today };
+  const legacyDetailBytes = `${JSON.stringify(todayDetail)}\n${JSON.stringify(todayCounter)}\n`;
+  writeFileSync(detFile, legacyDetailBytes);
+  writeFileSync(aggFile, `${JSON.stringify(A2_LEGACY_AGG)}\n`);
+  // 同日并存形态：过去日明细分片为压实残留（升级前崩溃于写聚合后、删明细前），
+  // 聚合权威 → start 自愈删除（残留明细不双算；残留行同样无 dir 键）
+  const residueFile = join(detDir, "2026-09-03.jsonl");
+  writeFileSync(residueFile, `${JSON.stringify(A2_LEGACY_DETAIL)}\n${JSON.stringify(A2_LEGACY_COUNTER)}\n`);
+
+  const warns = [];
+  const tracker = await TrendTracker.start({ root, now: () => T0, flushDebounceMs: 60000, warn: (m) => warns.push(m) });
+  const bPast = tracker.buckets().find((d) => d.day === "2026-09-03");
+  assert.ok(bPast, "旧格式聚合分片重建出过去日内存桶（启动不抛错）");
+  const cellPast = bPast.providers.find((p) => p.provider === "deepseek" && p.model === "deepseek-chat").cell;
+  assert.deepEqual(
+    { input: cellPast.input, output: cellPast.output, cacheRead: cellPast.cacheRead, cacheWrite: cellPast.cacheWrite, calls: cellPast.calls, turns: cellPast.turns, toolCalls: cellPast.toolCalls },
+    { input: 5000, output: 800, cacheRead: 120, cacheWrite: 10, calls: 30, turns: 12, toolCalls: 40 },
+    "过去日 agg 权威行数值与写入值一致",
+  );
+  const cellToday = tracker.buckets().find((d) => d.day === today).providers[0].cell;
+  assert.deepEqual(
+    { input: cellToday.input, output: cellToday.output, cacheRead: cellToday.cacheRead, cacheWrite: cellToday.cacheWrite, calls: cellToday.calls, turns: cellToday.turns, toolCalls: cellToday.toolCalls },
+    { input: 1200, output: 300, cacheRead: 45, cacheWrite: 6, calls: 1, turns: 1, toolCalls: 1 },
+    "当日旧格式明细/计数行重建数值与写入值一致",
+  );
+  assert.deepEqual(warns, [], "旧格式行（无 dir 键）全量通过校验，无坏行告警");
+  assert.equal(existsSync(residueFile), false, "过去日残留明细分片被聚合权威自愈删除（不双算）");
+  assert.equal(readFileSync(detFile, "utf8"), legacyDetailBytes, "当日旧 detail 分片文件逐字节不变（rebuild 不重写）");
+  assert.equal(readFileSync(aggFile, "utf8"), `${JSON.stringify(A2_LEGACY_AGG)}\n`, "旧 agg 分片文件不变（persisted 行 flush 不重写）");
+  await tracker.dispose();
+  assert.equal(readFileSync(detFile, "utf8"), legacyDetailBytes, "dispose 最终刷盘后旧 detail 分片仍逐字节不变");
+}
+
+{
+  // A2(b)：自愈压实路径——过去日明细无聚合分片（旧格式行无 dir 键）→ start 触发自愈，
+  // 新写聚合分片数值正确、明细分片已删（该路径本来就会重写，断言重写产物而非原文件保留）。
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-a2-heal-"));
+  const aggDir = join(root, "agg");
+  const detDir = join(root, "details");
+  mkdirSync(detDir, { recursive: true });
+  writeFileSync(join(detDir, "2026-09-03.jsonl"), `${JSON.stringify(A2_LEGACY_DETAIL)}\n${JSON.stringify(A2_LEGACY_COUNTER)}\n`);
+  const warns = [];
+  const tracker = await TrendTracker.start({ root, now: () => T0, flushDebounceMs: 60000, warn: (m) => warns.push(m) });
+  const b = tracker.buckets().find((d) => d.day === "2026-09-03");
+  assert.ok(b, "旧格式明细重建进内存（不抛错）");
+  const cell = b.providers.find((p) => p.provider === "deepseek" && p.model === "deepseek-chat").cell;
+  assert.equal(cell.calls, 1, "明细权威：calls = 明细行数");
+  assert.equal(cell.turns, 1, "counter 行 turns 重建");
+  assert.equal(cell.toolCalls, 1, "counter 行 toolCalls 重建");
+  assert.equal(cell.input, 1200, "input 与明细值一致");
+  assert.equal(cell.output, 300, "output 与明细值一致");
+  assert.equal(cell.cacheRead, 45, "cacheRead 与明细值一致");
+  assert.equal(cell.cacheWrite, 6, "cacheWrite 与明细值一致");
+  assert.equal(existsSync(join(aggDir, "2026-09-03.jsonl")), true, "自愈压实写出聚合分片");
+  assert.equal(existsSync(join(detDir, "2026-09-03.jsonl")), false, "明细分片压实后删除");
+  const aggRows = (await new TrendStore({ root }).readAggShard("2026-09-03"));
+  assert.equal(aggRows.length, 1, "压实产物恰一行（同 provider+model 折叠）");
+  assert.deepEqual(
+    { input: aggRows[0].input, output: aggRows[0].output, cacheRead: aggRows[0].cacheRead, cacheWrite: aggRows[0].cacheWrite, calls: aggRows[0].calls, turns: aggRows[0].turns, toolCalls: aggRows[0].toolCalls },
+    { input: 1200, output: 300, cacheRead: 45, cacheWrite: 6, calls: 1, turns: 1, toolCalls: 1 },
+    "压实产物数值与明细写入值一致（自愈不丢数不补造）",
+  );
+  assert.deepEqual(warns, [], "旧格式行全量通过校验，无坏行告警");
+  await tracker.dispose();
+}
+
+{
+  // A2(c)：round-trip——旧格式行经 rebuild → flushNow → 重读分片：行数不增不减、
+  // 原字段值不变、detail/counter 行不被补造 dir 键（当日明细重建路径）。
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-a2-roundtrip-"));
+  const detDir = join(root, "details");
+  mkdirSync(detDir, { recursive: true });
+  const detFile = join(detDir, `${dayKey(T0)}.jsonl`); // 当日明细（rebuild(true) 路径）
+  const legacyTodayDetail = { ...A2_LEGACY_DETAIL, time: T0 - HOUR, day: dayKey(T0) };
+  const legacyTodayCounter = { ...A2_LEGACY_COUNTER, time: T0 - HOUR, day: dayKey(T0) };
+  const legacyTodayDetail2 = { ...A2_LEGACY_DETAIL, time: T0 - 2 * HOUR, day: dayKey(T0), session: "旧会话-乙", turn: 1, step: 1, input: 50, output: 20, cacheRead: 3, cacheWrite: 4 };
+  const originalBytes = `${JSON.stringify(legacyTodayDetail)}\n${JSON.stringify(legacyTodayCounter)}\n${JSON.stringify(legacyTodayDetail2)}\n`;
+  writeFileSync(detFile, originalBytes);
+  const tracker = await TrendTracker.start({ root, now: () => T0, flushDebounceMs: 60000 });
+  const cell = tracker.buckets().find((d) => d.day === dayKey(T0)).providers[0].cell;
+  assert.equal(cell.calls, 2, "内存重建 calls = 旧明细行数");
+  assert.equal(cell.turns, 1, "内存重建 turns");
+  assert.equal(cell.toolCalls, 1, "内存重建 toolCalls");
+  assert.equal(cell.input, 1250, "内存重建 input 求和（1200+50）");
+  assert.equal(cell.output, 320, "内存重建 output 求和（300+20）");
+  await tracker.flushNow();
+  assert.equal(readFileSync(detFile, "utf8"), originalBytes, "flushNow 后分片逐字节不变（重建行 persisted=true 不二次落盘）");
+  const back = await new TrendStore({ root }).readDetailShard(dayKey(T0));
+  assert.equal(back.length, 3, "重读行数不增不减（3 行旧格式行全量读回）");
+  assert.deepEqual(
+    back.map((r) => ({ kind: r.kind, session: r.session, time: r.time, provider: r.provider, model: r.model, input: "input" in r ? r.input : undefined, turns: "turns" in r ? r.turns : undefined })),
+    [
+      { kind: "detail", session: "旧会话-甲", time: T0 - HOUR, provider: "deepseek", model: "deepseek-chat", input: 1200, turns: undefined },
+      { kind: "counter", session: "旧会话-甲", time: T0 - HOUR, provider: "deepseek", model: "deepseek-chat", input: undefined, turns: 1 },
+      { kind: "detail", session: "旧会话-乙", time: T0 - 2 * HOUR, provider: "deepseek", model: "deepseek-chat", input: 50, turns: undefined },
+    ],
+    "原字段值经读回不变（中文会话 id/数值逐字段一致）",
+  );
+  assert.ok(back.every((r) => !("dir" in r)), "旧格式行不被补造 dir 键（无 dir → 内存重建后落盘形态仍无 dir）");
+  await tracker.dispose();
+}
+
+{
+  // A2(d)：未知键容忍——detail 行附加未知字段 legacyFlag:"x" 不被拒绝、不抛错，
+  // 其余行正常重建（isValidShardRow 无键白名单遍历，未知键不参与校验 = 通过；
+  // 未知键随 JSON.parse 保留在行对象上，rebuild 只累加已知数值字段，无影响）。
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-a2-unknown-"));
+  const detDir = join(root, "details");
+  mkdirSync(detDir, { recursive: true });
+  const withUnknown = { ...A2_LEGACY_DETAIL, legacyFlag: "x" };
+  writeFileSync(join(detDir, "2026-09-03.jsonl"), `${JSON.stringify(withUnknown)}\n${JSON.stringify(A2_LEGACY_COUNTER)}\n`);
+  const warns = [];
+  const tracker = await TrendTracker.start({ root, now: () => T0, flushDebounceMs: 60000, warn: (m) => warns.push(m) });
+  const cell = tracker.buckets().find((d) => d.day === "2026-09-03").providers[0].cell;
+  assert.equal(cell.calls, 1, "未知键行不拒绝：calls 正常重建");
+  assert.equal(cell.input, 1200, "未知键行数值正常重建");
+  assert.deepEqual(warns, [], "未知键行不触发坏行告警");
+  await tracker.dispose();
+}
+
+{
+  // A2 补充：dir 值域防御仍是有效防线（与「未知键容忍」正交）——dir 为空字符串/
+  // 非字符串时按坏行拒绝并告警，同分片合法行不受连坐（A1 校验语义不因 A2 放宽回退）。
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-a2-dirguard-"));
+  const warns = [];
+  const store = new TrendStore({ root, warn: (m) => warns.push(m) });
+  mkdirSync(join(root, "details"), { recursive: true });
+  const good = { ...A2_LEGACY_DETAIL, dir: "proj" };
+  const badEmptyDir = { ...A2_LEGACY_DETAIL, session: "s-bad-1", dir: "" };
+  const badNumDir = { ...A2_LEGACY_DETAIL, session: "s-bad-2", dir: 7 };
+  writeFileSync(join(root, "details", "2026-09-03.jsonl"), [good, badEmptyDir, badNumDir].map((r) => JSON.stringify(r)).join("\n") + "\n");
+  const rows = await store.readDetailShard("2026-09-03");
+  assert.equal(rows.length, 1, "空串/非字符串 dir 按坏行拒绝（A1 值域防线不回退）");
+  assert.equal(rows[0].session, "旧会话-甲", "保留的是合法行");
+  assert.equal(warns.length, 2, "两个非法 dir 行均告警");
+}
+
 assert.equal(sumToken(null, 5), 5, "sumToken null+数字");
 assert.equal(sumToken(null, null), null, "sumToken null+null");
 console.log("unit-trend: all assertions passed");

--- a/packages/dsh-provider-usage/test/unit-trend.test.ts
+++ b/packages/dsh-provider-usage/test/unit-trend.test.ts
@@ -18,6 +18,8 @@
  * - 交叉：P0-1 HistoryStore.pruneAll 不误删 trend 分片
  * - tracker：启动重建（聚合权威）/ 过去日明细自愈 / 当日明细防二次落盘 /
  *   防抖刷盘 / dispose await 刷盘 / 日切压实与重启不双算 / 迟到旧日行合并防覆盖
+ * - 复核 M1（#633）：混存分片重启重建 dirDays 恢复（dir 行真读回）/ 自愈压实
+ *   dir 行 pending 同源折算不丢 / pruneDays 联动删除 dirDays
  * - config：trendRetentionDays 归一化
  */
 import { mkdtempSync, existsSync, readFileSync, writeFileSync, mkdirSync, utimesSync, rmdirSync } from "node:fs";
@@ -1482,6 +1484,92 @@ const A2_LEGACY_AGG = {
   assert.equal(rows.length, 995, "995 条明细行全量落盘");
   assert.ok(rows.filter((r) => r.session === "s1").every((r) => r.dir === "scale"), "dir 落盘值逐行正确（抽查 s1 全量）");
   console.error(`[#633 A4 量级基线] 1000 事件/5 session：start=${startMs}ms dispose=${disposeMs}ms（resolveCwd=5，995 行落盘）；取数时点 ${new Date().toISOString()} node ${process.version}`);
+}
+
+{
+  // M1(a)：复核 M1 修复——混存分片（agg+dir）重启重建后内存 dirDays 恢复：
+  // rebuildFromDisk 走 readAggDayShard 真读回 dir 行（经 rebuild dir 分支进
+  // dirDays，该分支由死分支变可达）；dir 行不进 cells/pending（防双计语义不变）。
+  // dirDays 当前无查询面消费，恢复断言走白盒（tracker.aggregator.dirDays）+
+  // cells 行为面锚定（读回不双算）。
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-m1-rebuild-"));
+  let nowMs = T0;
+  let tracker = await TrendTracker.start({
+    root,
+    now: () => nowMs,
+    flushDebounceMs: 60000,
+    resolveCwd: (session) => (session === "s1" ? "/home/u/alpha" : "/home/u/beta"),
+  });
+  tracker.handleEvent({ id: "s1" }, ev("request/header", HEADER(), T0, 1));
+  tracker.handleEvent({ id: "s1" }, ev("assistant/chunk", USAGE(10, 5), T0, 2));
+  tracker.handleEvent({ id: "s1" }, ev("turn/end", { turn: 1, reason: { kind: "completed" } }, T0, 3));
+  tracker.handleEvent({ id: "s2" }, ev("request/header", HEADER(), T0, 4));
+  tracker.handleEvent({ id: "s2" }, ev("tool/call", { turn: 1, step: 1, callId: "c", name: "bash", arguments: "{}" }, T0, 5));
+  tracker.handleEvent({ id: "s2" }, ev("assistant/chunk", USAGE(7, 7), T0, 6));
+  nowMs = T0 + 24 * HOUR;
+  await tracker.flushNow(); // 压实：agg+dir 混存落盘、明细分片删除
+  await tracker.dispose();
+  tracker = await TrendTracker.start({ root, now: () => nowMs, flushDebounceMs: 60000, resolveCwd: () => undefined });
+  const dirMap = tracker.aggregator.dirDays.get(DAY0);
+  assert.ok(dirMap, "重启重建：dirDays 恢复该日目录桶（M1 修复前恒空）");
+  assert.deepEqual(
+    [...dirMap.entries()].map(([dir, c]) => ({ dir, input: c.input, output: c.output, cacheRead: c.cacheRead, cacheWrite: c.cacheWrite, calls: c.calls, turns: c.turns, toolCalls: c.toolCalls })),
+    [
+      { dir: "alpha", input: 10, output: 5, cacheRead: 0, cacheWrite: 0, calls: 1, turns: 1, toolCalls: 0 },
+      { dir: "beta", input: 7, output: 7, cacheRead: 0, cacheWrite: 0, calls: 1, turns: 0, toolCalls: 1 },
+    ],
+    "dirDays 恢复值与分片 dir 行逐字段一致（读回不丢不变形）",
+  );
+  const cell = tracker.buckets().find((d) => d.day === DAY0).providers[0].cell;
+  assert.deepEqual(
+    { input: cell.input, output: cell.output, calls: cell.calls, turns: cell.turns, toolCalls: cell.toolCalls },
+    { input: 17, output: 12, calls: 2, turns: 1, toolCalls: 1 },
+    "dir 行读回不双算进 cells（agg 行权威，calls=2 而非 4）",
+  );
+  assert.equal(tracker.aggregator.stats().pendingRows, 0, "dir 行不进 pending（不二次落盘）");
+  await tracker.dispose();
+}
+
+{
+  // M1(b)：复核 M1 修复——自愈压实路径 dir 行为 + pruneDays 联动删除。
+  // 自愈：过去日明细（含 dir）无聚合分片 → start 重建 + rollupDay 压实；dir 折算
+  // 同源走 pending 行（takeDirUnpersisted 不过滤 persisted），重建行折算不丢——
+  // 维持「rebuild 明细/计数分支不进 dirDays」图纸口径即可（M1 处置方案留痕）。
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-m1-heal-"));
+  const day1 = "2026-09-03";
+  const detDir = join(root, "details");
+  mkdirSync(detDir, { recursive: true });
+  writeFileSync(join(detDir, `${day1}.jsonl`), [
+    JSON.stringify({ v: 1, kind: "detail", time: T0 - 24 * HOUR, day: day1, session: "sx", turn: 1, step: 1, retry: 1, provider: "p", model: "m", dir: "heal", input: 7, output: 3, cacheRead: null, cacheWrite: null, calls: 1 }),
+    JSON.stringify({ v: 1, kind: "counter", time: T0 - 24 * HOUR, day: day1, session: "sx", provider: "p", model: "m", dir: "heal", turns: 1, toolCalls: 1 }),
+    "",
+  ].join("\n"));
+  const tracker = await TrendTracker.start({ root, now: () => T0, flushDebounceMs: 60000 });
+  assert.deepEqual(
+    (await new TrendStore({ root }).readAggDayShard(day1)).filter((r) => r.kind === "dir"),
+    [{ v: TREND_ROW_VERSION, kind: "dir", day: day1, dir: "heal", input: 7, output: 3, cacheRead: null, cacheWrite: null, calls: 1, turns: 1, toolCalls: 1 }],
+    "自愈压实：dir 行从 pending 重建行同源折算，calls/turns/toolCalls 不丢",
+  );
+  assert.equal(tracker.aggregator.dirDays.has(day1), false, "rebuild 明细/计数分支不进 dirDays（图纸口径，压实折算不双算）");
+  assert.equal(tracker.buckets().find((d) => d.day === day1).providers[0].cell.calls, 1, "自愈重建 cells 行为不变");
+  await tracker.dispose();
+
+  // pruneDays 联动（单元面）：dirDays 与 days 同生命周期，cutoff 前日桶同步删除
+  // （M1 修复前只删 days，dirDays 泄漏有界但违背同生命周期口径）。
+  const agg = new TrendAggregator();
+  agg.rebuild(
+    [
+      { v: 1, kind: "agg", day: day1, provider: "p", model: "m", input: 1, output: null, cacheRead: null, cacheWrite: null, calls: 1, turns: 0, toolCalls: 0 },
+      { v: 1, kind: "dir", day: day1, dir: "stale", input: 1, output: null, cacheRead: null, cacheWrite: null, calls: 1, turns: 0, toolCalls: 0 },
+      { v: 1, kind: "agg", day: DAY0, provider: "p", model: "m", input: 2, output: null, cacheRead: null, cacheWrite: null, calls: 1, turns: 0, toolCalls: 0 },
+      { v: 1, kind: "dir", day: DAY0, dir: "keep", input: 2, output: null, cacheRead: null, cacheWrite: null, calls: 1, turns: 0, toolCalls: 0 },
+    ],
+    false,
+  );
+  assert.equal(agg.pruneDays(DAY0), 1, "pruneDays 返回 days 侧删除日数（语义不变）");
+  assert.equal(agg.days.has(day1), false, "pruneDays：cutoff 前 days 日桶删除");
+  assert.equal(agg.dirDays.has(day1), false, "pruneDays：dirDays 联动删除（与 dropPending 对称）");
+  assert.equal(agg.dirDays.get(DAY0)?.get("keep")?.input, 2, "cutoff 内 dirDays 日桶不受连坐");
 }
 
 assert.equal(sumToken(null, 5), 5, "sumToken null+数字");

--- a/packages/dsh-provider-usage/test/unit-trend.test.ts
+++ b/packages/dsh-provider-usage/test/unit-trend.test.ts
@@ -930,6 +930,116 @@ function writeAggShardLine(row) {
   assert.equal(normalizeConfig({ trendRetentionDays: 30 }).trendRetentionDays, 30, "合法透传");
 }
 
+// ---------------------------------------------------------------- #633 A1 补全：dir 落盘映射与 resolveCwd 契约接线
+
+{
+  // A1(a)：per-session 惰性单查——同 session 多次 emit 事件（call 定稿/校正/counter/
+  // 新 turn call），resolveCwd 恰查询 1 次（结果缓存进会话状态）
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-dir-once-"));
+  const cwdCalls = [];
+  const tracker = await TrendTracker.start({
+    root,
+    now: () => T0,
+    flushDebounceMs: 60000,
+    resolveCwd: (session) => {
+      cwdCalls.push(session);
+      return "/home/u/project-a";
+    },
+  });
+  tracker.handleEvent({ id: "s1" }, ev("request/header", HEADER(), T0, 1));
+  tracker.handleEvent({ id: "s1" }, ev("assistant/chunk", USAGE(10, 5), T0, 2)); // call 定稿（首次查询）
+  tracker.handleEvent({ id: "s1" }, ev("assistant/chunk", USAGE(11, 6), T0, 3)); // 同 fold 校正
+  tracker.handleEvent({ id: "s1" }, ev("tool/call", { turn: 1, step: 1, callId: "c", name: "bash", arguments: "{}" }, T0, 4)); // counter
+  tracker.handleEvent({ id: "s1" }, ev("turn/end", { turn: 1, reason: { kind: "completed" } }, T0, 5)); // counter
+  tracker.handleEvent({ id: "s1" }, ev("request/header", HEADER(), T0, 6));
+  tracker.handleEvent({ id: "s1" }, ev("assistant/chunk", { turn: 2, step: 1, chunk: { type: "usage", usage: { inputTokens: 3, outputTokens: 3 } } }, T0, 7)); // 新 turn call
+  await tracker.flushNow();
+  assert.deepEqual(cwdCalls, ["s1"], "同 session 多次 emit 事件，resolveCwd 恰查询 1 次");
+  assert.equal(tracker.stats().unpersistedRows, 0, "事件正常入账（2 call + 2 counter）");
+  await tracker.dispose();
+}
+
+{
+  // A1(b)：resolveCwd 返回 undefined（store 无该 session / cwd 缺失）或抛错 →
+  // 归 TREND_UNIDENTIFIED 且各自仅查询 1 次（未识别结果同样缓存，防重复查询）
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-dir-miss-"));
+  const counts = { s1: 0, s2: 0 };
+  const tracker = await TrendTracker.start({
+    root,
+    now: () => T0,
+    flushDebounceMs: 60000,
+    resolveCwd: (session) => {
+      counts[session] = (counts[session] ?? 0) + 1;
+      if (session === "s1") return undefined;
+      throw new Error("boom");
+    },
+  });
+  tracker.handleEvent({ id: "s1" }, ev("request/header", HEADER(), T0, 1));
+  tracker.handleEvent({ id: "s1" }, ev("assistant/chunk", USAGE(10, 5), T0, 2));
+  tracker.handleEvent({ id: "s1" }, ev("turn/end", { turn: 1, reason: { kind: "completed" } }, T0, 3));
+  tracker.handleEvent({ id: "s2" }, ev("request/header", HEADER(), T0, 4));
+  tracker.handleEvent({ id: "s2" }, ev("assistant/chunk", USAGE(7, 7), T0, 5));
+  tracker.handleEvent({ id: "s2" }, ev("tool/call", { turn: 1, step: 1, callId: "c", name: "bash", arguments: "{}" }, T0, 6));
+  await tracker.flushNow();
+  assert.equal(counts.s1, 1, "undefined 路径仅查询 1 次");
+  assert.equal(counts.s2, 1, "抛错路径仅查询 1 次");
+  const rows = readFileSync(join(root, "details", `${dayKey(T0)}.jsonl`), "utf8").trimEnd().split("\n").map((l) => JSON.parse(l));
+  assert.equal(rows.find((r) => r.kind === "detail" && r.session === "s1").dir, TREND_UNIDENTIFIED, "undefined → 未识别桶");
+  assert.equal(rows.find((r) => r.kind === "detail" && r.session === "s2").dir, TREND_UNIDENTIFIED, "抛错 → 未识别桶");
+  await tracker.dispose();
+}
+
+{
+  // A1(c)：resolveCwd 返回含路径分隔符/尾斜杠的 cwd → 落盘为 sanitizeDirName
+  // 净化后的 basename（数据层即存净化值，B1 可区分性约定）
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-dir-sanitize-"));
+  const tracker = await TrendTracker.start({
+    root,
+    now: () => T0,
+    flushDebounceMs: 60000,
+    resolveCwd: () => "/home/u/my proj/v2/",
+  });
+  tracker.handleEvent({ id: "s1" }, ev("request/header", HEADER(), T0, 1));
+  tracker.handleEvent({ id: "s1" }, ev("assistant/chunk", USAGE(10, 5), T0, 2));
+  tracker.handleEvent({ id: "s1" }, ev("turn/end", { turn: 1, reason: { kind: "completed" } }, T0, 3));
+  await tracker.flushNow();
+  const rows = readFileSync(join(root, "details", `${dayKey(T0)}.jsonl`), "utf8").trimEnd().split("\n").map((l) => JSON.parse(l));
+  const detail = rows.find((r) => r.kind === "detail");
+  const counter = rows.find((r) => r.kind === "counter");
+  assert.equal(detail.dir, "v2", "detail 行 dir = basename 净化值（尾斜杠剥除取末段）");
+  assert.equal(counter.dir, "v2", "counter 行 dir 同口径");
+  assert.ok(!detail.dir.includes("/"), "落盘 dir 不含路径分隔符");
+  await tracker.dispose();
+}
+
+{
+  // A1(d)：落盘 detail/counter 行均含 dir 字段且值正确（多 session 各自归属不串桶）
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-dir-persist-"));
+  const tracker = await TrendTracker.start({
+    root,
+    now: () => T0,
+    flushDebounceMs: 60000,
+    resolveCwd: (session) => (session === "s1" ? "/home/u/alpha" : "/home/u/beta"),
+  });
+  tracker.handleEvent({ id: "s1" }, ev("request/header", HEADER(), T0, 1));
+  tracker.handleEvent({ id: "s1" }, ev("assistant/chunk", USAGE(10, 5), T0, 2));
+  tracker.handleEvent({ id: "s1" }, ev("turn/end", { turn: 1, reason: { kind: "completed" } }, T0, 3));
+  tracker.handleEvent({ id: "s2" }, ev("request/header", HEADER(), T0, 4));
+  tracker.handleEvent({ id: "s2" }, ev("assistant/chunk", USAGE(7, 7), T0, 5));
+  tracker.handleEvent({ id: "s2" }, ev("turn/end", { turn: 1, reason: { kind: "completed" } }, T0, 6));
+  await tracker.flushNow();
+  const rows = readFileSync(join(root, "details", `${dayKey(T0)}.jsonl`), "utf8").trimEnd().split("\n").map((l) => JSON.parse(l));
+  const dS1 = rows.find((r) => r.kind === "detail" && r.session === "s1");
+  const dS2 = rows.find((r) => r.kind === "detail" && r.session === "s2");
+  const cS1 = rows.find((r) => r.kind === "counter" && r.session === "s1");
+  const cS2 = rows.find((r) => r.kind === "counter" && r.session === "s2");
+  assert.equal(dS1.dir, "alpha", "s1 detail 行 dir=alpha");
+  assert.equal(dS2.dir, "beta", "s2 detail 行 dir=beta（多 session 不串桶）");
+  assert.equal(cS1.dir, "alpha", "s1 counter 行 dir=alpha");
+  assert.equal(cS2.dir, "beta", "s2 counter 行 dir=beta");
+  await tracker.dispose();
+}
+
 assert.equal(sumToken(null, 5), 5, "sumToken null+数字");
 assert.equal(sumToken(null, null), null, "sumToken null+null");
 console.log("unit-trend: all assertions passed");


### PR DESCRIPTION
## 概要

issue #633（用量统计按工作目录区分）按降粒度链拆片实施，本 PR 为**分片 a**：数据链路（spec A 节 A1-A4）与 D1 报告生成链路回归用例。分支 task/633a，共 7 commits，全部工作在独立 worktree 完成，主 checkout 未触碰。

## 全量断言表

> 结论三态与 spec-writer 条目分级对齐（PASS / BLOCKED / UNVERIFIABLE）；证据为测试文件行号断言 + 命令退出码。

| 验收条目 | 结论 | 证据或漂移解释 |
|---|---|---|
| A1 cwd 归属获取与缓存 [硬性] | PASS | `test/unit-trend.test.ts:188` 归属缺失入未识别桶（TREND_UNIDENTIFIED，不静默丢弃）；`:965` store 无 session/获取抛错时同样缓存且查询计数 ≤1/session；`:1480` 1000 事件/5 session 场景 resolveCwd 恰 5 次（per-session 惰性单查）；A4(f) `:1427` 含 dir 记账后 buckets()/seriesDays() 查询面零变化（既有 day×provider×model 聚合数值不变） |
| A2 存量数据兼容割接（旧数据缺 cwd 键不退化） [硬性] | PASS | `test/unit-trend.test.ts:1096`（A2a）旧格式分片启动重建不抛错、两日数值与写入一致、同日残留明细聚合权威自愈删除不双算、当日旧分片逐字节不变；`:1178`（A2c）round-trip：不丢行、不改写原值、不补造 dir 键；`:1214`（A2d）未知键容忍不拒绝不告警；`:1231` dir 值域防御不回退（空串/非字符串 dir 仍按坏行拒收） |
| A3 子代理会话同目录归并 [硬性] | PASS | `test/unit-trend.test.ts:1251`（A3a）双 session 同 cwd 全链路 apply → 压实产物归并同一目录桶（shared 桶 2 calls，不按会话拆分）；`:1298`（A3b）dir 汇总行 rebuild 只进目录维度桶、不与 cells 双算 |
| A4 数据路径开销 [量级参考] | PASS | 无逐事件同步磁盘 IO：归属查询走 per-session 缓存、dir 落盘为 session 级映射 + 日级 dir 汇总分片（不逐事件记）。基线实测三要素——取数时点 2026-09-07T15:38:10Z；环境 node v24.19.0（worktree task/633a）；口径 = resolveCwd 调用数与落盘行数。基线数据：1000 事件/5 session → start=0ms dispose=4ms（resolveCwd=5，995 行落盘）；五连门禁复跑确认（时点 2026-09-07T16:12:06.186Z，同口径）：start=1ms dispose=2ms（resolveCwd=5，995 行落盘）。量级用例 `test/unit-trend.test.ts:1459`（stderr 一行留痕） |
| D1 旧数据无 cwd 键回归用例 [硬性] | PASS | spec 三条链路：启动重建、统计/趋势查询由 `test/unit-trend.test.ts:1096-1229`（A2 用例）覆盖；报告生成链路本片补齐——`test/unit-report.test.ts:703-773`：旧格式（无 cwd/dir 键）分片 fixture 经 TrendTracker.start 重建 → buckets() 查询 → buildStatsSnapshot + generateReport 全链路不抛错；快照含 byDirectory 且未识别桶（dir=TREND_UNIDENTIFIED）计入正确数值（`:738`，窗口外 dir 行不计、旧格式日无 dir 事实不补造）；既有 byProvider/byDay/totals/派生维度与无 dir 维度时完全一致（`:755`，零回归）；{stats} 注入面含未识别桶、dir 键与 provider/model 同口径剥控制字符 + 截断 80 字符 |
| 复核闸 M1：dirDays 生命周期三合一（注释矛盾 + prune 联动 + rebuild 死分支） [复核修复] | PASS | `test/unit-trend.test.ts`（M1a）混存分片（agg+dir）→ 重启重建 → 内存 dirDays 恢复逐字段断言 + cells 不双算（calls=2 而非 4）+ dir 行不进 pending；（M1b）自愈压实路径 dir 行为断言 + pruneDays 联动删除/保留断言。修复：rebuildFromDisk 改走 readAggDayShard 真读回 dir 行（dir 分支由死分支变可达）；自愈路径核实结论——rollupDay 的 dir 折算源是 takeDirUnpersisted（pending 行同源、不过滤 persisted），非 dirDays，明细 rebuild(true) 的 dir 行折算不丢，故维持「明细/计数分支不进 dirDays」图纸口径（最小正确方案：零代码改动 + 测试锁定）；pruneDays 补 dirDays.delete 联动（与 dropPending 对称）；注释统一（aggregator dirDays 字段四段生命周期口径 / retokenCell L1 按 persisted 可区分改写、裁定不变 / store readAggDayShard 重建描述对齐 / types TREND_DIR_MAX=256 补 NAME_MAX 255 字节→字符推导，L4）。查询面既有行为零变化（buckets/series 断言不变），未动 .github/、package.json、pnpm-lock.yaml、shared/ |
| 复核闸 L1+L4 注释/推导改写 [复核修复] | PASS | 随 M1 commit 落地：retokenCell 注释按「PendingEntry.persisted 可区分 apply 产行（false，已入 dirDays）与重建行（true，不进）」实况改写，结论不变（dirDays 无查询面、权威数据只从 pending 行折算，统一不同步）；TREND_DIR_MAX=256 注释补「NAME_MAX 限 255 字节、JS 字符串按码元计长、255 字节 ≤ 255 字符 < 256 留 1 安全余量」推导 |

五连门禁：`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 全绿（链式退出码 0）。M1 修复 commit（`cf1573a`）后复跑五连：build 0 错、test 8 包全 Done、contract / pack:check / typecheck 退出码均 0。

## 分片说明

覆盖 spec（A-D 节）的 a 片部分：

- A 节全部（A1-A4）：数据链路 cwd 维度——collector 归属获取 + per-session 缓存、aggregator dir 落盘映射、内存 dirDays 日桶、日汇总 dir 行生成与压实合并（mergeDirRows、混存 round-trip）；
- D1：报告生成链路回归用例（补齐第三条链路）。快照新增 byDirectory 为**加性可选数据面**——`dirRows` 可选输入、缺省空数组不补造桶（与 A2「旧格式零变化」口径一致），runner 接线与三周期模板升级属分片 b。

不在本 PR（属分片 b）：B1-B4（UI 胶囊/趋势/设置页与目录过滤呈现）、C1-C3（byDirectory 完整接线、三周期模板升级、脱敏出口与 README 安全节重估）、D2（smoke 全链路与 dir 过滤 API 围栏断言）。

## 接续说明（三次中断降粒度链）

实施链：实现（A1 首片）→ 固化（A1 补全 + A2 用例）→ 补全（A4 实现 + A3/A4 断言）→ 收官（D1 报告链路 + 五连门禁 + 本 PR）。

commit 清单（7 个）：

1. `82d6a3c` feat(dsh-provider-usage): trend cwd 归属获取与 per-session 缓存（分片 a 首片，A1 待续）
2. `9c88191` feat(dsh-provider-usage): aggregator dir 落盘映射与 resolveCwd 契约接线（A1 补全）
3. `cc24fed` test(dsh-provider-usage): 存量分片 A2 兼容割接回归用例（重建/自愈/round-trip/未知键）
4. `9143928` feat(dsh-provider-usage): trend dir 维度内存态与日汇总行生成（A4）
5. `342b55f` test(dsh-provider-usage): dir 维度归并与日汇总断言（A3+A4）
6. `34a5fe9` feat(dsh-provider-usage): 快照 byDirectory 数据面与旧格式报告链路回归用例（D1）
7. `cf1573a` fix(dsh-provider-usage): dirDays 生命周期补全——rebuild 读回 dir 行、prune 联动与注释统一（复核 M1）

**Partially addresses #633**（分片实施：a 片落实 spec A 节全部 + D1；B/C 节与 D2 属分片 b，故不使用 Closes。）

