### PR TITLE
refactor(dsh-provider-usage): 阶段三——R8 台账守恒护栏 + aggregator 拆分 + 域2错误面（#670）

### DIFF
--- a/packages/dsh-provider-usage/src/apply.ts
+++ b/packages/dsh-provider-usage/src/apply.ts
@@ -37,6 +37,7 @@ import { HotReloadableAdapter } from "./hotreload.ts";
 import { resolvePath } from "./path-resolve.ts";
 import { Config, normalizeConfig, type NormalizedConfig } from "./config.ts";
 import { readUiConfig } from "./ui-config.ts";
+import { makeLayerErrorSurface } from "./errsurf.ts";
 import { readAdapterStateResult, readUserAdapters } from "./user-adapters.ts";
 import { loadUserAdapterChecked } from "./user-adapter-loader.ts";
 import { StatsService } from "./stats-service.ts";
@@ -214,6 +215,11 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
     // dsh-gate:allow-homedir #517 展示层脱敏：把诊断文本中的 home 前缀折叠为 ~，不产生读写面
     s.split(dshHome()).join("~/.dsh").split(homedir()).join("~");
 
+  // #670 阶段三 B：域2每层错误面（aggregate/schedule/execute）——装配层组合根创建，
+  // 经各对象既有 warn 诊断出口接线（层代码零改动，避免与 aggregator 拆分任务 A 冲突）；
+  // health per-layer 段经 UiRoutesContext 注入 routes/ui.ts 读取。
+  const layerErrors = makeLayerErrorSurface();
+
   const registry = makeAdapterRegistry({
     sanitizePath: sanitizeDiagnostic,
   });
@@ -289,7 +295,13 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
   const trend = await TrendTracker.start({
     root: join(historyRoot, "trend"),
     retentionDays: config.trendRetentionDays,
-    warn: (msg) => console.warn(`[dsh-provider-usage] trend: ${sanitizeDiagnostic(msg)}`),
+    // #670 阶段三 B：aggregate 层错误面接线——压实失败/刷盘失败/归属异常等
+    // 趋势层运行时错误全部汇聚到 TrendTracker 的 warn 诊断出口，此处同时上报。
+    warn: (msg) => {
+      const safe = sanitizeDiagnostic(msg);
+      layerErrors.record("aggregate", safe);
+      console.warn(`[dsh-provider-usage] trend: ${safe}`);
+    },
     // #633 A1：目录归属主源 = 官方 store 的会话创建元数据（SessionHeader.cwd）。
     // SessionId 为官方品牌类型（string & BRAND），裸 string 经 get 参数位断言桥接
     // （官方品牌桥接须 import type @deepseek-ai/dsh-brand——catalog 已锁 0.1.2-rc.1，
@@ -328,7 +340,13 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
       historyRoot,
       sanitizeDiagnostic,
     }),
-    warn: (msg) => console.warn(`[dsh-provider-usage] report: ${sanitizeDiagnostic(msg)}`),
+    // #670 阶段三 B：execute 层错误面接线——任务执行失败（含 executor 脱敏后错误）
+    // 经队列 warn 出口汇聚于此。
+    warn: (msg) => {
+      const safe = sanitizeDiagnostic(msg);
+      layerErrors.record("execute", safe);
+      console.warn(`[dsh-provider-usage] report: ${safe}`);
+    },
   });
 
   const reportScheduler = ReportScheduler.start({
@@ -339,7 +357,13 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
       reportQueue.submit(due);
       return Promise.resolve();
     },
-    warn: (msg) => console.warn(`[dsh-provider-usage] report: ${sanitizeDiagnostic(msg)}`),
+    // #670 阶段三 B：schedule 层错误面接线——tick 异常/提交失败经调度器
+    // warn 出口汇聚于此。
+    warn: (msg) => {
+      const safe = sanitizeDiagnostic(msg);
+      layerErrors.record("schedule", safe);
+      console.warn(`[dsh-provider-usage] report: ${safe}`);
+    },
   });
 
   function ensureReportKind(): void {
@@ -376,7 +400,7 @@ export async function apply(ctx: Context, rawConfig: Record<string, unknown> = {
     ),
     ...createUiRoutes(
       { health: ROUTES.health, trend: ROUTES.trend, uiConfig: ROUTES.uiConfig, events: ROUTES.events },
-      { statsService, trend, uiConfig, sseClients, broadcastUiConfigChanged },
+      { statsService, trend, uiConfig, sseClients, broadcastUiConfigChanged, layerErrors },
     ),
     ...createReportRoutes(
       {

--- a/packages/dsh-provider-usage/src/errsurf.ts
+++ b/packages/dsh-provider-usage/src/errsurf.ts
@@ -1,0 +1,98 @@
+/**
+ * dsh-provider-usage — 域2每层错误面（阶段三 B，#670）。
+ *
+ * 背景：域2（trend/report）三层运行时错误原本只经 console.warn 诊断出口消散——
+ * 无计数、无最近记录，/health 不可观测。本模块为「aggregate（趋势聚合/压实）、
+ * schedule（报告调度）、execute（报告生成/执行）」三层提供统一的内存错误面：
+ * 每层 = 累计计数 + 最近 N 条（时间戳/消息/上下文）。
+ *
+ * 形态对齐 registry.recordError 既有模式（内存 Map + snapshot 只读快照），但补上
+ * 既有模式欠缺的两层语义：累计计数与最近 N 条环形缓冲——单 key 覆盖式 lastErrors
+ * 只能回答「最近一次」，撑不起层健康观测。
+ *
+ * 接入策略（阶段三约束）：aggregator.ts 正被并行任务 A 拆分，本模块不直接触碰
+ * src/trend/* 与 src/report/* 业务代码；三层上报经装配层 apply.ts 复用各对象既有
+ * warn 诊断出口接线（组合根特权）：
+ * - aggregate：TrendTracker 的 warn（压实失败/刷盘失败/归属异常汇聚于此）
+ * - schedule：ReportScheduler 的 warn（tick 异常/提交失败）
+ * - execute：ReportTaskQueue 的 warn（任务执行失败，消息已脱敏）
+ * A 拆分完成后若需在 aggregator 内部记账/rollup 出错点直连上报，可注入本模块
+ * 同形 record（空参 no-op 实现同签名，见 makeNoopLayerErrorSurface）。
+ */
+export type LayerErrorKey = "aggregate" | "schedule" | "execute";
+
+/** 每层最近一条错误记录（时间戳/消息/上下文）。 */
+export interface LayerErrorRecord {
+  at: number;
+  message: string;
+  /** 层内定位（如聚合日键 / 报告周期与窗口键），可空。 */
+  context?: string;
+}
+
+/** 单层错误面状态（health per-layer 段数据源）。 */
+export interface LayerErrorState {
+  /** 累计计数（自进程挂载起）。 */
+  count: number;
+  /** 最近 N 条（新在前；N = maxRecent）。 */
+  recent: LayerErrorRecord[];
+}
+
+/** 域2每层错误面接口（record 为层代码可注入的上报入口）。 */
+export interface LayerErrorSurface {
+  record(layer: LayerErrorKey, message: string, context?: string): void;
+  /** 只读快照（三键齐，未发生错误的层为 count 0 空队列）。 */
+  snapshot(): Record<LayerErrorKey, LayerErrorState>;
+}
+
+export interface LayerErrorSurfaceOptions {
+  /** 每层最近保留条数（默认 10）。 */
+  maxRecent?: number;
+  /** 注入时钟（测试用；默认 Date.now）。 */
+  now?: () => number;
+}
+
+export const LAYER_ERROR_KEYS: readonly LayerErrorKey[] = ["aggregate", "schedule", "execute"];
+export const LAYER_ERROR_MAX_RECENT_DEFAULT = 10;
+
+export function makeLayerErrorSurface(opts: LayerErrorSurfaceOptions = {}): LayerErrorSurface {
+  const maxRecent = opts.maxRecent ?? LAYER_ERROR_MAX_RECENT_DEFAULT;
+  const now = opts.now ?? Date.now;
+  const states = new Map<LayerErrorKey, LayerErrorState>(
+    LAYER_ERROR_KEYS.map((layer) => [layer, { count: 0, recent: [] }]),
+  );
+
+  return {
+    record(layer, message, context) {
+      const state = states.get(layer);
+      // 未知层忽略（防御：future 层枚举扩展时旧调用方不炸）
+      if (state === undefined) return;
+      state.count += 1;
+      const entry: LayerErrorRecord = { at: now(), message };
+      if (context !== undefined) entry.context = context;
+      state.recent.unshift(entry);
+      // 环形截断：Math.min 代替条件比较（语义 = 超限才裁，等价但无比较变异点）
+      state.recent.length = Math.min(state.recent.length, maxRecent);
+    },
+    snapshot() {
+      const out = {} as Record<LayerErrorKey, LayerErrorState>;
+      for (const [layer, state] of states) {
+        out[layer] = { count: state.count, recent: state.recent.map((r) => ({ ...r })) };
+      }
+      return out;
+    },
+  };
+}
+
+/** 空参数默认实现（供暂未接线/测试替身用；形态与真实 surface 一致）。 */
+export function makeNoopLayerErrorSurface(): LayerErrorSurface {
+  return {
+    record() {},
+    snapshot() {
+      return {
+        aggregate: { count: 0, recent: [] },
+        schedule: { count: 0, recent: [] },
+        execute: { count: 0, recent: [] },
+      };
+    },
+  };
+}

--- a/packages/dsh-provider-usage/src/routes/ui.ts
+++ b/packages/dsh-provider-usage/src/routes/ui.ts
@@ -6,6 +6,7 @@ import { basename } from "node:path";
 import type { WebRoute } from "@deepseek-ai/dsh-host-webserver";
 import { guardLoopbackMethod, readJsonBody, writeJson } from "../../../../shared/host-utils.js";
 import { ADAPTER_CONTRACT_VERSION } from "../contracts.ts";
+import type { LayerErrorSurface } from "../errsurf.ts";
 import type { StatsService } from "../stats-service.ts";
 import type { TrendTracker } from "../trend/index.ts";
 import { TREND_DIR_MAX } from "../trend/types.ts";
@@ -17,6 +18,8 @@ export interface UiRoutesContext {
   uiConfig: UiPlacementConfig;
   sseClients: Set<ServerResponse>;
   broadcastUiConfigChanged: () => void;
+  /** 域2每层错误面（phase3-B #670）：health 响应 per-layer 段数据源。 */
+  layerErrors: LayerErrorSurface;
 }
 
 const TREND_WINDOW: Record<string, number> = { day: 30, week: 12, month: 12 };
@@ -55,6 +58,9 @@ export function handleHealth(
     enabled: snap.enabled,
     errors: snap.errors,
     historyDir: statsService.historyRoot,
+    // 域2每层错误面（#670 phase3-B）：aggregate/schedule/execute 三层计数 + 最近 N 条；
+    // 与 errors（域1 适配器最近一次登记）并列，字段风格一致（camelCase 平铺）。
+    layerErrors: context.layerErrors.snapshot(),
     trend: trend.stats(),
   });
 }

--- a/packages/dsh-provider-usage/src/trend/aggregate-query.ts
+++ b/packages/dsh-provider-usage/src/trend/aggregate-query.ts
@@ -1,0 +1,629 @@
+/**
+ * dsh-provider-usage/trend — 查询投影纯函数（D2 aggregator 拆分的纯函数层之二，#670 阶段三）。
+ *
+ * 为什么独立成模块：趋势查询面（序列/堆叠/窗口摘要/目录投影）的计算与
+ * TrendAggregator 的状态容器解耦——本模块全部函数以 days/dirDays/rows 显式传参，
+ * 不接触 this（防「拆文件 = 共享 this」坏味道，layer-architecture.md §4 D-2）；
+ * 主类保留状态容器与需要 this 的 IO/记账方法，查询方法变成薄壳委托。
+ * 依赖方向无环：aggregate-query → types / charts / aggregate-rows；aggregator → 三者。
+ *
+ * 守恒边界（R8 不变量4，unit-trend-ledger.test.ts 对账口径）：dirRows() 输出 = 目录桶
+ * 快照 + 每日残差投影（归 TREND_UNIDENTIFIED）；无 dir 键的旧格式行只进聚合面不进
+ * 目录面——目录维度守恒以「有 dir 事实」为界。小时面（buildHourRows）不做残差投影
+ * （detail/counter 行必有 time，旧分片缺小时是物理缺失，报告侧 coveredDays 守卫降级）。
+ */
+import { dayKey, lastNDayKeys } from "../charts.ts";
+import { emptyCell, diffToken } from "./aggregate-rows.ts";
+import {
+  sumToken,
+  TREND_ROW_VERSION,
+  TREND_UNIDENTIFIED,
+  type TrendCell,
+  type TrendDirRow,
+  type TrendHourRow,
+} from "./types.ts";
+
+/** 聚合指标（序列查询的取值维度；total = 四项 token 之和）。 */
+export type TrendMetric = "total" | "input" | "output" | "cacheRead" | "cacheWrite" | "calls";
+
+/** 序列粒度。 */
+export type TrendGranularity = "day" | "week" | "month";
+
+/** 堆叠柱单段（一个 provider 或 provider+model 组合在一个时间桶内的取值）。 */
+export interface TrendStackPart {
+  provider: string;
+  model: string | null;
+  value: number | null;
+}
+
+/** 堆叠柱单根（一个时间桶）。 */
+export interface TrendStackPoint {
+  /** 桶键：day=YYYY-MM-DD / week=周首日 / month=YYYY-MM。 */
+  key: string;
+  parts: TrendStackPart[];
+  /** 各段之和（null-aware；空桶 null）。 */
+  total: number | null;
+}
+
+/** 窗口摘要（趋势页汇总卡数据源）。 */
+export interface TrendWindowSummary {
+  /** 当前窗口指标总量。 */
+  total: number | null;
+  calls: number;
+  turns: number;
+  toolCalls: number;
+  /** 峰值桶键（total 最大的时间桶；无数据 null）。 */
+  peakKey: string | null;
+  /** 取值最大的适配器段。 */
+  top: { provider: string; model: string | null; value: number } | null;
+  /** 上一同等窗口指标总量（环比基准；无数据 null）。 */
+  prevTotal: number | null;
+  /** 上一窗口数据是否完整（起点早于数据起点 = false；false 时环比不可比，#503 M2.1）。 */
+  prevComplete: boolean;
+}
+
+/** cell 的指标取值（total = 四项 token 之和）。 */
+export function metricValue(cell: TrendCell, metric: TrendMetric): number | null {
+  switch (metric) {
+    case "total":
+      return sumToken(sumToken(cell.input, cell.output), sumToken(cell.cacheRead, cell.cacheWrite));
+    case "input":
+      return cell.input;
+    case "output":
+      return cell.output;
+    case "cacheRead":
+      return cell.cacheRead;
+    case "cacheWrite":
+      return cell.cacheWrite;
+    case "calls":
+      return cell.calls;
+  }
+}
+
+/** 周一为起点的周首日 day key（本地时区；DST 安全——逐日回退不用毫秒减法）。 */
+export function weekStartKey(t: number): string {
+  const d = new Date(t);
+  const dow = d.getDay(); // 0=周日
+  const back = (dow + 6) % 7; // 距周一的天数
+  d.setDate(d.getDate() - back);
+  return dayKey(d.getTime());
+}
+
+/** 近 n 个周首日 key（升序，含当前周）。 */
+export function lastNWeekKeys(n: number, now: number): string[] {
+  const d = new Date(now);
+  d.setDate(d.getDate() - ((d.getDay() + 6) % 7));
+  const keys: string[] = [];
+  for (let i = 0; i < n; i += 1) {
+    keys.unshift(dayKey(d.getTime()));
+    d.setDate(d.getDate() - 7);
+  }
+  return keys;
+}
+
+/** 近 n 个月 key（YYYY-MM，升序，含当月；本地时区逐月回退）。 */
+export function lastNMonthKeys(n: number, now: number): string[] {
+  const d = new Date(now);
+  const keys: string[] = [];
+  for (let i = 0; i < n; i += 1) {
+    keys.unshift(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`);
+    d.setDate(1);
+    d.setMonth(d.getMonth() - 1);
+  }
+  return keys;
+}
+
+/** 月 key 的日区间（本地日字典序；月末取该月最后一天，DST 安全）。 */
+export function monthRange(key: string): { start: string; end: string } {
+  const [y, m] = key.split("-").map(Number);
+  const start = new Date(y, m - 1, 1);
+  const end = new Date(y, m, 0); // 次月 0 日 = 本月末日
+  return { start: dayKey(start.getTime()), end: dayKey(end.getTime()) };
+}
+
+/** 周首日 key 的日区间（7 天）。 */
+export function weekRange(weekStart: string): { start: string; end: string } {
+  const [y, m, d] = weekStart.split("-").map(Number);
+  const start = new Date(y, m - 1, d);
+  const endDate = new Date(y, m - 1, d + 6);
+  return { start: dayKey(start.getTime()), end: dayKey(endDate.getTime()) };
+}
+
+/** 内存日桶的最早 day key（无数据返回 null；day key 字典序即时间序）。 */
+function firstDayKeyOf(days: Map<string, unknown>): string | null {
+  let first: string | null = null;
+  for (const day of days.keys()) {
+    if (first === null || day < first) first = day;
+  }
+  return first;
+}
+
+/** 粒度桶键序列（升序，含当前桶）。 */
+function granKeysFor(n: number, gran: TrendGranularity, now: number): string[] {
+  if (gran === "week") return lastNWeekKeys(n, now);
+  if (gran === "month") return lastNMonthKeys(n, now);
+  return lastNDayKeys(n, now);
+}
+
+/** 桶键 → 本地日区间。 */
+function granRangeForKey(key: string, gran: TrendGranularity): { start: string; end: string } {
+  if (gran === "week") return weekRange(key);
+  if (gran === "month") return monthRange(key);
+  return { start: key, end: key };
+}
+
+/** 上一窗口锚点（把 now 前移 n 桶，得到 prevKeys 与当前窗口不重叠的时点）。 */
+function prevWindowAnchorFor(now: number, n: number, gran: TrendGranularity): number {
+  const d = new Date(now);
+  if (gran === "month") {
+    d.setMonth(d.getMonth() - n);
+    return d.getTime();
+  }
+  const days = gran === "week" ? n * 7 : n;
+  d.setDate(d.getDate() - days);
+  return d.getTime();
+}
+
+/** 日区间内的全部 (provider, model, cell)（升序日；provider 过滤可选）。 */
+function rangeCellsOf(days: Map<string, Map<string, Map<string | null, TrendCell>>>, range: { start: string; end: string }, provider?: string): Array<{ provider: string; model: string | null; cell: TrendCell }> {
+  const out: Array<{ provider: string; model: string | null; cell: TrendCell }> = [];
+  for (const [day, models] of days) {
+    if (day < range.start || day > range.end) continue;
+    for (const [p, cells] of models) {
+      if (provider !== undefined && p !== provider) continue;
+      for (const [m, cell] of cells) out.push({ provider: p, model: m, cell });
+    }
+  }
+  return out;
+}
+
+/** 单日取值（provider 过滤可选；跨 model 求和；aggregator.seriesDays 委托用）。 */
+export function dayValueOf(days: Map<string, Map<string, Map<string | null, TrendCell>>>, day: string, metric: TrendMetric, provider?: string): number | null {
+  const models = days.get(day);
+  if (models === undefined) return null;
+  let acc: number | null = null;
+  for (const [p, cells] of models) {
+    if (provider !== undefined && p !== provider) continue;
+    for (const cell of cells.values()) acc = sumToken(acc, metricValue(cell, metric));
+  }
+  return acc;
+}
+
+/** 日区间取值（[startDay, endDay] 闭区间，按本地日字典序比较；aggregator 序列方法委托用）。 */
+export function rangeValueOf(days: Map<string, Map<string, Map<string | null, TrendCell>>>, range: { start: string; end: string }, metric: TrendMetric, provider?: string): number | null {
+  let acc: number | null = null;
+  for (const [day, models] of days) {
+    if (day < range.start || day > range.end) continue;
+    for (const [p, cells] of models) {
+      if (provider !== undefined && p !== provider) continue;
+      for (const cell of cells.values()) acc = sumToken(acc, metricValue(cell, metric));
+    }
+  }
+  return acc;
+}
+
+/**
+ * 堆叠柱序列（/trend 路由数据源）：每时间桶按 provider（byModel 时细到
+ * provider+model）拆段；providers 为图例并集（窗口内出现过的段）。
+ */
+export function buildStackedSeries(
+  days: Map<string, Map<string, Map<string | null, TrendCell>>>,
+  n: number,
+  gran: TrendGranularity,
+  metric: TrendMetric,
+  provider: string | undefined,
+  byModel: boolean,
+  now: number,
+): { series: TrendStackPoint[]; providers: Array<{ provider: string; model: string | null }> } {
+  const keys = granKeysFor(n, gran, now);
+  // 桶日区间一次算全（评审 P1-2：原实现对每桶在 days 日循环内重复调 granRange）
+  const ranges = new Map(keys.map((k) => [k, granRangeForKey(k, gran)] as const));
+  const series: TrendStackPoint[] = keys.map((key) => {
+    const partsMap = new Map<string, TrendStackPart>();
+    const range = ranges.get(key)!;
+    for (const [day, models] of days) {
+      if (day < range.start || day > range.end) continue;
+      for (const [p, cells] of models) {
+        if (provider !== undefined && p !== provider) continue;
+        for (const [m, cell] of cells) {
+          const id = byModel ? `${p}\u0000${m ?? ""}` : p;
+          const v = metricValue(cell, metric);
+          const cur = partsMap.get(id);
+          if (cur !== undefined) cur.value = sumToken(cur.value, v);
+          else partsMap.set(id, { provider: p, model: byModel ? m : null, value: v });
+        }
+      }
+    }
+    const parts = [...partsMap.values()];
+    let total: number | null = null;
+    for (const pt of parts) total = sumToken(total, pt.value);
+    return { key, parts, total };
+  });
+  const legend = new Map<string, { provider: string; model: string | null }>();
+  for (const point of series) {
+    for (const pt of point.parts) {
+      legend.set(byModel ? `${pt.provider}\u0000${pt.model ?? ""}` : pt.provider, {
+        provider: pt.provider,
+        model: byModel ? pt.model : null,
+      });
+    }
+  }
+  return { series, providers: [...legend.values()] };
+}
+
+/**
+ * 堆叠柱序列（目录维度；#633 分片 b B1 数据接口）。语义与 seriesStacked 同构：
+ * 每时间桶按目录拆段；dirs 为图例并集（窗口内出现过的目录段，含未识别桶）。
+ * dir 过滤可选（单目录形态——未识别桶键同为合法过滤值）。
+ */
+export function buildDirStackedSeries(
+  rows: TrendDirRow[],
+  n: number,
+  gran: TrendGranularity,
+  metric: TrendMetric,
+  dir: string | undefined,
+  now: number,
+): { series: TrendStackPoint[]; dirs: Array<{ dir: string }> } {
+  const keys = granKeysFor(n, gran, now);
+  const ranges = new Map(keys.map((k) => [k, granRangeForKey(k, gran)] as const));
+  // 复核 P1-3：行快照提出桶循环（原实现每桶 this.dirRows() 全量快照，O(桶×行)
+  // 单请求重复；对齐 seriesStacked 的 P1-2 先例——range 一次算全 + 快照单次
+  // 取用，桶循环内只做窗口过滤消费）。
+  const series: TrendStackPoint[] = keys.map((key) => {
+    const partsMap = new Map<string, TrendStackPart>();
+    const range = ranges.get(key)!;
+    for (const row of rows) {
+      if (row.day < range.start || row.day > range.end) continue;
+      if (dir !== undefined && row.dir !== dir) continue;
+      const v = metricValue(row, metric);
+      const cur = partsMap.get(row.dir);
+      if (cur !== undefined) cur.value = sumToken(cur.value, v);
+      else partsMap.set(row.dir, { provider: row.dir, model: null, value: v });
+    }
+    const parts = [...partsMap.values()];
+    let total: number | null = null;
+    for (const pt of parts) total = sumToken(total, pt.value);
+    return { key, parts, total };
+  });
+  const legend = new Set<string>();
+  for (const point of series) {
+    for (const pt of point.parts) legend.add(pt.provider);
+  }
+  return { series, dirs: [...legend].sort().map((d) => ({ dir: d })) };
+}
+
+/**
+ * 窗口摘要（当前 n 桶 + 上一同等窗口环比基准）。
+ * @param stackSeries 可选传入路由已算好的堆叠序列（n/gran/metric/provider 必须与本
+ *   调用一致）——复用峰值/Top 遍历，消除单请求双算（评审 P1-2）；缺省时内部自算。
+ */
+export function buildWindowSummary(
+  days: Map<string, Map<string, Map<string | null, TrendCell>>>,
+  n: number,
+  gran: TrendGranularity,
+  metric: TrendMetric,
+  provider: string | undefined,
+  now: number,
+  stackSeries?: TrendStackPoint[],
+): TrendWindowSummary {
+  const keys = granKeysFor(n, gran, now);
+  const curRange = {
+    start: granRangeForKey(keys[0], gran).start,
+    end: granRangeForKey(keys[keys.length - 1], gran).end,
+  };
+  // 上一窗口：同长键序列整体前移 n 桶（day/week/month 各自步进语义）
+  const prevKeys = granKeysFor(n, gran, prevWindowAnchorFor(now, n, gran));
+  const prevRange = {
+    start: granRangeForKey(prevKeys[0], gran).start,
+    end: granRangeForKey(prevKeys[prevKeys.length - 1], gran).end,
+  };
+  let total: number | null = null;
+  let calls = 0;
+  let turns = 0;
+  let toolCalls = 0;
+  let prevTotal: number | null = null;
+  let peakKey: string | null = null;
+  let peakVal = -1;
+  let top: { provider: string; model: string | null; value: number } | null = null;
+  // 复用路由已算的 stack 序列（评审 P1-2：消除单请求双算；缺省自算保持独立可用）
+  const series = stackSeries ?? buildStackedSeries(days, n, gran, metric, provider, false, now).series;
+  for (const point of series) {
+    if (point.total !== null && point.total > peakVal) {
+      peakVal = point.total;
+      peakKey = point.key;
+    }
+    for (const pt of point.parts) {
+      if (pt.value !== null && (top === null || pt.value > top.value)) {
+        top = { provider: pt.provider, model: pt.model, value: pt.value };
+      }
+    }
+  }
+  for (const { cell } of rangeCellsOf(days, curRange, provider)) {
+    total = sumToken(total, metricValue(cell, metric));
+    calls += cell.calls;
+    turns += cell.turns;
+    toolCalls += cell.toolCalls;
+  }
+  return {
+    total,
+    calls,
+    turns,
+    toolCalls,
+    peakKey,
+    top,
+    prevTotal: rangeValueOf(days, prevRange, metric, provider),
+    // 上一窗口起点早于数据起点（内存最早日，即留存/起算边缘）→ 基准不完整，环比不可比（#503 M2.1）
+    prevComplete: prevRange.start >= (firstDayKeyOf(days) ?? "9999-12-31"),
+  };
+}
+
+/**
+ * 窗口摘要（目录维度；#633 分片 b B1 数据接口）。curRange/prevRange 语义与
+ * windowSummary 完全同构：当前窗口总量/调用数/峰值桶/目录 top 段 + 上一窗口环比。
+ * prevComplete 语义对齐：prev 窗口起点早于**目录面数据起点**（dirRows 最早日；
+ * 残差投影后该起点等于聚合面数据起点，故与 windowSummary 同值）→ 不可比。
+ */
+export function buildDirWindowSummary(
+  rows: TrendDirRow[],
+  n: number,
+  gran: TrendGranularity,
+  metric: TrendMetric,
+  dir: string | undefined,
+  now: number,
+  dirSeries?: TrendStackPoint[],
+): TrendWindowSummary {
+  const keys = granKeysFor(n, gran, now);
+  const curRange = {
+    start: granRangeForKey(keys[0], gran).start,
+    end: granRangeForKey(keys[keys.length - 1], gran).end,
+  };
+  const prevKeys = granKeysFor(n, gran, prevWindowAnchorFor(now, n, gran));
+  const prevRange = {
+    start: granRangeForKey(prevKeys[0], gran).start,
+    end: granRangeForKey(prevKeys[prevKeys.length - 1], gran).end,
+  };
+  let total: number | null = null;
+  let calls = 0;
+  let turns = 0;
+  let toolCalls = 0;
+  let prevTotal: number | null = null;
+  let peakKey: string | null = null;
+  let peakVal = -1;
+  let top: { provider: string; model: string | null; value: number } | null = null;
+  const series = dirSeries ?? buildDirStackedSeries(rows, n, gran, metric, dir, now).series;
+  for (const point of series) {
+    if (point.total !== null && point.total > peakVal) {
+      peakVal = point.total;
+      peakKey = point.key;
+    }
+    for (const pt of point.parts) {
+      if (pt.value !== null && (top === null || pt.value > top.value)) {
+        top = { provider: pt.provider, model: pt.model, value: pt.value };
+      }
+    }
+  }
+  let firstDirDay: string | null = null;
+  // 复核 P1-3：单遍遍历（原实现 3 次全量遍历 rows——最早日 + 当前窗口 + 上一
+  // 窗口各一遍；窗口区间互斥，同遍累加语义不变）。
+  for (const row of rows) {
+    if (firstDirDay === null || row.day < firstDirDay) firstDirDay = row.day;
+    const inDir = dir === undefined || row.dir === dir;
+    if (inDir && row.day >= curRange.start && row.day <= curRange.end) {
+      total = sumToken(total, metricValue(row, metric));
+      calls += row.calls;
+      turns += row.turns;
+      toolCalls += row.toolCalls;
+    }
+    if (inDir && row.day >= prevRange.start && row.day <= prevRange.end) {
+      prevTotal = sumToken(prevTotal, metricValue(row, metric));
+    }
+  }
+  return {
+    total,
+    calls,
+    turns,
+    toolCalls,
+    peakKey,
+    top,
+    prevTotal,
+    // 与 windowSummary.prevComplete 同口径：prev 窗口起点早于目录数据起点 → 环比不可比
+    prevComplete: prevRange.start >= (firstDirDay ?? "9999-12-31"),
+  };
+}
+
+/**
+ * 目录窗口总量表（#633 分片 b B4 目录范围口径影响 + B1 目录分布数据源）：
+ * 给定日区间内按目录聚合 calls 与 metric 总量（calls 降序）。
+ */
+export function buildDirTotals(
+  rows: TrendDirRow[],
+  startDay: string,
+  endDay: string,
+  metric: TrendMetric = "total",
+): Array<{ dir: string; calls: number; total: number | null }> {
+  const byDir = new Map<string, { dir: string; calls: number; total: number | null }>();
+  for (const row of rows) {
+    if (row.day < startDay || row.day > endDay) continue;
+    let cur = byDir.get(row.dir);
+    if (cur === undefined) {
+      cur = { dir: row.dir, calls: 0, total: null };
+      byDir.set(row.dir, cur);
+    }
+    cur.calls += row.calls;
+    cur.total = sumToken(cur.total, metricValue(row, metric));
+  }
+  return [...byDir.values()].sort((a, b) => b.calls - a.calls);
+}
+
+/**
+ * 全量目录日桶快照（day 升序；#633 分片 b 报告快照与统计目录分布数据源）。
+ *
+ * 权威口径（复核 P1-1）：dirDays 单源快照——apply 平行累加 + rebuild 双分支读回
+ * 已覆盖全部 dir 事实，不再折算 pending 行（旧折算侧与 dirDays 并存时双算：
+ * 同事实重建 → 2×；互补事实 → 按键去重丢数；实测同日重启续 apply input 17 → 7）。
+ *
+ * 残差投影（本次修复，取代「重建时补造」）：目录面 = dirDays 快照 + 每日残差。
+ * 残差(day) = 该日聚合面（cells，全量事实）− 该日 dirDays 合计（有目录归属的事实），
+ * 非零则投影为一条 `{day, dir: TREND_UNIDENTIFIED}` 行——语义即「该日无目录信息的
+ * 数据」。这样两个查询面的日总量恒等（目录面 = 聚合面），且**不会双算**：
+ *
+ * - 旧分片（#633 之前的 agg 行，无 kind:"dir" 行）：cells 有值、dirDays 空 → 残差
+ *   = 全量 → 历史柱恢复且不丢数（此前 dir 面历史全 null，实测差 20 倍）；
+ * - 新分片（agg + dir 并存，同一批事实的两个投影）：cells 含 agg 行、dirDays 含 dir 行
+ *   → 残差 ≈ 0（同一事实相减相消）→ 不补造、不双算；故**禁止**在 rebuild 里对
+ *   agg 行补造未识别桶（会与 dir 行双算，反例：9-05 的 rjk2 calls=22 会变 44）；
+ * - 混版日（升级当天：旧 agg 行 + 新 dir 行并存）：残差 = 旧 agg 部分 → 归未识别，
+ *   新 dir 行照常分目录，既不丢升级前的历史、也不把新数据算进未识别；
+ * - 当日未压实：apply 对 cells 与 dirDays 平行累加 → 残差 ≈ 0。
+ *
+ * 不变量：∀day 目录面日合计 == 聚合面日合计（残差为负即数据不一致——目录行多于聚合行，
+ * 属双算/漂移征兆，投影按 0 处理并保持数值可解释，不产生负柱）。
+ * 残留边界（文档化口径）：残差只有日粒度（dirDays 无 provider 维度），故「无目录信息的
+ * 数据」只能整体归未识别桶，无法细分到 provider/model——目录面与 provider 面本互斥
+ * （见 routes/ui.ts 的 dir/byDir 分流），无消费方需要该交叉维度。
+ */
+export function buildDirRows(
+  days: Map<string, Map<string, Map<string | null, TrendCell>>>,
+  dirDays: Map<string, Map<string, TrendCell>>,
+): TrendDirRow[] {
+  // 输出容器按 (day, dir) 唯一：dirDays 桶与残差行可能撞同一键（混版日已有
+  // (unidentified) 桶时），撞键即合并数值，绝不产出重复键行（公开面契约）。
+  // 保持 dirDays 分支的插入序（day 升序、day 内 dir 键插入序）——下游 dirTotals
+  // 用稳定排序，行序变化会改变「候选 calls 降序」的并列顺序。
+  const out: TrendDirRow[] = [];
+  const byKey = new Map<string, TrendDirRow>();
+  const put = (row: TrendDirRow): void => {
+    const key = `${row.day}\u0000${row.dir}`;
+    const cur = byKey.get(key);
+    if (cur === undefined) {
+      byKey.set(key, row);
+      out.push(row);
+      return;
+    }
+    cur.input = sumToken(cur.input, row.input);
+    cur.output = sumToken(cur.output, row.output);
+    cur.cacheRead = sumToken(cur.cacheRead, row.cacheRead);
+    cur.cacheWrite = sumToken(cur.cacheWrite, row.cacheWrite);
+    cur.calls += row.calls;
+    cur.turns += row.turns;
+    cur.toolCalls += row.toolCalls;
+  };
+  for (const day of [...dirDays.keys()].sort()) {
+    for (const [dir, cell] of dirDays.get(day)!) {
+      put({ v: TREND_ROW_VERSION, kind: "dir", day, dir, input: cell.input, output: cell.output, cacheRead: cell.cacheRead, cacheWrite: cell.cacheWrite, calls: cell.calls, turns: cell.turns, toolCalls: cell.toolCalls });
+    }
+  }
+  // 每日残差：聚合面（cells）− 目录面（dirDays）。cells 的键是 day → provider →
+  // model，逐层求和得该日全量；dirDays 的键是 day → dir，同法求该日目录合计。
+  const aggByDay = new Map<string, TrendCell>();
+  for (const [day, providers] of days) {
+    let cell = aggByDay.get(day);
+    if (cell === undefined) {
+      cell = emptyCell();
+      aggByDay.set(day, cell);
+    }
+    for (const models of providers.values()) {
+      for (const c of models.values()) {
+        cell.input = sumToken(cell.input, c.input);
+        cell.output = sumToken(cell.output, c.output);
+        cell.cacheRead = sumToken(cell.cacheRead, c.cacheRead);
+        cell.cacheWrite = sumToken(cell.cacheWrite, c.cacheWrite);
+        cell.calls += c.calls;
+        cell.turns += c.turns;
+        cell.toolCalls += c.toolCalls;
+      }
+    }
+  }
+  // 残差按 day 升序处理（cells 的 Map 键序是插入序，时钟回拨会让旧日新桶排在末尾；
+  // 公开方法契约声明 day 升序，故此处显式排序，不依赖插入序）。
+  for (const day of [...aggByDay.keys()].sort()) {
+    const cell = aggByDay.get(day)!;
+    let dirInput: number | null = null;
+    let dirOutput: number | null = null;
+    let dirCacheRead: number | null = null;
+    let dirCacheWrite: number | null = null;
+    let dirCalls = 0;
+    let dirTurns = 0;
+    let dirToolCalls = 0;
+    const dirs = dirDays.get(day);
+    if (dirs !== undefined) {
+      for (const c of dirs.values()) {
+        dirInput = sumToken(dirInput, c.input);
+        dirOutput = sumToken(dirOutput, c.output);
+        dirCacheRead = sumToken(dirCacheRead, c.cacheRead);
+        dirCacheWrite = sumToken(dirCacheWrite, c.cacheWrite);
+        dirCalls += c.calls;
+        dirTurns += c.turns;
+        dirToolCalls += c.toolCalls;
+      }
+    }
+    // 残差 = 聚合面 − 目录面（null-aware：双方皆 null → 0/无残差；单侧 null 按 0 计）
+    const input = diffToken(cell.input, dirInput);
+    const output = diffToken(cell.output, dirOutput);
+    const cacheRead = diffToken(cell.cacheRead, dirCacheRead);
+    const cacheWrite = diffToken(cell.cacheWrite, dirCacheWrite);
+    const calls = cell.calls - dirCalls;
+    const turns = cell.turns - dirTurns;
+    const toolCalls = cell.toolCalls - dirToolCalls;
+    // 全部为 0/空 = 该日目录面已覆盖全量（新分片常态）→ 不补造行。
+    // 负残差（目录面多于聚合面）同样走此分支（不产行）：属数据不一致征兆
+    // （例如明细目录误落 dir 行——已由 readDetailShard 白名单阻断），此时目录面
+    // 日合计会大于聚合面，README「总量守恒」节已注明该边界不保证恒等。
+    const hasResidual =
+      calls > 0 || turns > 0 || toolCalls > 0 || (input ?? 0) > 0 || (output ?? 0) > 0 || (cacheRead ?? 0) > 0 || (cacheWrite ?? 0) > 0;
+    if (!hasResidual) continue;
+    // 同键（该日已有 (unidentified) 桶，混版日常态）由 put 合并到既有行，
+    // 保证 (day, dir) 键唯一；负值按 0 处理（不产生负柱）。
+    put({
+      v: TREND_ROW_VERSION,
+      kind: "dir",
+      day,
+      dir: TREND_UNIDENTIFIED,
+      input: input !== null && input > 0 ? input : null,
+      output: output !== null && output > 0 ? output : null,
+      cacheRead: cacheRead !== null && cacheRead > 0 ? cacheRead : null,
+      cacheWrite: cacheWrite !== null && cacheWrite > 0 ? cacheWrite : null,
+      calls: calls > 0 ? calls : 0,
+      turns: turns > 0 ? turns : 0,
+      toolCalls: toolCalls > 0 ? toolCalls : 0,
+    });
+  }
+  // 顺序契约：dirDays 分支按 day 升序、day 内按 dir 键插入序输出；残差行按 day
+  // 升序追加在尾段（已显式排序，不依赖 cells 插入序）。**不做全局 sort(day, dir)**：
+  // 它会把残差行的未识别键排到该日首位（"(" 字典序最前），改变 dirTotals 的插入序；
+  // dirTotals 用稳定排序（同 calls 保持插入序），下游「候选 calls 降序」并列顺序
+  // 因此会被打破。
+  return out;
+}
+
+/**
+ * 全量小时日桶快照（day 升序、hour 升序；#662 报告快照 byHour/byPeriod/peakHour/
+ * coveredDays 数据源）。
+ * 权威口径（对齐 dirRows 单源约定）：hourDays 单源快照——apply 平行累加 + rebuild
+ * 双分支读回已覆盖全部 hour 事实，不折算 pending（防双算）；**不做残差投影**
+ * （detail/counter 必有 time、无缺键事实；旧分片缺 hour 行是物理缺失，报告侧
+ * coveredDays 守卫负责降级，不投影补造伪事实）。
+ */
+export function buildHourRows(hourDays: Map<string, Map<number, TrendCell>>): TrendHourRow[] {
+  const out: TrendHourRow[] = [];
+  for (const day of [...hourDays.keys()].sort()) {
+    const byHour = hourDays.get(day)!;
+    for (const hour of [...byHour.keys()].sort((a, b) => a - b)) {
+      const cell = byHour.get(hour)!;
+      out.push({
+        v: TREND_ROW_VERSION,
+        kind: "hour",
+        day,
+        hour,
+        input: cell.input,
+        output: cell.output,
+        cacheRead: cell.cacheRead,
+        cacheWrite: cell.cacheWrite,
+        calls: cell.calls,
+        turns: cell.turns,
+        toolCalls: cell.toolCalls,
+      });
+    }
+  }
+  return out;
+}

--- a/packages/dsh-provider-usage/src/trend/aggregate-rows.ts
+++ b/packages/dsh-provider-usage/src/trend/aggregate-rows.ts
@@ -1,0 +1,194 @@
+/**
+ * dsh-provider-usage/trend — 压实转换纯函数（D2 aggregator 拆分的纯函数层之一，#670 阶段三）。
+ *
+ * 为什么独立成模块：TrendAggregator（src/trend/aggregator.ts）原 1300+ 行混合「状态容器 +
+ * IO 方法」与纯函数转换；拆分后本模块只含行形态转换——明细/计数行并入聚合/目录/小时行、
+ * 汇总行合并（merge*）、null-aware token 差（sub/diffToken）与空行构造。全部参数显式传入、
+ * 不接触 this：防「拆文件 = 共享 this」坏味道（layer-architecture.md §4 D-2 前置约定，
+ * 需状态者一律留在主类）。本模块无 import 环（只依赖 types.ts）。
+ *
+ * null 语义（与聚合面一致）：token 求和 null-aware（sumToken）——缺失维度不参与求和；
+ * 0 是有效数字参与求和（校正把数字改 null 时 cell 残留 0 属既有增量语义，见 sub 注释）。
+ */
+import {
+  sumToken,
+  TREND_ROW_VERSION,
+  type TrendAggRow,
+  type TrendCell,
+  type TrendDetailRow,
+  type TrendDirRow,
+  type TrendHourRow,
+} from "./types.ts";
+
+/** token 差（cell 回退用）：有值→null 时增量为 -old（cell 同步扣减，保证内存聚合
+ *  与校正后的落盘明细一致）；双方皆 null 增量 0（null-aware 无变化）。 */
+export function sub(oldV: number | null, newV: number | null): number | null {
+  if (newV === null) return oldV === null ? null : -oldV;
+  if (oldV === null) return newV;
+  return newV - oldV;
+}
+
+/**
+ * 残差投影的 token 差（#633 修复）：聚合面 − 目录面，null-aware。
+ * 双方皆 null → null（无该维度事实）；单侧 null 按 0 参与（另一侧有值即有残差）；
+ * 负值保留给调用方判定（调用方按 0 处理并依赖「日总量恒等」断言暴露不一致）。
+ */
+export function diffToken(aggV: number | null, dirV: number | null): number | null {
+  if (aggV === null && dirV === null) return null;
+  return (aggV ?? 0) - (dirV ?? 0);
+}
+
+/** 单元格空壳（桶缺位时补建）。 */
+export function emptyCell(): TrendCell {
+  return { input: null, output: null, cacheRead: null, cacheWrite: null, calls: 0, turns: 0, toolCalls: 0 };
+}
+
+/** 空聚合行（压实折算起点；字段与 mergeCell 消费的 agg 行同构）。 */
+export function emptyAggRow(day: string, provider: string, model: string | null): TrendAggRow {
+  return {
+    v: TREND_ROW_VERSION,
+    kind: "agg",
+    day,
+    provider,
+    model,
+    input: null,
+    output: null,
+    cacheRead: null,
+    cacheWrite: null,
+    calls: 0,
+    turns: 0,
+    toolCalls: 0,
+  };
+}
+
+/** 空目录汇总行（#633 A4；与 agg 行十数值字段同构，仅键换成 dir）。 */
+export function emptyDirRow(day: string, dir: string): TrendDirRow {
+  return {
+    v: TREND_ROW_VERSION,
+    kind: "dir",
+    day,
+    dir,
+    input: null,
+    output: null,
+    cacheRead: null,
+    cacheWrite: null,
+    calls: 0,
+    turns: 0,
+    toolCalls: 0,
+  };
+}
+
+/** 空小时汇总行（#662；与 agg/dir 行同构，键换成 hour；「落盘即定型」的产出起点）。 */
+export function emptyHourRow(day: string, hour: number): TrendHourRow {
+  return {
+    v: TREND_ROW_VERSION,
+    kind: "hour",
+    day,
+    hour,
+    input: null,
+    output: null,
+    cacheRead: null,
+    cacheWrite: null,
+    calls: 0,
+    turns: 0,
+    toolCalls: 0,
+  };
+}
+
+/** 明细行并入聚合/目录/小时汇总行（三者字段同构，同函数复用；null-aware 求和）。 */
+export function addDetailTo(agg: TrendAggRow | TrendDirRow | TrendHourRow, row: TrendDetailRow): void {
+  agg.calls += 1;
+  agg.input = sumToken(agg.input, row.input);
+  agg.output = sumToken(agg.output, row.output);
+  agg.cacheRead = sumToken(agg.cacheRead, row.cacheRead);
+  agg.cacheWrite = sumToken(agg.cacheWrite, row.cacheWrite);
+}
+
+/** 计数行并入聚合/目录/小时汇总行（同上，同函数复用）。 */
+export function addCounterTo(agg: TrendAggRow | TrendDirRow | TrendHourRow, turns: number, toolCalls: number): void {
+  agg.turns += turns;
+  agg.toolCalls += toolCalls;
+}
+
+/** 聚合行并入 cell（重建用；null-aware。agg/dir/hour 汇总行十数值字段同构，同函数复用）。 */
+export function mergeCell(cell: TrendCell, row: TrendAggRow | TrendDirRow | TrendHourRow): void {
+  cell.calls += row.calls;
+  cell.turns += row.turns;
+  cell.toolCalls += row.toolCalls;
+  cell.input = sumToken(cell.input, row.input);
+  cell.output = sumToken(cell.output, row.output);
+  cell.cacheRead = sumToken(cell.cacheRead, row.cacheRead);
+  cell.cacheWrite = sumToken(cell.cacheWrite, row.cacheWrite);
+}
+
+/**
+ * 聚合行合并（flush 压实写盘前与既有聚合分片合并——迟到旧日行场景防覆盖丢数；
+ * null-aware 求和，同 (provider, model) 键累加）。
+ */
+export function mergeAggRows(base: TrendAggRow[], add: TrendAggRow[]): TrendAggRow[] {
+  const byKey = new Map<string, TrendAggRow>();
+  for (const r of [...base, ...add]) {
+    const key = `${r.provider}\u0000${r.model ?? ""}`;
+    const cur = byKey.get(key);
+    if (cur === undefined) {
+      byKey.set(key, { ...r });
+      continue;
+    }
+    cur.calls += r.calls;
+    cur.turns += r.turns;
+    cur.toolCalls += r.toolCalls;
+    cur.input = sumToken(cur.input, r.input);
+    cur.output = sumToken(cur.output, r.output);
+    cur.cacheRead = sumToken(cur.cacheRead, r.cacheRead);
+    cur.cacheWrite = sumToken(cur.cacheWrite, r.cacheWrite);
+  }
+  return [...byKey.values()];
+}
+
+/**
+ * dir 汇总行合并（#633 A4 flush 压实写盘前与既有聚合分片内的 dir 行合并——
+ * 迟到旧日行场景防覆盖丢数；十数值字段与 mergeAggRows 完全同构，null-aware
+ * 求和，同 dir 键累加。输出保持输入相对顺序：base 在前（dir 行位于分片尾段））。
+ */
+export function mergeDirRows(base: TrendDirRow[], add: TrendDirRow[]): TrendDirRow[] {
+  const byKey = new Map<string, TrendDirRow>();
+  for (const r of [...base, ...add]) {
+    const cur = byKey.get(r.dir);
+    if (cur === undefined) {
+      byKey.set(r.dir, { ...r });
+      continue;
+    }
+    cur.calls += r.calls;
+    cur.turns += r.turns;
+    cur.toolCalls += r.toolCalls;
+    cur.input = sumToken(cur.input, r.input);
+    cur.output = sumToken(cur.output, r.output);
+    cur.cacheRead = sumToken(cur.cacheRead, r.cacheRead);
+    cur.cacheWrite = sumToken(cur.cacheWrite, r.cacheWrite);
+  }
+  return [...byKey.values()];
+}
+
+/**
+ * hour 汇总行合并（#662，flush 压实写盘前与既有聚合分片内的 hour 行合并——
+ * 迟到旧日行二次压实防丢防重；与 mergeDirRows 完全同构，同 hour 键累加，
+ * 输出保持输入相对顺序：base 在前（hour 行位于分片尾段））。
+ */
+export function mergeHourRows(base: TrendHourRow[], add: TrendHourRow[]): TrendHourRow[] {
+  const byKey = new Map<number, TrendHourRow>();
+  for (const r of [...base, ...add]) {
+    const cur = byKey.get(r.hour);
+    if (cur === undefined) {
+      byKey.set(r.hour, { ...r });
+      continue;
+    }
+    cur.calls += r.calls;
+    cur.turns += r.turns;
+    cur.toolCalls += r.toolCalls;
+    cur.input = sumToken(cur.input, r.input);
+    cur.output = sumToken(cur.output, r.output);
+    cur.cacheRead = sumToken(cur.cacheRead, r.cacheRead);
+    cur.cacheWrite = sumToken(cur.cacheWrite, r.cacheWrite);
+  }
+  return [...byKey.values()];
+}

--- a/packages/dsh-provider-usage/src/trend/aggregator.ts
+++ b/packages/dsh-provider-usage/src/trend/aggregator.ts
@@ -1,5 +1,5 @@
 /**
- * dsh-provider-usage/trend — 内存聚合（#503 M1）。
+ * dsh-provider-usage/trend — 内存聚合主类（#503 M1；D2 拆分后 #670 阶段三）。
  *
  * 两级聚合（方案定稿）：
  * - cells：day×provider(×model) 桶，apply 时实时累加（含未压实的历史日）；
@@ -19,13 +19,18 @@
  *
  * null 语义：桶内 token 求和 null-aware（无任何有效数字保持 null）；
  * 调用/轮次/工具计数独立累加，与 token 有无无关。
+ *
+ * D2 拆分（#670 阶段三）：本文件只保留状态容器（days/dirDays/hourDays/pending）与
+ * 需要访问状态的方法——apply/rebuild/rollupSnapshot/consume/prune 等 IO 与状态操作；
+ * 压实转换纯函数迁至 aggregate-rows.ts，查询投影纯函数迁至 aggregate-query.ts
+ * （二者均参数显式传入、不接触 this，防「拆文件 = 共享 this」坏味道；公开导出面
+ * 经本文件尾部 re-export 保持可达，src/index.ts 与 src/report/*.ts 的 import 路径不变）。
  */
 import { dayKey, lastNDayKeys } from "../charts.ts";
 import {
   sumToken,
   hourOfDay,
   TREND_ROW_VERSION,
-  TREND_UNIDENTIFIED,
   type TrendAggRow,
   type TrendCell,
   type TrendCounterRow,
@@ -35,56 +40,41 @@ import {
   type TrendTokens,
 } from "./types.ts";
 import type { TrendCallRecord, TrendCorrectRecord, TrendCounterRecord, TrendEmit } from "./collector.ts";
-
-/** 聚合指标（序列查询的取值维度；total = 四项 token 之和）。 */
-export type TrendMetric = "total" | "input" | "output" | "cacheRead" | "cacheWrite" | "calls";
-
-/** 序列粒度。 */
-export type TrendGranularity = "day" | "week" | "month";
-
-/** 堆叠柱单段（一个 provider 或 provider+model 组合在一个时间桶内的取值）。 */
-export interface TrendStackPart {
-  provider: string;
-  model: string | null;
-  value: number | null;
-}
-
-/** 堆叠柱单根（一个时间桶）。 */
-export interface TrendStackPoint {
-  /** 桶键：day=YYYY-MM-DD / week=周首日 / month=YYYY-MM。 */
-  key: string;
-  parts: TrendStackPart[];
-  /** 各段之和（null-aware；空桶 null）。 */
-  total: number | null;
-}
-
-/** 窗口摘要（趋势页汇总卡数据源）。 */
-export interface TrendWindowSummary {
-  /** 当前窗口指标总量。 */
-  total: number | null;
-  calls: number;
-  turns: number;
-  toolCalls: number;
-  /** 峰值桶键（total 最大的时间桶；无数据 null）。 */
-  peakKey: string | null;
-  /** 取值最大的适配器段。 */
-  top: { provider: string; model: string | null; value: number } | null;
-  /** 上一同等窗口指标总量（环比基准；无数据 null）。 */
-  prevTotal: number | null;
-  /** 上一窗口数据是否完整（起点早于数据起点 = false；false 时环比不可比，#503 M2.1）。 */
-  prevComplete: boolean;
-}
+import {
+  emptyCell,
+  emptyAggRow,
+  emptyDirRow,
+  emptyHourRow,
+  addDetailTo,
+  addCounterTo,
+  mergeCell,
+  sub,
+} from "./aggregate-rows.ts";
+import {
+  lastNWeekKeys,
+  lastNMonthKeys,
+  monthRange,
+  weekRange,
+  dayValueOf,
+  rangeValueOf,
+  buildDirRows,
+  buildHourRows,
+  buildStackedSeries,
+  buildDirStackedSeries,
+  buildWindowSummary,
+  buildDirWindowSummary,
+  buildDirTotals,
+  type TrendGranularity,
+  type TrendMetric,
+  type TrendStackPoint,
+  type TrendWindowSummary,
+} from "./aggregate-query.ts";
 
 /** 未压实行（内存持有；flush 时持久化，压实后移除）。 */
 export interface PendingEntry {
   row: TrendDetailRow | TrendCounterRow;
   /** 已 append 到当日分片（重启重建的行也为 true，防二次落盘）。 */
   persisted: boolean;
-}
-
-/** 单元格空壳。 */
-function emptyCell(): TrendCell {
-  return { input: null, output: null, cacheRead: null, cacheWrite: null, calls: 0, turns: 0, toolCalls: 0 };
 }
 
 export class TrendAggregator {
@@ -358,172 +348,18 @@ export class TrendAggregator {
 
   /**
    * 全量目录日桶快照（day 升序；#633 分片 b 报告快照与统计目录分布数据源）。
-   *
-   * 权威口径（复核 P1-1）：dirDays 单源快照——apply 平行累加 + rebuild 双分支读回
-   * 已覆盖全部 dir 事实，不再折算 pending 行（旧折算侧与 dirDays 并存时双算：
-   * 同事实重建 → 2×；互补事实 → 按键去重丢数；实测同日重启续 apply input 17 → 7）。
-   *
-   * 残差投影（本次修复，取代「重建时补造」）：目录面 = dirDays 快照 + 每日残差。
-   * 残差(day) = 该日聚合面（cells，全量事实）− 该日 dirDays 合计（有目录归属的事实），
-   * 非零则投影为一条 `{day, dir: TREND_UNIDENTIFIED}` 行——语义即「该日无目录信息的
-   * 数据」。这样两个查询面的日总量恒等（目录面 = 聚合面），且**不会双算**：
-   *
-   * - 旧分片（#633 之前的 agg 行，无 kind:"dir" 行）：cells 有值、dirDays 空 → 残差
-   *   = 全量 → 历史柱恢复且不丢数（此前 dir 面历史全 null，实测差 20 倍）；
-   * - 新分片（agg + dir 并存，同一批事实的两个投影）：cells 含 agg 行、dirDays 含 dir 行
-   *   → 残差 ≈ 0（同一事实相减相消）→ 不补造、不双算；故**禁止**在 rebuild 里对
-   *   agg 行补造未识别桶（会与 dir 行双算，反例：9-05 的 rjk2 calls=22 会变 44）；
-   * - 混版日（升级当天：旧 agg 行 + 新 dir 行并存）：残差 = 旧 agg 部分 → 归未识别，
-   *   新 dir 行照常分目录，既不丢升级前的历史、也不把新数据算进未识别；
-   * - 当日未压实：apply 对 cells 与 dirDays 平行累加 → 残差 ≈ 0。
-   *
-   * 不变量：∀day 目录面日合计 == 聚合面日合计（残差为负即数据不一致——目录行多于聚合行，
-   * 属双算/漂移征兆，投影按 0 处理并保持数值可解释，不产生负柱）。
-   * 残留边界（文档化口径）：残差只有日粒度（dirDays 无 provider 维度），故「无目录信息的
-   * 数据」只能整体归未识别桶，无法细分到 provider/model——目录面与 provider 面本互斥
-   * （见 routes/ui.ts 的 dir/byDir 分流），无消费方需要该交叉维度。
+   * 委托 buildDirRows——权威口径（dirDays 单源 + 每日残差归未识别）见 buildDirRows 注释。
    */
   dirRows(): TrendDirRow[] {
-    // 输出容器按 (day, dir) 唯一：dirDays 桶与残差行可能撞同一键（混版日已有
-    // (unidentified) 桶时），撞键即合并数值，绝不产出重复键行（公开面契约）。
-    // 保持 dirDays 分支的插入序（day 升序、day 内 dir 键插入序）——下游 dirTotals
-    // 用稳定排序，行序变化会改变「候选 calls 降序」的并列顺序。
-    const out: TrendDirRow[] = [];
-    const byKey = new Map<string, TrendDirRow>();
-    const put = (row: TrendDirRow): void => {
-      const key = `${row.day}\u0000${row.dir}`;
-      const cur = byKey.get(key);
-      if (cur === undefined) {
-        byKey.set(key, row);
-        out.push(row);
-        return;
-      }
-      cur.input = sumToken(cur.input, row.input);
-      cur.output = sumToken(cur.output, row.output);
-      cur.cacheRead = sumToken(cur.cacheRead, row.cacheRead);
-      cur.cacheWrite = sumToken(cur.cacheWrite, row.cacheWrite);
-      cur.calls += row.calls;
-      cur.turns += row.turns;
-      cur.toolCalls += row.toolCalls;
-    };
-    for (const day of [...this.dirDays.keys()].sort()) {
-      for (const [dir, cell] of this.dirDays.get(day)!) {
-        put({ v: TREND_ROW_VERSION, kind: "dir", day, dir, input: cell.input, output: cell.output, cacheRead: cell.cacheRead, cacheWrite: cell.cacheWrite, calls: cell.calls, turns: cell.turns, toolCalls: cell.toolCalls });
-      }
-    }
-    // 每日残差：聚合面（cells）− 目录面（dirDays）。cells 的键是 day → provider →
-    // model，逐层求和得该日全量；dirDays 的键是 day → dir，同法求该日目录合计。
-    const aggByDay = new Map<string, TrendCell>();
-    for (const [day, providers] of this.days) {
-      let cell = aggByDay.get(day);
-      if (cell === undefined) {
-        cell = emptyCell();
-        aggByDay.set(day, cell);
-      }
-      for (const models of providers.values()) {
-        for (const c of models.values()) {
-          cell.input = sumToken(cell.input, c.input);
-          cell.output = sumToken(cell.output, c.output);
-          cell.cacheRead = sumToken(cell.cacheRead, c.cacheRead);
-          cell.cacheWrite = sumToken(cell.cacheWrite, c.cacheWrite);
-          cell.calls += c.calls;
-          cell.turns += c.turns;
-          cell.toolCalls += c.toolCalls;
-        }
-      }
-    }
-    // 残差按 day 升序处理（cells 的 Map 键序是插入序，时钟回拨会让旧日新桶排在末尾；
-    // 公开方法契约声明 day 升序，故此处显式排序，不依赖插入序）。
-    for (const day of [...aggByDay.keys()].sort()) {
-      const cell = aggByDay.get(day)!;
-      let dirInput: number | null = null;
-      let dirOutput: number | null = null;
-      let dirCacheRead: number | null = null;
-      let dirCacheWrite: number | null = null;
-      let dirCalls = 0;
-      let dirTurns = 0;
-      let dirToolCalls = 0;
-      const dirs = this.dirDays.get(day);
-      if (dirs !== undefined) {
-        for (const c of dirs.values()) {
-          dirInput = sumToken(dirInput, c.input);
-          dirOutput = sumToken(dirOutput, c.output);
-          dirCacheRead = sumToken(dirCacheRead, c.cacheRead);
-          dirCacheWrite = sumToken(dirCacheWrite, c.cacheWrite);
-          dirCalls += c.calls;
-          dirTurns += c.turns;
-          dirToolCalls += c.toolCalls;
-        }
-      }
-      // 残差 = 聚合面 − 目录面（null-aware：双方皆 null → 0/无残差；单侧 null 按 0 计）
-      const input = diffToken(cell.input, dirInput);
-      const output = diffToken(cell.output, dirOutput);
-      const cacheRead = diffToken(cell.cacheRead, dirCacheRead);
-      const cacheWrite = diffToken(cell.cacheWrite, dirCacheWrite);
-      const calls = cell.calls - dirCalls;
-      const turns = cell.turns - dirTurns;
-      const toolCalls = cell.toolCalls - dirToolCalls;
-      // 全部为 0/空 = 该日目录面已覆盖全量（新分片常态）→ 不补造行。
-      // 负残差（目录面多于聚合面）同样走此分支（不产行）：属数据不一致征兆
-      // （例如明细目录误落 dir 行——已由 readDetailShard 白名单阻断），此时目录面
-      // 日合计会大于聚合面，README「总量守恒」节已注明该边界不保证恒等。
-      const hasResidual =
-        calls > 0 || turns > 0 || toolCalls > 0 || (input ?? 0) > 0 || (output ?? 0) > 0 || (cacheRead ?? 0) > 0 || (cacheWrite ?? 0) > 0;
-      if (!hasResidual) continue;
-      // 同键（该日已有 (unidentified) 桶，混版日常态）由 put 合并到既有行，
-      // 保证 (day, dir) 键唯一；负值按 0 处理（不产生负柱）。
-      put({
-        v: TREND_ROW_VERSION,
-        kind: "dir",
-        day,
-        dir: TREND_UNIDENTIFIED,
-        input: input !== null && input > 0 ? input : null,
-        output: output !== null && output > 0 ? output : null,
-        cacheRead: cacheRead !== null && cacheRead > 0 ? cacheRead : null,
-        cacheWrite: cacheWrite !== null && cacheWrite > 0 ? cacheWrite : null,
-        calls: calls > 0 ? calls : 0,
-        turns: turns > 0 ? turns : 0,
-        toolCalls: toolCalls > 0 ? toolCalls : 0,
-      });
-    }
-    // 顺序契约：dirDays 分支按 day 升序、day 内按 dir 键插入序输出；残差行按 day
-    // 升序追加在尾段（已显式排序，不依赖 cells 插入序——时钟回拨会让旧日新桶排在
-    // 末尾）。**不做全局 sort(day, dir)**：它会把残差行的未识别键排到该日首位
-    // （"(" 字典序最前），改变 dirTotals 的插入序；dirTotals 用稳定排序（同 calls
-    // 保持插入序），下游「候选 calls 降序」并列顺序因此会被打破。
-    return out;
+    return buildDirRows(this.days, this.dirDays);
   }
 
   /**
-   * 全量小时日桶快照（day 升序、hour 升序；#662 报告快照 byHour/byPeriod/peakHour/
-   * coveredDays 数据源）。
-   * 权威口径（对齐 dirRows 单源约定）：hourDays 单源快照——apply 平行累加 + rebuild
-   * 双分支读回已覆盖全部 hour 事实，不折算 pending（防双算）；**不做残差投影**
-   * （detail/counter 必有 time、无缺键事实；旧分片缺 hour 行是物理缺失，报告侧
-   * coveredDays 守卫负责降级，不投影补造伪事实）。
+   * 全量小时日桶快照（day 升序、hour 升序；#662 报告快照数据源）。
+   * 委托 buildHourRows——hourDays 单源快照、不做残差投影（口径见 buildHourRows 注释）。
    */
   hourRows(): TrendHourRow[] {
-    const out: TrendHourRow[] = [];
-    for (const day of [...this.hourDays.keys()].sort()) {
-      const byHour = this.hourDays.get(day)!;
-      for (const hour of [...byHour.keys()].sort((a, b) => a - b)) {
-        const cell = byHour.get(hour)!;
-        out.push({
-          v: TREND_ROW_VERSION,
-          kind: "hour",
-          day,
-          hour,
-          input: cell.input,
-          output: cell.output,
-          cacheRead: cell.cacheRead,
-          cacheWrite: cell.cacheWrite,
-          calls: cell.calls,
-          turns: cell.turns,
-          toolCalls: cell.toolCalls,
-        });
-      }
-    }
-    return out;
+    return buildHourRows(this.hourDays);
   }
 
   /**
@@ -538,33 +374,7 @@ export class TrendAggregator {
     dir: string | undefined,
     now: number,
   ): { series: TrendStackPoint[]; dirs: Array<{ dir: string }> } {
-    const keys = this.granKeys(n, gran, now);
-    const ranges = new Map(keys.map((k) => [k, this.granRange(k, gran)] as const));
-    // 复核 P1-3：行快照提出桶循环（原实现每桶 this.dirRows() 全量快照，O(桶×行)
-    // 单请求重复；对齐 seriesStacked 的 P1-2 先例——range 一次算全 + 快照单次
-    // 取用，桶循环内只做窗口过滤消费）。
-    const rows = this.dirRows();
-    const series: TrendStackPoint[] = keys.map((key) => {
-      const partsMap = new Map<string, TrendStackPart>();
-      const range = ranges.get(key)!;
-      for (const row of rows) {
-        if (row.day < range.start || row.day > range.end) continue;
-        if (dir !== undefined && row.dir !== dir) continue;
-        const v = metricValue(row, metric);
-        const cur = partsMap.get(row.dir);
-        if (cur !== undefined) cur.value = sumToken(cur.value, v);
-        else partsMap.set(row.dir, { provider: row.dir, model: null, value: v });
-      }
-      const parts = [...partsMap.values()];
-      let total: number | null = null;
-      for (const pt of parts) total = sumToken(total, pt.value);
-      return { key, parts, total };
-    });
-    const legend = new Set<string>();
-    for (const point of series) {
-      for (const pt of point.parts) legend.add(pt.provider);
-    }
-    return { series, dirs: [...legend].sort().map((d) => ({ dir: d })) };
+    return buildDirStackedSeries(this.dirRows(), n, gran, metric, dir, now);
   }
 
   /**
@@ -581,64 +391,7 @@ export class TrendAggregator {
     now: number,
     dirSeries?: TrendStackPoint[],
   ): TrendWindowSummary {
-    const keys = this.granKeys(n, gran, now);
-    const curRange = {
-      start: this.granRange(keys[0], gran).start,
-      end: this.granRange(keys[keys.length - 1], gran).end,
-    };
-    const prevKeys = this.granKeys(n, gran, this.prevWindowAnchor(now, n, gran));
-    const prevRange = {
-      start: this.granRange(prevKeys[0], gran).start,
-      end: this.granRange(prevKeys[prevKeys.length - 1], gran).end,
-    };
-    let total: number | null = null;
-    let calls = 0;
-    let turns = 0;
-    let toolCalls = 0;
-    let prevTotal: number | null = null;
-    let peakKey: string | null = null;
-    let peakVal = -1;
-    let top: { provider: string; model: string | null; value: number } | null = null;
-    const series = dirSeries ?? this.dirStacked(n, gran, metric, dir, now).series;
-    for (const point of series) {
-      if (point.total !== null && point.total > peakVal) {
-        peakVal = point.total;
-        peakKey = point.key;
-      }
-      for (const pt of point.parts) {
-        if (pt.value !== null && (top === null || pt.value > top.value)) {
-          top = { provider: pt.provider, model: pt.model, value: pt.value };
-        }
-      }
-    }
-    const rows = this.dirRows();
-    let firstDirDay: string | null = null;
-    // 复核 P1-3：单遍遍历（原实现 3 次全量遍历 rows——最早日 + 当前窗口 + 上一
-    // 窗口各一遍；窗口区间互斥，同遍累加语义不变）。
-    for (const row of rows) {
-      if (firstDirDay === null || row.day < firstDirDay) firstDirDay = row.day;
-      const inDir = dir === undefined || row.dir === dir;
-      if (inDir && row.day >= curRange.start && row.day <= curRange.end) {
-        total = sumToken(total, metricValue(row, metric));
-        calls += row.calls;
-        turns += row.turns;
-        toolCalls += row.toolCalls;
-      }
-      if (inDir && row.day >= prevRange.start && row.day <= prevRange.end) {
-        prevTotal = sumToken(prevTotal, metricValue(row, metric));
-      }
-    }
-    return {
-      total,
-      calls,
-      turns,
-      toolCalls,
-      peakKey,
-      top,
-      prevTotal,
-      // 与 windowSummary.prevComplete 同口径：prev 窗口起点早于目录数据起点 → 环比不可比
-      prevComplete: prevRange.start >= (firstDirDay ?? "9999-12-31"),
-    };
+    return buildDirWindowSummary(this.dirRows(), n, gran, metric, dir, now, dirSeries);
   }
 
   /**
@@ -650,18 +403,7 @@ export class TrendAggregator {
     endDay: string,
     metric: TrendMetric = "total",
   ): Array<{ dir: string; calls: number; total: number | null }> {
-    const byDir = new Map<string, { dir: string; calls: number; total: number | null }>();
-    for (const row of this.dirRows()) {
-      if (row.day < startDay || row.day > endDay) continue;
-      let cur = byDir.get(row.dir);
-      if (cur === undefined) {
-        cur = { dir: row.dir, calls: 0, total: null };
-        byDir.set(row.dir, cur);
-      }
-      cur.calls += row.calls;
-      cur.total = sumToken(cur.total, metricValue(row, metric));
-    }
-    return [...byDir.values()].sort((a, b) => b.calls - a.calls);
+    return buildDirTotals(this.dirRows(), startDay, endDay, metric);
   }
 
   /**
@@ -829,24 +571,25 @@ export class TrendAggregator {
 
   /** 近 n 日序列（含今日；空日补 null——零 usage 语义，非 0）。 */
   seriesDays(n: number, now: number, metric: TrendMetric, provider?: string): Array<{ day: string; value: number | null }> {
-    return lastNDayKeys(n, now).map((day) => ({ day, value: this.dayValue(day, metric, provider) }));
+    return lastNDayKeys(n, now).map((day) => ({ day, value: dayValueOf(this.days, day, metric, provider) }));
   }
 
   /** 近 n 周序列（周一起点；key = 周首日 day key）。 */
   seriesWeeks(n: number, now: number, metric: TrendMetric, provider?: string): Array<{ day: string; value: number | null }> {
     const keys = lastNWeekKeys(n, now);
-    return keys.map((day) => ({ day, value: this.rangeValue(weekRange(day), metric, provider) }));
+    return keys.map((day) => ({ day, value: rangeValueOf(this.days, weekRange(day), metric, provider) }));
   }
 
   /** 近 n 月序列（key = YYYY-MM）。 */
   seriesMonths(n: number, now: number, metric: TrendMetric, provider?: string): Array<{ day: string; value: number | null }> {
     const keys = lastNMonthKeys(n, now);
-    return keys.map((key) => ({ day: key, value: this.rangeValue(monthRange(key), metric, provider) }));
+    return keys.map((key) => ({ day: key, value: rangeValueOf(this.days, monthRange(key), metric, provider) }));
   }
 
   /**
    * 堆叠柱序列（/trend 路由数据源）：每时间桶按 provider（byModel 时细到
    * provider+model）拆段；providers 为图例并集（窗口内出现过的段）。
+   * 委托 buildStackedSeries（days 显式传参，查询投影纯计算）。
    */
   seriesStacked(
     n: number,
@@ -856,46 +599,13 @@ export class TrendAggregator {
     byModel: boolean,
     now: number,
   ): { series: TrendStackPoint[]; providers: Array<{ provider: string; model: string | null }> } {
-    const keys = this.granKeys(n, gran, now);
-    // 桶日区间一次算全（评审 P1-2：原实现对每桶在 days 日循环内重复调 granRange）
-    const ranges = new Map(keys.map((k) => [k, this.granRange(k, gran)] as const));
-    const series: TrendStackPoint[] = keys.map((key) => {
-      const partsMap = new Map<string, TrendStackPart>();
-      const range = ranges.get(key)!;
-      for (const [day, models] of this.days) {
-        if (day < range.start || day > range.end) continue;
-        for (const [p, cells] of models) {
-          if (provider !== undefined && p !== provider) continue;
-          for (const [m, cell] of cells) {
-            const id = byModel ? `${p}\u0000${m ?? ""}` : p;
-            const v = metricValue(cell, metric);
-            const cur = partsMap.get(id);
-            if (cur !== undefined) cur.value = sumToken(cur.value, v);
-            else partsMap.set(id, { provider: p, model: byModel ? m : null, value: v });
-          }
-        }
-      }
-      const parts = [...partsMap.values()];
-      let total: number | null = null;
-      for (const pt of parts) total = sumToken(total, pt.value);
-      return { key, parts, total };
-    });
-    const legend = new Map<string, { provider: string; model: string | null }>();
-    for (const point of series) {
-      for (const pt of point.parts) {
-        legend.set(byModel ? `${pt.provider}\u0000${pt.model ?? ""}` : pt.provider, {
-          provider: pt.provider,
-          model: byModel ? pt.model : null,
-        });
-      }
-    }
-    return { series, providers: [...legend.values()] };
+    return buildStackedSeries(this.days, n, gran, metric, provider, byModel, now);
   }
 
   /**
    * 窗口摘要（当前 n 桶 + 上一同等窗口环比基准）。
-   * @param stackSeries 可选传入路由已算好的堆叠序列（n/gran/metric/provider 必须与本
-   *   调用一致）——复用峰值/Top 遍历，消除单请求双算（评审 P1-2）；缺省时内部自算。
+   * 委托 buildWindowSummary；stackSeries 可选传入路由已算好的堆叠序列复用遍历
+   * （须与 n/gran/metric/provider 同参，见 aggregator.windowSummary 契约）。
    */
   windowSummary(
     n: number,
@@ -905,120 +615,7 @@ export class TrendAggregator {
     now: number,
     stackSeries?: TrendStackPoint[],
   ): TrendWindowSummary {
-    const keys = this.granKeys(n, gran, now);
-    const curRange = {
-      start: this.granRange(keys[0], gran).start,
-      end: this.granRange(keys[keys.length - 1], gran).end,
-    };
-    // 上一窗口：同长键序列整体前移 n 桶（day/week/month 各自步进语义）
-    const prevKeys = this.granKeys(n, gran, this.prevWindowAnchor(now, n, gran));
-    const prevRange = {
-      start: this.granRange(prevKeys[0], gran).start,
-      end: this.granRange(prevKeys[prevKeys.length - 1], gran).end,
-    };
-    let total: number | null = null;
-    let calls = 0;
-    let turns = 0;
-    let toolCalls = 0;
-    let peakKey: string | null = null;
-    let peakVal = -1;
-    let top: { provider: string; model: string | null; value: number } | null = null;
-    // 复用路由已算的 stack 序列（评审 P1-2：消除单请求双算；缺省自算保持独立可用）
-    const series = stackSeries ?? this.seriesStacked(n, gran, metric, provider, false, now).series;
-    for (const point of series) {
-      if (point.total !== null && point.total > peakVal) {
-        peakVal = point.total;
-        peakKey = point.key;
-      }
-      for (const pt of point.parts) {
-        if (pt.value !== null && (top === null || pt.value > top.value)) {
-          top = { provider: pt.provider, model: pt.model, value: pt.value };
-        }
-      }
-    }
-    for (const { cell } of this.rangeCells(curRange, provider)) {
-      total = sumToken(total, metricValue(cell, metric));
-      calls += cell.calls;
-      turns += cell.turns;
-      toolCalls += cell.toolCalls;
-    }
-    return {
-      total,
-      calls,
-      turns,
-      toolCalls,
-      peakKey,
-      top,
-      prevTotal: this.rangeValue(prevRange, metric, provider),
-      // 上一窗口起点早于数据起点（内存最早日，即留存/起算边缘）→ 基准不完整，环比不可比（#503 M2.1）
-      prevComplete: prevRange.start >= (firstDayKeyOf(this.days) ?? "9999-12-31"),
-    };
-  }
-
-  // ---------------------------------------------------------------- 内部
-
-  /** 粒度桶键序列（升序，含当前桶）。 */
-  private granKeys(n: number, gran: TrendGranularity, now: number): string[] {
-    if (gran === "week") return lastNWeekKeys(n, now);
-    if (gran === "month") return lastNMonthKeys(n, now);
-    return lastNDayKeys(n, now);
-  }
-
-  /** 桶键 → 本地日区间。 */
-  private granRange(key: string, gran: TrendGranularity): { start: string; end: string } {
-    if (gran === "week") return weekRange(key);
-    if (gran === "month") return monthRange(key);
-    return { start: key, end: key };
-  }
-
-  /** 上一窗口锚点（把 now 前移 n 桶，得到 prevKeys 与当前窗口不重叠的时点）。 */
-  private prevWindowAnchor(now: number, n: number, gran: TrendGranularity): number {
-    const d = new Date(now);
-    if (gran === "month") {
-      d.setMonth(d.getMonth() - n);
-      return d.getTime();
-    }
-    const days = gran === "week" ? n * 7 : n;
-    d.setDate(d.getDate() - days);
-    return d.getTime();
-  }
-
-  /** 日区间内的全部 (provider, model, cell)（升序日；provider 过滤可选）。 */
-  private rangeCells(range: { start: string; end: string }, provider?: string): Array<{ provider: string; model: string | null; cell: TrendCell }> {
-    const out: Array<{ provider: string; model: string | null; cell: TrendCell }> = [];
-    for (const [day, models] of this.days) {
-      if (day < range.start || day > range.end) continue;
-      for (const [p, cells] of models) {
-        if (provider !== undefined && p !== provider) continue;
-        for (const [m, cell] of cells) out.push({ provider: p, model: m, cell });
-      }
-    }
-    return out;
-  }
-
-  /** 单日取值（provider 过滤可选；跨 model 求和）。 */
-  private dayValue(day: string, metric: TrendMetric, provider?: string): number | null {
-    const models = this.days.get(day);
-    if (models === undefined) return null;
-    let acc: number | null = null;
-    for (const [p, cells] of models) {
-      if (provider !== undefined && p !== provider) continue;
-      for (const cell of cells.values()) acc = sumToken(acc, metricValue(cell, metric));
-    }
-    return acc;
-  }
-
-  /** 日区间取值（[startDay, endDay] 闭区间，按本地日字典序比较）。 */
-  private rangeValue(range: { start: string; end: string }, metric: TrendMetric, provider?: string): number | null {
-    let acc: number | null = null;
-    for (const [day, models] of this.days) {
-      if (day < range.start || day > range.end) continue;
-      for (const [p, cells] of models) {
-        if (provider !== undefined && p !== provider) continue;
-        for (const cell of cells.values()) acc = sumToken(acc, metricValue(cell, metric));
-      }
-    }
-    return acc;
+    return buildWindowSummary(this.days, n, gran, metric, provider, now, stackSeries);
   }
 
   /** 统计摘要（health 观测面）。 */
@@ -1082,248 +679,24 @@ export class TrendAggregator {
   }
 }
 
-// ---------------------------------------------------------------- 纯函数
+// ---------------------------------------------------------------- 纯函数 re-export（公开面兼容）
 
-/** token 差（cell 回退用）：有值→null 时增量为 -old（cell 同步扣减，保证内存聚合
- *  与校正后的落盘明细一致）；双方皆 null 增量 0（null-aware 无变化）。 */
-function sub(oldV: number | null, newV: number | null): number | null {
-  if (newV === null) return oldV === null ? null : -oldV;
-  if (oldV === null) return newV;
-  return newV - oldV;
-}
-
-/**
- * 残差投影的 token 差（#633 修复）：聚合面 − 目录面，null-aware。
- * 双方皆 null → null（无该维度事实）；单侧 null 按 0 参与（另一侧有值即有残差）；
- * 负值保留给调用方判定（调用方按 0 处理并依赖「日总量恒等」断言暴露不一致）。
- */
-function diffToken(aggV: number | null, dirV: number | null): number | null {
-  if (aggV === null && dirV === null) return null;
-  return (aggV ?? 0) - (dirV ?? 0);
-}
-
-/** 内存日桶的最早 day key（无数据返回 null；day key 字典序即时间序）。 */
-function firstDayKeyOf(days: Map<string, unknown>): string | null {
-  let first: string | null = null;
-  for (const day of days.keys()) {
-    if (first === null || day < first) first = day;
-  }
-  return first;
-}
-
-/** 空聚合行（压实折算起点；字段与 mergeCell 消费的 agg 行同构）。 */
-function emptyAggRow(day: string, provider: string, model: string | null): TrendAggRow {
-  return {
-    v: TREND_ROW_VERSION,
-    kind: "agg",
-    day,
-    provider,
-    model,
-    input: null,
-    output: null,
-    cacheRead: null,
-    cacheWrite: null,
-    calls: 0,
-    turns: 0,
-    toolCalls: 0,
-  };
-}
-
-/** 空目录汇总行（#633 A4；与 agg 行十数值字段同构，仅键换成 dir）。 */
-function emptyDirRow(day: string, dir: string): TrendDirRow {
-  return {
-    v: TREND_ROW_VERSION,
-    kind: "dir",
-    day,
-    dir,
-    input: null,
-    output: null,
-    cacheRead: null,
-    cacheWrite: null,
-    calls: 0,
-    turns: 0,
-    toolCalls: 0,
-  };
-}
-
-/** 空小时汇总行（#662；与 agg/dir 行同构，键换成 hour；「落盘即定型」的产出起点）。 */
-function emptyHourRow(day: string, hour: number): TrendHourRow {
-  return {
-    v: TREND_ROW_VERSION,
-    kind: "hour",
-    day,
-    hour,
-    input: null,
-    output: null,
-    cacheRead: null,
-    cacheWrite: null,
-    calls: 0,
-    turns: 0,
-    toolCalls: 0,
-  };
-}
-
-/** 明细行并入聚合/目录/小时汇总行（三者字段同构，同函数复用；null-aware 求和）。 */
-function addDetailTo(agg: TrendAggRow | TrendDirRow | TrendHourRow, row: TrendDetailRow): void {
-  agg.calls += 1;
-  agg.input = sumToken(agg.input, row.input);
-  agg.output = sumToken(agg.output, row.output);
-  agg.cacheRead = sumToken(agg.cacheRead, row.cacheRead);
-  agg.cacheWrite = sumToken(agg.cacheWrite, row.cacheWrite);
-}
-
-/** 计数行并入聚合/目录/小时汇总行（同上，同函数复用）。 */
-function addCounterTo(agg: TrendAggRow | TrendDirRow | TrendHourRow, turns: number, toolCalls: number): void {
-  agg.turns += turns;
-  agg.toolCalls += toolCalls;
-}
-
-/** 聚合行并入 cell（重建用；null-aware。agg/dir/hour 汇总行十数值字段同构，同函数复用）。 */
-function mergeCell(cell: TrendCell, row: TrendAggRow | TrendDirRow | TrendHourRow): void {
-  cell.calls += row.calls;
-  cell.turns += row.turns;
-  cell.toolCalls += row.toolCalls;
-  cell.input = sumToken(cell.input, row.input);
-  cell.output = sumToken(cell.output, row.output);
-  cell.cacheRead = sumToken(cell.cacheRead, row.cacheRead);
-  cell.cacheWrite = sumToken(cell.cacheWrite, row.cacheWrite);
-}
-
-/** cell 的指标取值（total = 四项 token 之和）。 */
-export function metricValue(cell: TrendCell, metric: TrendMetric): number | null {
-  switch (metric) {
-    case "total":
-      return sumToken(sumToken(cell.input, cell.output), sumToken(cell.cacheRead, cell.cacheWrite));
-    case "input":
-      return cell.input;
-    case "output":
-      return cell.output;
-    case "cacheRead":
-      return cell.cacheRead;
-    case "cacheWrite":
-      return cell.cacheWrite;
-    case "calls":
-      return cell.calls;
-  }
-}
-
-/**
- * 聚合行合并（flush 压实写盘前与既有聚合分片合并——迟到旧日行场景防覆盖丢数；
- * null-aware 求和，同 (provider, model) 键累加）。
- */
-export function mergeAggRows(base: TrendAggRow[], add: TrendAggRow[]): TrendAggRow[] {
-  const byKey = new Map<string, TrendAggRow>();
-  for (const r of [...base, ...add]) {
-    const key = `${r.provider}\u0000${r.model ?? ""}`;
-    const cur = byKey.get(key);
-    if (cur === undefined) {
-      byKey.set(key, { ...r });
-      continue;
-    }
-    cur.calls += r.calls;
-    cur.turns += r.turns;
-    cur.toolCalls += r.toolCalls;
-    cur.input = sumToken(cur.input, r.input);
-    cur.output = sumToken(cur.output, r.output);
-    cur.cacheRead = sumToken(cur.cacheRead, r.cacheRead);
-    cur.cacheWrite = sumToken(cur.cacheWrite, r.cacheWrite);
-  }
-  return [...byKey.values()];
-}
-
-/**
- * dir 汇总行合并（#633 A4 flush 压实写盘前与既有聚合分片内的 dir 行合并——
- * 迟到旧日行场景防覆盖丢数；十数值字段与 mergeAggRows 完全同构，null-aware
- * 求和，同 dir 键累加。输出保持输入相对顺序：base 在前（dir 行位于分片尾段））。
- */
-export function mergeDirRows(base: TrendDirRow[], add: TrendDirRow[]): TrendDirRow[] {
-  const byKey = new Map<string, TrendDirRow>();
-  for (const r of [...base, ...add]) {
-    const cur = byKey.get(r.dir);
-    if (cur === undefined) {
-      byKey.set(r.dir, { ...r });
-      continue;
-    }
-    cur.calls += r.calls;
-    cur.turns += r.turns;
-    cur.toolCalls += r.toolCalls;
-    cur.input = sumToken(cur.input, r.input);
-    cur.output = sumToken(cur.output, r.output);
-    cur.cacheRead = sumToken(cur.cacheRead, r.cacheRead);
-    cur.cacheWrite = sumToken(cur.cacheWrite, r.cacheWrite);
-  }
-  return [...byKey.values()];
-}
-
-/**
- * hour 汇总行合并（#662，flush 压实写盘前与既有聚合分片内的 hour 行合并——
- * 迟到旧日行二次压实防丢防重；与 mergeDirRows 完全同构，同 hour 键累加，
- * 输出保持输入相对顺序：base 在前（hour 行位于分片尾段））。
- */
-export function mergeHourRows(base: TrendHourRow[], add: TrendHourRow[]): TrendHourRow[] {
-  const byKey = new Map<number, TrendHourRow>();
-  for (const r of [...base, ...add]) {
-    const cur = byKey.get(r.hour);
-    if (cur === undefined) {
-      byKey.set(r.hour, { ...r });
-      continue;
-    }
-    cur.calls += r.calls;
-    cur.turns += r.turns;
-    cur.toolCalls += r.toolCalls;
-    cur.input = sumToken(cur.input, r.input);
-    cur.output = sumToken(cur.output, r.output);
-    cur.cacheRead = sumToken(cur.cacheRead, r.cacheRead);
-    cur.cacheWrite = sumToken(cur.cacheWrite, r.cacheWrite);
-  }
-  return [...byKey.values()];
-}
-
-/** 周一为起点的周首日 day key（本地时区；DST 安全——逐日回退不用毫秒减法）。 */
-export function weekStartKey(t: number): string {
-  const d = new Date(t);
-  const dow = d.getDay(); // 0=周日
-  const back = (dow + 6) % 7; // 距周一的天数
-  d.setDate(d.getDate() - back);
-  return dayKey(d.getTime());
-}
-
-/** 近 n 个周首日 key（升序，含当前周）。 */
-export function lastNWeekKeys(n: number, now: number): string[] {
-  const d = new Date(now);
-  d.setDate(d.getDate() - ((d.getDay() + 6) % 7));
-  const keys: string[] = [];
-  for (let i = 0; i < n; i += 1) {
-    keys.unshift(dayKey(d.getTime()));
-    d.setDate(d.getDate() - 7);
-  }
-  return keys;
-}
-
-/** 近 n 个月 key（YYYY-MM，升序，含当月；本地时区逐月回退）。 */
-export function lastNMonthKeys(n: number, now: number): string[] {
-  const d = new Date(now);
-  const keys: string[] = [];
-  for (let i = 0; i < n; i += 1) {
-    keys.unshift(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`);
-    d.setDate(1);
-    d.setMonth(d.getMonth() - 1);
-  }
-  return keys;
-}
-
-/** 月 key 的日区间（本地日字典序；月末取该月最后一天，DST 安全）。 */
-export function monthRange(key: string): { start: string; end: string } {
-  const [y, m] = key.split("-").map(Number);
-  const start = new Date(y, m - 1, 1);
-  const end = new Date(y, m, 0); // 次月 0 日 = 本月末日
-  return { start: dayKey(start.getTime()), end: dayKey(end.getTime()) };
-}
-
-/** 周首日 key 的日区间（7 天）。 */
-export function weekRange(weekStart: string): { start: string; end: string } {
-  const [y, m, d] = weekStart.split("-").map(Number);
-  const start = new Date(y, m - 1, d);
-  const endDate = new Date(y, m - 1, d + 6);
-  return { start: dayKey(start.getTime()), end: dayKey(endDate.getTime()) };
-}
+// 以下符号原定义于本文件，D2 拆分迁至 aggregate-rows.ts / aggregate-query.ts 后经此处
+// re-export——src/index.ts、src/report/*.ts 与 lib 产物对 "trend/aggregator.ts" 的
+// import 路径保持不变（纯内部移动，公开导出面不破坏）。
+export {
+  metricValue,
+  weekStartKey,
+  lastNWeekKeys,
+  lastNMonthKeys,
+  monthRange,
+  weekRange,
+} from "./aggregate-query.ts";
+export { mergeAggRows, mergeDirRows, mergeHourRows } from "./aggregate-rows.ts";
+export type {
+  TrendGranularity,
+  TrendMetric,
+  TrendStackPart,
+  TrendStackPoint,
+  TrendWindowSummary,
+} from "./aggregate-query.ts";

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -34,6 +34,7 @@ import "./unit-refresh-revalidate.test.ts";
 import "./unit-deepseek-official.test.ts";
 import "./unit-fetch-timeout.test.ts";
 import "./unit-trend.test.ts";
+import "./unit-trend-ledger.test.ts";
 import "./unit-trend-view.test.ts";
 import "./unit-report.test.ts";
 import "./unit-stats-service.test.ts";

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -30,6 +30,7 @@ import "./unit-v1.test.ts";
 import "./unit-signal-lock.test.ts";
 import "./unit-apply.test.ts";
 import "./unit-detect.test.ts";
+import "./unit-errsurf.test.ts";
 import "./unit-refresh-revalidate.test.ts";
 import "./unit-deepseek-official.test.ts";
 import "./unit-fetch-timeout.test.ts";

--- a/packages/dsh-provider-usage/test/unit-errsurf.test.ts
+++ b/packages/dsh-provider-usage/test/unit-errsurf.test.ts
@@ -1,0 +1,240 @@
+// @ts-nocheck
+/**
+ * dsh-provider-usage — unit：域2每层错误面（#670 阶段三 B）+ /health per-layer 段
+ * + 崩溃注入冒烟。
+ *
+ * 覆盖：
+ * 1. errsurf 模块行为：累计计数 / 最近 N 条环形缓冲（新在前）/ snapshot 深拷贝 /
+ *    时钟注入 / noop 实现 / 未知层忽略；
+ * 2. handleHealth per-layer 段：注入错误记录后 /health 反映（记录→呈现链路）；
+ * 3. execute 层真实退出冒烟：ReportTaskQueue 执行失败 → warn 出口 → 错误面记录；
+ * 4. schedule 层真实退出冒烟：ReportScheduler onDue 失败 → warn 出口 → 错误面记录；
+ * 5. apply 集成：装配接线后 /health 携带三键齐 layerErrors（初始零值）。
+ *
+ * aggregate 层的真实故障（压实/刷盘失败）触发依赖 store 故障注入，成本高，
+ * 由 apply.ts 的 TrendTracker warn 接线覆盖（代码路径与 3/4 同构），此处以
+ * 模块级记录 + health 断言验证链路。
+ */
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { assert, pollUntil } from "./helpers.ts";
+import { makeLayerErrorSurface, makeNoopLayerErrorSurface, LAYER_ERROR_KEYS } from "../src/errsurf.ts";
+import { handleHealth } from "../src/routes/ui.ts";
+import { ReportTaskQueue } from "../src/report/tasks.ts";
+import { ReportScheduler } from "../src/report/scheduler.ts";
+import { normalizeReportConfig } from "../src/report/config.ts";
+
+function fakeReq(overrides = {}) {
+  return {
+    socket: { remoteAddress: "127.0.0.1" },
+    headers: { host: "127.0.0.1:3080", "sec-fetch-site": "same-origin" },
+    method: "GET",
+    url: "/",
+    ...overrides,
+  };
+}
+
+function callSyncHandler(handler, req) {
+  let payload;
+  handler(req, { writeHead: () => {}, end: (chunk) => { payload = JSON.parse(String(chunk)); } });
+  return payload;
+}
+
+/** handleHealth 的 UiRoutesContext mock（仅 health 用到的面）。 */
+function healthContext(layerErrors) {
+  return {
+    statsService: {
+      registry: { snapshot: () => ({ infos: [], enabled: {}, enabledProviders: [], errors: [] }) },
+      config: { provider: "opencode-go" },
+      cacheSize: () => 0,
+      historyRoot: "/tmp/dou-fake-root",
+    },
+    trend: { stats: () => ({ days: 0, pendingRows: 0, unpersistedRows: 0, lastFlushAt: null }) },
+    uiConfig: {},
+    sseClients: new Set(),
+    broadcastUiConfigChanged: () => {},
+    layerErrors,
+  };
+}
+
+// ---------------------------------------------------------------- 1) errsurf 模块行为
+
+{
+  let t = 1_700_000_000_000;
+  const surface = makeLayerErrorSurface({ now: () => t });
+  const initial = surface.snapshot();
+  assert.deepEqual(Object.keys(initial).sort(), [...LAYER_ERROR_KEYS].sort(), "snapshot 三键齐（aggregate/schedule/execute）");
+  for (const layer of LAYER_ERROR_KEYS) {
+    assert.equal(initial[layer].count, 0, `${layer} 初始 count=0`);
+    assert.deepEqual(initial[layer].recent, [], `${layer} 初始 recent 为空`);
+  }
+
+  surface.record("aggregate", "压实失败（2026-01-14）：注入故障"); // at = 1700000000000
+  t += 1000;
+  surface.record("aggregate", "归属异常：resolve 失败", "session-abc"); // at = 1700000001000
+  surface.record("execute", "task daily 2026-01-14 执行失败：注入故障");
+  const snap = surface.snapshot();
+  assert.equal(snap.aggregate.count, 2, "aggregate 累计计数=2");
+  assert.equal(snap.execute.count, 1, "execute 累计计数=1");
+  assert.equal(snap.aggregate.recent.length, 2, "recent 保留全部 ≤N 记录");
+  assert.equal(snap.aggregate.recent[0].message, "归属异常：resolve 失败", "recent 新在前（后记的在前）");
+  assert.equal(snap.aggregate.recent[0].context, "session-abc", "context 原样保留");
+  assert.equal(snap.aggregate.recent[0].at, t, "时间戳取注入时钟");
+  assert.equal(snap.aggregate.recent[1].at, t - 1000, "时间戳逐条取自注入时点");
+  assert.equal(snap.schedule.count, 0, "未发生错误的层保持 0");
+
+  // snapshot 深拷贝：改返回对象不影响内部状态
+  snap.execute.recent[0].message = "被污染";
+  snap.execute.count = 99;
+  const again = surface.snapshot();
+  assert.equal(again.execute.count, 1, "snapshot 修改不污染内部");
+  assert.notEqual(again.execute.recent[0].message, "被污染", "snapshot 修改不污染内部（recent 条目）");
+
+  // 未知层忽略（防御）
+  surface.record("bogus", "不应记录");
+  assert.deepEqual(Object.keys(surface.snapshot()).sort(), [...LAYER_ERROR_KEYS].sort(), "未知层不新增键");
+}
+
+{
+  // 环形截断：maxRecent 自定义
+  const surface = makeLayerErrorSurface({ maxRecent: 2 });
+  for (let i = 1; i <= 3; i++) surface.record("execute", `故障 ${i}`);
+  const snap = surface.snapshot();
+  assert.equal(snap.execute.count, 3, "截断不影响累计计数");
+  assert.equal(snap.execute.recent.length, 2, "recent 截断到 maxRecent=2");
+  assert.equal(snap.execute.recent[0].message, "故障 3", "截断保留最新在前");
+  assert.equal(snap.execute.recent[1].message, "故障 2", "最旧一条被淘汰");
+}
+
+{
+  // noop 实现：同形态、零副作用
+  const noop = makeNoopLayerErrorSurface();
+  noop.record("aggregate", "应被忽略");
+  const snap = noop.snapshot();
+  for (const layer of LAYER_ERROR_KEYS) {
+    assert.equal(snap[layer].count, 0, `noop ${layer}.count=0（record 不记录）`);
+    assert.deepEqual(snap[layer].recent, [], `noop ${layer}.recent 恒空`);
+  }
+}
+
+{
+  // context 字段按注入存在与否精确呈现（双向覆盖 if 变异：有/无都必须正确）
+  const surface = makeLayerErrorSurface();
+  surface.record("aggregate", "无上下文的错误");
+  surface.record("aggregate", "带上下文的错误", "daily 2026-01-14");
+  const snap = surface.snapshot();
+  assert.equal("context" in snap.aggregate.recent[0], true, "注入 context 时记录携带 context");
+  assert.equal(snap.aggregate.recent[0].context, "daily 2026-01-14", "context 值原样");
+  assert.equal("context" in snap.aggregate.recent[1], false, "未注入 context 时记录不带 context 字段");
+}
+
+// ---------------------------------------------------------------- 2) handleHealth per-layer 段（记录→呈现链路）
+
+{
+  const surface = makeLayerErrorSurface();
+  surface.record("execute", "注入故障：persist 失败（/reports/generate）", "daily 2026-01-14");
+  const payload = callSyncHandler((req, res) => handleHealth(req, res, healthContext(surface)), fakeReq());
+
+  assert.equal(payload.ok, true, "health 正常响应");
+  const layerErrors = payload.layerErrors;
+  assert.ok(layerErrors !== undefined, "health 响应携带 layerErrors 段");
+  assert.deepEqual(Object.keys(layerErrors).sort(), [...LAYER_ERROR_KEYS].sort(),
+    "layerErrors 三键齐（aggregate/schedule/execute）");
+  assert.equal(layerErrors.execute.count, 1, "注入的 execute 故障被 health 反映");
+  assert.equal(layerErrors.execute.recent.length, 1, "最近记录条数正确");
+  assert.equal(layerErrors.execute.recent[0].message, "注入故障：persist 失败（/reports/generate）",
+    "最近记录消息与注入一致");
+  assert.equal(typeof layerErrors.execute.recent[0].at, "number", "最近记录带时间戳");
+  assert.equal(layerErrors.execute.recent[0].context, "daily 2026-01-14", "最近记录带上下文");
+  assert.equal(layerErrors.aggregate.count, 0, "未注入层保持 0（加性段不误报）");
+  assert.equal(layerErrors.schedule.count, 0, "未注入层保持 0（加性段不误报）");
+  // 与既有段并存（回归护栏：加性字段不破坏原结构）
+  assert.ok(Array.isArray(payload.adapters), "adapters 段保留");
+  assert.ok(Array.isArray(payload.errors), "errors 段保留");
+  assert.ok(payload.trend !== undefined, "trend 段保留");
+}
+
+// ---------------------------------------------------------------- 3) execute 层真实退出冒烟（ReportTaskQueue）
+
+{
+  const surface = makeLayerErrorSurface();
+  const queue = new ReportTaskQueue({
+    executor: async () => { throw new Error("注入故障：生成器崩溃"); },
+    warn: (m) => surface.record("execute", m),
+  });
+  queue.submit({ period: "daily", key: "2026-01-14", startDay: "2026-01-14", endDay: "2026-01-14" });
+  const surfaced = await pollUntil(() => surface.snapshot().execute.count >= 1);
+  assert.equal(surfaced, true, "队列执行失败经 warn 出口进入 execute 层错误面");
+  const snap = surface.snapshot();
+  assert.ok(snap.execute.recent[0].message.includes("注入故障：生成器崩溃"),
+    "任务失败消息内容原样记录（含 task 定位）");
+  assert.equal(snap.execute.count, 1, "单次失败计数=1");
+}
+
+// ---------------------------------------------------------------- 4) schedule 层真实退出冒烟（ReportScheduler onDue 失败）
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dou-errsurf-schedule-"));
+  const surface = makeLayerErrorSurface();
+  const scheduler = ReportScheduler.start({
+    root: dir,
+    config: normalizeReportConfig({ daily: { enabled: true, time: "00:00" } }),
+    now: () => new Date(2026, 0, 15, 12, 0).getTime(),
+    onDue: async () => { throw new Error("注入故障：调度提交崩溃"); },
+    warn: (m) => surface.record("schedule", m),
+  });
+  try {
+    await scheduler.tick(); // start 内异步首 tick 之外，再显式走一轮（断言同步化）
+    const surfaced = await pollUntil(() => surface.snapshot().schedule.count >= 1);
+    assert.equal(surfaced, true, "调度提交失败经 warn 出口进入 schedule 层错误面");
+    assert.ok(surface.snapshot().schedule.recent[0].message.includes("注入故障：调度提交崩溃"),
+      "调度失败消息内容原样记录");
+  } finally {
+    scheduler.dispose();
+  }
+}
+
+// ---------------------------------------------------------------- 5) apply 集成：装配接线后 /health 携带 layerErrors
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "dou-errsurf-apply-"));
+  const savedDshHome = process.env.DSH_HOME;
+  process.env.DSH_HOME = join(dir, "dshhome");
+  mkdirSync(process.env.DSH_HOME, { recursive: true });
+  const historyDir = join(dir, "history");
+  mkdirSync(historyDir, { recursive: true });
+  try {
+    const { apply, ROUTES } = await import("../lib/index.js");
+    const routes = [];
+    const disposers = [];
+    const ctx = {
+      logger: { warn: () => {} },
+      webServer: { register(route) { routes.push(route); return () => {}; } },
+      on: () => () => {},
+      llm: { listProviders() { return []; } },
+      fiber: { state: "active" },
+      inject: (deps, cb) => { cb({ settings: {} }); },
+      effect(fn) {
+        const d = fn();
+        if (typeof d === "function") disposers.push(d);
+        return typeof d === "function" ? d : () => {};
+      },
+    };
+    await apply(ctx, { autoReload: false, apiKey: "sk-test", apiEndpoint: "http://127.0.0.1:9", historyDir });
+    const health = routes.find((r) => r.path === ROUTES.health);
+    assert.ok(health !== undefined, "apply 挂载 health 路由");
+    const payload = callSyncHandler(health.handler, fakeReq());
+    const layerErrors = payload.layerErrors;
+    assert.ok(layerErrors !== undefined, "apply 接线后 /health 携带 layerErrors");
+    assert.deepEqual(Object.keys(layerErrors).sort(), [...LAYER_ERROR_KEYS].sort(), "三键齐");
+    for (const layer of LAYER_ERROR_KEYS) {
+      assert.equal(layerErrors[layer].count, 0, `初始 ${layer}.count=0（无故障时零污染）`);
+      assert.deepEqual(layerErrors[layer].recent, [], `初始 ${layer}.recent 空`);
+    }
+    for (const dispose of [...disposers].reverse()) { try { dispose(); } catch {} }
+  } finally {
+    if (savedDshHome === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = savedDshHome;
+  }
+}

--- a/packages/dsh-provider-usage/test/unit-trend-ledger.test.ts
+++ b/packages/dsh-provider-usage/test/unit-trend-ledger.test.ts
@@ -1,0 +1,266 @@
+// @ts-nocheck
+/**
+ * dsh-provider-usage — unit：R8 台账守恒（不变量4）事件回放式端到端对账（阶段三 #670）。
+ *
+ * 为什么要端到端回放（真缺口定位，layer-architecture.md §3 R8）：不变量 1/2/3（身份快照 /
+ * 防双计 / 残差归未识别）已被 unit-trend.test.ts 分段覆盖；唯「台账守恒」从未被断言——
+ * Σ事件 == buckets == agg == dirRows + unidentified 是 D2 aggregator 拆分的前置安全网
+ * （拆分后若压实/折算逻辑漂移，本文件应第一时间红）。
+ *
+ * 对账口径（四视角，与 aggregator 记账语义一一对应）：
+ * - a. Σ事件：emitted 中 call 事件数（correct 只覆盖 token 不新增调用计数）；token 按
+ *   最终值求和——同一 fold 键 (session,turn,step,retry) 的 call 先入账、后续 correct
+ *   覆盖为该键的最终 tokens（与 applyCorrect 的「回退旧值再累加新值」语义等价，
+ *   因为正确路径下 correct 必命中 pending 内该键的最后一条 detail）。
+ * - b. buckets：aggregator 内存聚合面（days 桶 cells 合计，buckets() 公开查询面）。
+ * - c. agg：rollupSnapshot(day).aggRows 合计——压实折算只做「落盘形态转换」，
+ *   与 cells 同源（apply 已累加，折算不二次累加）。
+ * - d. dirRows + unidentified：rollupSnapshot(day).dirRows 合计（pending 中带 dir 键的
+ *   事实折算）与 dirRows() 快照（dirDays 桶 + 每日残差投影）双线对齐；unidentified
+ *   份额逐键对齐（归属/目录缺失的事实不静默丢弃、不双计）。无 dir 键的行只进 agg 不进
+ *   dir（旧格式 rebuild 行），目录守恒以「有 dir 事实」为界——本回放全部经 collector
+ *   apply 路径，collector.dirOf 恒返回 string（缺失时 TREND_UNIDENTIFIED），
+ *   故目录守恒基准 == 聚合面基准。
+ * - null 语义：缺失维度（null）不参与求和（sumToken）；0 是有效数字参与求和。
+ *   校正若把数字改为 null，cell 增量修正 sub(v,null)=-v 会把值折回（0 残留为 0 属
+ *   既有 null-aware 增量语义），故本回放中 correct 一律带完整四维 token，避免该
+ *   既有边界干扰守恒判定（该边界不在本文件范围，unit-trend 校正段已覆盖其行为）。
+ *
+ * 场景清单（单次回放全覆盖）：request/header 归属折叠、assistant/chunk usage 定稿、
+ * 同调用重复 usage（产生 correct 校正）、message 补记（含零 usage 与 interrupted）、
+ * retry 逐次计（同 fold 键新 header 后 retry+1）、turn/end 与 tool/call（counter 事件）、
+ * 归属缺失（provider/model 缺失 → TREND_UNIDENTIFIED）、#633 目录归属两条线
+ * （合法 dir 经 resolveCwd 净化、缺失归 TREND_UNIDENTIFIED）、跨天（DAY0/DAY1 逐日对账）。
+ */
+import { assert } from "./helpers.ts";
+import { TrendCollector, TrendAggregator, dayKey, sumToken, TREND_UNIDENTIFIED } from "../lib/index.js";
+
+// ---------------------------------------------------------------- 工具（与 unit-trend.test.ts 同口径）
+
+/** 固定本地时刻：2026-09-04（周五）12:00 与次日（跨天对账）。 */
+const T0 = new Date(2026, 8, 4, 12, 0, 0).getTime();
+const T1 = T0 + 86400000; // 2026-09-05（DAY1）
+const DAY0 = dayKey(T0);
+const DAY1 = dayKey(T1);
+const HOUR = 3600_000;
+
+function ev(type, data, time, seq = 1) {
+  return { type, seq, time, data };
+}
+const HEADER = (provider, model) => ({ header: { config: { provider, model } }, reason: "initial" });
+/** usage chunk：cacheRead/cacheWrite 省略时为 undefined → parseTokens 记 null（缺失维度语义）。 */
+const USAGE = (turn, step, input, output, cacheRead, cacheWrite) => ({
+  turn,
+  step,
+  chunk: { type: "usage", usage: { inputTokens: input, outputTokens: output, cacheReadTokens: cacheRead, cacheWriteTokens: cacheWrite } },
+});
+/** assistant/message：source 缺省 = 无副源（归属缺失路径）；usage 为 null = 零 usage 补记。 */
+const MESSAGE = (turn, step, usage, opts = {}) => ({
+  turn,
+  step,
+  message: { role: "assistant", ...(opts.source === undefined ? {} : { source: opts.source }) },
+  ...(usage === null ? {} : { usage }),
+  ...(opts.interrupted ? { interrupted: true } : {}),
+});
+
+function makeCollector(resolveCwd) {
+  const emitted = [];
+  const collector = new TrendCollector({ now: () => T0, resolveCwd, emit: (e) => emitted.push(e) });
+  const send = (session, event) => collector.handleEvent(typeof session === "string" ? session : session?.id, event);
+  return { collector, emitted, send };
+}
+
+/** #633 目录归属：s1/s3 合法 cwd（净化 basename），s2/s4 缺失（归未识别桶）。 */
+const resolveCwd = (session) => ({ s1: "/home/u/proj-a", s3: "/home/u/proj-b" })[session];
+
+// ---------------------------------------------------------------- 回放序列
+
+const { emitted, send } = makeCollector(resolveCwd);
+
+// DAY0 —— s1：合法归属 + 合法目录 + correct 校正 + retry 逐次计 + turn/tool 计数
+send("s1", ev("request/header", HEADER("deepseek", "deepseek-chat"), T0, 1)); // 归属主源折叠
+send("s1", ev("assistant/chunk", USAGE(1, 1, 100, 50, 10, 5), T0 + 1000, 2)); // 定稿 call#1（retry1）
+send("s1", ev("assistant/chunk", USAGE(1, 1, 120, 60, 0, 0), T0 + 2000, 3)); // 同调用重复 usage → correct
+send("s1", ev("assistant/message", MESSAGE(1, 1, { inputTokens: 200, outputTokens: 80, cacheReadTokens: 2, cacheWriteTokens: 1 }), T0 + 3000, 4)); // 已定稿 message → correct（覆盖）
+send("s1", ev("request/header", HEADER("deepseek", "deepseek-chat"), T0 + 5000, 5)); // 重试边界
+send("s1", ev("assistant/chunk", USAGE(1, 1, 70, 30), T0 + 6000, 6)); // retry2 逐次入账
+send("s1", ev("tool/call", { turn: 1, step: 1, callId: "c1", name: "bash", arguments: "{}" }, T0 + 7000, 7)); // counter toolCalls
+send("s1", ev("tool/call", { turn: 1, step: 1, callId: "c2", name: "bash", arguments: "{}" }, T0 + 8000, 8)); // counter toolCalls
+send("s1", ev("turn/end", { turn: 1, reason: { kind: "completed" } }, T0 + 9000, 9)); // counter turns
+
+// DAY0 —— s2：归属缺失（无 header 无 source）+ interrupted 补记 + 后续 usage（未识别桶）
+send("s2", ev("assistant/message", MESSAGE(1, 1, { inputTokens: 30, outputTokens: 20 }, { interrupted: true }), T0 + 10000, 10)); // 补记 call（interrupted）
+send("s2", ev("assistant/chunk", USAGE(2, 1, 10, 5), T0 + 11000, 11)); // 未识别 call
+send("s2", ev("tool/call", { turn: 1, step: 1, callId: "c1", name: "bash", arguments: "{}" }, T0 + 12000, 12)); // counter toolCalls（未识别）
+send("s2", ev("turn/end", { turn: 1, reason: { kind: "completed" } }, T0 + 13000, 13)); // counter turns（未识别）
+
+// DAY1 —— s3：合法 dir（proj-b）+ 零 usage 补记；s4：目录缺失归未识别 + 合法归属
+send("s3", ev("request/header", HEADER("deepseek", "deepseek-reasoner"), T1, 14));
+send("s3", ev("assistant/chunk", USAGE(1, 1, 50, 25, 0, 50), T1 + 1000, 15)); // call（dir=proj-b）
+send("s3", ev("assistant/message", MESSAGE(2, 1, null), T1 + 2000, 16)); // 零 usage 补记：调用照计、token null
+send("s3", ev("turn/end", { turn: 1, reason: { kind: "completed" } }, T1 + 3000, 17)); // counter turns（dir=proj-b）
+send("s4", ev("request/header", HEADER("opencode", "glm-4"), T1 + 3100, 18));
+send("s4", ev("assistant/chunk", USAGE(1, 1, 8, 4, 1, 0), T1 + 4000, 19)); // call（dir=unidentified）
+
+// emitted 结构 sanity（correct 不新增调用计数；counter 独立）
+const calls = emitted.filter((e) => e.type === "call").map((e) => e.record);
+const corrects = emitted.filter((e) => e.type === "correct").map((e) => e.record);
+const counters = emitted.filter((e) => e.type === "counter").map((e) => e.record);
+assert.equal(calls.length, 7, "Σ事件：call 事件数 = 7（correct 不新增调用计数）");
+assert.equal(corrects.length, 2, "同调用重复 usage + 已定稿 message 各产生一次校正");
+assert.equal(counters.length, 6, "turn/end×3 + tool/call×3 = 6 个 counter 事件");
+assert.equal(calls[0].provider, "deepseek", "归属折叠正确（s1 header 主源）");
+assert.equal(calls[2].interrupted, true, "s2 补记带 interrupted 标记");
+assert.equal(calls[2].provider, TREND_UNIDENTIFIED, "归属缺失 → TREND_UNIDENTIFIED 桶");
+assert.equal(calls[2].model, null, "未识别桶 model=null");
+assert.equal(calls[5].tokens, null, "零 usage 补记（s3 第二条 call）token 为 null");
+assert.deepEqual(
+  calls.map((c) => c.dir).sort(),
+  [TREND_UNIDENTIFIED, TREND_UNIDENTIFIED, TREND_UNIDENTIFIED, "proj-a", "proj-a", "proj-b", "proj-b"],
+  "#633 目录归属两条线：合法 basename 与缺失归未识别均落盘",
+);
+
+// ---------------------------------------------------------------- 对账
+
+const agg = new TrendAggregator();
+for (const e of emitted) agg.apply(e);
+
+// ---- 期望值：Σ事件（a 视角）——fold 键最终 tokens（correct 覆盖语义）+ counter 计数 ----
+const ZERO = () => ({ input: null, output: null, cacheRead: null, cacheWrite: null, calls: 0, turns: 0, toolCalls: 0 });
+const TOKEN_FIELDS = ["input", "output", "cacheRead", "cacheWrite"];
+const NUM_FIELDS = ["calls", "turns", "toolCalls"];
+const ALL_FIELDS = [...TOKEN_FIELDS, ...NUM_FIELDS];
+
+function addTokens(acc, tokens) {
+  if (tokens === null) return acc;
+  for (const f of TOKEN_FIELDS) acc[f] = sumToken(acc[f], tokens[f]);
+  return acc;
+}
+/** 十数值字段同构行（cell / agg / dir 行）并入合计。 */
+function addRowTotals(acc, row) {
+  for (const f of TOKEN_FIELDS) acc[f] = sumToken(acc[f], row[f]);
+  for (const f of NUM_FIELDS) acc[f] += row[f];
+  return acc;
+}
+
+// 身份快照基准：fold 键 → { day, dir, tokens }（correct 覆盖 tokens；day/dir 取 call 定稿事实）
+const finalByKey = new Map();
+for (const e of emitted) {
+  if (e.type === "call") {
+    const r = e.record;
+    finalByKey.set(`${r.session}\u0000${r.turn}\u0000${r.step}\u0000${r.retry}`, { day: dayKey(r.time), dir: r.dir, tokens: r.tokens });
+  } else if (e.type === "correct") {
+    const r = e.record;
+    const cur = finalByKey.get(`${r.session}\u0000${r.turn}\u0000${r.step}\u0000${r.retry}`);
+    if (cur !== undefined) cur.tokens = r.tokens; // 校正覆盖（与 applyCorrect 命中语义一致）
+  }
+}
+
+const expectByDay = new Map(); // day → 全量合计
+const expectByDayDir = new Map(); // day → Map<dir, 合计>
+const dayTotals = (day) => {
+  let t = expectByDay.get(day);
+  if (t === undefined) {
+    t = ZERO();
+    expectByDay.set(day, t);
+  }
+  return t;
+};
+const dayDirTotals = (day, dir) => {
+  let byDir = expectByDayDir.get(day);
+  if (byDir === undefined) {
+    byDir = new Map();
+    expectByDayDir.set(day, byDir);
+  }
+  let t = byDir.get(dir);
+  if (t === undefined) {
+    t = ZERO();
+    byDir.set(dir, t);
+  }
+  return t;
+};
+for (const { day, dir, tokens } of finalByKey.values()) {
+  const e = dayTotals(day);
+  e.calls += 1;
+  addTokens(e, tokens);
+  const d = dayDirTotals(day, dir);
+  d.calls += 1;
+  addTokens(d, tokens);
+}
+for (const c of counters) {
+  const day = dayKey(c.time);
+  const e = dayTotals(day);
+  e.turns += c.turns;
+  e.toolCalls += c.toolCalls;
+  const d = dayDirTotals(day, c.dir);
+  d.turns += c.turns;
+  d.toolCalls += c.toolCalls;
+}
+
+// ---- 对账断言（失败消息给出视角 / 日 / 键 / 期望与实得，精确缺账多账定位）----
+function assertEqualTotals(label, expected, actual) {
+  for (const f of ALL_FIELDS) {
+    assert.equal(actual[f], expected[f], `${label}：字段 ${f} 不守恒——期望 ${expected[f]}，实得 ${actual[f]}（${expected[f] === null || actual[f] === null ? "null 语义参与" : `差 ${actual[f] - expected[f]}`}）`);
+  }
+}
+
+function bucketsTotalsOf(day) {
+  const acc = ZERO();
+  const b = agg.buckets().find((d) => d.day === day);
+  if (b !== undefined) for (const p of b.providers) addRowTotals(acc, p.cell);
+  return acc;
+}
+function aggRowsTotalsOf(day) {
+  const acc = ZERO();
+  for (const r of agg.rollupSnapshot(day).aggRows) addRowTotals(acc, r);
+  return acc;
+}
+function dirRowsTotalsOf(day) {
+  const acc = ZERO();
+  for (const r of agg.rollupSnapshot(day).dirRows) addRowTotals(acc, r);
+  return acc;
+}
+function dirSnapshotTotalsOf(day) {
+  const acc = ZERO();
+  for (const r of agg.dirRows()) if (r.day === day) addRowTotals(acc, r);
+  return acc;
+}
+function dirRowsOfDirTotals(day, dir) {
+  const acc = ZERO();
+  for (const r of agg.rollupSnapshot(day).dirRows) if (r.dir === dir) addRowTotals(acc, r);
+  return acc;
+}
+function dirSnapshotOfDirTotals(day, dir) {
+  const acc = ZERO();
+  for (const r of agg.dirRows()) if (r.day === day && r.dir === dir) addRowTotals(acc, r);
+  return acc;
+}
+
+assert.equal(finalByKey.size, calls.length, "身份快照键数 == call 事件数（correct 不新增）");
+const days = [...expectByDay.keys()].sort();
+assert.deepEqual(days, [DAY0, DAY1], "回放覆盖两天（跨天逐日对账）");
+for (const day of days) {
+  const expected = expectByDay.get(day);
+  // a. Σ事件 == b. buckets（内存聚合面）
+  assertEqualTotals(`[${day}] a→b：Σ事件 vs 内存桶 buckets 合计`, expected, bucketsTotalsOf(day));
+  // a. Σ事件 == c. agg（压实折算，不二次累加）
+  assertEqualTotals(`[${day}] a→c：Σ事件 vs rollupSnapshot.aggRows 合计`, expected, aggRowsTotalsOf(day));
+  // a. Σ事件 == d. dirRows（pending 折算）+ dirRows() 快照（dirDays+残差；有 dir 事实为界）
+  assertEqualTotals(`[${day}] a→d：Σ事件 vs rollupSnapshot.dirRows 合计`, expected, dirRowsTotalsOf(day));
+  assertEqualTotals(`[${day}] a→d：Σ事件 vs dirRows() 快照（残差应为 0）`, expected, dirSnapshotTotalsOf(day));
+  // 未识别桶份额逐键对齐（归属/目录缺失不静默丢弃、不双计）
+  const byDir = expectByDayDir.get(day);
+  for (const [dir, expectedDir] of byDir) {
+    assertEqualTotals(`[${day}] dir=${dir}（rollupSnapshot 折算）`, expectedDir, dirRowsOfDirTotals(day, dir));
+    assertEqualTotals(`[${day}] dir=${dir}（dirRows() 快照）`, expectedDir, dirSnapshotOfDirTotals(day, dir));
+  }
+  assert.equal(byDir.has(TREND_UNIDENTIFIED), true, "该日未识别桶确有份额（防口径空转）");
+}
+
+// 台账守恒链完整表达式（终态抽查）：Σ事件 == buckets == agg == dirRows + unidentified
+{
+  const day = DAY0;
+  const chain = [bucketsTotalsOf(day), aggRowsTotalsOf(day), dirRowsTotalsOf(day), dirSnapshotTotalsOf(day)];
+  for (const t of chain) assertEqualTotals(`[${day}] 守恒链终态`, expectByDay.get(day), t);
+  console.log(`unit-trend-ledger: DAY0/DAY1 四视角台账守恒全部通过（calls=${expectByDay.get(DAY0).calls + expectByDay.get(DAY1).calls}，corrects=${corrects.length}，counters=${counters.length}）`);
+}

--- a/packages/dsh-provider-usage/test/unit-trend.test.ts
+++ b/packages/dsh-provider-usage/test/unit-trend.test.ts
@@ -90,6 +90,8 @@ const correctsOf = (emitted) => emitted.filter((e) => e.type === "correct").map(
 const countersOf = (emitted) => emitted.filter((e) => e.type === "counter").map((e) => e.record);
 
 // ---------------------------------------------------------------- collector：定稿主信号
+// 不变量1：身份快照（event 归属折叠正确）——request/header 折叠为 per-session 归属主源，
+// usage chunk 定稿按当前折叠归属出账（R8 四不变量归组，见 refactor-implementation-plan.md 阶段三）。
 
 {
   const { emitted, send } = makeCollector();
@@ -108,6 +110,7 @@ const countersOf = (emitted) => emitted.filter((e) => e.type === "counter").map(
 }
 
 // ---------------------------------------------------------------- collector：重复 usage 校正
+// 不变量2：防双计（同 fold 键不重复记账、压实不二次累加）——同调用重复 usage 只校正 token、不重计调用。
 
 {
   const { emitted, send } = makeCollector();
@@ -124,6 +127,7 @@ const countersOf = (emitted) => emitted.filter((e) => e.type === "counter").map(
 }
 
 // ---------------------------------------------------------------- collector：retry 逐次计
+// 不变量2：防双计——retry 复用同一 (turn,step)，新 header 边界后逐次独立入账（重试消耗不合并、不丢）。
 
 {
   const { emitted, send } = makeCollector();
@@ -141,6 +145,7 @@ const countersOf = (emitted) => emitted.filter((e) => e.type === "counter").map(
 }
 
 // ---------------------------------------------------------------- collector：message 补记/校正/interrupted
+// 不变量2：防双计——未定稿 message 补记、已定稿仅校正不重记；零 usage 调用照计（token 记 null 非 0）。
 
 {
   // 补记：usage chunk 缺失，message.usage 到达
@@ -186,6 +191,8 @@ const countersOf = (emitted) => emitted.filter((e) => e.type === "counter").map(
 }
 
 // ---------------------------------------------------------------- collector：归属
+// 不变量1+3：身份快照与残差归未识别——归属缺失显式入 TREND_UNIDENTIFIED 桶（不静默丢弃）；
+// message.source 副源仅缺失时补齐、不一致告警不覆盖主源（主源权威）。
 
 {
   // 归属缺失 → 未识别桶（不静默丢弃）
@@ -220,6 +227,8 @@ const countersOf = (emitted) => emitted.filter((e) => e.type === "counter").map(
 }
 
 // ---------------------------------------------------------------- collector：turn/end 与计数
+// 不变量2：防双计——turn/end 只丢未定稿缓冲，定稿记忆保留（同 turn 乱序迟到 message 不双算）；
+// turn/tool 计数独立 +1（与调用计数互不干扰）。
 
 {
   const { emitted, send } = makeCollector();
@@ -248,6 +257,7 @@ const countersOf = (emitted) => emitted.filter((e) => e.type === "counter").map(
 }
 
 // ---------------------------------------------------------------- collector：TTL 与销毁
+// 不变量2：防双计——fold/会话 TTL 回收后迟到 message 仍经 done 定稿记忆走校正路径（不双算）。
 
 {
   let nowMs = T0;
@@ -290,6 +300,8 @@ const countersOf = (emitted) => emitted.filter((e) => e.type === "counter").map(
 }
 
 // ---------------------------------------------------------------- aggregator
+// 不变量2：防双计——apply 实时累加 cells，压实只做「落盘形态转换」绝不二次累加；
+// 重建时 agg 分片权威 + 明细/计数行二选一来源（不双算）。null 语义：null 不参与求和。
 
 function cellTotals(agg, day, provider = "deepseek") {
   const b = agg.buckets().find((d) => d.day === day);
@@ -559,6 +571,7 @@ function cellTotals(agg, day, provider = "deepseek") {
 }
 
 // ---------------------------------------------------------------- tracker
+// 不变量2：防双计——启动重建（聚合权威）/ 当日明细防二次落盘 / 自愈压实 / 迟到旧日行合并防覆盖丢数。
 
 function writeAggShardLine(row) {
   return `${JSON.stringify(row)}\n`;
@@ -783,6 +796,7 @@ function writeAggShardLine(row) {
 }
 
 // ---------------------------------------------------------------- 评审修复：P2-2 补记定稿后 headerSeen 对称重置
+// 不变量2：防双计——message 补记定稿后对称重置 headerSeen（迟到 usage 不被误判为新调用双算）。
 
 {
   // P2-2 双算反例：header → message（带 usage）补记定稿 → 同 (turn,step) 迟到 usage chunk。
@@ -805,6 +819,7 @@ function writeAggShardLine(row) {
 }
 
 // ---------------------------------------------------------------- 评审修复：P2-3 done 定稿记忆 Map 化
+// 不变量2：防双计——done 定稿记忆（retry 记忆 + TREND_DONE_MAX 淘汰）防乱序迟到 message 双算。
 
 {
   // P2-3(a)：retry=2 定稿后 folds 被 TTL 清空 → 迟到 message 校正的 retry
@@ -880,6 +895,7 @@ function writeAggShardLine(row) {
 }
 
 // ---------------------------------------------------------------- 评审修复：P2-6 归属不一致告警
+// 不变量1：身份快照——主源在场且与副源不一致时仅告警不覆盖（主源 header 是记账归属权威）。
 
 {
   // P2-6：主源在场且 message.source 解析结果与之不一致 → onAnomaly 告警（带上下文）、
@@ -950,6 +966,8 @@ function writeAggShardLine(row) {
 }
 
 // ---------------------------------------------------------------- #633 A1 补全：dir 落盘映射与 resolveCwd 契约接线
+// 不变量1+3：身份快照 / 残差归未识别——dir 归属经 resolveCwd 惰性单查、sanitizeDirName 净化落盘；
+// store 无 session / cwd 缺失 / 抛错显式归 TREND_UNIDENTIFIED 桶（不静默丢弃、不重复查询）。
 
 {
   // A1(a)：per-session 惰性单查——同 session 多次 emit 事件（call 定稿/校正/counter/
@@ -1071,6 +1089,8 @@ function writeAggShardLine(row) {
 }
 
 // ---------------------------------------------------------------- #633 A2 兼容割接：存量分片（无 cwd/dir 键）升级后首次启动重建
+// 不变量3+4：残差归未识别 / 台账守恒边界——旧格式（无 dir 键）行只进 cells（agg 面）、
+// 不补造 dir 行；其目录事实由「每日残差归未识别」投影承担（目录面守恒以有 dir 事实为界）。
 
 // A2 前提（图纸第 1 步已验证）：isValidShardRow 按 kind 校验必填键，无键白名单遍历
 // ——未知键不拒绝；detail/counter 的 dir 为加性可选键（dir === undefined 放行）。
@@ -1275,6 +1295,8 @@ const A2_LEGACY_AGG = {
 }
 
 // ---------------------------------------------------------------- #633 A3/A4：dir 维度归并内存态与日汇总行生成
+// 不变量2：防双计——dir 维度平行累加（同 record 不二次 emit）；rebuild 时 dir 行只进
+// dirDays、不进 cells（防双计）、不进 pending（不二次落盘）。
 
 {
   // A3(a)：内存态归并（tracker 全链路）——apply 平行累加后压实产物 dir 行：
@@ -1643,6 +1665,7 @@ const A2_LEGACY_AGG = {
 }
 
 // ---------------------------------------------------------------- #662 hour 维度（day×hour 聚合行数据链路）
+// 不变量2：防双计——小时面与 agg/dir 同一批事实的第三个投影（同源折算，不二次累加）。
 
 {
   // #662(a)：apply 平行累加 hourDays（hourOfDay 本地时区现算）+ rollupDay 同源产出
@@ -1851,6 +1874,7 @@ const A2_LEGACY_AGG = {
 }
 
 // ---------------------------------------------------------------- #654 压实快照消费
+// 不变量2：防双计——折算与消费取同一份身份快照（await 间隙新到行不连带删除、不丢行不重算）。
 
 {
   // 单元级：rollupSnapshot 的 consumed 与折算行严格同源；consume 只删快照内 entry。
@@ -1957,6 +1981,7 @@ const A2_LEGACY_AGG = {
 }
 
 // ---------------------------------------------------------------- #655 fold 清理后重复记账
+// 不变量2：防双计——fold 被 TTL 清理后迟到 usage 只校正不重记（done 记忆取真实 retry）。
 
 {
   // fold 被 fold TTL 清理后，同一 fold 键的迟到 usage 不得重复记账（与 onMessage 对称）。
@@ -1999,6 +2024,8 @@ assert.equal(sumToken(null, 5), 5, "sumToken null+数字");
 assert.equal(sumToken(null, null), null, "sumToken null+null");
 
 // ---------------------------------------------------------------- #633 修复：目录面残差投影
+// 不变量3+4：残差归未识别 / 台账守恒——目录面 = dirDays 快照 + 每日残差（聚合面 − 目录面），
+// 残差归 TREND_UNIDENTIFIED 桶；∀day 目录面日合计 == 聚合面日合计（本段断言 (e) 即该恒等的纯函数面）。
 // 背景（实测）：分片 a/b 上线后目录维度全链路失效——(1) inject 缺 sessions 致
 // resolveCwd 恒 undefined，所有会话归未识别桶；(2) 旧 agg 分片（无 kind:"dir" 行）
 // 重建时目录面全空，历史柱消失（实测目录面/聚合面总量差 20 倍）。

--- a/scripts/data/gauntlet.config.json
+++ b/scripts/data/gauntlet.config.json
@@ -78,9 +78,9 @@
         "baselineDuration": "13m54s（阶段二重建：十一段基线 + report 两段含 D8 新文件）",
         "baselineScope": "src 级十段全量（#342 二期六段 + 阶段零四段，口径详见 scope 字段；旧 lib 行号区间口径见 git history 2026-08-25）",
         "config": "stryker.conf.d/dsh-provider-usage-{entry,apply,contracts,sanitize,registry,pipeline,trend-aggregate,trend-collect,report-schedule,report-execute,routes}.json（#342 二期六段 + 阶段零四段 + 阶段一 routes 段 + 阶段二 D8 归位）",
-        "hardeningNote": "#150 两阶段达标开启 strict；阶段零（#670）：补盲区四段 + testFiles；阶段一（#670）：routes 段开段；阶段二（#670）：D8 last-run/report-index/executor/list-dirs/report-config-service 新文件并入 report 段",
+        "hardeningNote": "#150 两阶段达标开启 strict；阶段零（#670）：补盲区四段 + testFiles；阶段一（#670）：routes 段开段；阶段二（#670）：D8 last-run/report-index/executor/list-dirs/report-config-service 新文件并入 report 段；阶段三（#670）：aggregator 拆分为 aggregate-rows/aggregate-query 两纯函数模块并入 trend-aggregate 段（baseline 数字待 observe 夜间重建，见报告）",
         "threshold": 60,
-        "scope": "src 级十一段（#342 二期六段 + 阶段零四段 + 阶段一 routes 段）：entry / apply / contracts / sanitize / registry registry+user-adapter-loader / pipeline history+v2+hotreload+placement-math+path-resolve+client-logic+provider-config+charts+stats-service / trend-aggregate aggregator+store+index / trend-collect collector+types / report-schedule config+schedule+scheduler+tasks+last-run+report-config-service（D8 归位）/ report-execute runner+generate+format+report-index+executor+list-dirs（D8 归位）/ routes stats+adapters+ui+reports；基线为 src 口径，由四班次 observe 重建"
+        "scope": "src 级十一段（#342 二期六段 + 阶段零四段 + 阶段一 routes 段）：entry / apply / contracts / sanitize / registry registry+user-adapter-loader / pipeline history+v2+hotreload+placement-math+path-resolve+client-logic+provider-config+charts+stats-service / trend-aggregate aggregator+aggregate-rows+aggregate-query+store+index（阶段三 D2 拆分并入 mutate 面） / trend-collect collector+types / report-schedule config+schedule+scheduler+tasks+last-run+report-config-service（D8 归位）/ report-execute runner+generate+format+report-index+executor+list-dirs（D8 归位）/ routes stats+adapters+ui+reports；基线为 src 口径，由四班次 observe 重建"
       },
       "dsh-lan-proxy": {
         "baselineScore": 52.43,

--- a/scripts/data/gauntlet.config.json
+++ b/scripts/data/gauntlet.config.json
@@ -66,21 +66,21 @@
         "scope": "src 级六段（#342 二期）：manager manager.ts / entry index+normalize+import / supervisor supervisor+middleware-state+store+scope / middleware middleware+middleware-utils+middleware-const / routes middleware-register+routes / runtime catalog+apply+transport+placement-math+config-schema+protocol+middleware-types；基线为 src 口径，由四班次 observe 重建"
       },
       "dsh-provider-usage": {
-        "baselineScore": 69.03,
-        "baselineCovered": 69.03,
-        "baselineKilled": 3423,
-        "baselineTimeout": 30,
-        "baselineSurvived": 1549,
-        "baselineTotal": 5002,
-        "baselineNoCoverage": 900,
+        "baselineScore": 71.41,
+        "baselineCovered": 71.41,
+        "baselineKilled": 3586,
+        "baselineTimeout": 34,
+        "baselineSurvived": 1449,
+        "baselineTotal": 6400,
+        "baselineNoCoverage": 1331,
         "baselineErrors": 0,
         "baselineDate": "2026-09-09",
-        "baselineDuration": "13m54s（阶段二重建：十一段基线 + report 两段含 D8 新文件）",
-        "baselineScope": "src 级十段全量（#342 二期六段 + 阶段零四段，口径详见 scope 字段；旧 lib 行号区间口径见 git history 2026-08-25）",
-        "config": "stryker.conf.d/dsh-provider-usage-{entry,apply,contracts,sanitize,registry,pipeline,trend-aggregate,trend-collect,report-schedule,report-execute,routes}.json（#342 二期六段 + 阶段零四段 + 阶段一 routes 段 + 阶段二 D8 归位）",
-        "hardeningNote": "#150 两阶段达标开启 strict；阶段零（#670）：补盲区四段 + testFiles；阶段一（#670）：routes 段开段；阶段二（#670）：D8 last-run/report-index/executor/list-dirs/report-config-service 新文件并入 report 段；阶段三（#670）：aggregator 拆分为 aggregate-rows/aggregate-query 两纯函数模块并入 trend-aggregate 段（baseline 数字待 observe 夜间重建，见报告）",
+        "baselineDuration": "约 21m（阶段三重建：十二段基线全包实测——含 errsurf 新段 + trend-aggregate 拆分面 aggregate-rows/aggregate-query）",
+        "baselineScope": "src 级十二段全量（#342 二期六段 + 阶段零四段 + 阶段一 routes 段 + 阶段三 errsurf 段，口径详见 scope 字段）",
+        "config": "stryker.conf.d/dsh-provider-usage-{entry,apply,contracts,sanitize,registry,pipeline,trend-aggregate,trend-collect,report-schedule,report-execute,routes,errsurf}.json（#342 二期六段 + 阶段零四段 + 阶段一 routes 段 + 阶段二 D8 归位 + 阶段三 errsurf 新段）",
+        "hardeningNote": "#150 两阶段达标开启 strict；阶段零（#670）：补盲区四段 + testFiles；阶段一（#670）：routes 段开段；阶段二（#670）：D8 last-run/report-index/executor/list-dirs/report-config-service 新文件并入 report 段；阶段三（#670）：aggregator 拆分为 aggregate-rows/aggregate-query 两纯函数模块并入 trend-aggregate 段 + R8 台账守恒断言（unit-trend-ledger）与 errsurf（unit-errsurf）入 testFiles + errsurf 新段；基线已全包 12 段实测重建 71.41%",
         "threshold": 60,
-        "scope": "src 级十一段（#342 二期六段 + 阶段零四段 + 阶段一 routes 段）：entry / apply / contracts / sanitize / registry registry+user-adapter-loader / pipeline history+v2+hotreload+placement-math+path-resolve+client-logic+provider-config+charts+stats-service / trend-aggregate aggregator+aggregate-rows+aggregate-query+store+index（阶段三 D2 拆分并入 mutate 面） / trend-collect collector+types / report-schedule config+schedule+scheduler+tasks+last-run+report-config-service（D8 归位）/ report-execute runner+generate+format+report-index+executor+list-dirs（D8 归位）/ routes stats+adapters+ui+reports；基线为 src 口径，由四班次 observe 重建"
+        "scope": "src 级十二段（#342 二期六段 + 阶段零四段 + 阶段一 routes 段 + 阶段三 errsurf 段）：entry / apply / contracts / sanitize / registry registry+user-adapter-loader / pipeline history+v2+hotreload+placement-math+path-resolve+client-logic+provider-config+charts+stats-service / trend-aggregate aggregator+aggregate-rows+aggregate-query+store+index（阶段三 D2 拆分并入 mutate 面） / trend-collect collector+types / report-schedule config+schedule+scheduler+tasks+last-run+report-config-service（D8 归位）/ report-execute runner+generate+format+report-index+executor+list-dirs（D8 归位）/ routes stats+adapters+ui+reports / errsurf errsurf.ts（阶段三 B）；基线为 src 口径，由四班次 observe 重建"
       },
       "dsh-lan-proxy": {
         "baselineScore": 52.43,

--- a/scripts/data/mutation-topology.json
+++ b/scripts/data/mutation-topology.json
@@ -253,6 +253,7 @@
         "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
         "packages/dsh-provider-usage/test/unit-v1.test.ts",
         "packages/dsh-provider-usage/test/unit-trend.test.ts",
+        "packages/dsh-provider-usage/test/unit-trend-ledger.test.ts",
         "packages/dsh-provider-usage/test/unit-trend-view.test.ts",
         "packages/dsh-provider-usage/test/unit-report.test.ts",
         "packages/dsh-provider-usage/test/unit-routes.test.ts",

--- a/scripts/data/mutation-topology.json
+++ b/scripts/data/mutation-topology.json
@@ -336,6 +336,8 @@
         "trend-aggregate": {
           "mutate": [
             "packages/dsh-provider-usage/src/trend/aggregator.ts",
+            "packages/dsh-provider-usage/src/trend/aggregate-rows.ts",
+            "packages/dsh-provider-usage/src/trend/aggregate-query.ts",
             "packages/dsh-provider-usage/src/trend/store.ts",
             "packages/dsh-provider-usage/src/trend/index.ts"
           ],
@@ -343,7 +345,7 @@
             "!packages/dsh-provider-usage/src/client/**",
             "!packages/dsh-provider-usage/src/types.ts"
           ],
-          "comment": "阶段零新段（D17 分层变异）：E2 聚合/压实/存储面——aggregator+store+index（目录维度与 provider 面查询）；testFiles 含 unit-trend/unit-trend-view（杀灭面为该层测试）；aggregator 单文件 5-8 分钟，独立段防超时。"
+          "comment": "阶段零新段（D17 分层变异）：E2 聚合/压实/存储面——aggregator+store+index；阶段三（#670 D2）aggregator 拆分为 aggregate-rows（压实转换纯函数）+ aggregate-query（查询投影纯函数），两新文件并入 mutate 面（防新文件变异盲区）；testFiles 含 unit-trend/unit-trend-ledger/unit-trend-view（杀灭面为该层测试，R8 台账守恒断言覆盖守恒链）；aggregator 单文件 5-8 分钟，独立段防超时。"
         },
         "trend-collect": {
           "mutate": [

--- a/scripts/data/mutation-topology.json
+++ b/scripts/data/mutation-topology.json
@@ -249,6 +249,7 @@
         "packages/dsh-provider-usage/test/unit-config.test.ts",
         "packages/dsh-provider-usage/test/unit-contract.test.ts",
         "packages/dsh-provider-usage/test/unit-deepseek-official.test.ts",
+        "packages/dsh-provider-usage/test/unit-errsurf.test.ts",
         "packages/dsh-provider-usage/test/unit-history.test.ts",
         "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
         "packages/dsh-provider-usage/test/unit-v1.test.ts",
@@ -269,6 +270,16 @@
             "!packages/dsh-provider-usage/src/types.ts"
           ],
           "comment": "#342 v4：src 级文件组分段（2）——apply 单列（#316 拆分后最重文件独立成段）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+        },
+        "errsurf": {
+          "mutate": [
+            "packages/dsh-provider-usage/src/errsurf.ts"
+          ],
+          "excludes": [
+            "!packages/dsh-provider-usage/src/client/**",
+            "!packages/dsh-provider-usage/src/types.ts"
+          ],
+          "comment": "#670 阶段三 B 新段：域2每层错误面——errsurf.ts（累计计数+最近 N 条环形缓冲+snapshot/noop）；testFiles 含 unit-errsurf（杀灭面）；apply 接线与 routes/ui health per-layer 段由既有 apply/routes 段覆盖（mutate 已含对应文件）。"
         },
         "contracts": {
           "mutate": [

--- a/stryker.conf.d/dsh-provider-usage-apply.json
+++ b/stryker.conf.d/dsh-provider-usage-apply.json
@@ -44,6 +44,7 @@
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",
       "packages/dsh-provider-usage/test/unit-trend.test.ts",
+      "packages/dsh-provider-usage/test/unit-trend-ledger.test.ts",
       "packages/dsh-provider-usage/test/unit-trend-view.test.ts",
       "packages/dsh-provider-usage/test/unit-report.test.ts",
       "packages/dsh-provider-usage/test/unit-routes.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-apply.json
+++ b/stryker.conf.d/dsh-provider-usage-apply.json
@@ -40,6 +40,7 @@
       "packages/dsh-provider-usage/test/unit-config.test.ts",
       "packages/dsh-provider-usage/test/unit-contract.test.ts",
       "packages/dsh-provider-usage/test/unit-deepseek-official.test.ts",
+      "packages/dsh-provider-usage/test/unit-errsurf.test.ts",
       "packages/dsh-provider-usage/test/unit-history.test.ts",
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-contracts.json
+++ b/stryker.conf.d/dsh-provider-usage-contracts.json
@@ -45,6 +45,7 @@
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",
       "packages/dsh-provider-usage/test/unit-trend.test.ts",
+      "packages/dsh-provider-usage/test/unit-trend-ledger.test.ts",
       "packages/dsh-provider-usage/test/unit-trend-view.test.ts",
       "packages/dsh-provider-usage/test/unit-report.test.ts",
       "packages/dsh-provider-usage/test/unit-routes.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-contracts.json
+++ b/stryker.conf.d/dsh-provider-usage-contracts.json
@@ -41,6 +41,7 @@
       "packages/dsh-provider-usage/test/unit-config.test.ts",
       "packages/dsh-provider-usage/test/unit-contract.test.ts",
       "packages/dsh-provider-usage/test/unit-deepseek-official.test.ts",
+      "packages/dsh-provider-usage/test/unit-errsurf.test.ts",
       "packages/dsh-provider-usage/test/unit-history.test.ts",
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-entry.json
+++ b/stryker.conf.d/dsh-provider-usage-entry.json
@@ -43,6 +43,7 @@
       "packages/dsh-provider-usage/test/unit-config.test.ts",
       "packages/dsh-provider-usage/test/unit-contract.test.ts",
       "packages/dsh-provider-usage/test/unit-deepseek-official.test.ts",
+      "packages/dsh-provider-usage/test/unit-errsurf.test.ts",
       "packages/dsh-provider-usage/test/unit-history.test.ts",
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-entry.json
+++ b/stryker.conf.d/dsh-provider-usage-entry.json
@@ -47,6 +47,7 @@
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",
       "packages/dsh-provider-usage/test/unit-trend.test.ts",
+      "packages/dsh-provider-usage/test/unit-trend-ledger.test.ts",
       "packages/dsh-provider-usage/test/unit-trend-view.test.ts",
       "packages/dsh-provider-usage/test/unit-report.test.ts",
       "packages/dsh-provider-usage/test/unit-routes.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-errsurf.json
+++ b/stryker.conf.d/dsh-provider-usage-errsurf.json
@@ -1,10 +1,7 @@
 {
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
-    "packages/dsh-provider-usage/src/routes/stats.ts",
-    "packages/dsh-provider-usage/src/routes/adapters.ts",
-    "packages/dsh-provider-usage/src/routes/ui.ts",
-    "packages/dsh-provider-usage/src/routes/reports.ts",
+    "packages/dsh-provider-usage/src/errsurf.ts",
     "!packages/dsh-provider-usage/src/client/**",
     "!packages/dsh-provider-usage/src/types.ts"
   ],
@@ -56,9 +53,9 @@
     ]
   },
   "jsonReporter": {
-    "fileName": "coverage/mutation/dsh-provider-usage-routes.json"
+    "fileName": "coverage/mutation/dsh-provider-usage-errsurf.json"
   },
   "incremental": true,
-  "incrementalFile": "coverage/mutation/incremental-provider-usage-routes.json",
-  "_comment": "阶段一新段（评审 P1-5 前置）：E5/C6 路由面——stats+adapters+ui+reports；先抽纯函数（clampTrendN/isReportPeriodValid/isReportKeyValid/isTaskIdValid）补 unit-routes 再开段；testFiles 含 unit-routes/unit-report/unit-apply。"
+  "incrementalFile": "coverage/mutation/incremental-provider-usage-errsurf.json",
+  "_comment": "#670 阶段三 B 新段：域2每层错误面——errsurf.ts（累计计数+最近 N 条环形缓冲+snapshot/noop）；testFiles 含 unit-errsurf（杀灭面）；apply 接线与 routes/ui health per-layer 段由既有 apply/routes 段覆盖（mutate 已含对应文件）。"
 }

--- a/stryker.conf.d/dsh-provider-usage-pipeline.json
+++ b/stryker.conf.d/dsh-provider-usage-pipeline.json
@@ -52,6 +52,7 @@
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",
       "packages/dsh-provider-usage/test/unit-trend.test.ts",
+      "packages/dsh-provider-usage/test/unit-trend-ledger.test.ts",
       "packages/dsh-provider-usage/test/unit-trend-view.test.ts",
       "packages/dsh-provider-usage/test/unit-report.test.ts",
       "packages/dsh-provider-usage/test/unit-routes.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-pipeline.json
+++ b/stryker.conf.d/dsh-provider-usage-pipeline.json
@@ -48,6 +48,7 @@
       "packages/dsh-provider-usage/test/unit-config.test.ts",
       "packages/dsh-provider-usage/test/unit-contract.test.ts",
       "packages/dsh-provider-usage/test/unit-deepseek-official.test.ts",
+      "packages/dsh-provider-usage/test/unit-errsurf.test.ts",
       "packages/dsh-provider-usage/test/unit-history.test.ts",
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-registry.json
+++ b/stryker.conf.d/dsh-provider-usage-registry.json
@@ -45,6 +45,7 @@
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",
       "packages/dsh-provider-usage/test/unit-trend.test.ts",
+      "packages/dsh-provider-usage/test/unit-trend-ledger.test.ts",
       "packages/dsh-provider-usage/test/unit-trend-view.test.ts",
       "packages/dsh-provider-usage/test/unit-report.test.ts",
       "packages/dsh-provider-usage/test/unit-routes.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-registry.json
+++ b/stryker.conf.d/dsh-provider-usage-registry.json
@@ -41,6 +41,7 @@
       "packages/dsh-provider-usage/test/unit-config.test.ts",
       "packages/dsh-provider-usage/test/unit-contract.test.ts",
       "packages/dsh-provider-usage/test/unit-deepseek-official.test.ts",
+      "packages/dsh-provider-usage/test/unit-errsurf.test.ts",
       "packages/dsh-provider-usage/test/unit-history.test.ts",
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-report-execute.json
+++ b/stryker.conf.d/dsh-provider-usage-report-execute.json
@@ -45,6 +45,7 @@
       "packages/dsh-provider-usage/test/unit-config.test.ts",
       "packages/dsh-provider-usage/test/unit-contract.test.ts",
       "packages/dsh-provider-usage/test/unit-deepseek-official.test.ts",
+      "packages/dsh-provider-usage/test/unit-errsurf.test.ts",
       "packages/dsh-provider-usage/test/unit-history.test.ts",
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-report-execute.json
+++ b/stryker.conf.d/dsh-provider-usage-report-execute.json
@@ -49,6 +49,7 @@
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",
       "packages/dsh-provider-usage/test/unit-trend.test.ts",
+      "packages/dsh-provider-usage/test/unit-trend-ledger.test.ts",
       "packages/dsh-provider-usage/test/unit-trend-view.test.ts",
       "packages/dsh-provider-usage/test/unit-report.test.ts",
       "packages/dsh-provider-usage/test/unit-routes.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-report-schedule.json
+++ b/stryker.conf.d/dsh-provider-usage-report-schedule.json
@@ -45,6 +45,7 @@
       "packages/dsh-provider-usage/test/unit-config.test.ts",
       "packages/dsh-provider-usage/test/unit-contract.test.ts",
       "packages/dsh-provider-usage/test/unit-deepseek-official.test.ts",
+      "packages/dsh-provider-usage/test/unit-errsurf.test.ts",
       "packages/dsh-provider-usage/test/unit-history.test.ts",
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-report-schedule.json
+++ b/stryker.conf.d/dsh-provider-usage-report-schedule.json
@@ -49,6 +49,7 @@
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",
       "packages/dsh-provider-usage/test/unit-trend.test.ts",
+      "packages/dsh-provider-usage/test/unit-trend-ledger.test.ts",
       "packages/dsh-provider-usage/test/unit-trend-view.test.ts",
       "packages/dsh-provider-usage/test/unit-report.test.ts",
       "packages/dsh-provider-usage/test/unit-routes.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-routes.json
+++ b/stryker.conf.d/dsh-provider-usage-routes.json
@@ -47,6 +47,7 @@
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",
       "packages/dsh-provider-usage/test/unit-trend.test.ts",
+      "packages/dsh-provider-usage/test/unit-trend-ledger.test.ts",
       "packages/dsh-provider-usage/test/unit-trend-view.test.ts",
       "packages/dsh-provider-usage/test/unit-report.test.ts",
       "packages/dsh-provider-usage/test/unit-routes.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-sanitize.json
+++ b/stryker.conf.d/dsh-provider-usage-sanitize.json
@@ -44,6 +44,7 @@
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",
       "packages/dsh-provider-usage/test/unit-trend.test.ts",
+      "packages/dsh-provider-usage/test/unit-trend-ledger.test.ts",
       "packages/dsh-provider-usage/test/unit-trend-view.test.ts",
       "packages/dsh-provider-usage/test/unit-report.test.ts",
       "packages/dsh-provider-usage/test/unit-routes.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-sanitize.json
+++ b/stryker.conf.d/dsh-provider-usage-sanitize.json
@@ -40,6 +40,7 @@
       "packages/dsh-provider-usage/test/unit-config.test.ts",
       "packages/dsh-provider-usage/test/unit-contract.test.ts",
       "packages/dsh-provider-usage/test/unit-deepseek-official.test.ts",
+      "packages/dsh-provider-usage/test/unit-errsurf.test.ts",
       "packages/dsh-provider-usage/test/unit-history.test.ts",
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-trend-aggregate.json
+++ b/stryker.conf.d/dsh-provider-usage-trend-aggregate.json
@@ -2,6 +2,8 @@
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
     "packages/dsh-provider-usage/src/trend/aggregator.ts",
+    "packages/dsh-provider-usage/src/trend/aggregate-rows.ts",
+    "packages/dsh-provider-usage/src/trend/aggregate-query.ts",
     "packages/dsh-provider-usage/src/trend/store.ts",
     "packages/dsh-provider-usage/src/trend/index.ts",
     "!packages/dsh-provider-usage/src/client/**",
@@ -58,5 +60,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-provider-usage-trend-aggregate.json",
-  "_comment": "阶段零新段（D17 分层变异）：E2 聚合/压实/存储面——aggregator+store+index（目录维度与 provider 面查询）；testFiles 含 unit-trend/unit-trend-view（杀灭面为该层测试）；aggregator 单文件 5-8 分钟，独立段防超时。"
+  "_comment": "阶段零新段（D17 分层变异）：E2 聚合/压实/存储面——aggregator+store+index；阶段三（#670 D2）aggregator 拆分为 aggregate-rows（压实转换纯函数）+ aggregate-query（查询投影纯函数），两新文件并入 mutate 面（防新文件变异盲区）；testFiles 含 unit-trend/unit-trend-ledger/unit-trend-view（杀灭面为该层测试，R8 台账守恒断言覆盖守恒链）；aggregator 单文件 5-8 分钟，独立段防超时。"
 }

--- a/stryker.conf.d/dsh-provider-usage-trend-aggregate.json
+++ b/stryker.conf.d/dsh-provider-usage-trend-aggregate.json
@@ -44,6 +44,7 @@
       "packages/dsh-provider-usage/test/unit-config.test.ts",
       "packages/dsh-provider-usage/test/unit-contract.test.ts",
       "packages/dsh-provider-usage/test/unit-deepseek-official.test.ts",
+      "packages/dsh-provider-usage/test/unit-errsurf.test.ts",
       "packages/dsh-provider-usage/test/unit-history.test.ts",
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-trend-aggregate.json
+++ b/stryker.conf.d/dsh-provider-usage-trend-aggregate.json
@@ -46,6 +46,7 @@
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",
       "packages/dsh-provider-usage/test/unit-trend.test.ts",
+      "packages/dsh-provider-usage/test/unit-trend-ledger.test.ts",
       "packages/dsh-provider-usage/test/unit-trend-view.test.ts",
       "packages/dsh-provider-usage/test/unit-report.test.ts",
       "packages/dsh-provider-usage/test/unit-routes.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-trend-collect.json
+++ b/stryker.conf.d/dsh-provider-usage-trend-collect.json
@@ -45,6 +45,7 @@
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",
       "packages/dsh-provider-usage/test/unit-trend.test.ts",
+      "packages/dsh-provider-usage/test/unit-trend-ledger.test.ts",
       "packages/dsh-provider-usage/test/unit-trend-view.test.ts",
       "packages/dsh-provider-usage/test/unit-report.test.ts",
       "packages/dsh-provider-usage/test/unit-routes.test.ts",

--- a/stryker.conf.d/dsh-provider-usage-trend-collect.json
+++ b/stryker.conf.d/dsh-provider-usage-trend-collect.json
@@ -41,6 +41,7 @@
       "packages/dsh-provider-usage/test/unit-config.test.ts",
       "packages/dsh-provider-usage/test/unit-contract.test.ts",
       "packages/dsh-provider-usage/test/unit-deepseek-official.test.ts",
+      "packages/dsh-provider-usage/test/unit-errsurf.test.ts",
       "packages/dsh-provider-usage/test/unit-history.test.ts",
       "packages/dsh-provider-usage/test/unit-signal-lock.test.ts",
       "packages/dsh-provider-usage/test/unit-v1.test.ts",


### PR DESCRIPTION
## 阶段三 · 护栏 + aggregator 拆分（跟踪 #670）

### 变更内容

**1. R8 台账守恒断言（安全网先行）**
- 四不变量归组：`test/unit-trend.test.ts` 对「身份快照 / 防双计 / 残差归未识别」既有覆盖加显式不变量归组标注（只加注释、未动断言）
- 新增 `test/unit-trend-ledger.test.ts`：事件回放式端到端台账对账（真缺口「台账守恒」）——注入时钟 + 回放 19 事件 collector emit 序列 → TrendAggregator.apply 纯内存对账，四视角（Σ事件 / buckets / agg / dirRows+unidentified）逐日逐字段守恒断言，覆盖 correct 校正 / retry / message 补记 / interrupted / 归属缺失 / #633 目录两条线 / 跨天

**2. aggregator 拆分（D2）**
- `src/trend/aggregator.ts` 1329→701 行：主类保留状态容器（days/dirDays/hourDays/pending）+ 需 this 的方法
- 新增 `aggregate-rows.ts`（193 行，压实转换纯函数）+ `aggregate-query.ts`（628 行，查询投影纯函数）——全部参数显式传入，无共享 this 坏味道，依赖无环，公开导出面经 re-export 兼容
- 变异拓扑同步：trend-aggregate 段 mutate 面 +2 文件；新测试入 testFiles 杀灭面

**3. 域2每层错误面（B，并行）**
- 新增 `src/errsurf.ts`：aggregate/schedule/execute 三层统一错误面（累计计数 + 最近 N 条环形缓冲 + 快照），形态对齐 registry.recordError 模式
- 三处经 apply.ts 既有 warn 诊断出口接线（零改动 src/trend/* 与 src/report/* 业务代码），/health 新增 layerErrors per-layer 段
- 崩溃注入冒烟：execute/schedule 走真实层出口注入故障，aggregate 模块级注入 + health 断言
- mutation-topology 新增 errsurf 独立变异段

### 门禁证据
- build / test（21 pass）/ typecheck / contract / pack:check / stryker:check 全绿
- trend-aggregate 段变异：covered 81.19%（killed 788 + timeout 2 / survived 183 / noCoverage 160 / errors 0）
- errsurf 段变异：100% 杀灭（25/25）
- 全包 12 段变异重建基线：covered 69.03% → 71.41%（gauntlet.config.json baseline* 已同步，baselineDate 2026-09-09）

### 设计决策摘要
- R8 守恒断言先于拆分（D2 前置安全网）：拆分后压实/折算逻辑漂移首红于此文件
- 拆分只搬纯函数，状态留主类：防「拆文件=共享 this」坏味道；行为等价由 21 pass + 变异覆盖验证
- B 错误面经组合根 warn 出口接线：与 A 拆分零文件重叠，A 拆分后 aggregator 内部出错点可经 record 接口补接

Related: #670
