### PR TITLE
feat(dsh-mcp-manager): 阶段1测试基建+配置域——unit-call-stats 双登记接线 + B2/B7/B13/B14/B17 修复

### DIFF
--- a/packages/dsh-mcp-manager/src/call-stats.ts
+++ b/packages/dsh-mcp-manager/src/call-stats.ts
@@ -59,14 +59,20 @@ export class McpStatsCollector {
   /** 更新运行配置（热重载 / 设置同步）。 */
   configure(options: { enabled?: boolean; filePath?: string; logger?: { info?: (msg: string) => void } }): void {
     const prevEnabled = this.enabled;
-    if (options.enabled !== undefined) this.enabled = options.enabled;
+    const nextEnabled = options.enabled ?? prevEnabled;
     if (options.filePath) this.filePath = resolve(options.filePath);
     if (options.logger) this.logger = options.logger;
 
-    if (!prevEnabled && this.enabled) {
-      this.loadExisting();
-    } else if (prevEnabled && !this.enabled) {
+    if (prevEnabled && !nextEnabled) {
+      // B2：关闭前先刷盘——flushSync 以 enabled 为闸，先置 false 会把最后一批
+      // 脏数据短路丢弃（flushSync 内部同样以 isDirty 兜底，无脏数据不写盘）。
       this.flushSync();
+      this.enabled = false;
+    } else {
+      this.enabled = nextEnabled;
+      if (nextEnabled && !prevEnabled) {
+        this.loadExisting();
+      }
     }
   }
 

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -57,7 +57,7 @@ export { panelAnchorForPosition } from "./placement-math.ts";
 
 // 插件契约转发（apply 主流程 + 宣告文本实现于 apply.ts）
 export { apply, MCP_GUIDANCE } from "./apply.ts";
-export { resolveDebugConfig } from "./apply-config.ts";
+export { resolveDebugConfig, resolveMiddlewareMode } from "./apply-config.ts";
 
 // 服务器配置归一化（纯函数单一事实源）
 export { SERVER_NAME_PATTERN, normalizeServer } from "./normalize.ts";

--- a/packages/dsh-mcp-manager/src/middleware-utils.ts
+++ b/packages/dsh-mcp-manager/src/middleware-utils.ts
@@ -88,6 +88,9 @@ export function normalizeToolName(serverName: string, toolName: string, caller =
 /** 归一化 ws_mcp_call 的 arguments 参数（模型可能把参数字典填成 JSON 字符串）。 */
 export function normalizeArguments(raw: unknown): unknown {
   let value: unknown = raw ?? {};
+  // B14：arguments 按 MCP 规范应为 object，数组形态归一无害空态
+  // （含顶层数组入参与 JSON 解包解出数组两种路径）。
+  if (Array.isArray(value)) return {};
   let depth = 0;
   while (typeof value === "string" && depth < 4) {
     const trimmed = value.trim();
@@ -102,7 +105,10 @@ export function normalizeArguments(raw: unknown): unknown {
     } catch {
       break;
     }
-    if (parsed !== null && typeof parsed === "object") return parsed;
+    if (parsed !== null && typeof parsed === "object") {
+      if (Array.isArray(parsed)) return {}; // B14：解包出数组同样拒绝
+      return parsed;
+    }
     const inner = typeof parsed === "string" ? parsed.trim() : "";
     const innerLooksContainer = inner.startsWith("{") || inner.startsWith("[");
     if (!isQuotedJson || !innerLooksContainer) break;

--- a/packages/dsh-mcp-manager/src/normalize.ts
+++ b/packages/dsh-mcp-manager/src/normalize.ts
@@ -30,10 +30,16 @@ export function normalizeServer(input: unknown): ServerConfig {
     if (typeof src.url !== "string" || (src.url as string).trim() === "") {
       throw new Error("streamable-http server requires a url");
     }
+    let parsed: URL;
     try {
-      new URL(src.url as string);
+      parsed = new URL(src.url as string);
     } catch {
       throw new Error(`invalid url: ${src.url}`);
+    }
+    // B13：streamable-http 仅接受 http(s)；ftp/file 等协议可解析但语义不符
+    // （README 口径「streamable-http(远程)」），显式白名单拒绝。
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error(`unsupported protocol: ${parsed.protocol}//`);
     }
   }
   const server: ServerConfig = {

--- a/packages/dsh-mcp-manager/src/routes-controllers.ts
+++ b/packages/dsh-mcp-manager/src/routes-controllers.ts
@@ -81,6 +81,12 @@ export function buildConfigRoute(manager: RoutesManager, helpers: RouteHelpers):
         try {
           const rec = body as Record<string, unknown>;
           if (typeof rec.middleware === "string") {
+            // B7：非法 middleware 显式 400 拒绝——不得静默回落 off 并热切换+落盘
+            // （合法集合与 config-schema z.union 同源，勿只依赖 normalize 兜底）。
+            if (rec.middleware !== "off" && rec.middleware !== "project" && rec.middleware !== "all") {
+              writeJson(res, 400, { error: `invalid middleware mode: ${rec.middleware}` });
+              return;
+            }
             // 中间层模式热切换：先热生效（当前进程立即切换），再落盘（重启保留）。
             if (typeof manager.setMiddlewareMode === "function") {
               await manager.setMiddlewareMode(rec.middleware);

--- a/packages/dsh-mcp-manager/src/store.ts
+++ b/packages/dsh-mcp-manager/src/store.ts
@@ -5,7 +5,7 @@
  * 由 lib/index.js 组合根 re-export。
  */
 
-import { mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { dshHome } from "../../../shared/dsh-home.js";
@@ -60,9 +60,19 @@ export class McpStore {
   async save() {
     const dir = dirname(this.path);
     if (!existsSync(dir)) await mkdir(dir, { recursive: true });
-    const tmp = `${this.path}.tmp`;
-    await writeFile(tmp, JSON.stringify(this.data, null, 2), { encoding: "utf8", mode: 0o600 });
-    await rename(tmp, this.path);
+    // B17：唯一 tmp 名（pid+时间戳）防并发写相互踩踏；失败时清理残留后上抛。
+    const tmp = `${this.path}.tmp.${process.pid}.${Date.now()}`;
+    try {
+      await writeFile(tmp, JSON.stringify(this.data, null, 2), { encoding: "utf8", mode: 0o600 });
+      await rename(tmp, this.path);
+    } catch (error) {
+      try {
+        await rm(tmp, { force: true });
+      } catch {
+        // 清理失败忽略：tmp 可能未创建，或权限问题，主错误优先上抛
+      }
+      throw error;
+    }
     try {
       this.mtimeMs = (await stat(this.path)).mtimeMs;
     } catch {

--- a/packages/dsh-mcp-manager/test/helpers.ts
+++ b/packages/dsh-mcp-manager/test/helpers.ts
@@ -94,3 +94,65 @@ export async function assertNoGrowth(label, measure, baseline, { windowMs = 120,
     await new Promise((r) => setTimeout(r, tickMs));
   }
 }
+
+/**
+ * 伪造 MCP 传输面（统一 mock 面，防各测试自造桩漂移：issue #664 阶段 1 基建）。
+ *
+ * 形态贴合 supervisor/protocol 对 transport 的消费面：
+ * - `sdk`：SDK Client.connect 的连接对象（protocol initialize 透传 `transport.sdk`）；
+ * - `stderrTail`：stdio 启动失败诊断尾巴（protocol initialize 读取）；
+ * - `close()`：fire-and-forget 异步关闭，closeCalls 计数供轮询断言，
+ *   onClose 回调列表随 onClose 触发（supervisor teardownGeneration 语义）。
+ */
+export function fakeTransport(overrides = {}) {
+  const transport = {
+    sdk: {},
+    stderrTail: undefined,
+    closeCalls: 0,
+    onClose: [],
+    async close() {
+      transport.closeCalls += 1;
+      transport.onClose.forEach((cb) => {
+        try {
+          cb();
+        } catch {
+          // 回调抛错与 close 自身抛错语义一致：吞掉不炸 teardown
+        }
+      });
+    },
+  };
+  return Object.assign(transport, overrides);
+}
+
+/**
+ * 伪造 MCPClient（连接监督器的最小执行面）。
+ *
+ * 消费面（supervisor.ts）：initialize() / listTools(cursor?) / callTool(name, args, opts)；
+ * script 可注入各方法返回值（Promise 或同步均可）；`calls` 记录每次调用参数，供
+ * 「调用顺序/参数面」断言（如 B5 代际清理顺序、B18 退避口径）。未注入的默认值：
+ * initialize 返回版本协商素对象、listTools 返回空工具集、callTool 返回文本 content。
+ */
+export function fakeMCPClient(script = {}) {
+  const transport = fakeTransport();
+  const calls = [];
+  const client = {
+    transport,
+    calls,
+    async initialize() {
+      calls.push(["initialize"]);
+      if (script.initialize) return script.initialize();
+      return { protocolVersion: "2024-11-05" };
+    },
+    async listTools(cursor) {
+      calls.push(["listTools", cursor]);
+      if (script.listTools) return script.listTools(cursor);
+      return { tools: [] };
+    },
+    async callTool(name, args, opts) {
+      calls.push(["callTool", name, args, opts]);
+      if (script.callTool) return script.callTool(name, args, opts);
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+  };
+  return client;
+}

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -92,6 +92,8 @@ import "./unit-middleware.test.ts";
 // 缺失期间这两个文件的用例只在 mutation 跑——smoke 门禁从未执行它们）
 import "./unit-manager2.test.ts";
 import "./unit-routes-sse.test.ts";
+// call-stats 统计（#664 阶段 1 双登记接线：原 node:test 零执行孤儿，改造自执行后接入）
+import "./unit-call-stats.test.ts";
 
 const failures = [];
 const check = (label, fn) => {
@@ -1000,6 +1002,12 @@ const main = async () => {
   check("http 缺 url / 非法 url 被拒绝", () => {
     assert.throws(() => normalizeServer({ name: "a", transport: "streamable-http" }));
     assert.throws(() => normalizeServer({ name: "a", transport: "streamable-http", url: "not a url" }));
+  });
+  check("B13: http(s) 之外的协议被拒绝（ftp/file 非 streamable-http）", () => {
+    assert.throws(() => normalizeServer({ name: "a", transport: "streamable-http", url: "ftp://host/path" }), /protocol/, "B13：ftp 协议拒绝");
+    assert.throws(() => normalizeServer({ name: "a", transport: "streamable-http", url: "file:///etc/passwd" }), /protocol/, "B13：file 协议拒绝");
+    assert.doesNotThrow(() => normalizeServer({ name: "a", transport: "streamable-http", url: "https://host/path" }), "https 放行");
+    assert.doesNotThrow(() => normalizeServer({ name: "a", transport: "streamable-http", url: "http://host/path" }), "http 放行");
   });
   check("enabled: false 保留", () => {
     assert.equal(normalizeServer({ name: "a", transport: "stdio", command: "x", enabled: false }).enabled, false);
@@ -2442,16 +2450,6 @@ const main = async () => {
   // ---------- SDK 端到端（issue #11 PoC 契约不漂移证据：真实 stdio 连接 /
   // initialize 版本协商 / 工具注册 / callTool / 断线自动重连，全程无网络）。
 
-  /** 轮询等待条件成立（防 flake 纪律：轮询替代固定 sleep）。 */
-  async function waitFor(label, cond, timeoutMs = 10_000) {
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      if (cond()) return;
-      await new Promise((resolve) => setTimeout(resolve, 25));
-    }
-    throw new Error(`timeout waiting for ${label}`);
-  }
-
   console.log("SDK 端到端连接（连接/工具注册/callTool/断线重连）");
   {
     // 最小 stdio MCP server fixture：node 子进程，行分隔 JSON-RPC，
@@ -2517,12 +2515,13 @@ const main = async () => {
       assert.ok(oldPid > 0);
       process.kill(oldPid, "SIGTERM");
       // 新代际 transport 建立且恢复 connected（旧 pid 不复用即证明发生过重连）。
-      await waitFor("reconnected with new generation", () =>
+      await pollUntil("reconnected with new generation", () =>
         supervisor.status === "connected" &&
         supervisor.transport !== undefined &&
         supervisor.transport.sdk.pid !== undefined &&
         supervisor.transport.sdk.pid !== oldPid &&
         supervisor.tools.length === 1,
+        { timeoutMs: 10_000 },
       );
       assert.ok(registered.length >= 2, "重连后工具重新注册");
       const value = await registered.at(-1).execute({ text: "after reconnect" }, { signal: undefined });

--- a/packages/dsh-mcp-manager/test/unit-apply.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-apply.test.ts
@@ -245,3 +245,30 @@ import { join } from "node:path";
     rmSync(dir, { recursive: true, force: true });
   }
 }
+// ---- resolveMiddlewareMode 三态（issue #664 阶段 1：配置域逻辑归位，C-CFG 契约）----
+
+{
+  const { McpManager, McpStore, resolveMiddlewareMode } = await import("../lib/index.js");
+  const dir = mkdtempSync(join(tmpdir(), "dsh-mcp-manager-mode-"));
+  try {
+    const store = new McpStore(join(dir, "mcp.json"));
+    const manager = new McpManager({ logger: { info: () => {}, warn: () => {} } } as any, store);
+
+    // 态 1：settings 持久化值 = 运行权威（覆盖 schema 默认）
+    manager.uiConfigSource = () => ({ middleware: "all" });
+    assert.equal(resolveMiddlewareMode(manager, "project"), "all", "settings 有值优先于 fallback");
+
+    // 态 2：settings 无值 → fallbackRaw（resolve 侧显式传值）
+    manager.uiConfigSource = () => ({});
+    assert.equal(resolveMiddlewareMode(manager, "off"), "off", "settings 无值回落 fallback");
+    // 态 2b：settings 无值且无 fallback → schema 默认 project（第一启动形态）
+    manager.uiConfigSource = () => ({});
+    assert.equal(resolveMiddlewareMode(manager, undefined), "project", "无 fallback 回落 schema 默认 project");
+
+    // 态 3：settings 非法值 → normalize 回落 off（读取兼容、不迁移写回）
+    manager.uiConfigSource = () => ({ middleware: "bogus" });
+    assert.equal(resolveMiddlewareMode(manager, "project"), "off", "settings 非法值回落 off");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/packages/dsh-mcp-manager/test/unit-call-stats.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-call-stats.test.ts
@@ -1,12 +1,35 @@
-import { test } from "node:test";
+// @ts-nocheck
+/**
+ * dsh-mcp-manager — unit：McpStatsCollector 全形态 + 配置域接线。
+ *
+ * 本文件原为 node:test 零执行孤儿（unit-call-stats.test.ts 不在 smoke import、
+ * 不在任何 stryker testFiles、不在 mutation-topology.json——B2 未被发现的直接
+ * 原因之一）。issue #664 阶段 1 改造为与其余 unit 一致的顶层自执行 + node:assert
+ * 形态，并双登记接线（smoke.ts import + mutation-topology testFiles），
+ * 单份断言同时服务 smoke 与 stryker tap-runner。
+ *
+ * 覆盖：
+ * - 默认关闭：完全无 I/O、零写盘、快照零服务器
+ * - 开启：聚合（total/success/failed + 每工具指标）+ 渐进式披露漏斗 + 原子落盘
+ *   + 进程重启恢复（从已存在文件加载）
+ * - 配置守护：updateUiConfig 不抹除既有 debug 配置
+ * - B2（修复红测）：configure({enabled:false}) 关闭前最后一批脏数据必须刷盘
+ */
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { McpStatsCollector } from "../lib/index.js";
+import { join } from "node:path";
 
-test("McpStatsCollector: 默认关闭时完全无 I/O，不写盘", async () => {
-  const dir = mkdtempSync(join(tmpdir(), "mcp-stats-test-"));
+const { McpStatsCollector } = await import("../lib/index.js");
+
+function tempDir() {
+  return mkdtempSync(join(tmpdir(), "mcp-stats-test-"));
+}
+
+// ---- 默认关闭时完全无 I/O，不写盘 ----
+
+{
+  const dir = tempDir();
   const statsFile = join(dir, "stats.json");
   try {
     const collector = new McpStatsCollector({ enabled: false, filePath: statsFile });
@@ -24,10 +47,12 @@ test("McpStatsCollector: 默认关闭时完全无 I/O，不写盘", async () => 
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
-});
+}
 
-test("McpStatsCollector: 开启时正确聚合调用与渐进式披露指标并原子落盘", async () => {
-  const dir = mkdtempSync(join(tmpdir(), "mcp-stats-test-"));
+// ---- 开启时正确聚合调用与渐进式披露指标并原子落盘 ----
+
+{
+  const dir = tempDir();
   const statsFile = join(dir, "stats.json");
   try {
     const collector = new McpStatsCollector({ enabled: true, filePath: statsFile });
@@ -88,11 +113,13 @@ test("McpStatsCollector: 开启时正确聚合调用与渐进式披露指标并�
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
-});
+}
 
-test("McpManager & routes: 前端 POST /config 不会覆盖抹除已有的 debug 配置", async () => {
+// ---- McpManager & routes: 前端 POST /config 不会覆盖抹除已有的 debug 配置 ----
+
+{
   const { McpManager, McpStore, resolveDebugConfig } = await import("../lib/index.js");
-  const dir = mkdtempSync(join(tmpdir(), "mcp-config-guard-"));
+  const dir = tempDir();
   try {
     const store = new McpStore(join(dir, "mcp.json"));
     const manager = new McpManager({ logger: { info: () => {}, warn: () => {} } } as any, store);
@@ -123,5 +150,29 @@ test("McpManager & routes: 前端 POST /config 不会覆盖抹除已有的 debug
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
-});
+}
 
+// ---- B2 红测：configure({enabled:false}) 关闭前最后一批脏数据必须刷盘 ----
+
+{
+  const dir = tempDir();
+  const statsFile = join(dir, "stats.json");
+  try {
+    const collector = new McpStatsCollector({ enabled: true, filePath: statsFile });
+    collector.recordCall("codegraph", "codegraph_search", 120, true); // 置脏（防抖 1s 未到）
+
+    // 关闭统计：注释承诺「关闭时 flush」，最后一批不得丢
+    collector.configure({ enabled: false });
+
+    assert.equal(collector.isEnabled(), false);
+    assert.equal(
+      existsSync(statsFile),
+      true,
+      "B2：configure 关闭前应刷盘最后一批脏数据（现状 flushSync 因 enabled=false 短路）",
+    );
+    const raw = JSON.parse(readFileSync(statsFile, "utf8"));
+    assert.equal(raw.servers.codegraph.totalCalls, 1, "B2：关闭时最后一批调用计入文件");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/packages/dsh-mcp-manager/test/unit-manager2.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-manager2.test.ts
@@ -18,7 +18,7 @@ import assert from "node:assert/strict";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { pollUntil } from "./helpers.ts";
+import { pollUntil, assertNoGrowth } from "./helpers.ts";
 
 const {
   apply,
@@ -724,7 +724,12 @@ function rmStatSafe(p) {
     fakeMw.units.get(projRoot).userDisabled.add("p2");
     manager.start("p2", "project");
     await pollUntil("projectUnitFor 触达完成", () => calls614.some((c) => c[0] === "projectUnitFor" && c[1] === projRoot));
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    // 反向验证：userDisabled 命中后稳定不连接（观察窗口内持续断言，替代固定 sleep）
+    await assertNoGrowth(
+      "userDisabled命中不连接",
+      () => calls614.filter((c) => c[0] === "ensureConnected" && c[2] === "p2").length,
+      0,
+    );
     assert.ok(!calls614.some((c) => c[0] === "ensureConnected" && c[2] === "p2"), "userDisabled 命中不连接");
     fakeMw.units.get(projRoot).userDisabled.delete("p2");
   } finally {

--- a/packages/dsh-mcp-manager/test/unit-middleware.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.test.ts
@@ -24,6 +24,7 @@ const {
   parseFullServerName,
   normalizeToolName,
   normalizeArguments,
+  createRedactor,
   globMatch,
   policyAllows,
   policyDenialReason,
@@ -94,9 +95,13 @@ function makeHost(serversByRoot = new Map()) {
 {
   assert.deepEqual(normalizeArguments({ a: 1 }), { a: 1 });
   assert.deepEqual(normalizeArguments('{"a":1}'), { a: 1 });
-  assert.deepEqual(normalizeArguments('"[1,2]"'), [1, 2]);
   assert.equal(normalizeArguments("hello"), "hello"); // 标量保留
   assert.deepEqual(normalizeArguments(""), {}); // 空串 → 空对象
+  // B14 红测：arguments 按 MCP 规范应为 object，数组形态一律归一无害空态
+  // （原断言 `'"[1,2]"'` → `[1,2]` 即 B14 泄漏路径，改用拒绝语义）
+  assert.deepEqual(normalizeArguments("[1,2]"), {}, "B14：数组 JSON 不应作为 arguments");
+  assert.deepEqual(normalizeArguments('"[1,2]"'), {}, "B14：引号包裹的数组 JSON 同样拒绝");
+  assert.deepEqual(normalizeArguments([1, 2]), {}, "B14：数组入参拒绝");
 }
 
 // ---- globMatch / policy ----
@@ -917,4 +922,42 @@ function makeHost(serversByRoot = new Map()) {
     assert.equal(fallbackCalls, 0, "fallbackText 惰性：正常 content 路径不调用");
     assert.deepEqual(normal.content, [{ type: "text", text: "ok" }]);
   }
+}
+
+// ---- createRedactor 基线（issue #664 阶段 1：先锁现状整 URL 脱敏；B8 改「仅用户
+// 信息」口径在阶段 2，届时本基线按新契约修订）----
+
+{
+  const redact = createRedactor([
+    {
+      name: "http1",
+      transport: "streamable-http",
+      url: "https://user:pass@example.com/path?token=abc",
+      headers: { Authorization: "Bearer secret-token" },
+      enabled: true,
+    },
+    {
+      name: "stdio1",
+      transport: "stdio",
+      command: "echo",
+      env: { API_KEY: "k-123" },
+      args: ["--token", "tok-456"],
+      enabled: true,
+    },
+  ]);
+
+  const out = redact(
+    new Error("failed connect to https://user:pass@example.com/path?token=abc with Bearer secret-token k-123 tok-456"),
+  );
+
+  // 现状口径（middleware-utils.ts createRedactor L146）：http 分支把整 URL 加入
+  // secrets；env 全值、args 凭据形参、headers 全值同样脱敏。
+  assert.ok(!out.includes("user:pass"), "URL 用户信息脱敏");
+  assert.ok(!out.includes("token=abc"), "URL searchParams 脱敏");
+  assert.ok(!out.includes("secret-token"), "header 值脱敏");
+  assert.ok(!out.includes("k-123"), "env 全值脱敏");
+  assert.ok(!out.includes("tok-456"), "args 凭据形参值脱敏");
+  // 基线锚点：整 URL 全部 [REDACTED]（含无凭据的 host/path，可诊断性差的现状——
+  // B8 修复后此处应保留 host/path 可读，成为差异断言）。
+  assert.ok(!out.includes("example.com"), "基线：整 URL 均被脱敏（阶段 2 B8 改为仅用户信息）");
 }

--- a/packages/dsh-mcp-manager/test/unit-routes-sse.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-routes-sse.test.ts
@@ -386,4 +386,28 @@ const countPing = (res) => (res.state.body.match(/data: \{"type":"ping"\}/g) ?? 
   }
 }
 
+// ---- B7：POST /config 非法 middleware → 400 拒绝（不热切换、不落盘） ----
+
+{
+  const { dir, manager } = setup();
+  try {
+    const uiUpdates: string[] = [];
+    manager.uiUpdate = async (patch: Record<string, unknown>) => {
+      // 记录落盘意图：非法值不得触达（现状会落盘 {middleware:"off"}）
+      uiUpdates.push(String(patch.middleware));
+    };
+    const routes = makeRoutes(manager);
+    const configRoute = routes.find((r) => r.path === ROUTES.config);
+    assert.ok(configRoute, "config 路由存在");
+
+    const res = await callHandler(configRoute, fakeReq("POST", ROUTES.config, { middleware: "bogus" }));
+    assert.equal(res.status, 400, "B7：非法 middleware 应 400 拒绝（现状静默回落 off 并落盘）");
+    assert.match(res.payload.error, /middleware/, "错误文案指明 middleware 非法");
+    assert.equal(manager.middlewareMode, "off", "非法值不改写运行模式");
+    assert.equal(uiUpdates.length, 0, "非法值不触达 uiUpdate（不落盘）");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 console.log("  ok   unit-routes-sse: SSE 帧/健康检查/路由边界");

--- a/packages/dsh-mcp-manager/test/unit-store.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-store.test.ts
@@ -226,4 +226,23 @@ function tempDir() {
   assert.throws(() => parseClaudeJson("{oops"), SyntaxError);
 }
 
+// ---- B17：save 失败时 tmp 残留必须清理（唯一 tmp 名 + 失败清理） ----
+
+{
+  const dir = tempDir();
+  try {
+    // rename 目标为已存在目录 → EISDIR，注入写入失败路径
+    const victimPath = join(dir, "victim");
+    mkdirSync(victimPath);
+    const store = new McpStore(victimPath);
+    store.data = { version: 1, servers: [{ name: "s1", transport: "stdio", command: "echo", enabled: true }] };
+
+    await assert.rejects(() => store.save(), /EISDIR|ENOTEMPTY|EEXIST|EPERM|ENOTDIR/, "save 失败应上抛");
+    assert.equal(existsSync(`${victimPath}.tmp`), false, "B17：save 失败后 tmp 残留应清理（现状固定名 tmp 残留）");
+    assert.equal(existsSync(`${victimPath}.tmp.`), false, "B17：pid 后缀残留同样不应存在");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 console.log("  ok   unit-store: McpStore 全分支 + import 映射");

--- a/scripts/data/mutation-topology.json
+++ b/scripts/data/mutation-topology.json
@@ -93,7 +93,8 @@
         "packages/dsh-mcp-manager/test/unit-routes-sse.test.ts",
         "packages/dsh-mcp-manager/test/unit-store.test.ts",
         "packages/dsh-mcp-manager/test/unit-supervisor.test.ts",
-        "packages/dsh-mcp-manager/test/unit-transport.test.ts"
+        "packages/dsh-mcp-manager/test/unit-transport.test.ts",
+        "packages/dsh-mcp-manager/test/unit-call-stats.test.ts"
       ],
       "segments": {
         "entry": {

--- a/stryker.conf.d/dsh-mcp-manager-entry.json
+++ b/stryker.conf.d/dsh-mcp-manager-entry.json
@@ -48,7 +48,8 @@
       "packages/dsh-mcp-manager/test/unit-routes-sse.test.ts",
       "packages/dsh-mcp-manager/test/unit-store.test.ts",
       "packages/dsh-mcp-manager/test/unit-supervisor.test.ts",
-      "packages/dsh-mcp-manager/test/unit-transport.test.ts"
+      "packages/dsh-mcp-manager/test/unit-transport.test.ts",
+      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts"
     ]
   },
   "jsonReporter": {

--- a/stryker.conf.d/dsh-mcp-manager-manager.json
+++ b/stryker.conf.d/dsh-mcp-manager-manager.json
@@ -46,7 +46,8 @@
       "packages/dsh-mcp-manager/test/unit-routes-sse.test.ts",
       "packages/dsh-mcp-manager/test/unit-store.test.ts",
       "packages/dsh-mcp-manager/test/unit-supervisor.test.ts",
-      "packages/dsh-mcp-manager/test/unit-transport.test.ts"
+      "packages/dsh-mcp-manager/test/unit-transport.test.ts",
+      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts"
     ]
   },
   "jsonReporter": {

--- a/stryker.conf.d/dsh-mcp-manager-middleware.json
+++ b/stryker.conf.d/dsh-mcp-manager-middleware.json
@@ -48,7 +48,8 @@
       "packages/dsh-mcp-manager/test/unit-routes-sse.test.ts",
       "packages/dsh-mcp-manager/test/unit-store.test.ts",
       "packages/dsh-mcp-manager/test/unit-supervisor.test.ts",
-      "packages/dsh-mcp-manager/test/unit-transport.test.ts"
+      "packages/dsh-mcp-manager/test/unit-transport.test.ts",
+      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts"
     ]
   },
   "jsonReporter": {

--- a/stryker.conf.d/dsh-mcp-manager-routes.json
+++ b/stryker.conf.d/dsh-mcp-manager-routes.json
@@ -47,7 +47,8 @@
       "packages/dsh-mcp-manager/test/unit-routes-sse.test.ts",
       "packages/dsh-mcp-manager/test/unit-store.test.ts",
       "packages/dsh-mcp-manager/test/unit-supervisor.test.ts",
-      "packages/dsh-mcp-manager/test/unit-transport.test.ts"
+      "packages/dsh-mcp-manager/test/unit-transport.test.ts",
+      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts"
     ]
   },
   "jsonReporter": {

--- a/stryker.conf.d/dsh-mcp-manager-runtime.json
+++ b/stryker.conf.d/dsh-mcp-manager-runtime.json
@@ -52,7 +52,8 @@
       "packages/dsh-mcp-manager/test/unit-routes-sse.test.ts",
       "packages/dsh-mcp-manager/test/unit-store.test.ts",
       "packages/dsh-mcp-manager/test/unit-supervisor.test.ts",
-      "packages/dsh-mcp-manager/test/unit-transport.test.ts"
+      "packages/dsh-mcp-manager/test/unit-transport.test.ts",
+      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts"
     ]
   },
   "jsonReporter": {

--- a/stryker.conf.d/dsh-mcp-manager-supervisor.json
+++ b/stryker.conf.d/dsh-mcp-manager-supervisor.json
@@ -49,7 +49,8 @@
       "packages/dsh-mcp-manager/test/unit-routes-sse.test.ts",
       "packages/dsh-mcp-manager/test/unit-store.test.ts",
       "packages/dsh-mcp-manager/test/unit-supervisor.test.ts",
-      "packages/dsh-mcp-manager/test/unit-transport.test.ts"
+      "packages/dsh-mcp-manager/test/unit-transport.test.ts",
+      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts"
     ]
   },
   "jsonReporter": {


### PR DESCRIPTION
Part of #664（分阶段重构 · 阶段 1：测试基建 + 配置域，B2/B7/B13/B14/B17 红测先行）

## 说明

阶段 1 = 测试基建 + 配置域逻辑归位（不动文件）。核心是把零执行孤儿
`unit-call-stats.test.ts` 双登记接线（B2 未被发现的直接原因），并为后续
阶段 2/3 准备标准协议桩。

## 改动

**测试基建（commit `ff916cd`）**
- `unit-call-stats.test.ts`：node:test → 顶层自执行 + node:assert 形态，**双登记**
  （smoke.ts import + mutation-topology testFiles；gen-stryker-conf 重新生成六段，--check 一致）
- `test/helpers.ts`：新增 `fakeTransport` / `fakeMCPClient` 标准协议桩（阶段 2/3 复用）
- `createRedactor` 基线测试（锁现状整 URL 脱敏；B8 改口径在阶段 2 修订）
- `resolveMiddlewareMode` 三态测试（C-CFG 配置演进契约）+ lib 导出面补 re-export
- 防 flake 违例顺手改：unit-manager2 L727 固定 sleep → `assertNoGrowth` 观察窗口；
  smoke 本地 waitFor → 复用 `helpers.pollUntil`
- **红测先行**：B2 configure 关闭丢盘 / B7 非法 middleware 静默回落 / B13 非 http(s)
  协议被接受 / B14 数组 JSON 当 arguments / B17 save 失败 tmp 残留

**修复（commit `5f10fa3`）**
- B2 `call-stats.configure({enabled:false})` 先刷盘再关闭（flushSync 以 enabled 为闸）
- B7 POST /config 非法 middleware → **400 拒绝**（不再静默回落 off 并热切换+落盘）
- B13 normalizeServer streamable-http 协议白名单（http/https 之外拒绝）
- B14 normalizeArguments 数组形态归一无害空态
- B17 store.save 唯一 tmp 名（pid+时间戳）+ 失败清理残留

## 验证

- 红测确认红（5 项均复现现状错误行为）→ 修复后全绿
- 本地门禁全绿：`pnpm build && pnpm test && pnpm contract && pnpm pack:check &&
  pnpm typecheck` + `gen-stryker-conf --check`（21 份配置与拓扑严格一致）
- 测试落盘全部 mkdtempSync 隔离；无固定 sleep 违例残留

### 客户端改动截图证据（勾选式）

- [x] **不涉及客户端改动**（未改动 `src/client/**`、`src/client/style.css`、客户端产物 `lib/client.js`）
