### PR TITLE
fix(dsh-provider-usage): trend 压实消费改按身份快照，修复 await 窗口丢行与删除失败双算

### DIFF
--- a/packages/dsh-provider-usage/src/trend/aggregator.ts
+++ b/packages/dsh-provider-usage/src/trend/aggregator.ts
@@ -84,7 +84,7 @@ export class TrendAggregator {
   /**
    * #633 A3：day → dir → cell（目录维度日汇总内存态）。
    * 生命周期与 days 同步（复核 P1-1 统一口径）：apply 实时累加 → rebuild 的
-   * dir 汇总行与明细/计数行（有 dir 键者）双向读回 → dropPending 不删（与
+   * dir 汇总行与明细/计数行（有 dir 键者）双向读回 → 压实消费不删（与
    * cells 同策略，跨天后目录查询面历史柱不失——dirRows 纯内存无分片回读）
    * → prune 同步收缩（pruneDays 联动删除）。
    * 权威口径（复核 P1-1）：dirDays 是目录维度的唯一事实源——apply 平行累加 +
@@ -465,97 +465,98 @@ export class TrendAggregator {
   }
 
   /**
-   * 取走给定日的目录维度未压实行快照（#633 A4 压实素材，纯读不消费）。
-   * flush 压实两步式安全序：纯计算行 → IO → 成功后才 dropPending(day)（联动消费）。
-   * 同源折算：与 rollupRowsOf 遍历同一批 pending 行，按 row.dir 分桶；dir 键缺失的
-   * 行（旧格式/无归属）不产 dir 行——目录维度为加性可选键，缺键 = 无 dir 事实可
-   * 折叠（未识别桶由 collector 显式归桶产生，不在折算侧补造；旧格式日压实产物
-   * 与 #633 前形态一致，A2「旧格式零变化」口径）。
+   * 给定日的目录维度折算行（读侧投影；#633 A4）。
+   * 实现委托 {@link rollupSnapshot}——与压实路径共用同一份折算逻辑，保证「读侧
+   * 看到的行」与「压实写入的行」永远同源（单一事实源，防两套实现漂移）。
    */
   takeDirUnpersisted(day: string): TrendDirRow[] {
-    const byDir = new Map<string, TrendDirRow>();
-    for (const p of this.pending) {
-      if (p.row.day !== day) continue;
-      if (p.row.dir === undefined) continue;
-      const dir = p.row.dir;
-      let agg = byDir.get(dir);
-      if (agg === undefined) {
-        agg = { v: TREND_ROW_VERSION, kind: "dir", day, dir, input: null, output: null, cacheRead: null, cacheWrite: null, calls: 0, turns: 0, toolCalls: 0 };
-        byDir.set(dir, agg);
-      }
-      if (p.row.kind === "detail") {
-        agg.calls += 1;
-        agg.input = sumToken(agg.input, p.row.input);
-        agg.output = sumToken(agg.output, p.row.output);
-        agg.cacheRead = sumToken(agg.cacheRead, p.row.cacheRead);
-        agg.cacheWrite = sumToken(agg.cacheWrite, p.row.cacheWrite);
-      } else {
-        agg.turns += p.row.turns;
-        agg.toolCalls += p.row.toolCalls;
-      }
-    }
-    return [...byDir.values()];
+    return this.rollupSnapshot(day).dirRows;
   }
 
   /**
-   * 日切压实（纯计算）：把给定日的明细/计数行折叠为聚合行返回，**不从 pending 移除**。
-   * 供 flush 压实路径「先算 → IO → 成功后才消费」的安全序使用（IO 失败内存行保留）。
-   * cells 不动（apply 时已累加，压实只做落盘形态转换，绝不二次累加）。
+   * 压实快照（#654）：一次遍历同时产出「该日 pending 行的身份快照」与「同源折算的
+   * agg / dir 行」。
+   *
+   * 为什么必须同源：压实是「折算 → 落盘 → 消费」三段式，中间隔着若干 await。若消费
+   * 时按日键重新查询（旧 dropPending(day) 的实现），await 期间新到达的同日行既没被
+   * 折算、也没落盘，却会被连带删除（永久丢行 + 内存/磁盘漂移）。这里返回的 consumed
+   * 与 aggRows/dirRows 出自同一批行，调用方持久化成功后只消费 consumed——新到达的行
+   * 留待下一轮压实。
+   *
+   * 折算口径与 #633 A4 一致：dir 键缺失的行只进 agg 行（目录维度为加性可选键，
+   * 缺键 = 无 dir 事实可折叠，不在折算侧补造）。cells/dirDays 不动（apply 时已累加，
+   * 压实只做落盘形态转换，绝不二次累加）。
    */
-  rollupRowsOf(day: string): TrendAggRow[] {
-    const byKey = new Map<string, TrendAggRow>();
+  rollupSnapshot(day: string): { consumed: PendingEntry[]; aggRows: TrendAggRow[]; dirRows: TrendDirRow[] } {
+    const consumed: PendingEntry[] = [];
+    const aggByKey = new Map<string, TrendAggRow>();
+    const dirByKey = new Map<string, TrendDirRow>();
     for (const p of this.pending) {
       if (p.row.day !== day) continue;
+      consumed.push(p);
       const row = p.row;
-      const key = `${row.provider}\u0000${row.model ?? ""}`;
-      let agg = byKey.get(key);
+      const aggKey = `${row.provider}\u0000${row.model ?? ""}`;
+      let agg = aggByKey.get(aggKey);
       if (agg === undefined) {
-        agg = {
-          v: TREND_ROW_VERSION,
-          kind: "agg",
-          day,
-          provider: row.provider,
-          model: row.model,
-          input: null,
-          output: null,
-          cacheRead: null,
-          cacheWrite: null,
-          calls: 0,
-          turns: 0,
-          toolCalls: 0,
-        };
-        byKey.set(key, agg);
+        agg = emptyAggRow(day, row.provider, row.model);
+        aggByKey.set(aggKey, agg);
+      }
+      let dirAgg: TrendDirRow | undefined;
+      if (row.dir !== undefined) {
+        dirAgg = dirByKey.get(row.dir);
+        if (dirAgg === undefined) {
+          dirAgg = emptyDirRow(day, row.dir);
+          dirByKey.set(row.dir, dirAgg);
+        }
       }
       if (row.kind === "detail") {
-        agg.calls += 1;
-        agg.input = sumToken(agg.input, row.input);
-        agg.output = sumToken(agg.output, row.output);
-        agg.cacheRead = sumToken(agg.cacheRead, row.cacheRead);
-        agg.cacheWrite = sumToken(agg.cacheWrite, row.cacheWrite);
+        addDetailTo(agg, row);
+        if (dirAgg !== undefined) addDetailTo(dirAgg, row);
       } else {
-        agg.turns += row.turns;
-        agg.toolCalls += row.toolCalls;
+        addCounterTo(agg, row.turns, row.toolCalls);
+        if (dirAgg !== undefined) addCounterTo(dirAgg, row.turns, row.toolCalls);
       }
     }
-    return [...byKey.values()];
+    return { consumed, aggRows: [...aggByKey.values()], dirRows: [...dirByKey.values()] };
   }
 
   /**
-   * 消费给定日的 pending 行（压实 IO 全部成功后调用；cells 不动）。
-   * 复核 P1-1：dirDays 不再联动删除（含过去日）——目录查询面（dirRows 纯内存
-   * 快照）无分片回读，删桶 = 跨天历史柱全 null（常驻运行期实测 Day0 空柱）；
-   * 压实事实已固化在 dir 分片 + dirDays，pending 行删除只影响明细/计数素材，
-   * dir 维度不丢（与 cells 同策略：只随 pruneDays 收缩）。today 参数保留
-   * （调用方语义锚点 + 与 rollupDay 透传约定兼容；当前无消费逻辑）。
+   * 给定日的折算聚合行（读侧投影；纯读不消费）。
+   * 实现委托 {@link rollupSnapshot}——与压实路径共用同一份折算逻辑（单一事实源）。
+   */
+  rollupRowsOf(day: string): TrendAggRow[] {
+    return this.rollupSnapshot(day).aggRows;
+  }
+
+  /**
+   * 按身份消费 pending 行（压实 IO 全部成功后调用；#654）。
+   * 只删除传入快照（{@link rollupSnapshot} 的 consumed）内的 entry——await 期间新到达
+   * 的同日行不在快照内，保留到下一轮压实。空数组为 no-op，重复 entry 幂等。
+   *
+   * cells/dirDays 不动（压实只做落盘形态转换，绝不二次累加）。复核 P1-1：dirDays 亦
+   * 不随消费联动删除——目录查询面（dirRows 纯内存快照）无分片回读，删桶 = 跨天历史
+   * 柱全 null；压实事实已固化在 dir 分片 + dirDays，只随 pruneDays 收缩。
+   */
+  consume(entries: readonly PendingEntry[]): void {
+    if (entries.length === 0) return;
+    const doomed = new Set(entries);
+    this.pending = this.pending.filter((p) => !doomed.has(p));
+  }
+
+  /**
+   * 按日键消费 pending 行（兼容面）。
+   * @deprecated #654：按日键删除会在压实 await 窗口内连带删除新到达的同日行（丢行），
+   * 不再用于压实路径。新代码请用 {@link rollupSnapshot} + {@link consume}（按身份消费）；
+   * 本方法保留仅为不破坏已发布的公开面，实现已委托为「按日取快照后按身份消费」。
    */
   dropPending(day: string, today: string): void {
     void today;
-    this.pending = this.pending.filter((p) => p.row.day !== day);
+    this.consume(this.pending.filter((p) => p.row.day === day));
   }
 
   /**
    * 裁剪内存日桶（prune 同步收缩，长期运行不重启时 days 有界；cells 随桶整体丢弃）。
-   * #633 复核 M1：dirDays 联动删除（与 dropPending 对称，生命周期与 days 一致；
+   * #633 复核 M1：dirDays 联动删除（与压实消费对称，生命周期与 days 一致；
    * 独立遍历不依赖 days 键集，纯 dir 日桶（无 agg 行的防御形态）也能清）。
    */
   pruneDays(beforeDay: string): number {
@@ -574,17 +575,16 @@ export class TrendAggregator {
 
   /**
    * 日切压实（一步式）：折叠为聚合行返回并从 pending 移除。
-   * 仅供启动自愈等「无并发 IO 失败窗口」的同步场景使用；flush 压实路径
-   * 一律走 rollupRowsOf + dropPending 两步式（IO 失败内存行保留，防丢数）。
+   * 仅供启动自愈等「无并发 IO 失败窗口」的同步场景使用；flush 压实路径一律走
+   * rollupSnapshot + consume 两步式（IO 失败内存行保留，防丢数）。
    * #633 A4：返回混存行——agg 行在前、dir 行在后（writeAggDay 写入约定）。
-   * today 由调用方传入（与 TrendTracker.rebuildFromDisk 的注入时钟同源），
-   * 透传 dropPending（复核 P1-1 后不再影响 dirDays 生命周期，参数保留）。
+   * today 参数保留（与调用方注入时钟同源的语义锚点；消费已不依赖日键，见 consume）。
    */
   rollupDay(day: string, today: string): Array<TrendAggRow | TrendDirRow> {
-    const rows = this.rollupRowsOf(day);
-    const dirRows = this.takeDirUnpersisted(day);
-    this.dropPending(day, today);
-    return [...rows, ...dirRows];
+    void today;
+    const { consumed, aggRows, dirRows } = this.rollupSnapshot(day);
+    this.consume(consumed);
+    return [...aggRows, ...dirRows];
   }
 
   /** 从内存 pending 移除给定日已全部落盘的登记（重启自愈删除明细分片后同步内存视图）。 */
@@ -866,6 +866,56 @@ function firstDayKeyOf(days: Map<string, unknown>): string | null {
     if (first === null || day < first) first = day;
   }
   return first;
+}
+
+/** 空聚合行（压实折算起点；字段与 mergeCell 消费的 agg 行同构）。 */
+function emptyAggRow(day: string, provider: string, model: string | null): TrendAggRow {
+  return {
+    v: TREND_ROW_VERSION,
+    kind: "agg",
+    day,
+    provider,
+    model,
+    input: null,
+    output: null,
+    cacheRead: null,
+    cacheWrite: null,
+    calls: 0,
+    turns: 0,
+    toolCalls: 0,
+  };
+}
+
+/** 空目录汇总行（#633 A4；与 agg 行十数值字段同构，仅键换成 dir）。 */
+function emptyDirRow(day: string, dir: string): TrendDirRow {
+  return {
+    v: TREND_ROW_VERSION,
+    kind: "dir",
+    day,
+    dir,
+    input: null,
+    output: null,
+    cacheRead: null,
+    cacheWrite: null,
+    calls: 0,
+    turns: 0,
+    toolCalls: 0,
+  };
+}
+
+/** 明细行并入聚合/目录汇总行（两者字段同构，同函数复用；null-aware 求和）。 */
+function addDetailTo(agg: TrendAggRow | TrendDirRow, row: TrendDetailRow): void {
+  agg.calls += 1;
+  agg.input = sumToken(agg.input, row.input);
+  agg.output = sumToken(agg.output, row.output);
+  agg.cacheRead = sumToken(agg.cacheRead, row.cacheRead);
+  agg.cacheWrite = sumToken(agg.cacheWrite, row.cacheWrite);
+}
+
+/** 计数行并入聚合/目录汇总行（同上，同函数复用）。 */
+function addCounterTo(agg: TrendAggRow | TrendDirRow, turns: number, toolCalls: number): void {
+  agg.turns += turns;
+  agg.toolCalls += toolCalls;
 }
 
 /** 聚合行并入 cell（重建用；null-aware。agg 与 dir 汇总行十数值字段同构，同函数复用）。 */

--- a/packages/dsh-provider-usage/src/trend/index.ts
+++ b/packages/dsh-provider-usage/src/trend/index.ts
@@ -194,8 +194,9 @@ export class TrendTracker {
       if (day >= today) continue;
       if (this.aggregator.hasUnpersisted(day)) continue; // 上一步失败：留到下轮
       try {
-        const pendingAgg = this.aggregator.rollupRowsOf(day);
-        const pendingDir = this.aggregator.takeDirUnpersisted(day); // #633 A4：dir 汇总行同源折算
+        // #654：折算与消费取同一份身份快照——下面三个 await 期间新到达的同日行既不入
+        // 本次折算、也不被消费，留待下一轮压实（旧实现按日键删除会连带丢掉这些行）。
+        const { consumed, aggRows: pendingAgg, dirRows: pendingDir } = this.aggregator.rollupSnapshot(day);
         // #633 A4：既有聚合分片全量取回（agg+dir 混存）——若仍走 readAggShard（只取
         // agg 行），整日原子重写会把分片内既有 dir 行抹掉；dir 行必须与 pendingDir
         // 合并后一起重写（迟到旧日行二次压实防丢防重）。
@@ -209,8 +210,12 @@ export class TrendTracker {
           pendingDir,
         );
         await this.store.writeAggDay(day, [...aggRows, ...dirRows]); // agg 行在前、dir 行在后（写入约定）
+        // #654：聚合事实落盘后立即按身份消费。若把消费放在 deleteDetailShard 之后，
+        // 删除失败时内存行保留，下一轮会拿「已含本轮值的聚合分片」再 merge 一次 →
+        // 磁盘双算（实测 agg 20/2 vs 内存 10/1）。消费后 pending 不再含该日，下轮不再
+        // 压实；残留的明细分片由重启时的「聚合权威」分支自愈删除。
+        this.aggregator.consume(consumed);
         await this.store.deleteDetailShard(day);
-        this.aggregator.dropPending(day, today);
       } catch (e: unknown) {
         this.warn(`压实失败（${day}）：${e instanceof Error ? e.message : String(e)}`);
       }

--- a/packages/dsh-provider-usage/test/unit-trend.test.ts
+++ b/packages/dsh-provider-usage/test/unit-trend.test.ts
@@ -1685,6 +1685,112 @@ const A2_LEGACY_AGG = {
   );
 }
 
+// ---------------------------------------------------------------- #654 压实快照消费
+
+{
+  // 单元级：rollupSnapshot 的 consumed 与折算行严格同源；consume 只删快照内 entry。
+  const agg = new TrendAggregator();
+  const past = T0 - 24 * HOUR;
+  const pastDay = dayKey(past);
+  const call = (session, input, output) => ({
+    type: "call",
+    record: { time: past, session, turn: 1, step: 1, retry: 1, provider: "p", model: "m", dir: "d", tokens: { input, output, cacheRead: 0, cacheWrite: 0 } },
+  });
+  agg.apply(call("sA", 10, 5));
+  const snap = agg.rollupSnapshot(pastDay);
+  assert.equal(snap.consumed.length, 1, "快照含先到行");
+  assert.deepEqual(snap.aggRows.map((r) => ({ calls: r.calls, input: r.input })), [{ calls: 1, input: 10 }], "折算行只含先到行（同源）");
+  // 模拟压实 await 窗口内到达的同日行
+  agg.apply(call("sB", 7, 7));
+  agg.consume(snap.consumed);
+  assert.equal(agg.stats().pendingRows, 1, "consume 只消费快照内 entry，迟到行保留");
+  assert.equal(agg.stats().unpersistedRows, 1, "迟到行仍未落盘（留待下一轮）");
+  const snap2 = agg.rollupSnapshot(pastDay);
+  assert.equal(snap2.consumed.length, 1, "二次快照含迟到行");
+  assert.deepEqual(snap2.aggRows.map((r) => ({ calls: r.calls, input: r.input })), [{ calls: 1, input: 7 }], "二次折算只含迟到行（不重复折算已消费行）");
+  agg.consume(snap2.consumed);
+  assert.equal(agg.stats().pendingRows, 0, "二次消费后排空");
+  // 边界：空数组 no-op、重复 entry 幂等
+  agg.consume([]);
+  agg.consume([{ row: { kind: "detail" }, persisted: true }]);
+  assert.equal(agg.stats().pendingRows, 0, "空/异物 entry 消费安全（幂等 no-op）");
+}
+
+{
+  // 集成级（#654 竞态）：压实 await 窗口内到达的过去日行不得被连带消费。
+  // 用 gate 卡住 readAggDayShard 的返回，把「迟到行」精确插入 await 窗口内；
+  // 等待用 setImmediate 轮询（不是固定 sleep），符合防 flake 纪律。
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-654-"));
+  const nowMs = T0; // 当日 09-04，迟到行落 09-03（时钟回拨形态）
+  const pastDay = dayKey(T0 - 24 * HOUR);
+  const tracker = await TrendTracker.start({ root, now: () => nowMs, flushDebounceMs: 60000, warn: () => {} });
+  const store = tracker.store;
+  const origReadAggDayShard = store.readAggDayShard.bind(store);
+  let release;
+  const gate = new Promise((r) => { release = r; });
+  let gateHit = false;
+  store.readAggDayShard = async (day) => {
+    const rows = await origReadAggDayShard(day);
+    if (day === pastDay && !gateHit) {
+      gateHit = true;
+      await gate;
+    }
+    return rows;
+  };
+
+  tracker.handleEvent({ id: "sA" }, ev("request/header", HEADER(), T0 - 24 * HOUR, 1));
+  tracker.handleEvent({ id: "sA" }, ev("assistant/chunk", USAGE(10, 5), T0 - 24 * HOUR, 2));
+
+  const flushing = tracker.flushNow();
+  for (let i = 0; i < 2000 && !gateHit; i += 1) await new Promise((r) => setImmediate(r));
+  assert.equal(gateHit, true, "压实已进入 readAggDayShard await 窗口");
+
+  // await 窗口内到达的迟到行（同过去日、未落盘）
+  tracker.handleEvent({ id: "sB" }, ev("request/header", HEADER(), T0 - 24 * HOUR, 3));
+  tracker.handleEvent({ id: "sB" }, ev("assistant/chunk", USAGE(7, 7), T0 - 24 * HOUR, 4));
+  release();
+  await flushing;
+
+  assert.equal(tracker.stats().pendingRows, 1, "迟到行保留在 pending（修复前 dropPending 按日键连带删除 → 0）");
+
+  // 下一轮 flush：迟到行落盘 → 压实 → 两行都进 agg 分片（端到端无丢行）
+  await tracker.flushNow();
+  const aggRows = (await store.readAggDayShard(pastDay)).filter((r) => r.kind === "agg");
+  assert.equal(aggRows.length, 1, "同 (provider,model) 折叠为一行");
+  assert.deepEqual(
+    { calls: aggRows[0].calls, input: aggRows[0].input, output: aggRows[0].output },
+    { calls: 2, input: 17, output: 12 },
+    "先到行 + 迟到行都入账（calls=2 / input=17）",
+  );
+  assert.equal(tracker.stats().pendingRows, 0, "二次压实后 pending 排空");
+  await tracker.dispose();
+}
+
+{
+  // #654 同域：deleteDetailShard 失败不得导致下一轮磁盘双算。
+  // 消费提前到删除之前——聚合事实落盘即消费，残留明细分片留待重启的「聚合权威」自愈。
+  const root = mkdtempSync(join(tmpdir(), "dou-trend-654-del-"));
+  const nowMs = T0;
+  const pastDay = dayKey(T0 - 24 * HOUR);
+  const tracker = await TrendTracker.start({ root, now: () => nowMs, flushDebounceMs: 60000, warn: () => {} });
+  const store = tracker.store;
+  const origDelete = store.deleteDetailShard.bind(store);
+  tracker.handleEvent({ id: "sA" }, ev("request/header", HEADER(), T0 - 24 * HOUR, 1));
+  tracker.handleEvent({ id: "sA" }, ev("assistant/chunk", USAGE(10, 5), T0 - 24 * HOUR, 2));
+  store.deleteDetailShard = async () => { throw new Error("EACCES simulated"); }; // 删除失败，其余步骤成功
+  await tracker.flushNow();
+  assert.equal(tracker.stats().pendingRows, 0, "聚合事实落盘后即消费（不等待删除成功）");
+  store.deleteDetailShard = origDelete;
+  await tracker.flushNow();
+  const aggRows = (await store.readAggDayShard(pastDay)).filter((r) => r.kind === "agg");
+  assert.deepEqual(
+    aggRows.map((r) => ({ calls: r.calls, input: r.input })),
+    [{ calls: 1, input: 10 }],
+    "二次 flush 不双算（消费在删除之前 → 磁盘与内存一致）",
+  );
+  await tracker.dispose();
+}
+
 assert.equal(sumToken(null, 5), 5, "sumToken null+数字");
 assert.equal(sumToken(null, null), null, "sumToken null+null");
 console.log("unit-trend: all assertions passed");


### PR DESCRIPTION
## 关联 issue

Fixes #654

## 问题

`trend` 压实过去日分片是「折算 → 落盘 → 消费」三段式，中间隔着三个 await；而消费侧
`dropPending(day, today)` 按**日键**删除该日全部 pending 行。await 窗口内新到达的
过去日行（时钟回拨 / 回放类事件）既没被折算、也没落盘，却被连带删除：

- 内存 `cells` / `dirDays` 已累加；
- 磁盘 agg 分片不含该行；
- `pending` 清空、明细分片已删除。

结果 = 永久丢行 + 内存/磁盘漂移，重启重建后消失。

同域还发现一处顺序缺陷：`consume` 原先排在 `deleteDetailShard` 之后，删除失败时内存行
保留，下一轮会拿「已含本轮值的聚合分片」再 merge 一次 → **磁盘双算**（实测 agg
`input=20/calls=2` vs 内存 `10/1`）。

## 修法

把消费单位从「日键」改为「本次折算覆盖的身份快照」：

1. 新增 `TrendAggregator.rollupSnapshot(day)`——**一次遍历**同时产出
   `{ consumed, aggRows, dirRows }`，`consumed` 与折算行严格同源（同一遍历、无 await）；
2. 新增 `TrendAggregator.consume(entries)`——按对象身份删除（`Set` 比对），
   await 期间新到达的同日行不在快照内，保留到下一轮压实；
3. `flushInner` 改用 `rollupSnapshot` + `consume`，且**消费提前到 `deleteDetailShard`
   之前**（聚合事实落盘即消费；残留明细分片由重启的「聚合权威」分支自愈删除）；
4. `rollupDay(day, today)` 内部改走同一路径（签名、返回值不变；同步场景无 await 窗口，
   行为等价）；
5. `rollupRowsOf` / `takeDirUnpersisted` 保留为读侧投影，实现委托 `rollupSnapshot`
   ——单一事实源，防两套折算实现漂移；
6. `dropPending(day, today)` **保留**并标记 `@deprecated`，实现委托为「按日取快照后按身份
   消费」——不破坏已发布的公开面（`lib/trend/aggregator.d.ts`）。

### 公开面

零破坏：仅**新增** `rollupSnapshot` / `consume` 两个方法，既有方法签名与语义全部不变
（`dropPending` 保留为 deprecated 兼容面）。

## 验证证据

### 1. 缺陷复现（修复前 / 修复后对照，同一脚本）

```text
修复前：agg input=10/calls=1  cells input=20/calls=2  pendingRows=0   ← 迟到行永久丢失
修复后：agg input=10/calls=1  cells input=20/calls=2  pendingRows=1   ← 迟到行保留，下一轮落盘
```

### 2. 顺序缺陷复现（deleteDetailShard 失败）

```text
修复前：轮1 pending=1（未消费）→ 轮2 agg input=20/calls=2（双算，内存仍 10/1）
修复后：轮1 pending=0（已消费）→ 轮2 agg input=10/calls=1（不双算）
```

### 3. 等价性与性能（真实分片 7000 行回放）

```text
旧实现 rollupRowsOf + takeDirUnpersisted 两次遍历：2.0933 ms/op
新实现 rollupSnapshot 一次遍历（含 consumed 快照）：2.0893 ms/op
aggRows 逐字段一致: true    dirRows 逐字段一致: true
```

### 4. 新增回归用例（`test/unit-trend.test.ts`，+106 行）

- **单元级（确定性）**：`consumed` 与折算行同源；`consume` 只删快照内 entry，迟到行保留；
  二次快照只含迟到行；空数组 / 异物 entry 幂等 no-op。
- **集成级（竞态）**：用 gate 卡住 `readAggDayShard` 返回，把迟到行**精确插入 await 窗口内**
  （等待用 `setImmediate` 轮询，非固定 sleep，符合防 flake 纪律）→ 断言迟到行保留、
  下一轮 flush 后两行都入 agg 分片（`calls=2 / input=17`）。
- **顺序缺陷**：`deleteDetailShard` 抛错 → 断言已消费、二次 flush 不双算。

### 5. 门禁

```text
pnpm build      PASS
pnpm test       PASS（provider-usage 21/21 + 全仓各包）
pnpm typecheck  PASS
pnpm contract   PASS
pnpm pack:check PASS
pnpm verify:npmlayout / aggregate:check / test:scripts /
forbid-src-tests / forbid-homedir-src / docs:check  PASS
```

`src/trend/**` 不在任一 Stryker mutate 段（`stryker.conf.d/dsh-provider-usage-*.json`），
本改动对变异门禁无影响。

无客户端 UI 改动，跳过隔离浏览器实测（按 ISSUE-WORKFLOW §2.4）。

## 遗留（记录在 #654，不在本 PR 修）

- `rebuildFromDisk` 的「聚合权威」分支在 agg 与 details 并存时静默删除明细分片；
  若该分片含压实后新写入的行（时钟回拨 + 删除持续失败 + 崩溃的组合），会丢行。属既有设计
  约定，触发条件罕见，另议。
- `prune()` 未串入 `flushChain`；`forgetPersisted` 全仓零消费者。

## 客户端改动

- [x] **不涉及客户端改动**（未改动 `src/client/**`、`src/client/style.css`、客户端产物 `lib/client.js`）

## 断言表（coder 自断言，待 qa 独立复核）

| 验收条目 | 结论 | 证据 |
|---|---|---|
| [硬性] A1 压实 await 窗口内到达的过去日行不被消费 | PASS | gate 注入竞态后 `stats().pendingRows === 1`；独立复现脚本同值（修复前 `0`） |
| [硬性] A2 迟到行下一轮落盘并计入 agg（无丢无重） | PASS | 第二轮 flush 后 agg `calls=2 / input=17`；重启重建后 cells 一致 |
| [硬性] A3 `deleteDetailShard` 失败时不双算 | PASS | 注入 EACCES 后轮2 agg 仍 `10/1`（修复前 `20/2` vs 内存 `10/1`） |
| [硬性] A4 公开面零破坏 | PASS | `lib/trend/aggregator.d.ts` 仍导出 `dropPending(day, today)`；`rollupDay`/`rollupRowsOf`/`takeDirUnpersisted` 签名与语义不变 |
| [硬性] A5 既有语义不回归 | PASS | `unit-trend.test.ts` 全绿、`smoke.ts` 21/21、全仓 `pnpm test` 绿 |
| [量级] A6 折算性能不劣化 | PASS | 真实分片 7000 行：旧两次遍历 2.0933 ms → 新一次遍历 2.0893 ms；`aggRows`/`dirRows` 逐字段一致 |
