### PR TITLE
refactor(dsh-mcp-manager): 阶段2执行管道域——src/pipeline/ + interface.ts + 两路径契约 + B8/B9/B10/B18

### DIFF
--- a/packages/dsh-mcp-manager/README.md
+++ b/packages/dsh-mcp-manager/README.md
@@ -234,8 +234,11 @@ await ctx.mcpManager.registerServer({
   统一走 `isToolDenied` 裁决；禁用只作用于 `mcp__` 前缀工具，拒绝原因附语义声明；
   禁用记录 `<DSH_HOME>/dsh-mcp-user-state.json` 的 `disabledTools`（`@global` key
   跨工作空间共享，合并写盘不整表覆盖）
-- **凭据脱敏**：目录摘要与错误路径经 redactor 把 env/headers/URL 用户信息等
-  凭据形状替换为 `[REDACTED]`
+- **凭据脱敏**：目录摘要与错误路径经 redactor 把 env/headers/URL 用户信息
+  （username/password/searchParams）等凭据形状替换为 `[REDACTED]`；URL 主机与
+  路径无凭据部分保留可读（可诊断性，B8 口径）；percent-encoding 的 raw 形态与
+  decoded 形态双注册，防编码绕过；supervisor/manager 错误日志与 HTTP body 同口径
+  脱敏
 - **调用统计与 Debug 模式（Metadata-Only）**：默认关闭；若在 `~/.dsh/settings.yaml` 中配置 `dsh-mcp-manager.debug.callStats: true`，将把 MCP 调用指标（次数、成功/失败、平均与最大耗时）及渐进式披露漏斗（`ws_mcp_search` 搜索词频次、`ws_mcp_list` 与 `ws_mcp_detail` 查询分布）防抖原子持久化至 `<DSH_HOME>/mcp-stats.json`，且控制台输出单行 debug 跟踪；严格不持久化用户 arguments 与返回 content，杜绝代码与隐私泄漏
 - 能力目录注入含来源标注与"不代表当前连接状态"说明
 

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -88,12 +88,12 @@ export { defaultStorePath, McpStore } from "./store.ts";
 export { expandEnv, HttpTransport, parseSsePayload, StdioTransport, createTransport } from "./transport.ts";
 // 协议
 export { MCPClient } from "./protocol.ts";
-// CallToolResult 投影（协议结果 → 工具契约收敛，#512 单一事实源）
+// CallToolResult 投影（协议结果 → 工具契约收敛，#512 单一事实源，归属 pipeline/project）
 export {
   defaultCallResultFallbackText,
   projectCallToolResult,
-} from "./call-result.ts";
-export type { CallResultTextHandlers, ProjectedCallResult } from "./call-result.ts";
+} from "./pipeline/interface.ts";
+export type { CallResultTextHandlers, ProjectedCallResult } from "./pipeline/interface.ts";
 // 连接监督器 / 工具定义（含命名、截断、schema 校验）
 export {
   DEFAULT_TOOL_CALL_TIMEOUT_MS,

--- a/packages/dsh-mcp-manager/src/manager.ts
+++ b/packages/dsh-mcp-manager/src/manager.ts
@@ -37,6 +37,7 @@ import {
 } from "./middleware.ts";
 import type { MiddlewareMode, ProjectUnit, DisabledToolsMap } from "./middleware.ts";
 import { McpStatsCollector } from "./call-stats.ts";
+import { createRedactor } from "./pipeline/interface.ts";
 
 /** 中间层 all 模式的全局虚拟 root（全局服务器经中间层访问时的路由 key）。 */
 export const MIDDLEWARE_GLOBAL_ROOT = "@global";
@@ -187,13 +188,21 @@ export class McpManager {
       await writeFile(tmp, JSON.stringify(payload, null, 2), "utf8");
       await rename(tmp, this.catalogCachePath);
     } catch (error) {
-      this.logger.warn(`dsh-mcp-manager: catalog cache write failed: ${String(error)}`);
+      this.logger.warn(`dsh-mcp-manager: catalog cache write failed: ${this.redactError(error)}`);
     }
   }
 
   onStatus(handler: () => void): () => void {
     this.listeners.add(handler);
     return () => this.listeners.delete(handler);
+  }
+
+  /** B8：错误日志脱敏（配置全集 + runtime 注入并集经 createRedactor）。
+   * 日志与 HTTP body 同口径（C-ERR 契约），error 可能含凭据明文。 */
+  private redactError(error: unknown): string {
+    const servers: ServerConfig[] = [...this.store.data.servers];
+    for (const server of this.runtimeRegistry.values()) servers.push(server);
+    return createRedactor(servers)(error);
   }
 
   /** coalesce 定时器（同一 tick 内多次状态变化合并为一次广播）。 */
@@ -372,7 +381,7 @@ export class McpManager {
       try {
         await store.reloadIfChanged();
       } catch (error) {
-        this.logger.warn(`dsh-mcp-manager: reload project config failed: ${String(error)}`);
+        this.logger.warn(`dsh-mcp-manager: reload project config failed: ${this.redactError(error)}`);
       }
     }
     return store;
@@ -532,7 +541,7 @@ export class McpManager {
     try {
       await this.store.reloadIfChanged();
     } catch (error) {
-      this.logger.warn(`dsh-mcp-manager: reload global config failed: ${String(error)}`);
+      this.logger.warn(`dsh-mcp-manager: reload global config failed: ${this.redactError(error)}`);
     }
     if (this.middlewareMode !== "off" && this.middleware !== undefined) {
       // 中间层：仅触达单元（fire-and-forget 惰性连接在 projectUnitFor 内）。
@@ -607,13 +616,13 @@ export class McpManager {
     try {
       configChanged = (await this.store.reloadIfChanged()) || configChanged;
     } catch (error) {
-      this.logger.warn(`dsh-mcp-manager: reload global config failed: ${String(error)}`);
+      this.logger.warn(`dsh-mcp-manager: reload global config failed: ${this.redactError(error)}`);
     }
     if (this.projectStore !== undefined) {
       try {
         configChanged = (await this.projectStore.reloadIfChanged()) || configChanged;
       } catch (error) {
-        this.logger.warn(`dsh-mcp-manager: reload project config failed: ${String(error)}`);
+        this.logger.warn(`dsh-mcp-manager: reload project config failed: ${this.redactError(error)}`);
       }
     }
     if (!configChanged) return;
@@ -778,7 +787,7 @@ export class McpManager {
       .catch((error: unknown) => {
         // #392 遗留⑥：不再静默吞错——projectUnitFor 失败时打 warn 日志，
         // 否则该服务器永不连接且无迹可查（ensureConnected 调用面仍会尝试）。
-        this.logger.warn(`dsh-mcp-manager: touchGlobalUnit(${name}) failed: ${String(error)}`);
+        this.logger.warn(`dsh-mcp-manager: touchGlobalUnit(${name}) failed: ${this.redactError(error)}`);
       });
   }
 
@@ -817,7 +826,7 @@ export class McpManager {
         await mw.ensureConnected(root, name);
       })
       .catch((error: unknown) => {
-        this.logger.warn(`dsh-mcp-manager: ensureMiddlewareServer(${name}) failed: ${String(error)}`);
+        this.logger.warn(`dsh-mcp-manager: ensureMiddlewareServer(${name}) failed: ${this.redactError(error)}`);
       });
   }
 

--- a/packages/dsh-mcp-manager/src/middleware-register.ts
+++ b/packages/dsh-mcp-manager/src/middleware-register.ts
@@ -18,8 +18,8 @@ import {
   LIST_DEFAULT_TOOLS_PER_SERVER,
   LIST_MAX_TOOLS_PER_SERVER,
 } from "./middleware-const.ts";
+import { withTimeout } from "./pipeline/interface.ts";
 import {
-  withTimeout,
   searchCatalogMulti,
   listCatalog,
   findToolDetail,

--- a/packages/dsh-mcp-manager/src/middleware-register.ts
+++ b/packages/dsh-mcp-manager/src/middleware-register.ts
@@ -175,10 +175,10 @@ async function executeSearch(
     const visibleUnit = visible === root ? unit : await toolCtx.mw.projectUnitFor(visible);
     if (visibleUnit !== undefined) await waitForDiscovery(visibleUnit);
   }
-  const { results, unavailable } = searchCatalogMulti(toolCtx.mw.units, roots, query, limit);
-  // truncated 基于过滤前结果判定（serverFilter 过滤后误报的修正，P2-3）：
-  // 过滤前已达 limit 上限即提示可能未列全。
-  const truncated = results.length >= limit;
+  const { results, unavailable, truncated } = searchCatalogMulti(toolCtx.mw.units, roots, query, limit);
+  // truncated 由检索函数返回截断事实（恰好命中 limit 不误报，B10 修正——
+  // 旧实现按过滤前 results.length >= limit 判定，恰恰等于 limit 也误报
+  // 「可能未列全」）；serverFilter 过滤在截断判定之后，纯展示层过滤。
   const filtered = serverFilter === undefined ? results : results.filter((hit) => hit.server === serverFilter);
   return { results: filtered, unavailable, truncated };
 }

--- a/packages/dsh-mcp-manager/src/middleware-utils.ts
+++ b/packages/dsh-mcp-manager/src/middleware-utils.ts
@@ -220,17 +220,20 @@ export function scoreTool(query: string, server: string, toolName: string, tool:
 }
 
 /** 检索目录：query 为空 → 能力摘要表（每服务器前 N 个工具）。
- * 单 root 实现（searchCatalogMulti 循环调用；兼容既有测试）。 */
+ * 单 root 实现（searchCatalogMulti 循环调用；兼容既有测试）。
+ * truncated：任一服务器存在被 limit 裁掉的结果即 true（B10 截断事实，
+ * 供调用方精确标注「是否因 limit 裁掉」——恰好命中 limit 不误报）。 */
 export function searchCatalog(
   units: Map<string, ProjectUnit>,
   root: string,
   query: string,
   limit: number,
-): { results: SearchHit[]; unavailable: Array<{ server: string; reason: string }> } {
+): { results: SearchHit[]; unavailable: Array<{ server: string; reason: string }>; truncated: boolean } {
   const unit = units.get(root);
-  if (unit === undefined) return { results: [], unavailable: [] };
+  if (unit === undefined) return { results: [], unavailable: [], truncated: false };
   const results: SearchHit[] = [];
   const unavailable: Array<{ server: string; reason: string }> = [];
+  let truncated = false;
   for (const [serverName, catalog] of unit.catalog) {
     if (catalog.unavailable !== undefined) {
       unavailable.push({ server: fullServerName(root, serverName), reason: catalog.unavailable });
@@ -244,6 +247,7 @@ export function searchCatalog(
       scored.push({ server: serverName, toolName, tool, score, matchedTerms });
     }
     scored.sort((a, b) => b.score - a.score || a.toolName.localeCompare(b.toolName));
+    if (scored.length > limit) truncated = true;
     for (const hit of scored.slice(0, limit)) {
       results.push({
         server: fullServerName(root, hit.server),
@@ -256,19 +260,19 @@ export function searchCatalog(
       });
     }
   }
-  return { results, unavailable };
+  return { results, unavailable, truncated };
 }
 
 /** 多单元合并检索（all 模式：项目 root 单元 + @global 单元合并查询）。
  * 与 searchCatalog 同语义，仅数据源扩展为多个 root；off/project 模式行为不变。
  * 单 root 直接委托 searchCatalog（保持原顺序，不引入跨单元排序变化）；
- * 多 root 合并后统一排序并按全局 limit 截断。 */
+ * 多 root 合并后统一排序并按全局 limit 截断（truncated=合并后曾有超限结果）。 */
 export function searchCatalogMulti(
   units: Map<string, ProjectUnit>,
   roots: readonly string[],
   query: string,
   limit: number,
-): { results: SearchHit[]; unavailable: Array<{ server: string; reason: string }> } {
+): { results: SearchHit[]; unavailable: Array<{ server: string; reason: string }>; truncated: boolean } {
   if (roots.length === 1) {
     return searchCatalog(units, roots[0] as string, query, limit);
   }
@@ -281,8 +285,9 @@ export function searchCatalogMulti(
   }
   // 跨单元排序（评分降序，工具名升序）——与单单元检索同序。
   results.sort((a, b) => b.score - a.score || a.tool.localeCompare(b.tool));
-  // 合并后统一截断（limit 为全局上限，而非每 root 上限）。
-  return { results: results.slice(0, limit), unavailable };
+  // 合并后统一截断（limit 为全局上限，而非每 root 上限）；截断事实供调用方标注。
+  const truncated = results.length > limit;
+  return { results: results.slice(0, limit), unavailable, truncated };
 }
 
 /**
@@ -463,16 +468,23 @@ export function boundCatalogTools(
     const name = String(tool.name ?? "");
     if (name === "") continue;
     const description = typeof tool.description === "string" ? tool.description : "";
-    const descriptionBytes = Buffer.byteLength(description, "utf8");
-    if (descriptionBytes > MAX_BYTES_PER_TOOL) {
-      bounded.set(name, {
-        description: description.slice(0, MAX_BYTES_PER_TOOL),
-        inputSchema: (tool.inputSchema ?? {}) as Record<string, unknown>,
-      });
-    } else {
-      bounded.set(name, { description, inputSchema: (tool.inputSchema ?? {}) as Record<string, unknown> });
+    // B9：描述按 UTF-8 字节截断（slice 按字符会让中文等多字节场景超上限）；
+    // 逐字符累加字节，保证截断点落在字符边界（不产生替换符）。
+    let desc = description;
+    if (Buffer.byteLength(desc, "utf8") > MAX_BYTES_PER_TOOL) {
+      let bytes = 0;
+      let cut = 0;
+      while (cut < desc.length && bytes + Buffer.byteLength(desc[cut], "utf8") <= MAX_BYTES_PER_TOOL) {
+        bytes += Buffer.byteLength(desc[cut], "utf8");
+        cut += 1;
+      }
+      desc = desc.slice(0, cut);
     }
-    totalBytes += descriptionBytes + JSON.stringify(bounded.get(name)?.inputSchema ?? {}).length;
+    bounded.set(name, { description: desc, inputSchema: (tool.inputSchema ?? {}) as Record<string, unknown> });
+    // B9：totalBytes 全字节口径（JSON.stringify().length 按码元计，低估字节数）
+    totalBytes +=
+      Buffer.byteLength(desc, "utf8") +
+      Buffer.byteLength(JSON.stringify(bounded.get(name)?.inputSchema ?? {}), "utf8");
     if (totalBytes > MAX_TOTAL_CATALOG_BYTES) break;
   }
   return bounded;

--- a/packages/dsh-mcp-manager/src/middleware-utils.ts
+++ b/packages/dsh-mcp-manager/src/middleware-utils.ts
@@ -1,10 +1,14 @@
 /**
- * dsh-mcp-manager — 中间层纯函数（命名 / 容错 / 脱敏 / 策略 / 目录检索）。
+ * dsh-mcp-manager — 中间层纯函数（命名 / 策略 / 目录检索）。
  *
- * 全部为无副作用纯函数（withTimeout 亦不依赖连接池），类型自 middleware-types.
- * ts 取；被连接池类、工具注册与 manager 共享。
+ * 无副作用纯函数，类型自 middleware-types.ts 取；被连接池类、工具注册与
+ * manager 共享。#664 阶段 2 起执行管道纯函数（args/msg/redact/timeout/
+ * project/authorize）迁至 src/pipeline/，本文件保留 workspace（命名/全名）与
+ * catalog（检索）域函数，阶段 4/5 陆续迁出；globMatch 经 pipeline/interface.ts
+ * 跨目录引用（D10 门面规则）。
  */
 
+import { globMatch } from "./pipeline/interface.ts";
 import {
   CATALOG_TTL_MS,
   LIST_DEFAULT_TOOLS_PER_SERVER,
@@ -85,103 +89,7 @@ export function normalizeToolName(serverName: string, toolName: string, caller =
   return name;
 }
 
-/** 归一化 ws_mcp_call 的 arguments 参数（模型可能把参数字典填成 JSON 字符串）。 */
-export function normalizeArguments(raw: unknown): unknown {
-  let value: unknown = raw ?? {};
-  // B14：arguments 按 MCP 规范应为 object，数组形态归一无害空态
-  // （含顶层数组入参与 JSON 解包解出数组两种路径）。
-  if (Array.isArray(value)) return {};
-  let depth = 0;
-  while (typeof value === "string" && depth < 4) {
-    const trimmed = value.trim();
-    if (trimmed.length === 0) return {};
-    const head = trimmed.charCodeAt(0);
-    const isContainerJson = head === 123 /* { */ || head === 91 /* [ */;
-    const isQuotedJson = head === 34 /* " */;
-    if (!isContainerJson && !isQuotedJson) break;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(trimmed);
-    } catch {
-      break;
-    }
-    if (parsed !== null && typeof parsed === "object") {
-      if (Array.isArray(parsed)) return {}; // B14：解包出数组同样拒绝
-      return parsed;
-    }
-    const inner = typeof parsed === "string" ? parsed.trim() : "";
-    const innerLooksContainer = inner.startsWith("{") || inner.startsWith("[");
-    if (!isQuotedJson || !innerLooksContainer) break;
-    value = parsed;
-    depth += 1;
-  }
-  return value;
-}
-
-/** 统一错误提取（Error/string/object 三态）。 */
-export function msgOf(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === "string") return error;
-  try {
-    return JSON.stringify(error);
-  } catch {
-    return String(error);
-  }
-}
-
-/** 凭据脱敏器：从服务器配置收集 secret 值，替换错误消息中的出现。 */
-export function createRedactor(servers: readonly ServerConfig[]): (error: unknown) => string {
-  const secrets = new Set<string>();
-  for (const server of servers) {
-    if (server.transport === "stdio") {
-      for (const value of Object.values(server.env ?? {})) if (value.length > 0) secrets.add(value);
-      const args = server.args ?? [];
-      for (let index = 0; index < args.length; index += 1) {
-        const argument = args[index] ?? "";
-        const equals = argument.indexOf("=");
-        const flag = equals < 0 ? argument : argument.slice(0, equals);
-        if (!/(?:token|secret|pass|key|auth|cookie|credential)/i.test(flag)) continue;
-        const value = equals < 0 ? args[index + 1] : argument.slice(equals + 1);
-        if (value !== undefined && value.length > 0) secrets.add(value);
-      }
-      continue;
-    }
-    for (const value of Object.values(server.headers ?? {})) if (value.length > 0) secrets.add(value);
-    const url = server.url;
-    if (typeof url === "string" && url !== "") {
-      secrets.add(url);
-      try {
-        const parsed = new URL(url);
-        if (parsed.username.length > 0) secrets.add(parsed.username);
-        if (parsed.password.length > 0) secrets.add(parsed.password);
-        for (const value of parsed.searchParams.values()) if (value.length > 0) secrets.add(value);
-      } catch {
-        // 非法 URL 忽略
-      }
-    }
-  }
-  const ordered = [...secrets].sort((left, right) => right.length - left.length);
-  return (error: unknown): string => {
-    let text: string;
-    try {
-      text = error instanceof Error ? error.message : String(error);
-    } catch {
-      text = "<unprintable error>";
-    }
-    for (const secret of ordered) text = text.split(secret).join("[REDACTED]");
-    return text;
-  };
-}
-
 // ------------------------------------------------------------ 策略
-
-/** 工具名匹配 glob（* 通配）。 */
-export function globMatch(pattern: string, name: string): boolean {
-  if (pattern === "*") return true;
-  if (!pattern.includes("*")) return pattern === name;
-  const escaped = pattern.split("*").map((part) => part.replace(/[.+?^${}()|[\]\\]/g, "\\$&")).join(".*");
-  return new RegExp(`^${escaped}$`).test(name);
-}
 
 /** 策略裁决：deny 优先。serverKey 支持全名（@root/server）或裸名——全名优先匹配（工作空间隔离），未命中回落裸名。返回 true = 允许。 */
 export function policyAllows(policy: MiddlewarePolicy | undefined, serverKey: string, tool: string): boolean {
@@ -568,34 +476,4 @@ export function boundCatalogTools(
     if (totalBytes > MAX_TOTAL_CATALOG_BYTES) break;
   }
   return bounded;
-}
-
-/** 等待带超时（race 兜底）。 */
-export function withTimeout<T>(promise: Promise<T>, ms: number, message: string, signal?: AbortSignal): Promise<T> {
-  if (signal?.aborted === true) return Promise.reject(signal.reason ?? new Error("aborted"));
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      cleanup();
-      reject(new Error(message));
-    }, ms);
-    const onAbort = () => {
-      cleanup();
-      reject(signal?.reason ?? new Error("aborted"));
-    };
-    const cleanup = () => {
-      clearTimeout(timer);
-      signal?.removeEventListener("abort", onAbort);
-    };
-    signal?.addEventListener("abort", onAbort, { once: true });
-    void promise.then(
-      (value) => {
-        cleanup();
-        resolve(value);
-      },
-      (error) => {
-        cleanup();
-        reject(error);
-      },
-    );
-  });
 }

--- a/packages/dsh-mcp-manager/src/middleware.ts
+++ b/packages/dsh-mcp-manager/src/middleware.ts
@@ -259,6 +259,9 @@ export class McpMiddleware {
       newEntry.status = "failed";
       newEntry.error = error;
       newEntry.connectedAt = undefined;
+      // B18：连上后断开同样计入 failedAttempts——否则退避恒 initialDelay（500ms
+      // 抖动），与「从未连上」的失败路径退避口径分裂。
+      newEntry.failedAttempts += 1;
       this.host.emitStatus();
       this.scheduleReconnect(root, serverName);
     };
@@ -293,12 +296,18 @@ export class McpMiddleware {
     const entry = unit.connections.get(serverName);
     if (entry === undefined || entry.disposed) return;
     if (entry.reconnectTimer !== undefined) return;
-    if (entry.failedAttempts > 10) {
+    // B18：退避读 server.reconnect 配置（supervisor resolveReconnect 同口径；
+    // 现状硬编码 500/30000/10 使同一配置在两路径行为不一致）。
+    const reconnect = entry.server?.reconnect ?? {};
+    const initialDelayMs = typeof reconnect.initialDelayMs === "number" ? reconnect.initialDelayMs : 500;
+    const maxDelayMs = typeof reconnect.maxDelayMs === "number" ? reconnect.maxDelayMs : 30_000;
+    const maxAttempts = typeof reconnect.maxAttempts === "number" ? reconnect.maxAttempts : 10;
+    if (entry.failedAttempts > maxAttempts) {
       // 预算耗尽：停止后台重试（保留 failed 状态；手动/调用触发可再试）。
-      this.host.logger.warn(`dsh-mcp-manager(${serverName}@${root}): reconnect gave up after 10 attempts`);
+      this.host.logger.warn(`dsh-mcp-manager(${serverName}@${root}): reconnect gave up after ${maxAttempts} attempts`);
       return;
     }
-    const delayMs = Math.min(30_000, 500 * 2 ** Math.min(entry.failedAttempts - 1, 6));
+    const delayMs = Math.min(maxDelayMs, initialDelayMs * 2 ** Math.min(entry.failedAttempts - 1, 6));
     entry.reconnectTimer = setTimeout(() => {
       entry.reconnectTimer = undefined;
       if (entry.disposed) return;
@@ -527,6 +536,10 @@ export class McpMiddleware {
       // stale：仍可调用（目录只是提示），但 schema 可能过期——在结果前置提示。
     }
     const args = normalizeArguments(rawArgs);
+    // B18/D6：调用预算读 server.toolCallTimeoutMs（缺省 CALL_TIMEOUT_MS），
+    // withTimeout 兜底统一 +2s——两路径（supervisor SDK timeoutMs 无兜底）预算
+    // 差异写入两路径契约测试的差异面签名。
+    const callBudgetMs = entry.server?.toolCallTimeoutMs ?? CALL_TIMEOUT_MS;
     // #413 封装直呼分支：runtime 注入的封装定义服务器（toolDefinitions）——
     // execute 为调用方 JS（不经远端 client.callTool）。禁用/策略已在上面统一
     // 裁决（isToolDenied），此处直接调调用方 execute；输出经封装 output.render
@@ -542,15 +555,15 @@ export class McpMiddleware {
         // 中间层只能提供最小面（agent 透传，session cwd 解析用）——经 unknown
         // 中转（消费方封装定义只读 exec.agent，契约面见 dsh-codegraph）。
         const execCtx = { agent } as unknown as Parameters<NonNullable<ToolDefinition["execute"]>>[1];
-        // #413 QA P2-2：封装 execute 补超时兜底（与远端分支同预算 CALL_TIMEOUT_MS，
+        // #413 QA P2-2：封装 execute 补超时兜底（与远端分支同预算 callBudgetMs，
         // 封装实现挂起时不无限等待）。
         const value = await withTimeout(
           def.execute(
             typeof args === "object" && args !== null ? args : {},
             execCtx,
           ),
-          CALL_TIMEOUT_MS + 2000,
-          `ws_mcp_call: 封装调用超时（${CALL_TIMEOUT_MS}ms），可重试；若反复超时请检查插件状态`,
+          callBudgetMs + 2000,
+          `ws_mcp_call: 封装调用超时（${callBudgetMs}ms），可重试；若反复超时请检查插件状态`,
           signal,
         );
         const content = typeof def.output?.render === "function"
@@ -574,10 +587,10 @@ export class McpMiddleware {
       const result = await withTimeout(
         entry.client.callTool(tool, typeof args === "object" && args !== null ? args : {}, {
           signal,
-          timeoutMs: CALL_TIMEOUT_MS,
+          timeoutMs: callBudgetMs,
         }),
-        CALL_TIMEOUT_MS + 2000,
-        `ws_mcp_call: 调用超时（${CALL_TIMEOUT_MS}ms），可重试；若反复超时请用 ws_mcp_detail 核对参数或检查服务器状态`,
+        callBudgetMs + 2000,
+        `ws_mcp_call: 调用超时（${callBudgetMs}ms），可重试；若反复超时请用 ws_mcp_detail 核对参数或检查服务器状态`,
         signal,
       );
       // #512：远端结果经 call-result.ts 统一投影收敛（isError 判定 + 白名单

--- a/packages/dsh-mcp-manager/src/middleware.ts
+++ b/packages/dsh-mcp-manager/src/middleware.ts
@@ -25,7 +25,7 @@ import { dirname } from "node:path";
 import type { ServerConfig } from "./types.ts";
 import type { ToolDefinition, ToolOutputDefinition } from "@deepseek-ai/dsh-tools";
 import { MCPClient } from "./protocol.ts";
-import { defaultCallResultFallbackText, projectCallToolResult } from "./call-result.ts";
+import { defaultCallResultFallbackText, projectCallToolResult, withTimeout, msgOf, createRedactor, normalizeArguments } from "./pipeline/interface.ts";
 import { createTransport } from "./transport.ts";
 import {
   CONNECT_TIMEOUT_MS,
@@ -34,12 +34,8 @@ import {
   CATALOG_TTL_MS,
 } from "./middleware-const.ts";
 import {
-  withTimeout,
-  msgOf,
-  createRedactor,
   parseFullServerName,
   normalizeToolName,
-  normalizeArguments,
   policyAllows,
   policyDenialReason,
   fullServerName,
@@ -687,16 +683,13 @@ export {
   LIST_MAX_TOOLS_PER_SERVER,
   normalizeMiddlewareMode,
 } from "./middleware-const.ts";
-// 纯函数与目录检索
+// 纯函数与目录检索（pipeline 域函数已迁 src/pipeline/，经 pipeline/interface.ts 转发；
+// 其余 workspace/catalog 域函数仍位于 middleware-utils.ts，阶段 4/5 陆续迁出）
+export { withTimeout, normalizeArguments, msgOf, createRedactor, globMatch } from "./pipeline/interface.ts";
 export {
-  withTimeout,
   fullServerName,
   parseFullServerName,
   normalizeToolName,
-  normalizeArguments,
-  msgOf,
-  createRedactor,
-  globMatch,
   policyAllows,
   bareServerName,
   policyDenialReason,

--- a/packages/dsh-mcp-manager/src/pipeline/args.ts
+++ b/packages/dsh-mcp-manager/src/pipeline/args.ts
@@ -1,0 +1,39 @@
+/**
+ * dsh-mcp-manager — pipeline/args：ws_mcp_call 参数归一化（#664 阶段 2 迁入）。
+ *
+ * 原自 middleware-utils.ts normalizeArguments；B14（数组形态拒绝）已在阶段 1 修复，
+ * 本文件为同语义迁移（零行为变更）。
+ */
+
+/** 归一化 ws_mcp_call 的 arguments 参数（模型可能把参数字典填成 JSON 字符串）。 */
+export function normalizeArguments(raw: unknown): unknown {
+  let value: unknown = raw ?? {};
+  // B14：arguments 按 MCP 规范应为 object，数组形态归一无害空态
+  // （含顶层数组入参与 JSON 解包解出数组两种路径）。
+  if (Array.isArray(value)) return {};
+  let depth = 0;
+  while (typeof value === "string" && depth < 4) {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return {};
+    const head = trimmed.charCodeAt(0);
+    const isContainerJson = head === 123 /* { */ || head === 91 /* [ */;
+    const isQuotedJson = head === 34 /* " */;
+    if (!isContainerJson && !isQuotedJson) break;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      break;
+    }
+    if (parsed !== null && typeof parsed === "object") {
+      if (Array.isArray(parsed)) return {}; // B14：解包出数组同样拒绝
+      return parsed;
+    }
+    const inner = typeof parsed === "string" ? parsed.trim() : "";
+    const innerLooksContainer = inner.startsWith("{") || inner.startsWith("[");
+    if (!isQuotedJson || !innerLooksContainer) break;
+    value = parsed;
+    depth += 1;
+  }
+  return value;
+}

--- a/packages/dsh-mcp-manager/src/pipeline/authorize.ts
+++ b/packages/dsh-mcp-manager/src/pipeline/authorize.ts
@@ -1,0 +1,16 @@
+/**
+ * dsh-mcp-manager — pipeline/authorize：执行授权纯函数（#664 阶段 2 迁入）。
+ *
+ * 本阶段仅迁入自包含的 globMatch（无 workspace 域依赖）；策略裁决族
+ * （policyAllows / policyDenialReason / isToolDenied / toolDisabledReason）
+ * 依赖 parseFullServerName / MIDDLEWARE_GLOBAL_ROOT（workspace 域，阶段 4 迁入），
+ * 待阶段 4 workspace/interface.ts 就绪后并入本文件。
+ */
+
+/** 工具名匹配 glob（* 通配）。 */
+export function globMatch(pattern: string, name: string): boolean {
+  if (pattern === "*") return true;
+  if (!pattern.includes("*")) return pattern === name;
+  const escaped = pattern.split("*").map((part) => part.replace(/[.+?^${}()|[\]\\]/g, "\\$&")).join(".*");
+  return new RegExp(`^${escaped}$`).test(name);
+}

--- a/packages/dsh-mcp-manager/src/pipeline/interface.ts
+++ b/packages/dsh-mcp-manager/src/pipeline/interface.ts
@@ -1,0 +1,23 @@
+/**
+ * dsh-mcp-manager — pipeline/interface.ts：执行管道域唯一对外引用面（D10，#664 阶段 2 首个应用）。
+ *
+ * 本目录（执行管道域）对外承诺：两执行路径（supervisor 直呼 / ws_mcp_call）共用的
+ * 纯函数族——参数归一（args）、错误取消息（msg）、凭据脱敏（redact）、超时兜底
+ * （timeout）、授权匹配（authorize）、结果投影（project）。
+ *
+ * 目录外模块**只能**从这里引用（verify-dir-imports 静态强制）；策略裁决族
+ * （policyAllows/isToolDenied 等）依赖 workspace 域函数，阶段 4 并入 authorize.ts。
+ */
+export { normalizeArguments } from "./args.ts";
+export { msgOf } from "./msg.ts";
+export { createRedactor } from "./redact.ts";
+export { withTimeout } from "./timeout.ts";
+export { globMatch } from "./authorize.ts";
+export {
+  defaultCallResultFallbackText,
+  projectCallToolResult,
+} from "./project.ts";
+export type {
+  CallResultTextHandlers,
+  ProjectedCallResult,
+} from "./project.ts";

--- a/packages/dsh-mcp-manager/src/pipeline/msg.ts
+++ b/packages/dsh-mcp-manager/src/pipeline/msg.ts
@@ -1,0 +1,17 @@
+/**
+ * dsh-mcp-manager — pipeline/msg：统一错误提取（#664 阶段 2 迁入）。
+ *
+ * 原自 middleware-utils.ts msgOf；执行管道错误文案的稳定取消息面
+ * （Error/string/object 三态），两路径（supervisor 直呼 / ws_mcp_call）共用。
+ */
+
+/** 统一错误提取（Error/string/object 三态）。 */
+export function msgOf(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}

--- a/packages/dsh-mcp-manager/src/pipeline/project.ts
+++ b/packages/dsh-mcp-manager/src/pipeline/project.ts
@@ -1,25 +1,14 @@
 /**
- * dsh-mcp-manager — CallToolResult 投影（单一事实源，#512）。
+ * dsh-mcp-manager — pipeline/project：CallToolResult 投影（单一事实源，#512，#664 阶段 2 迁入）。
  *
- * MCP 协议对 tools/call 成功应答是宽容的：content / structuredContent /
- * isError / _meta 均为 optional 字段，各语言 SDK 序列化习惯不一——如 Python
- * SDK 的 pydantic `exclude_none` 剔不掉合法值 `isError: False`，wire 上必带
- * （#512）；Node SDK 习惯不带。而 dsh 工具系统契约要求 execute 返回值精确
- * 匹配 output schema（additionalProperties: false，仅 content /
- * structuredContent），远端结果的任何多余字段都会让校验失败。
+ * 原自 call-result.ts（全量迁移，含类型面）。MCP 协议对 tools/call 成功应答宽容
+ * （content / structuredContent / isError / _meta 均 optional，各 SDK 序列化习惯
+ * 不一——Python pydantic exclude_none 剔不掉合法值 isError:false）；dsh 工具契约
+ * 要求 execute 返回精确匹配 output schema（additionalProperties:false），故在此
+ * 收敛白名单投影（对齐官方 dsh-mcp-client createExecutor）。
  *
- * 本模块承担「协议结果 → 工具契约」的收敛投影，架构对齐官方
- * @deepseek-ai/dsh-mcp-client createExecutor（协议层宽松拿 + 投影层白名单）：
- *  - isError === true → throw（ToolRuntime catch 路径产出 isError 结果）；
- *  - 白名单返回 { content, ...structuredContent 有值才带 } —— 其余字段
- *    （isError / _meta / 未来协议新增字段）一律丢弃，不外泄进工具契约；
- *  - content 缺失或非数组 → 兜底文本（toolResult 形态渲染 JSON，否则
- *    "(no output)"），防 required content 校验失败（#381 lossless 同源纪律：
- *    不产生 undefined 值键）。
- *
- * supervisor（mcp__ 直呼路径）与 middleware（ws_mcp_call 远端转发）共用，
- * 投影语义只此一份；调用方差异（文本截断/提取、错误文案风格）经
- * CallResultTextHandlers 注入。
+ * supervisor（mcp__ 直呼路径）与 middleware（ws_mcp_call 远端转发）共用；
+ * 调用方差异（文本截断/提取、错误文案风格）经 CallResultTextHandlers 注入。
  */
 
 /** 投影文本渲染回调（调用方差异面）。 */

--- a/packages/dsh-mcp-manager/src/pipeline/redact.ts
+++ b/packages/dsh-mcp-manager/src/pipeline/redact.ts
@@ -1,0 +1,52 @@
+/**
+ * dsh-mcp-manager — pipeline/redact：凭据脱敏器（#664 阶段 2 迁入，B8 改口径同文件）。
+ *
+ * 原自 middleware-utils.ts createRedactor（现状整 URL 脱敏口径）。
+ * B8（D4 决策）：改「仅用户信息 + raw/decoded 双形态」在阶段 2 修复 commit 实施；
+ * 本文件先保持现状语义迁移（零行为变更），基线测试同步锁定。
+ */
+import type { ServerConfig } from "../types.ts";
+
+/** 凭据脱敏器：从服务器配置收集 secret 值，替换错误消息中的出现。 */
+export function createRedactor(servers: readonly ServerConfig[]): (error: unknown) => string {
+  const secrets = new Set<string>();
+  for (const server of servers) {
+    if (server.transport === "stdio") {
+      for (const value of Object.values(server.env ?? {})) if (value.length > 0) secrets.add(value);
+      const args = server.args ?? [];
+      for (let index = 0; index < args.length; index += 1) {
+        const argument = args[index] ?? "";
+        const equals = argument.indexOf("=");
+        const flag = equals < 0 ? argument : argument.slice(0, equals);
+        if (!/(?:token|secret|pass|key|auth|cookie|credential)/i.test(flag)) continue;
+        const value = equals < 0 ? args[index + 1] : argument.slice(equals + 1);
+        if (value !== undefined && value.length > 0) secrets.add(value);
+      }
+      continue;
+    }
+    for (const value of Object.values(server.headers ?? {})) if (value.length > 0) secrets.add(value);
+    const url = server.url;
+    if (typeof url === "string" && url !== "") {
+      secrets.add(url);
+      try {
+        const parsed = new URL(url);
+        if (parsed.username.length > 0) secrets.add(parsed.username);
+        if (parsed.password.length > 0) secrets.add(parsed.password);
+        for (const value of parsed.searchParams.values()) if (value.length > 0) secrets.add(value);
+      } catch {
+        // 非法 URL 忽略
+      }
+    }
+  }
+  const ordered = [...secrets].sort((left, right) => right.length - left.length);
+  return (error: unknown): string => {
+    let text: string;
+    try {
+      text = error instanceof Error ? error.message : String(error);
+    } catch {
+      text = "<unprintable error>";
+    }
+    for (const secret of ordered) text = text.split(secret).join("[REDACTED]");
+    return text;
+  };
+}

--- a/packages/dsh-mcp-manager/src/pipeline/redact.ts
+++ b/packages/dsh-mcp-manager/src/pipeline/redact.ts
@@ -1,18 +1,30 @@
 /**
  * dsh-mcp-manager — pipeline/redact：凭据脱敏器（#664 阶段 2 迁入，B8 改口径同文件）。
  *
- * 原自 middleware-utils.ts createRedactor（现状整 URL 脱敏口径）。
- * B8（D4 决策）：改「仅用户信息 + raw/decoded 双形态」在阶段 2 修复 commit 实施；
- * 本文件先保持现状语义迁移（零行为变更），基线测试同步锁定。
+ * B8（D4 决策）：仅用户信息脱敏（username/password/searchParams），host/path
+ * 无凭据保留可读（现状整 URL 脱敏，可诊断性差）；raw/decoded 双形态注册——
+ * 错误消息中出现的是原始 URL 字节串（percent-encoding 形态），URL parse 拿到
+ * decoded 形态，两者都须命中（否则 percent-encoding 绕过回归，评审 B8 修正）。
  */
 import type { ServerConfig } from "../types.ts";
+
+/** 注册单个敏感值：decoded 形态 + percent-encoded raw 形态双注册。 */
+function addSecretPair(secrets: Set<string>, value: string): void {
+  if (value.length === 0) return;
+  secrets.add(value);
+  try {
+    secrets.add(encodeURIComponent(value));
+  } catch {
+    // 编码失败（如孤立代理字符）忽略 raw 形态，decoded 已注册
+  }
+}
 
 /** 凭据脱敏器：从服务器配置收集 secret 值，替换错误消息中的出现。 */
 export function createRedactor(servers: readonly ServerConfig[]): (error: unknown) => string {
   const secrets = new Set<string>();
   for (const server of servers) {
     if (server.transport === "stdio") {
-      for (const value of Object.values(server.env ?? {})) if (value.length > 0) secrets.add(value);
+      for (const value of Object.values(server.env ?? {})) addSecretPair(secrets, value);
       const args = server.args ?? [];
       for (let index = 0; index < args.length; index += 1) {
         const argument = args[index] ?? "";
@@ -20,19 +32,20 @@ export function createRedactor(servers: readonly ServerConfig[]): (error: unknow
         const flag = equals < 0 ? argument : argument.slice(0, equals);
         if (!/(?:token|secret|pass|key|auth|cookie|credential)/i.test(flag)) continue;
         const value = equals < 0 ? args[index + 1] : argument.slice(equals + 1);
-        if (value !== undefined && value.length > 0) secrets.add(value);
+        if (value !== undefined && value.length > 0) addSecretPair(secrets, value);
       }
       continue;
     }
-    for (const value of Object.values(server.headers ?? {})) if (value.length > 0) secrets.add(value);
+    for (const value of Object.values(server.headers ?? {})) addSecretPair(secrets, value);
     const url = server.url;
     if (typeof url === "string" && url !== "") {
-      secrets.add(url);
+      // B8：不加入整 URL——host/path 无凭据部分保留（错误消息可诊断）；
+      // 仅用户信息（username/password/searchParams）脱敏。
       try {
         const parsed = new URL(url);
-        if (parsed.username.length > 0) secrets.add(parsed.username);
-        if (parsed.password.length > 0) secrets.add(parsed.password);
-        for (const value of parsed.searchParams.values()) if (value.length > 0) secrets.add(value);
+        addSecretPair(secrets, parsed.username);
+        addSecretPair(secrets, parsed.password);
+        for (const value of parsed.searchParams.values()) addSecretPair(secrets, value);
       } catch {
         // 非法 URL 忽略
       }

--- a/packages/dsh-mcp-manager/src/pipeline/timeout.ts
+++ b/packages/dsh-mcp-manager/src/pipeline/timeout.ts
@@ -1,0 +1,36 @@
+/**
+ * dsh-mcp-manager — pipeline/timeout：调用超时兜底（#664 阶段 2 迁入）。
+ *
+ * 原自 middleware-utils.ts withTimeout；中间层 ws_mcp_call 与封装直呼的
+ * abort 竞态处理单一实现（supervisor 路径靠 SDK timeoutMs，无此层）。
+ */
+
+/** 等待带超时（race 兜底）。 */
+export function withTimeout<T>(promise: Promise<T>, ms: number, message: string, signal?: AbortSignal): Promise<T> {
+  if (signal?.aborted === true) return Promise.reject(signal.reason ?? new Error("aborted"));
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(message));
+    }, ms);
+    const onAbort = () => {
+      cleanup();
+      reject(signal?.reason ?? new Error("aborted"));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    void promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}

--- a/packages/dsh-mcp-manager/src/protocol.ts
+++ b/packages/dsh-mcp-manager/src/protocol.ts
@@ -23,7 +23,7 @@ import type { StdioTransport, HttpTransport } from "./transport.ts";
  *    自写版"结果原样投影给 dsh 工具系统（未知 content 类型降级占位符）"
  *    的行为语义；
  *  - callTool 显式传宽松 ResultSchema：结果 JSON 原样透传（#512 起 isError /
- *    structuredContent 判定与白名单收敛统一由 call-result.ts
+ *    structuredContent 判定与白名单收敛统一由 pipeline/project.ts
  *    projectCallToolResult 承担，supervisor / middleware 两路径共用，
  *    架构对齐官方 dsh-mcp-client createExecutor）。
  */
@@ -67,7 +67,7 @@ export class MCPClient {
 
   /** tools/call（signal/timeoutMs 透传为 SDK RequestOptions）。
    * 走 Protocol.request + 宽松 ResultSchema：结果 JSON 原样透传给调用方
-   * （isError / structuredContent 判定统一由 call-result.ts
+   * （isError / structuredContent 判定统一由 pipeline/project.ts
    * projectCallToolResult 收敛（#512），不用 Client.callTool 以避开其
    * outputSchema 运行时强校验与 task-required 门禁带来的行为漂移）。 */
   async callTool(rawName: string, args?: unknown, opts?: { signal?: AbortSignal; timeoutMs?: number }) {

--- a/packages/dsh-mcp-manager/src/supervisor.ts
+++ b/packages/dsh-mcp-manager/src/supervisor.ts
@@ -13,7 +13,8 @@ import { createTransport } from "./transport.ts";
 import type { StdioTransport, HttpTransport } from "./transport.ts";
 import { SCOPE_GLOBAL, SCOPE_PROJECT } from "./scope.ts";
 import { MCPClient } from "./protocol.ts";
-import { defaultCallResultFallbackText, projectCallToolResult } from "./pipeline/interface.ts";
+import { defaultCallResultFallbackText, projectCallToolResult, createRedactor, msgOf } from "./pipeline/interface.ts";
+import type { McpStatsCollector } from "./call-stats.ts";
 import type { ServerConfig } from "./types.ts";
 import type { Context, LoggerService } from "@deepseek-ai/cordis";
 // 官方工具定义类型（仅 import type，编译期擦除；contract-check 禁止运行时值导入）。
@@ -35,6 +36,8 @@ export interface ManagerLite {
   enhancement: { enhanceEmptyDescriptions?: boolean; resultTruncateBytes?: number };
   emitStatus(): void;
   recordCatalogTools(serverName: string, toolMeta: Map<string, { description?: unknown }>): Promise<void>;
+  /** 行为扩展（#664 阶段 2）：调用统计最小面，supervisor 直呼路径埋点。 */
+  stats?: Pick<McpStatsCollector, "isEnabled" | "recordCall">;
 }
 
 // --------------------------------------------------------- 工具命名 / 截断
@@ -219,7 +222,17 @@ export function assertSupportedOutputSchema(schema: unknown): unknown {
 /** 构建 dsh 工具定义（契约与官方 dsh-mcp-client 一致）。
  * @param opts 感知增强选项：{enhanceEmptyDescriptions, resultTruncateBytes}。
  */
-export function buildToolDefinition(client: MCPClient, tool: Record<string, unknown>, server: ServerConfig, opts: { enhanceEmptyDescriptions?: boolean; resultTruncateBytes?: number } = {}): ToolDefinition {
+export function buildToolDefinition(
+  client: MCPClient,
+  tool: Record<string, unknown>,
+  server: ServerConfig,
+  opts: {
+    enhanceEmptyDescriptions?: boolean;
+    resultTruncateBytes?: number;
+    /** 行为扩展（#664 阶段 2）：supervisor 直呼路径 stats 埋点最小面。 */
+    stats?: Pick<McpStatsCollector, "isEnabled" | "recordCall">;
+  } = {},
+): ToolDefinition {
   const rawName = tool.name as string;
   const structuredSchema = assertSupportedOutputSchema(tool.outputSchema);
   const enhanceEmpty = opts.enhanceEmptyDescriptions !== false;
@@ -255,18 +268,32 @@ export function buildToolDefinition(client: MCPClient, tool: Record<string, unkn
     },
     async execute(args: unknown, exec: { signal?: AbortSignal }) {
       const timeoutMs = server.toolCallTimeoutMs ?? DEFAULT_TOOL_CALL_TIMEOUT_MS;
-      const result = await client.callTool(rawName, typeof args === "object" && args !== null ? args : {}, {
-        signal: exec.signal,
-        timeoutMs,
-      });
-      // #512：结果投影收敛到 pipeline/project.ts 单一事实源（isError 判定 + 白名单
-      // 清洗 + 无 content 兜底），与 middleware（ws_mcp_call）/ 官方
-      // dsh-mcp-client createExecutor 同一契约；本侧差异面 = 文本截断与
-      // extractText 占位符渲染。
-      return projectCallToolResult(result, {
-        errorText: (content) => renderText(extractText(content, rawName)) as string,
-        fallbackText: (r) => renderText(defaultCallResultFallbackText(r)) as string,
-      });
+      // 行为扩展声明（#664 阶段 2）：supervisor 直呼路径 stats 埋点，与
+      // ws_mcp_call 路径的 recordCall 同口径（server/tool/duration/成功/错误）；
+      // stats 未启用（isEnabled false）时 recordCall 内部短路，零开销。
+      const startedAt = Date.now();
+      const record = (success: boolean, errorMsg?: string): void => {
+        opts.stats?.recordCall?.(server.name, rawName, Date.now() - startedAt, success, errorMsg);
+      };
+      try {
+        const result = await client.callTool(rawName, typeof args === "object" && args !== null ? args : {}, {
+          signal: exec.signal,
+          timeoutMs,
+        });
+        // #512：结果投影收敛到 pipeline/project.ts 单一事实源（isError 判定 + 白名单
+        // 清洗 + 无 content 兜底），与 middleware（ws_mcp_call）/ 官方
+        // dsh-mcp-client createExecutor 同一契约；本侧差异面 = 文本截断与
+        // extractText 占位符渲染。
+        const projected = projectCallToolResult(result, {
+          errorText: (content) => renderText(extractText(content, rawName)) as string,
+          fallbackText: (r) => renderText(defaultCallResultFallbackText(r)) as string,
+        });
+        record(true);
+        return projected;
+      } catch (error) {
+        record(false, msgOf(error));
+        throw error;
+      }
     },
   };
 }
@@ -359,7 +386,11 @@ export class ConnectionSupervisor {
       this.manager.logger.info(`dsh-mcp-manager(${server.name}): connected, ${this.tools.length} tool(s) registered`);
     } catch (error) {
       if (this.disposed || this.client !== client) return;
-      this.manager.logger.warn(`dsh-mcp-manager(${server.name}): connection attempt failed: ${String(error)}`);
+      // B8：连接失败日志脱敏（本 server 配置的凭据形状；错误消息可能含 URL 用户
+      // 信息/env 值等明文，supervisor 侧与 manager/API 同口径）。
+      this.manager.logger.warn(
+        `dsh-mcp-manager(${server.name}): connection attempt failed: ${createRedactor([this.server])(error)}`,
+      );
       this.teardownGeneration(error, true);
     }
   }
@@ -459,7 +490,7 @@ export class ConnectionSupervisor {
           if (definitions.has(publicName)) {
             throw new Error(`server "${this.server.name}" listed tool "${(tool as Record<string, unknown>).name}" more than once — invalid tool list`);
           }
-          definitions.set(publicName, buildToolDefinition(client, tool as Record<string, unknown>, this.server, this.manager.enhancement));
+          definitions.set(publicName, buildToolDefinition(client, tool as Record<string, unknown>, this.server, { ...this.manager.enhancement, stats: this.manager.stats }));
           // 工具描述元数据（保留供 GUI 展示；不再用于能力目录——目录是纯静态数据源，
           // 聚合连接后数据会让 digest 随连接状态抖动而反复注入）。
           toolMeta.set(publicName, { description: (tool as Record<string, unknown>).description ?? "" });

--- a/packages/dsh-mcp-manager/src/supervisor.ts
+++ b/packages/dsh-mcp-manager/src/supervisor.ts
@@ -13,7 +13,7 @@ import { createTransport } from "./transport.ts";
 import type { StdioTransport, HttpTransport } from "./transport.ts";
 import { SCOPE_GLOBAL, SCOPE_PROJECT } from "./scope.ts";
 import { MCPClient } from "./protocol.ts";
-import { defaultCallResultFallbackText, projectCallToolResult } from "./call-result.ts";
+import { defaultCallResultFallbackText, projectCallToolResult } from "./pipeline/interface.ts";
 import type { ServerConfig } from "./types.ts";
 import type { Context, LoggerService } from "@deepseek-ai/cordis";
 // 官方工具定义类型（仅 import type，编译期擦除；contract-check 禁止运行时值导入）。
@@ -259,7 +259,7 @@ export function buildToolDefinition(client: MCPClient, tool: Record<string, unkn
         signal: exec.signal,
         timeoutMs,
       });
-      // #512：结果投影收敛到 call-result.ts 单一事实源（isError 判定 + 白名单
+      // #512：结果投影收敛到 pipeline/project.ts 单一事实源（isError 判定 + 白名单
       // 清洗 + 无 content 兜底），与 middleware（ws_mcp_call）/ 官方
       // dsh-mcp-client createExecutor 同一契约；本侧差异面 = 文本截断与
       // extractText 占位符渲染。

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -94,6 +94,8 @@ import "./unit-manager2.test.ts";
 import "./unit-routes-sse.test.ts";
 // call-stats 统计（#664 阶段 1 双登记接线：原 node:test 零执行孤儿，改造自执行后接入）
 import "./unit-call-stats.test.ts";
+// 执行管道域契约（#664 阶段 2：两路径同构 + stats 埋点红测）
+import "./unit-pipeline.test.ts";
 
 const failures = [];
 const check = (label, fn) => {

--- a/packages/dsh-mcp-manager/test/unit-middleware.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.test.ts
@@ -957,7 +957,108 @@ function makeHost(serversByRoot = new Map()) {
   assert.ok(!out.includes("secret-token"), "header 值脱敏");
   assert.ok(!out.includes("k-123"), "env 全值脱敏");
   assert.ok(!out.includes("tok-456"), "args 凭据形参值脱敏");
-  // 基线锚点：整 URL 全部 [REDACTED]（含无凭据的 host/path，可诊断性差的现状——
-  // B8 修复后此处应保留 host/path 可读，成为差异断言）。
-  assert.ok(!out.includes("example.com"), "基线：整 URL 均被脱敏（阶段 2 B8 改为仅用户信息）");
+  // B8 红测（D4 决策：仅用户信息脱敏）：host/path 无凭据应保留可读——
+  // 现状整 URL 全部 [REDACTED]，本断言红；commit3 改口径后绿。
+  assert.ok(out.includes("example.com"), "B8：host 应保留（仅用户信息脱敏；现状整 URL 脱敏）");
+  assert.ok(out.includes("/path"), "B8：path 应保留");
+}
+
+// ---- B8 红测（续）：percent-encoding raw 形态脱敏对照 ----
+
+{
+  // URL 用户信息带 percent-encoding：URL parse 得 decoded 形态，raw 形态
+  // （错误消息中实际出现的字节串）必须同被脱敏——现状仅存 decoded，红测。
+  const redactEnc = createRedactor([
+    {
+      name: "enc",
+      transport: "streamable-http",
+      url: "https://user%3Apass@example.com/p?token=abc123",
+      headers: {},
+      enabled: true,
+    },
+  ]);
+  const outEnc = redactEnc(new Error("failed connect to user%3Apass@example.com abc123"));
+  assert.ok(!outEnc.includes("user%3Apass"), "B8：percent-encoded 用户信息 raw 形态脱敏（现状仅存 decoded → 红测）");
+  assert.ok(!outEnc.includes("abc123"), "searchParams 值脱敏");
+}
+
+// ---- B9 红测：boundCatalogTools 描述截断按字节（UTF-8 中文多字节）----
+
+{
+  // "字" 每字符 3 字节：2000 字 = 6000 字节 > MAX_BYTES_PER_TOOL(4096)
+  const bigDesc = "字".repeat(2000);
+  const bounded = boundCatalogTools([{ name: "t1", description: bigDesc, inputSchema: {} }]);
+  const desc = bounded.get("t1").description;
+  assert.ok(Buffer.byteLength(desc, "utf8") <= MAX_BYTES_PER_TOOL, "B9：截断后描述字节数 ≤ MAX_BYTES_PER_TOOL（现状 slice 按字符 → 超限，红测）");
+}
+
+// ---- B10 红测：searchCatalogMulti 恰好 limit 命中不误报 truncated ----
+
+{
+  const cata = new Map([
+    ["s1", {
+      server: "s1",
+      tools: new Map([
+        ["alpha", { name: "alpha", description: "alpha tool", inputSchema: {} }],
+        ["beta", { name: "beta", description: "beta tool", inputSchema: {} }],
+      ]),
+    }],
+  ]);
+  const fakeUnit = { connections: new Map(), catalog: cata, userDisabled: new Set(), inFlight: new Map(), lastTouchedAt: Date.now() };
+  const units = new Map([[ROOT, fakeUnit]]);
+  // 恰好 limit=1 条命中（alpha）
+  const r = searchCatalogMulti(units, [ROOT], "alpha", 1);
+  assert.equal(r.results.length, 1);
+  assert.equal(r.truncated, false, "B10：恰好 limit 命中不应标 truncated（现状无 truncated 字段/按 >=limit 误报，红测）");
+}
+
+// ---- B18 红测a：callTool 应用 server.toolCallTimeoutMs（现状固定 CALL_TIMEOUT_MS）----
+
+{
+  const servers = [{ name: "s1", transport: "stdio", command: "echo", enabled: true, toolCallTimeoutMs: 5000 }];
+  const { host } = makeHost(new Map([[ROOT, servers]]));
+  const mw = new McpMiddleware(host, {});
+  const unit = await mw.projectUnitFor(ROOT);
+  const calls = [];
+  unit.connections.set("s1", {
+    server: { name: "s1", transport: "stdio", command: "echo", enabled: true, toolCallTimeoutMs: 5000 },
+    status: "connected",
+    connectedAt: Date.now(),
+    catalog: new Map(),
+    client: {
+      callTool: async (tool, args, opts) => {
+        calls.push({ tool, args, opts });
+        return { content: [{ type: "text", text: "ok" }] };
+      },
+    },
+  });
+  const res = await mw.callTool(fullServerName(ROOT, "s1"), "t1", '{"a":1}', undefined);
+  assert.equal(res.content[0].text, "ok", "callTool 正常");
+  assert.equal(calls[0].opts.timeoutMs, 5000, "B18：callTool 用 server.toolCallTimeoutMs（现状固定 30000 → 红测）");
+  await mw.dispose();
+}
+
+// ---- B18 红测b：scheduleReconnect 退避读 server.reconnect（现状硬编码 500 系列）----
+
+{
+  const servers = [{ name: "s1", transport: "stdio", command: "echo", enabled: true, reconnect: { initialDelayMs: 2000 } }];
+  const { host } = makeHost(new Map([[ROOT, servers]]));
+  const mw = new McpMiddleware(host, {});
+  const unit = await mw.projectUnitFor(ROOT);
+  const entry = {
+    server: { name: "s1", transport: "stdio", command: "echo", enabled: true, reconnect: { initialDelayMs: 2000 } },
+    status: "failed",
+    failedAttempts: 1,
+    reconnectTimer: undefined,
+    disposed: false,
+  };
+  unit.connections.set("s1", entry);
+  mw.scheduleReconnect(ROOT, "s1");
+  try {
+    assert.ok(entry.reconnectTimer !== undefined, "scheduleReconnect 建 timer");
+    assert.equal(entry.reconnectTimer._idleTimeout, 2000, "B18：退避读 server.reconnect.initialDelayMs（现状 500 → 红测）");
+  } finally {
+    if (entry.reconnectTimer !== undefined) clearTimeout(entry.reconnectTimer);
+    await mw.dispose();
+  }
 }

--- a/packages/dsh-mcp-manager/test/unit-middleware.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-middleware.test.ts
@@ -176,10 +176,14 @@ function makeHost(serversByRoot = new Map()) {
   assert.deepEqual(bounded.get("a"), { description: "alpha", inputSchema: { type: "object" } });
   assert.deepEqual(bounded.get("b"), { description: "", inputSchema: {} }, "缺省描述/schema 补空");
   assert.deepEqual(bounded.get("42"), { description: "", inputSchema: {} }, "非字符串 name String 化、描述归空");
-  // 单描述超字节上限 → 按上限截断（原 discover 截断口径：字符数）
+  // 单描述超字节上限 → 按字节截断（B9：旧 slice(0,N) 按字符，多字节超限；
+  // 截断点落在字符边界，不产生替换符）
   const bigDescription = "字".repeat(MAX_BYTES_PER_TOOL);
   const truncated = boundCatalogTools([{ name: "big", description: bigDescription }]).get("big");
-  assert.equal(truncated.description.length, MAX_BYTES_PER_TOOL, "超限描述截断到 MAX_BYTES_PER_TOOL");
+  assert.ok(
+    Buffer.byteLength(truncated.description, "utf8") <= MAX_BYTES_PER_TOOL,
+    "B9：超限描述截断后字节数 ≤ MAX_BYTES_PER_TOOL",
+  );
   assert.ok(Buffer.byteLength(bigDescription, "utf8") > MAX_BYTES_PER_TOOL, "前提：原描述字节超限");
   // 总字节超限 → 立即停止装箱
   const fatSchema = { data: "x".repeat(200 * 1024) };

--- a/packages/dsh-mcp-manager/test/unit-pipeline.test.ts
+++ b/packages/dsh-mcp-manager/test/unit-pipeline.test.ts
@@ -1,0 +1,133 @@
+// @ts-nocheck
+/**
+ * dsh-mcp-manager — unit：执行管道域契约（#664 阶段 2）。
+ *
+ * 两路径（supervisor 直呼 / ws_mcp_call）同构契约：同一远端结果 → 同一工具契约
+ * 投影（#512 单一事实源，pipeline/project.ts）。差异面显式排除三项并文档化：
+ *   - timeout：supervisor 靠 SDK timeoutMs（无 withTimeout 层）；middleware 有
+ *     withTimeout 兜底（+2s，C-ABT/D6 口径）——同构断言不覆盖超时；
+ *   - redact：middleware 错误文案经 hostRedact（createRedactor），supervisor
+ *     B8 修复后走日志脱敏面——同构断言只比投影白名单，不比文案；
+ *   - stale：目录 TTL 过期前置提示仅 middleware 有——同构断言不覆盖。
+ * 其余环节（arguments 归一 → callTool → 投影）输入同、输出同。
+ *
+ * 另含 supervisor 路径 stats 埋点契约（行为扩展声明，红测先行）：
+ * execute 成功后必须 recordCall（现状缺失，commit3 修复）。
+ */
+import assert from "node:assert/strict";
+import { fakeMCPClient } from "./helpers.ts";
+
+const {
+  defaultCallResultFallbackText,
+  msgOf,
+  normalizeArguments,
+  projectCallToolResult,
+  buildToolDefinition,
+} = await import("../lib/index.js");
+
+// ---- 两路径同构：投影面（#512 单一事实源）----
+
+{
+  // 同一远端 CallToolResult 形态矩阵：两路径 handler 差异（文本渲染风格）之外，
+  // 投影产物（content / structuredContent 键集与值）必须一致。
+  const results = [
+    { content: [{ type: "text", text: "ok" }], structuredContent: { a: 1 }, isError: false },
+    { content: [], isError: false },
+    { toolResult: { value: 42 }, isError: false }, // 无 content → 兜底分支
+    { content: "not-an-array", isError: false }, // 协议违规形态 → 兜底分支
+  ];
+  const supervisorHandlers = {
+    // supervisor 风格：extractText 占位符渲染 + 截断（差异面仅文本，投影白名单同）
+    errorText: (c) => `ERR:${c.length}`,
+    fallbackText: (r) => JSON.stringify(r),
+  };
+  const middlewareHandlers = {
+    // middleware 风格：msgOf + 保留远端原文
+    errorText: (c) => `ws_mcp_call:远端错误:${msgOf(c)}`,
+    fallbackText: (r) =>
+      typeof r === "object" && r !== null && "content" in r && !Array.isArray(r.content)
+        ? msgOf(r.content)
+        : defaultCallResultFallbackText(r),
+  };
+  for (const result of results) {
+    const viaSupervisor = projectCallToolResult(result, supervisorHandlers);
+    const viaMiddleware = projectCallToolResult(result, middlewareHandlers);
+    // 结构契约同构：键集合一致（structuredContent 只随输入存在）
+    assert.equal(
+      "structuredContent" in viaMiddleware,
+      "structuredContent" in viaSupervisor,
+      "两路径投影键集合同构",
+    );
+    if ("structuredContent" in viaSupervisor) {
+      assert.deepEqual(viaMiddleware.structuredContent, viaSupervisor.structuredContent, "structuredContent 值同构");
+    }
+    // content 形态同构：数组 + 块数 + 块类型一致（渲染文本是 handler 注入的
+    // 调用方差异面，允许不同——同构断言只比投影结构）
+    assert.ok(Array.isArray(viaSupervisor.content));
+    assert.equal(viaMiddleware.content.length, viaSupervisor.content.length, "投影 content 块数同构");
+    if (viaSupervisor.content.length > 0) {
+      assert.equal(viaMiddleware.content[0].type, viaSupervisor.content[0].type, "投影 content 块类型同构");
+    }
+    // 正常 content 直通路径（无渲染差异）→ 内容逐字一致
+    if (Array.isArray(result.content) && result.isError !== true) {
+      assert.deepEqual(viaMiddleware.content, viaSupervisor.content, "直通路径 content 逐字同构");
+    }
+  }
+  // isError:true → 两路径统一抛错（错误契约同构：Error 形态，非裸对象；
+  // 具体文案是 handler 注入差异面，不强匹配）
+  for (const handlers of [supervisorHandlers, middlewareHandlers]) {
+    assert.throws(
+      () => projectCallToolResult({ content: [{ type: "text", text: "boom" }], isError: true }, handlers),
+      Error,
+    );
+    assert.throws(() => projectCallToolResult({ isError: true }, handlers), Error);
+  }
+}
+
+// ---- 两路径同构：args 面（middleware 归一化；supervisor 直传——同构点）----
+
+{
+  // middleware 路径：normalizeArguments 保证 arguments 为 object（B14 数组拒绝）
+  assert.deepEqual(normalizeArguments('{"a":1}'), { a: 1 });
+  assert.deepEqual(normalizeArguments("[1,2]"), {}, "B14 数组归一无害空态");
+  // supervisor 路径契约：execute 侧对象化（typeof args === object ? args : {}）——
+  // 对 normalizeArguments 产物两路同构（object 输入原样透传）。
+  const supShape = (args) => (typeof args === "object" && args !== null ? args : {});
+  assert.deepEqual(supShape(normalizeArguments({ a: 1 })), { a: 1 });
+  assert.deepEqual(supShape(normalizeArguments('{"a":1}')), { a: 1 });
+  assert.deepEqual(supShape(normalizeArguments("[1,2]")), {}, "数组经两路同样归一无害空态");
+}
+
+// ---- supervisor 路径 stats 埋点契约（行为扩展声明，红测：现状未埋点）----
+
+{
+  const statsCalls = [];
+  const manager = {
+    ctx: { tools: { register: () => () => {} } },
+    logger: { info: () => {}, warn: () => {} },
+    enhancement: {},
+    emitStatus: () => {},
+    recordCatalogTools: async () => {},
+    stats: {
+      isEnabled: () => true,
+      recordCall: (server, tool, durationMs, success, errorMsg) => {
+        statsCalls.push({ server, tool, durationMs, success, errorMsg });
+      },
+    },
+  };
+  const client = fakeMCPClient({
+    callTool: async () => ({ content: [{ type: "text", text: "ok" }] }),
+  });
+  const def = buildToolDefinition(
+    client,
+    { name: "echo", inputSchema: { type: "object", properties: { text: { type: "string" } } } },
+    { name: "srv", transport: "stdio", command: "echo", enabled: true },
+    { stats: manager.stats },
+  );
+  const res = await def.execute({ text: "hi" }, { signal: undefined });
+  assert.equal(res.content[0].text, "ok", "supervisor 路径 execute 正常");
+  assert.equal(statsCalls.length, 1, "supervisor execute 成功应 recordCall（现状缺失 → 红测）");
+  assert.equal(statsCalls[0].server, "srv");
+  assert.equal(statsCalls[0].tool, "echo");
+  assert.equal(statsCalls[0].success, true);
+}

--- a/scripts/data/mutation-topology.json
+++ b/scripts/data/mutation-topology.json
@@ -94,7 +94,8 @@
         "packages/dsh-mcp-manager/test/unit-store.test.ts",
         "packages/dsh-mcp-manager/test/unit-supervisor.test.ts",
         "packages/dsh-mcp-manager/test/unit-transport.test.ts",
-        "packages/dsh-mcp-manager/test/unit-call-stats.test.ts"
+        "packages/dsh-mcp-manager/test/unit-call-stats.test.ts",
+        "packages/dsh-mcp-manager/test/unit-pipeline.test.ts"
       ],
       "segments": {
         "entry": {

--- a/stryker.conf.d/dsh-mcp-manager-entry.json
+++ b/stryker.conf.d/dsh-mcp-manager-entry.json
@@ -49,7 +49,8 @@
       "packages/dsh-mcp-manager/test/unit-store.test.ts",
       "packages/dsh-mcp-manager/test/unit-supervisor.test.ts",
       "packages/dsh-mcp-manager/test/unit-transport.test.ts",
-      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts"
+      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts",
+      "packages/dsh-mcp-manager/test/unit-pipeline.test.ts"
     ]
   },
   "jsonReporter": {

--- a/stryker.conf.d/dsh-mcp-manager-manager.json
+++ b/stryker.conf.d/dsh-mcp-manager-manager.json
@@ -47,7 +47,8 @@
       "packages/dsh-mcp-manager/test/unit-store.test.ts",
       "packages/dsh-mcp-manager/test/unit-supervisor.test.ts",
       "packages/dsh-mcp-manager/test/unit-transport.test.ts",
-      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts"
+      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts",
+      "packages/dsh-mcp-manager/test/unit-pipeline.test.ts"
     ]
   },
   "jsonReporter": {

--- a/stryker.conf.d/dsh-mcp-manager-middleware.json
+++ b/stryker.conf.d/dsh-mcp-manager-middleware.json
@@ -49,7 +49,8 @@
       "packages/dsh-mcp-manager/test/unit-store.test.ts",
       "packages/dsh-mcp-manager/test/unit-supervisor.test.ts",
       "packages/dsh-mcp-manager/test/unit-transport.test.ts",
-      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts"
+      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts",
+      "packages/dsh-mcp-manager/test/unit-pipeline.test.ts"
     ]
   },
   "jsonReporter": {

--- a/stryker.conf.d/dsh-mcp-manager-routes.json
+++ b/stryker.conf.d/dsh-mcp-manager-routes.json
@@ -48,7 +48,8 @@
       "packages/dsh-mcp-manager/test/unit-store.test.ts",
       "packages/dsh-mcp-manager/test/unit-supervisor.test.ts",
       "packages/dsh-mcp-manager/test/unit-transport.test.ts",
-      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts"
+      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts",
+      "packages/dsh-mcp-manager/test/unit-pipeline.test.ts"
     ]
   },
   "jsonReporter": {

--- a/stryker.conf.d/dsh-mcp-manager-runtime.json
+++ b/stryker.conf.d/dsh-mcp-manager-runtime.json
@@ -53,7 +53,8 @@
       "packages/dsh-mcp-manager/test/unit-store.test.ts",
       "packages/dsh-mcp-manager/test/unit-supervisor.test.ts",
       "packages/dsh-mcp-manager/test/unit-transport.test.ts",
-      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts"
+      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts",
+      "packages/dsh-mcp-manager/test/unit-pipeline.test.ts"
     ]
   },
   "jsonReporter": {

--- a/stryker.conf.d/dsh-mcp-manager-supervisor.json
+++ b/stryker.conf.d/dsh-mcp-manager-supervisor.json
@@ -50,7 +50,8 @@
       "packages/dsh-mcp-manager/test/unit-store.test.ts",
       "packages/dsh-mcp-manager/test/unit-supervisor.test.ts",
       "packages/dsh-mcp-manager/test/unit-transport.test.ts",
-      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts"
+      "packages/dsh-mcp-manager/test/unit-call-stats.test.ts",
+      "packages/dsh-mcp-manager/test/unit-pipeline.test.ts"
     ]
   },
   "jsonReporter": {


### PR DESCRIPTION
Part of #664（阶段 2：执行管道域 src/pipeline/ + 两路径契约 + B8/B9/B10/B18 + stats 埋点）

## 说明

阶段 2 = 执行管道域成形（**D10 interface.ts 首个真实应用**）：纯函数族迁入
`src/pipeline/`（跨目录引用全部走 `pipeline/interface.ts`，verify-dir-imports 门禁
首个生效 PASS），两路径（supervisor 直呼 / ws_mcp_call）同构契约测试强制，B 系列
修复红测先行。

## 改动（3 commit，各自独立可验证）

**refactor `f9a05ca`**（pipeline/ 收敛，零行为变更）
- `src/pipeline/{args,msg,redact,timeout,authorize,project}.ts` + `interface.ts`：
  normalizeArguments/msgOf/createRedactor/withTimeout/globMatch/projectCallToolResult
  自 middleware-utils.ts / call-result.ts 迁入；`call-result.ts` 删除（→ project.ts）
- middleware.ts / supervisor.ts / middleware-register.ts / index.ts / middleware-utils.ts
  跨目录引用全部改走 pipeline/interface.ts；lib 导出面不变
- policy 裁决族依赖 workspace 域（阶段 4），本阶段不强行迁入（authorize 仅 globMatch）

**test `305fbf2`**（红测）
- `test/unit-pipeline.test.ts`（双登记）：两路径投影同构契约（结构契约同构、直通
  路径逐字一致；timeout/redact/stale 三项差异面显式排除并文档化）+ args 同构点 +
  supervisor stats 埋点红测（行为扩展声明）
- B8 基线修订（host/path 应保留 + percent-encoding raw 形态对照）/ B9 字节截断 /
  B10 truncated 不误报 / B18 callTool 预算 + 退避配置 红测

**fix `4efa36e`**（红转绿）
- **B8（D4 已批准，安全语义变更）**：仅用户信息脱敏 + raw/decoded 双形态防编码绕过；
  supervisor/manager 错误日志脱敏全覆盖（C-ERR 同口径）；README 安全模型同步
- **B9**：boundCatalogTools 字节感知截断 + totalBytes 全字节口径
- **B10**：searchCatalog(Multi) 返回截断事实，executeSearch 消费（恰好 limit 不误报）
- **B18**：callTool 预算读 server.toolCallTimeoutMs（+2s 兜底）；退避读
  server.reconnect；closeHandler 递增 failedAttempts
- **行为扩展**：supervisor 直呼路径 stats 埋点（ManagerLite 最小面 + execute recordCall）

## 验证

- 红测确认红（B8 host 被整 URL 脱敏 / B9 超字节 / B10 无 truncated / B18 30000 与
  500 硬编码 / 埋点未调用）→ 修复后全绿
- 本地门禁全绿：`pnpm build && pnpm test && pnpm contract && pnpm pack:check &&
  pnpm typecheck` + `gen-stryker-conf --check`；verify-dir-imports PASS
  （pipeline/ 首个受检目录）

### 客户端改动截图证据（勾选式）

- [x] **不涉及客户端改动**（未改动 `src/client/**`、`src/client/style.css`、客户端产物 `lib/client.js`）
