### PR TITLE
refactor(dsh-provider-usage): 收尾——死面清理（capsuleHtmlFromHistory + retention）(#670)

### DIFF
--- a/packages/dsh-provider-usage/README.en.md
+++ b/packages/dsh-provider-usage/README.en.md
@@ -301,7 +301,6 @@ export const version = 2;                    // required: contract version (fixe
 export const name = "my-stats";              // required: unique name (^[A-Za-z0-9_-]{2,64}$)
 export const label = "My Stats";             // optional: display name
 export const providers = ["my-relay"];       // required: claimed providers
-export const retention = { maxAgeDays: 30 }; // optional: retention policy
 
 /** Required: fetch raw data (runs on the host; args injected by the plugin) */
 export async function fetchData({ apiEndpoint, staticPath, apiKey, signal, timeoutMs }) {

--- a/packages/dsh-provider-usage/README.md
+++ b/packages/dsh-provider-usage/README.md
@@ -297,7 +297,6 @@ export const version = 2;                    // 必填：契约版本（固定 2
 export const name = "my-stats";              // 必填：唯一名（^[A-Za-z0-9_-]{2,64}$）
 export const label = "我的统计";              // 可选：展示名
 export const providers = ["my-relay"];       // 必填：认领的 provider 列表
-export const retention = { maxAgeDays: 30 }; // 可选：留存策略
 
 /** 必填：获取原始数据（宿主端执行；入参由插件注入） */
 export async function fetchData({ apiEndpoint, staticPath, apiKey, signal, timeoutMs }) {

--- a/packages/dsh-provider-usage/docs/adapter-guide.md
+++ b/packages/dsh-provider-usage/docs/adapter-guide.md
@@ -170,7 +170,6 @@ export function formatPanel({ entries, range, truncated, esc }) {
 
 ```js
 export const label = "我的统计";                      // 展示名
-export const retention = { maxAgeDays: 30, maxSizeMB: 20 };  // 留存策略
 ```
 
 ### 3.3 注入的共享图表工具（`utils`，#215）

--- a/packages/dsh-provider-usage/src/apply/index.ts
+++ b/packages/dsh-provider-usage/src/apply/index.ts
@@ -103,7 +103,7 @@ export { safeFetchData, safeFormat, fetchWithTimeout } from "../domain1/pipeline
 export { sanitizeHtml } from "../shared/interface.ts";
 // 客户端行为纯函数（设置页列表拆分/徽标文案，经此透出供单元测试）。
 export { splitProviderList, providerBadgeText } from "../shared/interface.ts";
-export { runV2Pipeline, runV2PanelPipeline, capsuleHtmlFromHistory, panelCacheKey, normalizeRangeDay, isPanelCacheStale, PANEL_CACHE_TTL_MS } from "../domain1/pipeline/interface.ts";
+export { runV2Pipeline, runV2PanelPipeline, panelCacheKey, normalizeRangeDay, isPanelCacheStale, PANEL_CACHE_TTL_MS } from "../domain1/pipeline/interface.ts";
 export type { PanelCacheEntry } from "../domain1/pipeline/interface.ts";
 export { HotReloadableAdapter, loadAndValidateAdapter, readStamp, stampEqual } from "../domain1/registry/interface.ts";
 // #503 会话用量趋势（M1 数据层）：trend 模块公共面（测试/外部消费者从 lib/index.js 导入）

--- a/packages/dsh-provider-usage/src/domain1/pipeline/interface.ts
+++ b/packages/dsh-provider-usage/src/domain1/pipeline/interface.ts
@@ -43,7 +43,6 @@ export { StatsService as StatsServiceCtor } from "./stats-service.ts";
 export {
   runV2Pipeline,
   runV2PanelPipeline,
-  capsuleHtmlFromHistory,
   panelCacheKey,
   normalizeRangeDay,
   isPanelCacheStale,

--- a/packages/dsh-provider-usage/src/domain1/pipeline/v2.ts
+++ b/packages/dsh-provider-usage/src/domain1/pipeline/v2.ts
@@ -168,22 +168,6 @@ export async function runV2Pipeline(ctx: V2PipelineContext): Promise<V2PipelineR
   };
 }
 
-/**
- * 从历史缓存路径返回胶囊内容（不重新拉取）。
- * 用于锁忙/降级场景。
- */
-export async function capsuleHtmlFromHistory(
-  history: HistoryStore,
-  provider: string,
-  adapterName: string,
-  fallbackText: string,
-): Promise<string | undefined> {
-  const last = await history.last(provider, adapterName);
-  if (last === null) return undefined;
-  // 无 formatCapsule 时返回简单文本 HTML
-  return `<span>${esc(fallbackText)}</span>`;
-}
-
 /** v2 面板管道：查询历史（全量）→ formatPanel → HTML。 */
 export async function runV2PanelPipeline(opts: {
   adapter: UsageStatsAdapter;

--- a/packages/dsh-provider-usage/src/shared/contracts.ts
+++ b/packages/dsh-provider-usage/src/shared/contracts.ts
@@ -104,8 +104,6 @@ export interface UsageStatsAdapter {
   label?: string;
   /** 认领的 provider 列表。 */
   providers: string[];
-  /** 可选：数据留存策略。 */
-  retention?: { maxAge?: number; maxSize?: number };
   /** 获取原始数据（宿主端执行）。 */
   fetchData(ctx: FetchContext): Promise<Record<string, unknown>>;
   /** 格式化胶囊展示内容（宿主端执行，返回 HTML）。 */

--- a/packages/dsh-provider-usage/test/unit/shared/unit-contract.test.ts
+++ b/packages/dsh-provider-usage/test/unit/shared/unit-contract.test.ts
@@ -329,7 +329,7 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { makeAdapterRegistry, sanitizeHtml, safeFetchData, safeFormat,
-  runV2Pipeline, runV2PanelPipeline, capsuleHtmlFromHistory, HistoryStore,
+  runV2Pipeline, runV2PanelPipeline, HistoryStore,
   HotReloadableAdapter, readStamp, stampEqual, miniChartSvgMarkup,
   OPENCODE_GO_PROVIDER } from "../../../lib/index.js";
 
@@ -699,12 +699,6 @@ function mkV2Adapter(over: Record<string, unknown> = {}): Record<string, unknown
     range: { start: day - 1000, end: day + 1000 },
   });
   assert.equal(emptyP.panelHtml, "n=0", "空历史 entries 为 0");
-
-  // capsuleHtmlFromHistory：有历史回退文本、无历史 undefined
-  const capOk = await capsuleHtmlFromHistory(store, "pv", "pipe-a", "fallback-text");
-  assert.equal(capOk, "<span>fallback-text</span>", "历史回退胶囊文本");
-  const capMiss = await capsuleHtmlFromHistory(store, "ghost", "none", "fb");
-  assert.equal(capMiss, undefined, "无历史返回 undefined");
 }
 
 // ================================================================ #150 二阶段：hotreload 纯函数与轮询


### PR DESCRIPTION
## 收尾 · 死面清理（跟踪 #670，D13 独立 PR）

### 变更内容（2 提交）

**1. 删除 capsuleHtmlFromHistory（breaking）**
- `src/domain1/pipeline/v2.ts` 实现删除（deprecated shim：读 history.last 弃结果只回退 fallbackText 的假降级死面）
- 三层 re-export 同步删除（v2.ts / pipeline/interface.ts / apply/index.ts）
- unit-contract.test.ts 相关断言删除
- **breaking**：lib 导出面 213→212 符号（D13「deprecated shim 一版后删除」的预期 breaking，独立 PR 承载）

**2. AdapterConfig.retention 死面删除**
- `src/shared/contracts.ts` retention 字段删除（契约 v2 起零消费方）
- 文档示例同步（adapter-guide.md §3.2、README.en.md、README.md）
- 范围区分：maxAgeDays/maxSizeMB/trendRetentionDays 等 retention 其他含义全部保留

### 门禁证据（主控复跑确认）
- build / test 21 套 / typecheck / docs:check / contract（verify-dir-imports 符号存在性 PASS）/ pack:check（10 PASS）/ stryker:check（27 份）全绿

Related: #670
