### PR TITLE
feat(gate): D10 目录 interface.ts 门面静态检查（verify-dir-imports 接入 contract）

### DIFF
--- a/packages/dsh-mcp-manager/docs/architecture-contract.md
+++ b/packages/dsh-mcp-manager/docs/architecture-contract.md
@@ -118,6 +118,7 @@
 | config-schema 跨域常量 | catalog/supervisor 域类型化单向 import | DEFAULT_ANNOUNCE_CATALOG / DEFAULT_RESULT_TRUNCATE_BYTES，保持 config→下游单向 |
 | catalogViewFor 私有缓存 | catalog 域（宿主最小面） | diskCatalogSummaryCache（mtime 缓存）随迁，薄桥接或最小面 host（阶段 5 先行） |
 | routes.ts:21 组合根类型环 | 改从 `types/ui.ts` 取 | 消除 `import type { ClientUiConfig } from "./index.ts"` 环 |
+| 每目录 `interface.ts`（D10） | 各物理目录根 | 目录唯一对外引用面（re-export 对外类型+函数）；跨目录引用只能走 interface.ts、禁直引实现文件；DTO 仍集中 types/；`verify-dir-imports.mjs` 静态强制（已接入 `pnpm contract`）；阶段 2 起新目录即带、阶段 6 存量补齐 |
 
 - **验证**：目录图与迁移 PR 静态面同步；`gen-stryker-conf --check` 绿。
 - **落位**：阶段 6（集中搬移）；catalogViewFor 条目阶段 5 先行。
@@ -187,6 +188,7 @@
 | D7 | 迁移门禁判分 | **机制决策**：covered 口径已达标（74.66≥60）；迁移 PR 走 observe 夜间重建豁免；日常守 `covered ≥ baseline−1pp`（见 2.5） | 0 决策 + 6 执行 |
 | D8 | off 模式 guard | **补挂载**：guard 与中间层实例解耦、数据源直查 manager.disabledTools、独立注册路径（三模式一致；off 无连接池副作用，guard 只读禁用表） | 4 |
 | D9 | getTools 键形态 | **注册名（`mcp__` 前缀，与 ctx.tools 注册表一致）**；文档化两套键口径（summary().tools=裸名） | 0 决策 + 3 实现 |
+| D10 | 目录解耦形态（维护者追加） | **严格门面**：每物理目录一个 `interface.ts`（对外类型+函数唯一引用面）；跨目录引用只能走 interface.ts、禁直引实现文件；DTO 仍集中 `types/`；`verify-dir-imports.mjs` 静态强制接入 `pnpm contract`；阶段 2 起新目录即带、阶段 6 存量补齐（细则见 C-DIR） | 2 起生效 + 6 补齐 |
 
 ---
 
@@ -194,7 +196,7 @@
 
 1. 本文档成文，且与 `refactor-phase0-spec.md` / `architecture-redesign.md`（v3）无矛盾
    （契约条款为裁决面，冲突以本文档为准并回改规格）；
-2. D1–D9 全部定稿，无 open 决策项（issue #664 已 `approved`，无维护者异议）；
+2. D1–D10 全部定稿，无 open 决策项（issue #664 已 `approved`；D10 由维护者现场拍板）；
 3. 门禁全绿：`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck`
    + `gen-stryker-conf --check`；
 4. PR 关联 issue #664，CI 绿后请求合并（squash）。

--- a/packages/dsh-mcp-manager/docs/architecture-redesign.md
+++ b/packages/dsh-mcp-manager/docs/architecture-redesign.md
@@ -64,12 +64,19 @@ src/client/
 - stryker exclude 同步补 `!src/types/**`（host-faces/middleware-types 不收变异）；
 - `config-schema.ts` 跨域常量（DEFAULT_ANNOUNCE_CATALOG/DEFAULT_RESULT_TRUNCATE_BYTES）改为从 catalog/
   supervisor 域类型化 import（保持单向 config→下游），机制写入契约。
+- **每目录 `interface.ts` 门面（D10）**：每个物理目录提供 `interface.ts`，re-export 目录对外
+  「类型 + 函数」作为该目录唯一对外引用面；跨目录引用只能 import 对方目录的 `interface.ts`，
+  禁直引目录内实现文件（同目录内自由引用）；跨目录共享 DTO 仍集中 `types/`；检查由
+  `scripts/gate/verify-dir-imports.mjs` 静态强制（已接入 `pnpm contract` 门禁）。阶段 2 起新建
+  目录即带 interface.ts，存量文件阶段 6 集中搬移时统一补齐。
 
 ---
 
 ## 三、每层职责与接口契约（7 逻辑层 + 组合根）
 
 > 契约口径：成功签名 + 错误契约 + 事件契约；只列「新增/缺口」项，现状稳定面引用代码。
+> **目录门面规则（D10）**：下述各域（物理目录）均以 `interface.ts` 为唯一对外引用面；
+> 跨域依赖的契约落在 interface.ts 上，实现文件不对外承诺任何引用面。
 
 ### ① 客户端层
 - 契约补齐：SSE 帧集合显式清单（summary/ui-config-changed/ping + 60s watchdog）；未知状态策略（C13 与 B1/B4 六态单 PR 同改）；204 备忘（C14）；tool-disable 全名形态与 projectRoot 缺失防御（C6/C7）；`src/client/index.ts` 保留 + style.css 相对引用路径。
@@ -161,6 +168,7 @@ src/client/
 | D7 | 门禁判分 | ~~先澄清判分输入~~（已闭环：covered 74.66≥60 达标）vs **observe 回落判据（covered<baseline-1pp）+ incremental 重建豁免** | **机制决策**：迁移 PR 走 observe 夜间重建豁免；日常守 covered≥baseline-1pp |
 | D8 | off 模式 guard | 补挂载（数据源 manager.disabledTools，独立注册路径）vs 文档化一入口 | **补挂载**（guard 与中间层实例解耦，三模式一致） |
 | D9 | getTools 键形态 | 注册名（mcp__ 前缀，与 ctx.tools 一致）vs 裸名（与 summary().tools 一致） | **注册名**（保持与现状 getTools 一致，文档化两套键口径） |
+| D10 | 目录解耦形态（维护者追加） | 每目录 interface.ts 门面 vs 维持类型集中 | **严格门面**：每物理目录一个 interface.ts（对外类型+函数唯一面）；跨目录引用只能走 interface.ts，禁直引实现文件；DTO 仍集中 types/；verify-dir-imports.mjs 静态强制接入 contract；阶段 2 起生效、阶段 6 存量补齐 |
 
 ---
 

--- a/scripts/gate/contract-check.ts
+++ b/scripts/gate/contract-check.ts
@@ -15,6 +15,7 @@
  * exports["./client"] 存在；src/client.ts ⇒ lib/client.js 产物存在）与报告汇总。
  */
 import { readFileSync, existsSync, readdirSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { assertClientContract } from '../lib/client-contract-lib.ts'
@@ -156,5 +157,16 @@ console.log(failed === 0 ? '客户端契约：全部通过' : `客户端契约�
   const matrixFailed = matrix.problems.length > 0
   if (matrixFailed) failed++ // 仅用于 exit code（汇总行文案在矩阵段前已打印，不受影响）
   console.log(matrixFailed ? `config-matrix | ${matrix.problems.length} 个失败` : 'config-matrix | PASS')
+}
+// D10（issue #664）：目录 interface.ts 门面静态检查——跨目录引用只能走目标目录
+// interface.ts；适用包白名单缺省 dsh-mcp-manager（#664 重构包），client/ 豁免
+// （index.ts 契约锚点）。独立脚本可单独跑；接入本门禁防约束漂移。
+{
+  const dirGate = spawnSync(process.execPath, [join(ROOT, 'scripts/gate/verify-dir-imports.mjs')], { encoding: 'utf8' })
+  for (const line of (dirGate.stdout ?? '').split('\n')) if (line.trim() !== '') console.log(line)
+  if (dirGate.status !== 0) {
+    console.log(`verify-dir-imports | FAIL exit=${dirGate.status}`)
+    failed++
+  }
 }
 process.exit(failed === 0 ? 0 : 1)

--- a/scripts/gate/verify-dir-imports.mjs
+++ b/scripts/gate/verify-dir-imports.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+'use strict'
+
+/**
+ * verify-dir-imports — 目录 interface.ts 门面静态检查（issue #664 D10 决策）。
+ *
+ * 规则（严格模式，维护者拍板）：
+ *   1. 每个 `src/<dir>/` 物理目录若被目录外文件引用，必须提供 `interface.ts`
+ *      （该目录的唯一对外引用面，re-export 目录对外「类型 + 函数」）；
+ *   2. 跨目录 import / export-from 只能解析到目标目录的 `interface.ts`，
+ *      禁止直引目录内实现文件；
+ *   3. 同目录相对 import 放行；`src/` 根文件之间互引暂不约束（阶段 6 集中
+ *      搬移后根只剩汇聚点，两两互引自然消失）；子目录 import 根文件放行
+ *      （阶段 2–5 过渡债，阶段 6 清零后如仍有残余应转硬校验）。
+ *
+ * 豁免：`src/client/`（index.ts 为 build-client 契约锚点，D10 只约束逻辑目录；
+ * 客户端分层在阶段 7 另行处理）；跨包 shared/ 共享层、lib/ 产物、node_modules、
+ * client/ 内部资源（style.css 等非 TS import）不在检查范围。
+ * 适用包白名单：`--package <name>`（可多次）；缺省 = 仅 dsh-mcp-manager
+ * （#664 重构包）。其他包目录形态不在本机制约束内，避免误伤历史结构。
+ *
+ * 用法：node scripts/gate/verify-dir-imports.mjs [--package dsh-mcp-manager] [--verbose]
+ * 退出码：0 = 通过；1 = 存在违规（任一包）。
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const VERBOSE = process.argv.includes('--verbose')
+// 适用包白名单：显式 --package 累加；缺省仅 #664 重构包
+const ARGV = process.argv.slice(2)
+const applyPackages = ARGV.includes('--package')
+  ? ARGV.filter((a, i) => ARGV[i - 1] === '--package')
+  : ['dsh-mcp-manager']
+const failures = []
+const summary = []
+
+/** 递归收集目录下全部 .ts/.tsx 文件（绝对路径）。 */
+function collectTsFiles(dir, acc = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) collectTsFiles(full, acc)
+    else if (/\.tsx?$/.test(entry.name)) acc.push(full)
+  }
+  return acc
+}
+
+/** 解析一个相对 import 目标的绝对路径（支持 .ts/.tsx 后缀与目录 index 落点）。 */
+function resolveTarget(fromFile, spec) {
+  if (!spec.startsWith('.') || isAbsolute(spec)) return null
+  const base = resolve(dirname(fromFile), spec)
+  for (const cand of [base, `${base}.ts`, `${base}.tsx`, join(base, 'index.ts'), join(base, 'index.tsx')]) {
+    if (existsSync(cand) && statSync(cand).isFile()) return cand
+  }
+  return null
+}
+
+for (const pkgName of applyPackages) {
+  const srcDir = join(ROOT, 'packages', pkgName, 'src')
+  if (!existsSync(srcDir)) continue
+  const rel = (p) => relative(join(ROOT, 'packages', pkgName), p)
+
+  // 物理目录集合（不含 src 根本身，豁免 client/——index.ts 为 build-client 契约锚点）
+  const dirSet = new Set()
+  for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name !== 'client') dirSet.add(join(srcDir, entry.name))
+  }
+
+  // 被外部引用的目录 → 必须有 interface.ts
+  const fileToDir = new Map() // 绝对文件路径 → 所属目录（根文件为 null）
+  for (const f of collectTsFiles(srcDir)) {
+    const d = dirname(f)
+    fileToDir.set(f, dirSet.has(d) ? d : null)
+  }
+
+  const importedDirs = new Set()
+  for (const [fromFile, fromDir] of fileToDir) {
+    const absDir = fromDir ?? srcDir // 根文件以 src 本身为边界起点
+    const text = readFileSync(fromFile, 'utf8')
+    // from 子句：import/export-from/dynamic-import 三种形态
+    const re = /(?:import|export)\s[^'"]*?\bfrom\s*['"]([^'"]+)['"]|import\s*\(\s*['"]([^'"]+)['"]\s*\)/g
+    let m
+    while ((m = re.exec(text)) !== null) {
+      const spec = m[1] ?? m[2]
+      const target = resolveTarget(fromFile, spec)
+      if (target === null) continue // 非相对/不存在（node_modules/shared 等）跳过
+      const targetDir = dirname(target)
+      const targetFile = target.split(sep).pop()
+      if (!dirSet.has(targetDir)) continue // client/、跨包/共享/根文件目标，不受目录门面约束
+      importedDirs.add(targetDir)
+      if (targetDir === absDir) continue // 同目录相对 import 放行
+      const dirName = relative(srcDir, targetDir).split(sep)[0]
+      if (targetFile !== 'interface.ts') {
+        failures.push(
+          `[${pkgName}] ${rel(fromFile)} → import "${spec}"（${dirName}/${targetFile}）：跨目录引用必须走 ${dirName}/interface.ts`,
+        )
+      }
+    }
+  }
+  // 被外部引用却无 interface.ts 的目录
+  for (const d of importedDirs) {
+    if (!existsSync(join(d, 'interface.ts'))) {
+      failures.push(`[${pkgName}] src/${relative(srcDir, d)}/ 被目录外引用但缺少 interface.ts（该目录唯一对外面）`)
+    }
+  }
+  summary.push(`${pkgName}: ${fileToDir.size} 个 src TS 文件、${dirSet.size} 个目录`)
+}
+
+for (const line of summary) console.log(`verify-dir-imports | ${line}`)
+if (failures.length > 0) {
+  console.log(`verify-dir-imports | FAIL ${failures.length} 条目录门面违规：`)
+  for (const f of failures) console.log(`  ${f}`)
+  process.exit(1)
+}
+console.log('verify-dir-imports | PASS（跨目录引用全部走 interface.ts）')
+process.exit(0)


### PR DESCRIPTION
Part of #664（D10 决策落地：目录 interface.ts 门面机制，独立于阶段 2）

## 说明

维护者追加架构约束 D10（已拍板并在 issue #664 评论记录）：**每物理目录一个
`interface.ts` 作为唯一对外引用面**，跨目录引用只能走 interface.ts、禁直引实现
文件，达成层级解耦。本 PR 落地决策文档 + 静态强制检查机制，阶段 2 起随目录建设生效。

## 改动

**文档（commit `d56e50f`）**
- `architecture-redesign.md`：§二破环与收敛清单 + §三契约口径 + §六决策表补 D10
- `architecture-contract.md`：C-DIR 补 interface.ts 行 + 决策定稿表补 D10

**机制（commit `fedeecb`）**
- 新增 `scripts/gate/verify-dir-imports.mjs`：检查「目录被外部引用必有 interface.ts」
  +「跨目录 import 只能走 interface.ts」；适用包白名单缺省 dsh-mcp-manager
  （`--package` 可扩展）；`src/client/` 豁免（index.ts 契约锚点）
- `contract-check.ts` 末尾接入（子进程调用，失败并入 exit code）

## 验证

- 红绿能力实测：无 interface.ts / 直引实现文件 → FAIL；走 interface.ts → PASS
- 本地门禁全绿：`pnpm build && pnpm test && pnpm contract && pnpm pack:check &&
  pnpm typecheck` + `gen-stryker-conf --check`（contract 输出含
  `verify-dir-imports | PASS` 新段）

### 客户端改动截图证据（勾选式）

- [x] **不涉及客户端改动**（未改动 `src/client/**`、`src/client/style.css`、客户端产物 `lib/client.js`）
