### PR TITLE
fix(dsh-provider-usage): onUsageChunk 补 done 检查，修复 fold 清理后重复记账

### DIFF
--- a/packages/dsh-provider-usage/src/trend/collector.ts
+++ b/packages/dsh-provider-usage/src/trend/collector.ts
@@ -306,7 +306,18 @@ export class TrendCollector {
     const tokens = parseTokens(d.chunk?.usage);
     let fold = state.folds.get(key);
     if (fold === undefined) {
-      fold = { retry: 1, finalized: false };
+      // #655：fold 可能已被 fold TTL 或 turn/end 清理，而定稿记忆 done 仍在（未被
+      // TREND_DONE_MAX 淘汰）。与 onMessage 的已定稿分支对称：无新 header = 同一调用的
+      // 重复/更新块 → 只校正 token、不重记调用；有新 header = 重试 → retry 从记忆值递增
+      // （不回落为 1 造成重号）。
+      const remembered = state.done.get(key);
+      if (remembered !== undefined && !state.headerSeen) {
+        if (tokens !== null) {
+          this.emit({ type: "correct", record: { session, turn, step, retry: remembered, tokens } });
+        }
+        return;
+      }
+      fold = { retry: remembered === undefined ? 1 : remembered + 1, finalized: false };
       state.folds.set(key, fold);
     } else if (fold.finalized) {
       if (!state.headerSeen) {

--- a/packages/dsh-provider-usage/test/unit-trend.test.ts
+++ b/packages/dsh-provider-usage/test/unit-trend.test.ts
@@ -1791,6 +1791,45 @@ const A2_LEGACY_AGG = {
   await tracker.dispose();
 }
 
+// ---------------------------------------------------------------- #655 fold 清理后重复记账
+
+{
+  // fold 被 fold TTL 清理后，同一 fold 键的迟到 usage 不得重复记账（与 onMessage 对称）。
+  // 真实数据形态：同一 (session,turn,step) 的 usage 间隔 13~19 分钟陆续到达，
+  // token 从 0/0 递增到真实值——修复前每次 fold 重建都多记一次 call。
+  let nowT = new Date(2026, 8, 8, 4, 22, 7).getTime();
+  const { emitted, send } = makeCollector(() => nowT);
+  const U = (input, output) => ev("assistant/chunk", { turn: 1, step: 9, chunk: { type: "usage", usage: { inputTokens: input, outputTokens: output } } }, nowT, 1);
+  send("s1", ev("request/header", HEADER("commandcode", "z-ai/glm-5.3-flash"), nowT, 0));
+  send("s1", U(0, 0));
+  nowT += 13 * 60_000; send("s1", U(0, 0));
+  nowT += 13 * 60_000; send("s1", U(0, 0));
+  nowT += 12 * 60_000; send("s1", U(118593, 41240));
+  assert.equal(callsOf(emitted).length, 1, "同一 fold 键只记一次调用（fold 被 TTL 清理后不重记）");
+  const corrects = correctsOf(emitted);
+  assert.equal(corrects.length, 3, "后续迟到 usage 走校正（不重记调用）");
+  assert.deepEqual(
+    corrects[2].tokens,
+    { input: 118593, output: 41240, cacheRead: null, cacheWrite: null },
+    "最后一次校正带真实 token（token 收敛到最新值）",
+  );
+}
+
+{
+  // 反例防线：fold 被清理后若出现新 header，同键 usage 仍按重试递增（不误判为重复块）。
+  let nowT = T0;
+  const { emitted, send } = makeCollector(() => nowT);
+  const U = (input, output) => ev("assistant/chunk", { turn: 1, step: 9, chunk: { type: "usage", usage: { inputTokens: input, outputTokens: output } } }, nowT, 1);
+  send("s1", ev("request/header", HEADER(), nowT, 0));
+  send("s1", U(10, 5));
+  nowT += 13 * 60_000;
+  send("s1", ev("request/header", HEADER(), nowT, 2)); // 重试边界：新 header
+  send("s1", U(20, 6));
+  const calls = callsOf(emitted);
+  assert.equal(calls.length, 2, "新 header 后的同键 usage 记为新一次调用（重试）");
+  assert.equal(calls[1].retry, 2, "retry 从定稿记忆递增为 2（不回落为 1 重号）");
+}
+
 assert.equal(sumToken(null, 5), 5, "sumToken null+数字");
 assert.equal(sumToken(null, null), null, "sumToken null+null");
 console.log("unit-trend: all assertions passed");


### PR DESCRIPTION
## 关联 issue

Fixes #655

## 问题

`src/trend/collector.ts` 的两条定稿路径不对称：

- `onMessage`：先查 `state.done.has(key)`，已定稿则只校正、不重记；
- `onUsageChunk`：`fold === undefined` 时**直接新建 fold 并 emit call**，不查 `done`。

`state.folds` 会被 `lazySweep` 的 `TREND_FOLD_TTL_MS`（10 分钟）或 `onTurnEnd` 的 turn 前缀
清理。清理后同一 `(turn, step)` 的迟到 usage 会重建 fold 并再记一次 call。
（`fold.finalized` 的校正分支提前 return、不更新 `lastFoldTouch`，正是 10 分钟窗口触发的原因。）

真实数据形态（已脱敏）：同一 `(session, turn=1, step=9, retry=1)` 的 4 条明细行 token
依次为 `0/0`、`0/0`、`0/0`、`118593/41240`——同一调用的 usage 更新块被重复计入 calls。

## 修法

`onUsageChunk` 在 `fold === undefined` 时查 `done` 记忆，与 `onMessage` 对称：

- `done` 命中且**无新 header** → 同一调用的重复/更新块 → `emit correct`（只校正 token）；
- `done` 命中且**有新 header** → 重试 → `retry = remembered + 1`（不回落为 1 造成重号）；
- `done` 未命中（`TREND_DONE_MAX` 淘汰）→ 保持原语义（新建 fold，retry=1）。

## 验证

### 复现对照（13 分钟间隔的 4 次 usage，确定性脚本）

```text
修复前：call=2  correct=2
修复后：call=1  correct=3   ← 最后一次 correct 带真实 token
```

### 新增回归用例

- 主用例：同一 fold 键 4 次 usage → 断言 `call=1`、`correct=3`、末次校正带真实 token；
- 反例防线：fold 被清理后出现新 header → 断言 `call=2` 且第二次 `retry=2`。

### 门禁

```text
pnpm build / pnpm test / pnpm typecheck / pnpm contract / pnpm pack:check  全绿
```

无客户端 UI 改动，跳过隔离浏览器实测（按 ISSUE-WORKFLOW §2.4）。

## 客户端改动

- [x] **不涉及客户端改动**（未改动 `src/client/**`、`src/client/style.css`、客户端产物 `lib/client.js`）

## 断言表（coder 自断言，待 qa 独立复核）

| 验收条目 | 结论 | 证据 |
|---|---|---|
| [硬性] B1 fold 被 10 分钟 TTL 清理后不重记 call | PASS | 13 分钟间隔 4 次 usage：`call=1 / correct=3`（修复前 `call=2`） |
| [硬性] B2 fold 被清理后出现新 header 仍按重试递增 | PASS | `call=2` 且第二次 `retry=2`（不回落为 1 重号） |
| [硬性] B3 既有 collector 语义不回归 | PASS | `unit-trend.test.ts` 全绿、`smoke.ts` 21/21 |
