### PR TITLE
docs: add dsh-mem0 to documentation

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -10,7 +10,7 @@ A collection of plugins for the **DSH (DeepSeek Harness)** web GUI, distributed 
 install them all at once as a single bundle, or pick individual plugins as needed.
 
 - **Bundle package**: `@wingsky-1/dsh-plugins-all` — install everything in one shot
-  (`dsh-codegraph` is published standalone and not in the bundle; see plugin list below)
+  (`dsh-codegraph` and `dsh-mem0` are published standalone and not in the bundle; see plugin list below)
 - **Individual plugins**: `@wingsky-1/dsh-*` — install only what you need
 
 ## Core advantages
@@ -59,9 +59,10 @@ This plugin set only adapts to **rc (release-candidate) releases of DeepSeek Har
 | `@wingsky-1/dsh-web-file-preview` | Web-side preview for conversation file links: images (lightbox zoom) / Markdown (with Mermaid diagram rendering) / code (25+ languages highlighted) / text / git Diff / sandboxed HTML preview (iframe sandbox, no script execution); @-mention recognition + path fallback search (unique basename match inside the workspace when the referenced path is wrong) | [README](packages/dsh-web-file-preview/README.md) · [Architecture](docs/architecture/dsh-web-file-preview.md) | Published |
 | `@wingsky-1/dsh-verify-isolated` | Isolated-environment browser verification skill for DSH plugin development: temp DSH_HOME + independent profile + independent port + independent browser instance (four-way isolation), one-command launch with automatic cleanup; bundled zero-dependency raw-CDP browser driver (snapshot / click / screenshot / eval), optional isolation audit | [README](packages/dsh-verify-isolated/README.md) · [Architecture](docs/architecture/dsh-verify-isolated.md) | Published |
 | `@wingsky-1/dsh-codegraph` | codegraph local code-graph MCP + worktree development discipline: 8 wrapper tools (impact / call chains / symbol search / file structure, etc.); queries force a sync first to guarantee index freshness and auto-complete projectPath; registered at runtime via mcp-manager | [README](packages/dsh-codegraph/README.md) · [Architecture](docs/architecture/dsh-codegraph.md) | Published (standalone, not in the bundle) |
+| `@wingsky-1/dsh-mem0` | DSH long-term memory system plugin: local/lightweight persistent memory based on mem0, native Git workspace awareness, all-English tool contracts, Chinese sedimentation and conflict resolution, 'Memory Center' management dashboard in the settings page. | [README](packages/dsh-mem0/README.en.md) · [Architecture](packages/dsh-mem0/docs/architecture-evolution.md) | Published (standalone, not in the bundle) |
 
-> **Standalone note**: `@wingsky-1/dsh-codegraph` is published **standalone** and is **not
-> included in `dsh-plugins-all`**; install it separately (it registers the codegraph MCP at
+> **Standalone note**: `@wingsky-1/dsh-codegraph` and `@wingsky-1/dsh-mem0` are published **standalone** and are **not
+> included in `dsh-plugins-all`**; install them separately as needed (`dsh-codegraph` registers the codegraph MCP at
 > runtime via mcp-manager, so install `dsh-mcp-manager` or the bundle first).
 
 <details>
@@ -90,7 +91,6 @@ dsh plugin --profile web remove @wingsky-1/dsh-idle-archive
 dsh plugin --profile web remove @wingsky-1/dsh-subagent-model-inherit
 ```
 
-> dsh-memory (project long-term memory) is not included yet; it is planned.
 
 **Legacy packages (published historically, no longer distributed)**:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 DSH（DeepSeek Harness）Web GUI 插件集，npm 分发：一键装全家桶，或按需单装。
 
-- 聚合包：`@wingsky-1/dsh-plugins-all`（一键装齐全部插件；`dsh-codegraph` 独立发包、不在聚合包内，见下文插件列表）
+- 聚合包：`@wingsky-1/dsh-plugins-all`（一键装齐全部插件；`dsh-codegraph` 与 `dsh-mem0` 独立发包、不在聚合包内，见下文插件列表）
 - 单插件：`@wingsky-1/dsh-*`（按需安装）
 
 ## 核心优势
@@ -47,10 +47,10 @@ DSH（DeepSeek Harness）Web GUI 插件集，npm 分发：一键装全家桶，�
 | `@wingsky-1/dsh-web-file-preview` | 对话文件链接 web 端预览：图片（灯箱缩放）/ Markdown（含 Mermaid 图表渲染）/ 代码（25+ 语言高亮）/ 文本 / git Diff / HTML 沙箱预览（iframe sandbox 不执行脚本）；@ 引用识别 + 路径兜底搜索（引用路径写错时按 basename 在工作区内唯一匹配） | [README](packages/dsh-web-file-preview/README.md) · [架构图解](docs/architecture/dsh-web-file-preview.md) | 已发布 |
 | `@wingsky-1/dsh-verify-isolated` | DSH 插件开发的隔离环境浏览器验证 skill：临时 DSH_HOME + 独立 profile + 独立端口 + 独立浏览器实例四重隔离，一键拉起、退出自动清理；自带 raw CDP 零依赖浏览器驱动（快照/点击/截图/求值），可选隔离审计 | [README](packages/dsh-verify-isolated/README.md) · [架构图解](docs/architecture/dsh-verify-isolated.md) | 已发布 |
 | `@wingsky-1/dsh-codegraph` | codegraph 本地代码图谱 MCP + worktree 开发纪律：8 个封装工具（影响面/调用链/符号搜索/文件结构等），查询前强制 sync 保证索引新鲜、projectPath 自动补全；经 mcp-manager 运行时注册 | [README](packages/dsh-codegraph/README.md) · [架构图解](docs/architecture/dsh-codegraph.md) | 已发布（独立发包，暂不进聚合包） |
+| `@wingsky-1/dsh-mem0` | DSH 长期记忆系统插件：基于 mem0 的本地/轻量持久记忆，原生感知 Git 工作空间，全英文工具契约，中文沉淀与冲突消解，设置页「记忆中心」管理大盘。 | [README](packages/dsh-mem0/README.md) · [架构演进](packages/dsh-mem0/docs/architecture-evolution.md) | 已发布（独立发包，暂不进聚合包） |
 
-> **独立发包说明**：`@wingsky-1/dsh-codegraph` 为**独立发包**、**未包含在
-> `dsh-plugins-all` 聚合包中**，需单独安装（它经 mcp-manager 运行时注册 codegraph MCP，
-> 请先装 `dsh-mcp-manager` 或聚合包再配合使用）。
+> **独立发包说明**：`@wingsky-1/dsh-codegraph` 与 `@wingsky-1/dsh-mem0` 为**独立发包**、**未包含在
+> `dsh-plugins-all` 聚合包中**，需单独按需安装（`dsh-codegraph` 经 mcp-manager 运行时注册 codegraph MCP，请先装 `dsh-mcp-manager` 或聚合包再配合使用）。
 
 <details>
 <summary><b>历史维护与迁移</b>——已停止维护的包、旧包迁移指引（装过旧包/退役包的用户请展开）</summary>
@@ -75,7 +75,6 @@ dsh plugin --profile web remove @wingsky-1/dsh-idle-archive
 dsh plugin --profile web remove @wingsky-1/dsh-subagent-model-inherit
 ```
 
-> dsh-memory（项目长期记忆）暂未包含，规划中。
 
 **旧包迁移（历史上发布过、现已不再分发）**：
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -24,6 +24,7 @@
 | `@wingsky-1/dsh-web-file-preview` | 点击对话文件链接在 web 端预览：图片/文本/Markdown/代码/Diff/HTML | [dsh-web-file-preview.md](dsh-web-file-preview.md) |
 | `@wingsky-1/dsh-codegraph` | codegraph MCP + worktree 开发纪律（依赖 mcp-manager 运行时注册） | [dsh-codegraph.md](dsh-codegraph.md) |
 | `@wingsky-1/dsh-verify-isolated` | 插件开发隔离浏览器验证 skill（临时 DSH_HOME + 独立 profile） | [dsh-verify-isolated.md](dsh-verify-isolated.md) |
+| `@wingsky-1/dsh-mem0` | mem0 长期记忆系统（基于本地轻量持久记忆，原生感知 Git 工作空间，中文沉淀） | [architecture-evolution.md](../../packages/dsh-mem0/docs/architecture-evolution.md) |
 | `@wingsky-1/dsh-plugins-all` | 全家桶聚合包（一键装齐 + 聚合 cordis patch） | [dsh-plugins-all.md](dsh-plugins-all.md) |
 
 ## 全景：插件如何挂载进 dsh web
@@ -40,6 +41,7 @@ flowchart LR
         P5["dsh-web-file-preview"]
         P6["dsh-codegraph"]
         P7["dsh-verify-isolated"]
+        P8["dsh-mem0"]
     end
 
     subgraph profile["dsh web profile（cordis 运行时）"]
@@ -59,6 +61,7 @@ flowchart LR
     P5 --> CORDIS
     P6 --> CORDIS
     P7 --> CORDIS
+    P8 --> CORDIS
 
     P6 -. "inject 强依赖 ctx.mcpManager" .-> P2
     P2 -. "提供 ctx.mcpManager service" .-> P6


### PR DESCRIPTION
Fixes documentation inconsistency by properly listing the newly published `@wingsky-1/dsh-mem0` plugin across `README.md`, `README.en.md`, and the architecture documentation.

---
*PR created automatically by Jules for task [6187839650928386310](https://jules.google.com/task/6187839650928386310) started by @wingsky-1*