### PR TITLE
chore(deps): 适配 dsh 0.1.5-rc.1——catalog 跃迁 + provider-usage 结算事件迁移 + mcp-manager 分节顺序（#695）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -38,7 +38,7 @@ install them all at once as a single bundle, or pick individual plugins as neede
 
 This plugin set only adapts to **rc (release-candidate) releases of DeepSeek Harness — alpha versions are not supported**.
 
-- All plugins are currently pinned to `dsh 0.1.2-rc.1` (the official type-layer catalog and
+- All plugins are currently pinned to `dsh 0.1.5-rc.1` (the official type-layer catalog and
   every package's peerDependencies are locked in lockstep)
 - npm/pnpm will surface a peer mismatch if your dsh version does not match — upgrade the
   dsh CLI to the corresponding rc release first

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ DSH（DeepSeek Harness）Web GUI 插件集，npm 分发：一键装全家桶，�
 
 本插件集**只适配 DeepSeek Harness 的 rc（候选发布）版本，不对 alpha 版本适配**。
 
-- 当前全部插件锚定 `dsh 0.1.2-rc.1`（官方类型层 catalog 与各包 peerDependencies 一致锁定）
+- 当前全部插件锚定 `dsh 0.1.5-rc.1`（官方类型层 catalog 与各包 peerDependencies 一致锁定）
 - 安装/更新时若 dsh 版本不匹配，npm/pnpm 会给出 peer 提示——请先将 dsh 本体升级到对应 rc 版本
 - 每版的具体适配基线、破坏性变更与升级指南见 [Release Notes](docs/release-notes/)
 - 官方发布新版 rc 后本插件集跟随升级；**alpha 版本不受支持**，请勿在 alpha 环境安装（或自行评估兼容风险）

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -172,7 +172,7 @@ shared**；X1 保证**已准入的模块随每个消费包完整发布**（机�
 contract-check 禁止运行时值导入）。原自建类型层 `types/dsh.d.ts` 已删除（issue #48）。
 
 **版本适配策略（只适配 rc）**：官方类型层 catalog 升级以 **dsh rc 版本**为锚定
-基线（当前 `0.1.2-rc.1`），peer 与 catalog 锁步；**不对 alpha 版本适配**，除非
+基线（当前 `0.1.5-rc.1`），peer 与 catalog 锁步；**不对 alpha 版本适配**，除非
 维护者明确决策。升级 catalog 须跑全量门禁并核验受影响的结构（如
 SessionHeader.origin / Agent.session），并同步根 README「版本适配」与 release notes
 锚定声明。

--- a/docs/archive/dsh-0.1.5-适配计划.md
+++ b/docs/archive/dsh-0.1.5-适配计划.md
@@ -1,0 +1,74 @@
+# dsh 0.1.5-rc.1 适配计划（#695）
+
+> 关联 issue：[#695](https://github.com/wingsky-1/dsh-plugin-hub/issues/695)
+> 适配基线：上游 `dsh-v0.1.5-rc.1`（`npm view @deepseek-ai/dsh dist-tags` 的 `latest` 与 `next` 同指；本机 CLI 已为该版本）
+> 起始 commit：`4d961ea`
+> 更新规则：逐项完成打 `[x]`。**发版（版本号对齐 + release-notes）属仓库红线，由维护者确认后另开 `chore(release):` PR**，不在本计划内。
+
+---
+
+## 一、背景
+
+`pnpm-workspace.yaml` 的 catalog 与各包 `peerDependencies` 长期锁 `0.1.2-rc.1`，而运行中的 `dsh` CLI 已是 `0.1.5-rc.1`——**发布物与宿主运行时已不匹配，落后三个 rc**。本计划把适配基线收敛到 `0.1.5-rc.1`。
+
+## 二、上游破坏性变更（实测 `lib/` 逐包 diff + 官方 release notes）
+
+| 包 | 变更 | 触达本仓 |
+|---|---|---|
+| `dsh-session` | **删除 `assistant/chunk` 事件**；新增 `assistant/attempt`；`assistant/message` 增内嵌 `stream`；`SESSION_FORMAT_VERSION` 0→3；删 `chunk-rows` 子路径导出；`Session.fromRestore` 增第 5 参；`EpochHeader.system` 删除 | **provider-usage**（采集主信号） |
+| `dsh-system-prompt` | `SECTION_ORDERS` 重排（`HARNESS_SOURCE` -900→10000、`WEB_SURFACE` -800→10100、`PERSONA` 拆 PREFIX 0 / SUFFIX 10200）；`PERSONA_SECTION`→`PERSONA_PREFIX_SECTION`；Config `persona`→`personaPrefix` | **mcp-manager**（分节 order 语义复核） |
+| `dsh-tools` | `tool/code-dispatch(-start)` → `tool/ptc-dispatch(-start)` | 无 |
+| `dsh-agent` | 删 `ctx.agent`、`InboxNotifications`；`AgentSetup` 加参；`Inbox` 变 type-only；新增 `agent/assistant-stream` | 无 |
+| `dsh-llm` | 纯追加（`assistant-stream`、`FileBlock` 等） | 无 |
+| `dsh-client-connection` | 删 `FetchHandler`；`ConnectionConfig`→`ConnectionRecoveryConfig`；`ConnectionFetchRoute` 增必填 `requestBody` | 无（`authenticatedUrl` 两版一致） |
+| `dsh-host-webserver` / `dsh-session-title` / `dsh-user-approval` / `dsh-settings` / `dsh-client-store` / `dsh-skill-filesystem` | **lib 零差异** | 安全 |
+
+**不适用项**：官方 `conversation` Slot 迁移为 `main` 的 key——本仓插件只注册 `settings.plugin.item` / `settings.section`，两者在新版仍有定义与消费者；会话日志 V3 迁移——本仓插件读写的是**自建** jsonl，不读 DSH 会话日志。
+
+## 三、记账口径决策（维护者已拍板）
+
+provider-usage 迁移后 `calls`/token 口径**与 0.1.2 零变化**（无损迁移）：
+
+- **Q1** 有 usage 的失败/重试 attempt → **计入**（0.1.2 本来就计入；实测 42 份真实会话日志中 2 条 attempt 有 1 条带 usage，丢弃即丢真实计费 token）
+- **Q2** 无 usage 的 attempt → **不计入**（无调用证据，避免 calls 虚高）
+- **Q3** `TREND_ROW_VERSION` → **不递增**（递增会在载入时静默丢弃全部历史，且无迁移路径）
+
+## 四、实施批次
+
+### PR-A 机制前置（commit `323bdcf`）
+
+- [x] catalog 补 3 个缺口包：`dsh-settings` / `dsh-skill-filesystem` / `dsh-client-connection`
+- [x] 20 处官方 peer 字面版本 → `catalog:`（版本事实源收敛为 catalog 一处；`pnpm pack` 自动替换回具体版本，已实测发布物字节等价）
+- [x] 新增 `scripts/lib/catalog-peers-lib.ts` 一致性门禁（peer/devDeps 必须 `catalog:`、`catalog:` 引用必须有条目、catalog 键必须登记豁免清单）+ 6 条单测 + 接入 `contract-check`
+- [x] 全量门禁通过（build / test / contract / pack:check / typecheck）
+
+### PR-B 版本跃迁 + 插件适配（本 PR）
+
+- [x] catalog 15 键 → `0.1.5-rc.1`（cordis `4.0.2` 不动）+ `minimumReleaseAgeExclude` 同步 + lock 重生成
+- [x] **provider-usage**：`assistant/chunk` → 结算事件（`assistant/message.usage ?? stream 内裸 usage chunk`，`assistant/attempt` 兜底）；`retry` 改为同 `(turn, step)` 的**结算序数**；删除 `fold`/`headerSeen`/`TREND_FOLD_TTL_MS`（发布导出面变更）
+- [x] provider-usage 测试改造：unit-trend / unit-trend-ledger / unit-report / smoke 全部随迁（含语义反转用例重设计 + Q1/Q2 新增用例）
+- [x] **mcp-manager**：`section({ order })` 具名常量化 + 分节顺序断言（`order` 在官方 `DEPLOYMENT_PERSONA_PREFIX(0)` 与 `PLAN_POLICY(500)` 之间，该相对位置两版一致）
+- [x] 文档锚定 4 处（`README.md` / `README.en.md` / `AGENTS.md` / `docs/DEVELOPMENT.md`）
+- [x] 全量门禁通过
+
+## 五、复核发现与处置
+
+| 发现 | 处置 |
+|---|---|
+| `dsh-llm` 的 `.d.ts` 引用 `@deepseek-ai/dsh-attachment`，但该包未列入 `dsh-llm` 自身 `dependencies`（上游漏声明） | **不 workaround**：当前被 `skipLibCheck: true` 掩盖且本仓不使用相关 API；加 devDep 会在上游修复后变僵尸依赖 |
+| `docs:check` 不校验版本一致性（catalog 已 0.1.5 而 README 仍 0.1.2 时仍 PASS） | 记为改进项，纳入 #690 的文档漂移门禁讨论 |
+| `data-pane="conversation"` 为**两版均失效**的死降级分支 | 记为清理项（非升级回归） |
+| 官方新增 rightbar 布局，浮动胶囊按 `[data-conversation-scroll].rect.right` 定位 | 需隔离环境视觉复核（见验收） |
+
+## 六、验收
+
+- [x] `pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` 全绿
+- [ ] 隔离环境（`dsh-verify-isolated`）真实会话实测：用量记账数值与旧版对拍（calls / retry / token 三元组）、MCP 目录注入、通知链路
+- [ ] 浏览器实测 5 个客户端插件渲染 + 窄屏/双主题 + 新 rightbar 布局下浮动胶囊落点
+- [ ] 发版 PR（版本号对齐 + `docs/release-notes/`）——维护者确认版本号后另开
+
+## 七、本轮不做
+
+- #690 四阶段（`deps.ts` / `--graph` / ESLint zones）
+- 「插件 ↔ 官方契约」对外防腐层（已作为 #690 增量补充记录，待 notifier 重构后统一承载）
+- `sidebar.panellist` / `main` 新面板 API 迁移

--- a/packages/dsh-mcp-manager/src/bootstrap/apply.ts
+++ b/packages/dsh-mcp-manager/src/bootstrap/apply.ts
@@ -35,6 +35,16 @@ import { MCP_GUIDANCE } from "./apply-guidance.ts";
 // 导出面兼容：index.ts 仍从 apply.ts re-export MCP_GUIDANCE（组合根单一来源不变）。
 export { MCP_GUIDANCE };
 
+/**
+ * MCP 能力宣告在系统提示中的排序位置：紧随部署 persona 之后、计划策略之前
+ * （官方 SECTION_ORDERS 里 DEPLOYMENT_PERSONA_PREFIX=0 与 PLAN_POLICY=500 之间）。
+ *
+ * 不写成 getSectionOrder() 派生：0.1.5 把 HARNESS_SOURCE/WEB_SURFACE 从 -900/-800
+ * 移到 10000/10100（官方对提示词整体重排），本段落与相邻段的相对位置不受影响，
+ * 派生只多一层运行时依赖与失败面；改由 smoke 的分节顺序断言锁定区间。
+ */
+export const MCP_SECTION_ORDER = 160;
+
 /** enabled 分支装配产物（disposer 集合，顶层 effect 统一收口）。 */
 interface EnabledRuntimeDisposers {
   disposeRoutes: () => void;
@@ -176,7 +186,7 @@ async function assembleEnabledRuntime(
     // 经 unknown 中转以维持局部最小面写法。
     disposeSection = (ctx.systemPrompt as unknown as { section(opts: Record<string, unknown>): () => void }).section({
       name: "plugin:dsh-mcp-manager",
-      order: 160,
+      order: MCP_SECTION_ORDER,
       text: MCP_GUIDANCE,
     });
   }

--- a/packages/dsh-mcp-manager/src/bootstrap/interface.ts
+++ b/packages/dsh-mcp-manager/src/bootstrap/interface.ts
@@ -5,6 +5,6 @@
  * apply-guidance）。目录外模块**只能**从这里引用（verify-dir-imports
  * 静态强制）；service-contract 静态扫描路径指向 apply-services.ts（源码级）。
  */
-export { apply, MCP_GUIDANCE } from "./apply.ts";
+export { apply, MCP_GUIDANCE, MCP_SECTION_ORDER } from "./apply.ts";
 export { resolveDebugConfig, resolveMiddlewareMode } from "./apply-config.ts";
 export { makeMiddlewareHotSwitch } from "./apply-runtime.ts";

--- a/packages/dsh-mcp-manager/src/index.ts
+++ b/packages/dsh-mcp-manager/src/index.ts
@@ -56,7 +56,7 @@ export { panelAnchorForPosition } from "./placement-math.ts";
 // 导出面与拆分前 lib/index.js 完全一致（smoke 验收契约）。
 
 // 插件契约转发（apply 主流程 + 宣告文本实现于 apply.ts）
-export { apply, MCP_GUIDANCE } from "./bootstrap/interface.ts";
+export { apply, MCP_GUIDANCE, MCP_SECTION_ORDER } from "./bootstrap/interface.ts";
 export { resolveDebugConfig, resolveMiddlewareMode } from "./bootstrap/interface.ts";
 // 运行期装配工厂（组合根）：热切换为 B20/C-EVT 契约测试面
 export { makeMiddlewareHotSwitch } from "./bootstrap/interface.ts";

--- a/packages/dsh-mcp-manager/test/smoke.ts
+++ b/packages/dsh-mcp-manager/test/smoke.ts
@@ -40,6 +40,7 @@ import {
   fromClaudeEntry,
   expandEnv,
   inject,
+  MCP_SECTION_ORDER,
   makeEventsRoute,
   makeHealthRoute,
   makeRoutes,
@@ -2000,6 +2001,14 @@ const main = async () => {
       assert.equal(ctx.sections.length, 1);
       assert.equal(ctx.sections[0].name, "plugin:dsh-mcp-manager");
       assert.match(ctx.sections[0].text, /dsh-mcp-manager/);
+      // 分节顺序契约：官方 SECTION_ORDERS 在 0.1.2→0.1.5 期间重排（HARNESS_SOURCE/
+      // WEB_SURFACE 从 -900/-800 移到 10000/10100）；本段落定位为「部署 persona 之后的
+      // 补充说明」，该相对位置不变——此断言防未来官方再重排后本段落静默贬值。
+      assert.equal(ctx.sections[0].order, MCP_SECTION_ORDER, "分节 order 取具名常量（防裸数字漂移）");
+      assert.ok(
+        ctx.sections[0].order > 0 && ctx.sections[0].order < 500,
+        "分节位置落在官方 DEPLOYMENT_PERSONA_PREFIX(0) 与 PLAN_POLICY(500) 之间",
+      );
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/dsh-provider-usage/src/apply/index.ts
+++ b/packages/dsh-provider-usage/src/apply/index.ts
@@ -109,7 +109,7 @@ export { HotReloadableAdapter, loadAndValidateAdapter, readStamp, stampEqual } f
 // 会话用量趋势：trend 模块公共面（测试/外部消费者从 lib/index.js 导入）
 export { TrendTracker } from "../domain2/aggregate/interface.ts";
 export type { TrendTrackerOptions } from "../domain2/aggregate/interface.ts";
-export { TrendCollector, TREND_FOLD_TTL_MS, TREND_DONE_MAX } from "../domain2/collect/interface.ts";
+export { TrendCollector, TREND_DONE_MAX } from "../domain2/collect/interface.ts";
 export type { TrendCallRecord, TrendCorrectRecord, TrendCounterRecord, TrendEmit } from "../domain2/collect/interface.ts";
 export { TrendAggregator, metricValue, weekStartKey, lastNWeekKeys, lastNMonthKeys, monthRange, weekRange, mergeAggRows, mergeDirRows, mergeHourRows } from "../domain2/aggregate/interface.ts";
 export type { TrendMetric, TrendGranularity, TrendStackPart, TrendStackPoint, TrendWindowSummary } from "../domain2/aggregate/interface.ts";

--- a/packages/dsh-provider-usage/src/domain2/collect/collector.ts
+++ b/packages/dsh-provider-usage/src/domain2/collect/collector.ts
@@ -1,23 +1,25 @@
 /**
  * dsh-provider-usage/trend — 事件折叠状态机。
  *
- * 纯逻辑模块：吃官方 SessionEvent 流，产出定稿记录（call/correct/counter），
- * 不碰 IO、不持时钟（now 可注入）。热路径纪律：handler 顶部先按 event.type /
- * chunk.type 廉价过滤，再做防御性深检查（payload 跨宿主边界不受信）。
+ * 纯逻辑模块：吃官方 SessionEvent 流，产出定稿记录（call/counter），不碰 IO、
+ * 不持时钟（now 可注入）。热路径纪律：handler 顶部先按 event.type 廉价过滤，
+ * 再做防御性深检查（payload 跨宿主边界不受信）。
  *
- * 记账口径（方案定稿 v1.2，证据 = @deepseek-ai/dsh-session 官方类型层）：
- * - usage chunk 到达即定稿（主信号）：fold 键 (session, turn, step, retry)；
- * - retry 判定：同一 (turn,step) 自上次定稿后出现新的 request/header（重试复用
- *   同一 (turn,step)，retrySeq 递增）→ 下一个 usage 定稿为新的一次调用；
- *   未出现新 header 的后续 usage chunk 视为同一调用的重复/更新块 → 校正不重记；
- * - assistant/message：已定稿 → 校正（token 覆盖，不重计调用）；未定稿/缺失 →
- *   补记（usage 缺失时调用照计、token 记 null——零 usage 语义）；interrupted 同口径；
+ * 记账口径（0.1.5-rc.1 起；证据 = @deepseek-ai/dsh-session 官方类型层）：
+ * - 0.1.2 的 `assistant/chunk`（逐 chunk firehose）已被官方移除，usage 改由**结算
+ *   事件**承载：`assistant/message` 带顶层 `usage` 且内嵌压缩 `stream`；
+ *   `assistant/attempt`（失败/中止且未提交消息的尝试）只带 `stream`。
+ * - 一次结算 = 一次尝试入账（call）；retry 取该 (session, turn, step) 内的结算序数，
+ *   同键多次结算即重试逐次计——与 0.1.2「每次尝试一条 usage chunk」同构。
+ * - token 取值顺序 = 顶层 `usage` ?? stream 内最后一条裸 usage chunk，**二选一**：
+ *   真实会话中 message 的两处 usage 恒等（实测 871/871），两处都取会翻倍。
+ * - 无 usage 的 `assistant/attempt` 不入账（0.1.2 无 usage chunk 即无调用证据）；
+ *   无 usage 的 `assistant/message` 仍入账、token 记 null（沿用零 usage 语义）。
  * - request/header 折叠为 per-session 归属主源（EpochHeader.config.provider/model）；
- *   message.source（kind:"model"）为副源（仅归属缺失时补）；两者皆缺 → 未识别桶；
- * - turn/end：该 turn 全部 fold 状态强制丢弃（已定稿的已入账，无证据的不入账）；
- *   turn 计数独立 +1（轮次指标）；tool/call 计数独立 +1；
- * - 缓冲 GC 三重保险之一：TTL 扫描（默认 10min 无活动整会话状态丢弃；
- *   下次活动必伴随新 request/header，归属随后自愈）。
+ *   message.source（kind:"model"）为副源（仅归属缺失时补）；两者皆缺 → 未识别桶。
+ * - turn/end 轮次计数独立 +1；tool/call 计数独立 +1。
+ * - 会话状态 TTL：默认 60min 无活动整会话丢弃（下次活动必伴随新 request/header，
+ *   归属随后自愈）。
  */
 import type { SessionEvent } from "@deepseek-ai/dsh-session/types";
 import {
@@ -29,13 +31,11 @@ import {
   type TrendTokens,
 } from "./types.ts";
 
-/** fold 缓冲 TTL（方案定稿：约 10min 强制兜底）。 */
-export const TREND_FOLD_TTL_MS = 10 * 60 * 1000;
-/** 会话状态（定稿记忆/归属）整体 TTL（长于 fold TTL，防乱序迟到 message 双算）。 */
+/** 会话状态（归属/目录/结算序数记忆）整体 TTL。 */
 export const TREND_SESSION_TTL_MS = 60 * 60 * 1000;
 /**
- * done 定稿记忆上限（键数）：超过后按 Map 插入序淘汰最旧键。
- * done 不按 turn 清（保留定稿记忆防乱序迟到 message 双算），本上限是唯一收缩路径，
+ * 结算序数记忆上限（键数）：超过后按 Map 插入序淘汰最旧键。
+ * 记忆不按 turn 清（保留跨 turn 的序数连续性），本上限是唯一收缩路径，
  * 防长命会话无界增长。
  */
 export const TREND_DONE_MAX = 200;
@@ -57,12 +57,16 @@ export interface TrendCallRecord {
    * 不静默丢弃，沿用 provider 维度未识别桶约定）。
    */
   dir: string;
-  /** token 计量（补记且 usage 缺失时 null——调用照计）。 */
+  /** token 计量（无 usage 的成功结算为 null——调用照计）。 */
   tokens: TrendTokens | null;
   interrupted?: true;
 }
 
-/** 校正记录：覆盖同 fold 键已定稿明细的 token 值（不重计调用）。 */
+/**
+ * 校正记录：覆盖同 fold 键已定稿明细的 token 值（不重计调用）。
+ * 0.1.5 起结算事件自带完整 token，collector 不再产出 correct；类型保留供
+ * 聚合层既有消费面（applyCorrect）与外部消费者使用。
+ */
 export interface TrendCorrectRecord {
   session: string;
   turn: number;
@@ -98,24 +102,14 @@ interface SessionFoldState {
    * 同 session 生命周期内至多发起一次 store.get（TTL 回收随会话状态）。
    */
   dir: string | null | undefined;
-  /** 进行中 fold 缓冲，key = `${turn}:${step}`。 */
-  folds: Map<string, { retry: number; finalized: boolean }>;
   /**
-   * 重试边界标记（会话级）：request/header 不携带 turn/step（官方类型只有
-   * header/reason/startsSeries），而会话内请求串行——「上次定稿后见过新 header」
-   * 即判定下一个 usage 为新一次调用（retry），未见 header 的 usage 为同调用重复块。
-   */
-  headerSeen: boolean;
-  /**
-   * 已定稿 fold 记忆（turn/end 丢弃的是未定稿缓冲，不是定稿记忆；防乱序迟到 message 双算）。
-   * 值 = 该键最后一次定稿的 retry（fold 被 TTL 清后，迟到校正据此取真实 retry）；
+   * (turn, step) → 该键已结算次数。下一次同键结算即 retry = 记忆值 + 1，
+   * 使重试逐次独立入账（结算序数内生于主事件，不依赖可选插件的重试事件）。
    * 上限 TREND_DONE_MAX 按插入序淘汰最旧键（长命会话防无界增长）。
    */
   done: Map<string, number>;
   /** 最近一次事件触达（墙钟，注入时钟）；会话级 TTL 依据。 */
   lastTouch: number;
-  /** 最近一次 fold 活动；fold 级 TTL 依据。 */
-  lastFoldTouch: number;
 }
 
 export interface TrendCollectorOptions {
@@ -134,9 +128,8 @@ export interface TrendCollectorOptions {
 }
 
 /**
- * done 定稿记忆写入：超上限按 Map 插入序淘汰最旧键（done.set 对已存键
- * 不重置插入序，淘汰目标恒为最早写入且未被复写的键）。失败路径不写 done——
- * 只有真实定稿才进记忆。
+ * 结算序数记忆写入：超上限按 Map 插入序淘汰最旧键（done.set 对已存键
+ * 不重置插入序，淘汰目标恒为最早写入且未被复写的键）。
  */
 function rememberDone(done: Map<string, number>, key: string, retry: number): void {
   done.set(key, retry);
@@ -168,6 +161,23 @@ function parseTokens(v: unknown): TrendTokens | null {
   return { input, output, cacheRead, cacheWrite };
 }
 
+/**
+ * 取压缩 stream 里最后一条**裸** usage chunk 的 usage（倒序扫，命中即返回）。
+ *
+ * 只需认 `{type:'chunk', chunk}` 一种记录形态：usage 属 RawStreamChunkType，
+ * 官方 accumulator 从不把非 delta chunk 打包成 text/reasoning/tool-call-chunks
+ * run，故 packed 形态结构上不可能承载 usage（无需展开 time0+dt 重建时间戳——
+ * 调用时刻统一取事件自身的 `time`）。
+ */
+function lastUsageFromStream(stream: unknown): unknown {
+  if (!Array.isArray(stream)) return undefined;
+  for (let i = stream.length - 1; i >= 0; i -= 1) {
+    const rec = stream[i] as { type?: unknown; chunk?: { type?: unknown; usage?: unknown } } | undefined;
+    if (rec?.type === "chunk" && rec.chunk?.type === "usage") return rec.chunk.usage;
+  }
+  return undefined;
+}
+
 export class TrendCollector {
   private readonly sessions = new Map<string, SessionFoldState>();
   private readonly now: () => number;
@@ -187,7 +197,7 @@ export class TrendCollector {
   private stateOf(session: string): SessionFoldState {
     let s = this.sessions.get(session);
     if (s === undefined) {
-      s = { attribution: null, dir: undefined, folds: new Map(), headerSeen: false, done: new Map<string, number>(), lastTouch: this.now(), lastFoldTouch: this.now() };
+      s = { attribution: null, dir: undefined, done: new Map<string, number>(), lastTouch: this.now() };
       this.sessions.set(session, s);
     }
     return s;
@@ -233,15 +243,13 @@ export class TrendCollector {
       state.lastTouch = nowMs;
       switch (event.type) {
         case "request/header":
-          this.onHeader(state, session, event);
-          return;
-        case "assistant/chunk":
-          // 热路径：先按 chunk.type 廉价过滤（token 级 firehose 的绝大多数 chunk 在此返回）
-          if ((event.data as { chunk?: { type?: unknown } } | undefined)?.chunk?.type !== "usage") return;
-          this.onUsageChunk(state, session, event, nowMs);
+          this.onHeader(state, event);
           return;
         case "assistant/message":
-          this.onMessage(state, session, event);
+          this.onSettled(state, session, event, "message");
+          return;
+        case "assistant/attempt":
+          this.onSettled(state, session, event, "attempt");
           return;
         case "turn/end":
           this.onTurnEnd(state, session, event);
@@ -268,87 +276,40 @@ export class TrendCollector {
     }
   }
 
-  /** TTL 兜底扫描（60s 惰性节流）：fold 缓冲 10min、会话状态 60min 分级回收。 */
+  /** TTL 兜底扫描（60s 惰性节流）：会话状态整体回收。 */
   private lazySweep(nowMs: number): void {
     if (nowMs - this.lastSweep < 60_000) return;
     this.lastSweep = nowMs;
     for (const [id, s] of this.sessions) {
-      if (nowMs - s.lastTouch > TREND_SESSION_TTL_MS) {
-        this.sessions.delete(id);
-        continue;
-      }
-      if (nowMs - s.lastFoldTouch > TREND_FOLD_TTL_MS && s.folds.size > 0) s.folds.clear();
+      if (nowMs - s.lastTouch > TREND_SESSION_TTL_MS) this.sessions.delete(id);
     }
   }
 
-  private onHeader(state: SessionFoldState, session: string, event: SessionEvent & { type: "request/header" }): void {
-    void session;
+  private onHeader(state: SessionFoldState, event: SessionEvent & { type: "request/header" }): void {
     // 归属主源：逐会话折叠最新 header（含 mid-session 切换的 series 语义——取最新即可）
     const config = (event.data as { header?: { config?: unknown } } | undefined)?.header?.config;
     const next = parseAttribution(config);
     if (next !== null) state.attribution = next;
-    // 重试边界标记（会话级）：已定稿调用之后的新 header → 下一个 usage 是新一次调用
-    state.headerSeen = true;
   }
 
-  private onUsageChunk(
+  /**
+   * 一次模型尝试的结算入账（0.1.5 的 usage 承载点）。
+   *
+   * kind 区分两类结算：`message` = 提交了消息（带顶层 usage，可能被中断），
+   * `attempt` = 失败/中止且未提交消息（usage 只可能在内嵌 stream 里）。
+   */
+  private onSettled(
     state: SessionFoldState,
     session: string,
-    event: SessionEvent & { type: "assistant/chunk" },
-    nowMs: number,
+    event: SessionEvent & { type: "assistant/message" | "assistant/attempt" },
+    kind: "message" | "attempt",
   ): void {
-    const d = event.data as { turn?: unknown; step?: unknown; chunk?: { usage?: unknown } };
-    const turn = typeof d.turn === "number" && Number.isFinite(d.turn) ? d.turn : null;
-    const step = typeof d.step === "number" && Number.isFinite(d.step) ? d.step : null;
-    if (turn === null || step === null) return;
-    const key = this.foldKey(turn, step);
-    const time = typeof event.time === "number" && Number.isFinite(event.time) ? event.time : nowMs;
-    const tokens = parseTokens(d.chunk?.usage);
-    let fold = state.folds.get(key);
-    if (fold === undefined) {
-      // fold 可能已被 fold TTL 或 turn/end 清理，而定稿记忆 done 仍在（未被
-      // TREND_DONE_MAX 淘汰）。与 onMessage 的已定稿分支对称：无新 header = 同一调用的
-      // 重复/更新块 → 只校正 token、不重记调用；有新 header = 重试 → retry 从记忆值递增
-      // （不回落为 1 造成重号）。
-      const remembered = state.done.get(key);
-      if (remembered !== undefined && !state.headerSeen) {
-        if (tokens !== null) {
-          this.emit({ type: "correct", record: { session, turn, step, retry: remembered, tokens } });
-        }
-        return;
-      }
-      fold = { retry: remembered === undefined ? 1 : remembered + 1, finalized: false };
-      state.folds.set(key, fold);
-    } else if (fold.finalized) {
-      if (!state.headerSeen) {
-        // 同一调用的重复/更新 usage 块 → 校正已定稿记录，不重计调用
-        if (tokens !== null) {
-          this.emit({ type: "correct", record: { session, turn, step, retry: fold.retry, tokens } });
-        }
-        return;
-      }
-      // 新 header 后的 usage → 重试：逐次独立入账
-      fold.retry += 1;
-      fold.finalized = false;
-    }
-    fold.finalized = true;
-    state.headerSeen = false;
-    state.lastFoldTouch = nowMs;
-    rememberDone(state.done, key, fold.retry);
-    const { provider, model } = this.providerOf(state);
-    const dir = this.dirOf(state, session);
-    this.emit({
-      type: "call",
-      record: { time, session, turn, step, retry: fold.retry, provider, model, dir, tokens },
-    });
-  }
-
-  private onMessage(state: SessionFoldState, session: string, event: SessionEvent & { type: "assistant/message" }): void {
     const d = event.data as {
       turn?: unknown;
       step?: unknown;
       usage?: unknown;
       interrupted?: unknown;
+      stream?: unknown;
       message?: { source?: unknown };
     };
     const turn = typeof d.turn === "number" && Number.isFinite(d.turn) ? d.turn : null;
@@ -357,43 +318,35 @@ export class TrendCollector {
     // 副源归属：归属缺失时用 message.source（kind:"model"）补齐；主源在场
     // 但与副源解析结果不一致（provider 或 model 不同）时仅告警不覆盖——主源 header
     // 是记账归属的权威，message.source 仅为缺失时的补齐副源。
-    const src = d.message?.source as Record<string, unknown> | undefined;
-    if (src !== undefined && src.kind === "model") {
-      const alt = parseAttribution(src);
-      if (alt !== null) {
-        if (state.attribution === null) {
-          state.attribution = alt;
-        } else if (state.attribution.provider !== alt.provider || state.attribution.model !== alt.model) {
-          this.onAnomaly?.(
-            `归属不一致（session=${session} turn=${turn} step=${step}）：主源 ${state.attribution.provider}/${state.attribution.model ?? "null"} 与 message.source ${alt.provider}/${alt.model} 不同，保留主源`,
-          );
+    if (kind === "message") {
+      const src = d.message?.source as Record<string, unknown> | undefined;
+      if (src !== undefined && src.kind === "model") {
+        const alt = parseAttribution(src);
+        if (alt !== null) {
+          if (state.attribution === null) {
+            state.attribution = alt;
+          } else if (state.attribution.provider !== alt.provider || state.attribution.model !== alt.model) {
+            this.onAnomaly?.(
+              `归属不一致（session=${session} turn=${turn} step=${step}）：主源 ${state.attribution.provider}/${state.attribution.model ?? "null"} 与 message.source ${alt.provider}/${alt.model} 不同，保留主源`,
+            );
+          }
         }
       }
     }
+    // token 二选一：顶层 usage 优先，回落 stream 内最后一条裸 usage chunk。
+    // message 与 attempt 的 stream 都可能带 usage，但 message 自带顶层 field，
+    // 二者恒等（实测），绝不可相加。
+    const tokens =
+      kind === "message"
+        ? (parseTokens(d.usage) ?? parseTokens(lastUsageFromStream(d.stream)))
+        : parseTokens(lastUsageFromStream(d.stream));
+    // 无 usage 的失败尝试无调用证据（0.1.2 同边界：无 usage chunk 即不入账）；
+    // 而提交了消息的结算即便无 usage 也要入账、token 记 null（零 usage 语义）。
+    if (kind === "attempt" && tokens === null) return;
+
     const key = this.foldKey(turn, step);
-    const fold = state.folds.get(key);
-    const tokens = parseTokens(d.usage);
-    if ((fold !== undefined && fold.finalized) || state.done.has(key)) {
-      // 已定稿（fold 在场或已成记忆）→ 仅校正不重记。
-      // retry 取值：fold 在场取 fold.retry；fold 被 TTL 清后从 done 记忆取
-      // 真实 retry（防迟到校正错改 retry=1 行）；两者皆缺兜底 1。
-      if (tokens !== null) {
-        const retry = fold?.retry ?? state.done.get(key) ?? 1;
-        this.emit({ type: "correct", record: { session, turn, step, retry, tokens } });
-      }
-      return;
-    }
-    // 未定稿/缺失 → 补记（usage 缺失：调用照计、token 记 null）；时间取事件 time（非单调容忍）
-    // headerSeen 对称重置：与 usage 定稿路径对称——header 后 message 补记定稿
-    // 若仍留 headerSeen=true，同 fold 键迟到 usage chunk 会被误判为新调用（retry+1 重记）双算。
-    const retry = fold !== undefined ? fold.retry : 1;
-    if (fold !== undefined) {
-      fold.finalized = true;
-    } else {
-      state.folds.set(key, { retry: 1, finalized: true });
-    }
-    state.lastFoldTouch = this.now();
-    state.headerSeen = false;
+    const settled = state.done.get(key);
+    const retry = settled === undefined ? 1 : settled + 1;
     rememberDone(state.done, key, retry);
     const time = typeof event.time === "number" && Number.isFinite(event.time) ? event.time : this.now();
     const { provider, model } = this.providerOf(state);
@@ -410,20 +363,13 @@ export class TrendCollector {
         model,
         dir,
         tokens,
-        ...(d.interrupted === true ? { interrupted: true as const } : {}),
+        ...(kind === "message" && d.interrupted === true ? { interrupted: true as const } : {}),
       },
     });
   }
 
   private onTurnEnd(state: SessionFoldState, session: string, event: SessionEvent & { type: "turn/end" }): void {
-    const turn = (event.data as { turn?: unknown }).turn;
-    if (typeof turn === "number" && Number.isFinite(turn)) {
-      // 强制收尾：该 turn 全部 fold 状态丢弃（已定稿已入账；无证据的不入账）
-      const prefix = `${turn}:`;
-      for (const key of state.folds.keys()) {
-        if (key.startsWith(prefix)) state.folds.delete(key);
-      }
-    }
+    void state;
     // counter 记账时间取事件 time（防时钟回拨时 counter 落错日桶），非有限数回落 now
     const time = typeof event.time === "number" && Number.isFinite(event.time) ? event.time : this.now();
     const { provider, model } = this.providerOf(state);
@@ -432,7 +378,7 @@ export class TrendCollector {
   }
 
   private onToolCall(state: SessionFoldState, session: string, event: SessionEvent & { type: "tool/call" }): void {
-    // 同 onTurnEnd：counter 记账时间取事件 time，非有限数回落 now（口径与 onMessage 一致）
+    // 同 onTurnEnd：counter 记账时间取事件 time，非有限数回落 now（口径与 onSettled 一致）
     const time = typeof event.time === "number" && Number.isFinite(event.time) ? event.time : this.now();
     const { provider, model } = this.providerOf(state);
     const dir = this.dirOf(state, session);

--- a/packages/dsh-provider-usage/src/domain2/collect/interface.ts
+++ b/packages/dsh-provider-usage/src/domain2/collect/interface.ts
@@ -11,7 +11,7 @@
 
 // ------------------------------------------------------------------ 事件折叠状态机（collector.ts）
 
-export { TrendCollector, TREND_FOLD_TTL_MS, TREND_DONE_MAX } from "./collector.ts";
+export { TrendCollector, TREND_DONE_MAX } from "./collector.ts";
 export type {
   TrendCallRecord,
   TrendCorrectRecord,

--- a/packages/dsh-provider-usage/src/domain2/collect/types.ts
+++ b/packages/dsh-provider-usage/src/domain2/collect/types.ts
@@ -1,13 +1,16 @@
 /**
  * dsh-provider-usage/trend — 会话用量趋势数据类型。
  *
- * 数据源与记账口径（方案定稿 v1.2，唯一事实源 = ctx.on("session/event") 官方契约）：
- * - 主信号：assistant/chunk 中 chunk.type==="usage" 到达即定稿（一次 LLM 调用）；
- * - 副源：assistant/message（含 interrupted）未定稿时补记、已定稿时仅校正不重记；
- * - fold 键 (session, turn, step, retrySeq)：retry 复用同一 (turn,step)，重试消耗逐次入账；
+ * 数据源与记账口径（0.1.5-rc.1 起，唯一事实源 = ctx.on("session/event") 官方契约）：
+ * - 主信号：**结算事件**到达即定稿一次尝试——assistant/message（顶层 usage，缺失时
+ *   回落内嵌 stream 的 usage）与 assistant/attempt（失败/中止且未提交消息，只在
+ *   stream 里可能带 usage）。0.1.2 的逐 chunk 事件 assistant/chunk 已被官方移除。
+ * - 副源：assistant/message.message.source（kind:"model"）仅在归属缺失时补齐；
+ * - retry = 同 (session, turn, step) 内的结算序数，重试消耗逐次入账；
  * - 归属主源 = 逐会话折叠 request/header（EpochHeader.config 的 provider/model），
- *   assistant/message.source（kind:"model"）为副源；归属缺失显式入「未识别」桶；
- * - 零 usage 语义：调用次数独立计数，token 记 null 而非 0；
+ *   归属缺失显式入「未识别」桶；
+ * - 零 usage 语义：提交了消息的结算即便无 usage 也计调用次数、token 记 null 而非 0；
+ *   未提交消息且无 usage 的 attempt 不计（无调用证据）；
  * - 时间与日界：event.time 非单调（seq 才单调）——按事件本地日 dayKey 落桶，
  *   时钟回拨时旧日事件追加进对应日分片（append-only，查询容忍）；禁缓存时区偏移（DST 安全）。
  *

--- a/packages/dsh-provider-usage/test/smoke.ts
+++ b/packages/dsh-provider-usage/test/smoke.ts
@@ -1512,7 +1512,7 @@ console.log("[smoke] #105① /history 渲染缓存断言全部通过 ✓");
   const t = Date.now();
   const session = { id: "sess-trend" };
   emitEvent("session/event", session, { type: "request/header", seq: 1, time: t, data: { header: { config: { provider: "deepseek", model: "deepseek-chat" } }, reason: "initial" } });
-  emitEvent("session/event", session, { type: "assistant/chunk", seq: 2, time: t, data: { turn: 1, step: 1, chunk: { type: "usage", usage: { inputTokens: 100, outputTokens: 50 } } } });
+  emitEvent("session/event", session, { type: "assistant/message", seq: 2, time: t, data: { turn: 1, step: 1, usage: { inputTokens: 100, outputTokens: 50 } } });
 
   // /health 观测面
   const healthRes = [];
@@ -1535,14 +1535,14 @@ console.log("[smoke] #105① /history 渲染缓存断言全部通过 ✓");
   const inst1 = makeFakeCtx();
   await apply(inst1.ctx, { ...ISOLATED_CONFIG });
   const t = Date.now();
-  inst1.emitEvent("session/event", { id: "s-hot" }, { type: "assistant/chunk", seq: 1, time: t, data: { turn: 1, step: 1, chunk: { type: "usage", usage: { inputTokens: 25, outputTokens: 25 } } } });
+  inst1.emitEvent("session/event", { id: "s-hot" }, { type: "assistant/message", seq: 1, time: t, data: { turn: 1, step: 1, usage: { inputTokens: 25, outputTokens: 25 } } });
   await inst1.effects.at(-1)(); // 卸载（async disposer：含 trend dispose await 刷盘）
 
-  inst1.emitEvent("session/event", { id: "s-hot" }, { type: "assistant/chunk", seq: 2, time: t + 10, data: { turn: 1, step: 2, chunk: { type: "usage", usage: { inputTokens: 100, outputTokens: 100 } } } }); // 卸载后事件
+  inst1.emitEvent("session/event", { id: "s-hot" }, { type: "assistant/message", seq: 2, time: t + 10, data: { turn: 1, step: 2, usage: { inputTokens: 100, outputTokens: 100 } } }); // 卸载后事件
 
   const inst2 = makeFakeCtx();
   await apply(inst2.ctx, { ...ISOLATED_CONFIG });
-  inst2.emitEvent("session/event", { id: "s-hot" }, { type: "assistant/chunk", seq: 3, time: t + 20, data: { turn: 1, step: 3, chunk: { type: "usage", usage: { inputTokens: 7, outputTokens: 7 } } } });
+  inst2.emitEvent("session/event", { id: "s-hot" }, { type: "assistant/message", seq: 3, time: t + 20, data: { turn: 1, step: 3, usage: { inputTokens: 7, outputTokens: 7 } } });
   await inst2.effects.at(-1)(); // 卸载即排空
 
   const day = dayKey(t);
@@ -1567,7 +1567,7 @@ console.log("[smoke] #105① /history 渲染缓存断言全部通过 ✓");
   const emitCall = (sessionId, seqBase, provider, model, input, output) => {
     const s = { id: sessionId };
     emitEvent("session/event", s, { type: "request/header", seq: seqBase, time: t, data: { header: { config: { provider, model } }, reason: "initial" } });
-    emitEvent("session/event", s, { type: "assistant/chunk", seq: seqBase + 1, time: t, data: { turn: 1, step: 1, chunk: { type: "usage", usage: { inputTokens: input, outputTokens: output } } } });
+    emitEvent("session/event", s, { type: "assistant/message", seq: seqBase + 1, time: t, data: { turn: 1, step: 1, usage: { inputTokens: input, outputTokens: output } } });
   };
   emitCall("sess-trend-api-a", 1, "deepseek", "deepseek-chat", 100, 50);
   emitCall("sess-trend-api-b", 1, "openai", "gpt-x", 10, 5);
@@ -1794,7 +1794,7 @@ console.log("[smoke] #503 trend 挂接 + /trend 集成断言全部通过 ✓");
   const t = new Date(wy, wm - 1, wd, 12, 0, 0).getTime();
   const sess = { id: "sess-report" };
   emitEvent("session/event", sess, { type: "request/header", seq: 1, time: t, data: { header: { config: { provider: "deepseek", model: "deepseek-chat" } }, reason: "initial" } });
-  emitEvent("session/event", sess, { type: "assistant/chunk", seq: 2, time: t, data: { turn: 1, step: 1, chunk: { type: "usage", usage: { inputTokens: 80, outputTokens: 40 } } } });
+  emitEvent("session/event", sess, { type: "assistant/message", seq: 2, time: t, data: { turn: 1, step: 1, usage: { inputTokens: 80, outputTokens: 40 } } });
   await listeners.get("session/flush")[0](); // 官方排空点先行刷盘
   const trendBefore = await callHandler(trendRoute, fakeReq({ url: ROUTES.trend }));
 
@@ -1860,7 +1860,7 @@ console.log("[smoke] #503 trend 挂接 + /trend 集成断言全部通过 ✓");
       const xt = new Date(xy, xm - 1, xd, 12, 0, 0).getTime();
       const xssSess = { id: "sess-xss" };
       xssCtx.emitEvent("session/event", xssSess, { type: "request/header", seq: 1, time: xt, data: { header: { config: { provider: "deepseek", model: "deepseek-chat" } }, reason: "initial" } });
-      xssCtx.emitEvent("session/event", xssSess, { type: "assistant/chunk", seq: 2, time: xt, data: { turn: 1, step: 1, chunk: { type: "usage", usage: { inputTokens: 80, outputTokens: 40 } } } });
+      xssCtx.emitEvent("session/event", xssSess, { type: "assistant/message", seq: 2, time: xt, data: { turn: 1, step: 1, usage: { inputTokens: 80, outputTokens: 40 } } });
       await xssCtx.listeners.get("session/flush")[0]();
     }
     const xssGenRoute = xssCtx.routes.find((r) => r.path === ROUTES.reportGenerate);
@@ -2072,7 +2072,7 @@ console.log("[smoke] #503 trend 挂接 + /trend 集成断言全部通过 ✓");
   const emitCall = (sessionId, seqBase, provider, model, input, output) => {
     const s = { id: sessionId };
     emitEvent("session/event", s, { type: "request/header", seq: seqBase, time: t, data: { header: { config: { provider, model } }, reason: "initial" } });
-    emitEvent("session/event", s, { type: "assistant/chunk", seq: seqBase + 1, time: t, data: { turn: 1, step: 1, chunk: { type: "usage", usage: { inputTokens: input, outputTokens: output } } } });
+    emitEvent("session/event", s, { type: "assistant/message", seq: seqBase + 1, time: t, data: { turn: 1, step: 1, usage: { inputTokens: input, outputTokens: output } } });
   };
   emitCall("sess-d2-a", 1, "deepseek", "deepseek-chat", 200, 100);   // dsh-plugin-hub 桶
   emitCall("sess-d2-b", 11, "openai", "gpt-x", 20, 10);              // xiaozhuge 桶

--- a/packages/dsh-provider-usage/test/unit/report/unit-report.test.ts
+++ b/packages/dsh-provider-usage/test/unit/report/unit-report.test.ts
@@ -1352,9 +1352,9 @@ const GEN = (over = {}) => ({
       resolveCwd: (session) => (session === "s1" ? "/w/alpha" : "/w/beta"),
     });
     tracker.handleEvent({ id: "s1" }, { type: "request/header", seq: 1, time: T0, data: { header: { config: { provider: "p", model: "m" } } } });
-    tracker.handleEvent({ id: "s1" }, { type: "assistant/chunk", seq: 2, time: T0, data: { turn: 1, step: 1, chunk: { type: "usage", usage: { inputTokens: 100, outputTokens: 50 } } } });
+    tracker.handleEvent({ id: "s1" }, { type: "assistant/message", seq: 2, time: T0, data: { turn: 1, step: 1, usage: { inputTokens: 100, outputTokens: 50 } } });
     tracker.handleEvent({ id: "s2" }, { type: "request/header", seq: 3, time: T0, data: { header: { config: { provider: "p", model: "m" } } } });
-    tracker.handleEvent({ id: "s2" }, { type: "assistant/chunk", seq: 4, time: T0, data: { turn: 1, step: 1, chunk: { type: "usage", usage: { inputTokens: 7, outputTokens: 3 } } } });
+    tracker.handleEvent({ id: "s2" }, { type: "assistant/message", seq: 4, time: T0, data: { turn: 1, step: 1, usage: { inputTokens: 7, outputTokens: 3 } } });
     const fakeCtx = { llm: { stream: () => (async function* () { yield* CHUNKS; })(), listProviders: () => [{ id: "p" }], listModels: async () => [{ id: "m" }] } };
     const due = { period: "daily", key: "2026-09-03", startDay: "2026-09-03", endDay: "2026-09-03", force: true };
     // 全部（空数组）：两目录都在

--- a/packages/dsh-provider-usage/test/unit/trend/unit-trend-ledger.test.ts
+++ b/packages/dsh-provider-usage/test/unit/trend/unit-trend-ledger.test.ts
@@ -44,7 +44,29 @@ const DAY0 = dayKey(T0);
 const DAY1 = dayKey(T1);
 const HOUR = 3600_000;
 
+/**
+ * 事件工厂。0.1.5 迁移适配（与 unit-trend.test.ts 同口径）：旧用例以
+ * `assistant/chunk` + 内嵌 usage 表达一次 usage 到达，官方已移除该事件、usage 改由
+ * 结算事件承载——这里把 usage chunk 形态映射为 assistant/message 结算形态；
+ * 非 usage chunk 映射为空 stream 的 assistant/attempt（不构成调用证据）。
+ */
 function ev(type, data, time, seq = 1) {
+  if (type === "assistant/chunk") {
+    if (data?.chunk?.type !== "usage") {
+      return { type: "assistant/attempt", seq, time, data: { turn: data?.turn, step: data?.step, stream: [] } };
+    }
+    return {
+      type: "assistant/message",
+      seq,
+      time,
+      data: {
+        turn: data.turn,
+        step: data.step,
+        usage: data.chunk.usage,
+        stream: [{ type: "chunk", time, chunk: data.chunk }],
+      },
+    };
+  }
   return { type, seq, time, data };
 }
 const HEADER = (provider, model) => ({ header: { config: { provider, model } }, reason: "initial" });
@@ -102,21 +124,21 @@ send("s3", ev("turn/end", { turn: 1, reason: { kind: "completed" } }, T1 + 3000,
 send("s4", ev("request/header", HEADER("opencode", "glm-4"), T1 + 3100, 18));
 send("s4", ev("assistant/chunk", USAGE(1, 1, 8, 4, 1, 0), T1 + 4000, 19)); // call（dir=unidentified）
 
-// emitted 结构 sanity（correct 不新增调用计数；counter 独立）
+// emitted 结构 sanity（0.1.5：一次结算一条 call；counter 独立；无校正事件）
 const calls = emitted.filter((e) => e.type === "call").map((e) => e.record);
 const corrects = emitted.filter((e) => e.type === "correct").map((e) => e.record);
 const counters = emitted.filter((e) => e.type === "counter").map((e) => e.record);
-assert.equal(calls.length, 7, "Σ事件：call 事件数 = 7（correct 不新增调用计数）");
-assert.equal(corrects.length, 2, "同调用重复 usage + 已定稿 message 各产生一次校正");
+assert.equal(calls.length, 9, "Σ事件：call 事件数 = 9（每次结算一条）");
+assert.equal(corrects.length, 0, "0.1.5 结算自带完整 token，无校正事件");
 assert.equal(counters.length, 6, "turn/end×3 + tool/call×3 = 6 个 counter 事件");
 assert.equal(calls[0].provider, "deepseek", "归属折叠正确（s1 header 主源）");
-assert.equal(calls[2].interrupted, true, "s2 补记带 interrupted 标记");
-assert.equal(calls[2].provider, TREND_UNIDENTIFIED, "归属缺失 → TREND_UNIDENTIFIED 桶");
-assert.equal(calls[2].model, null, "未识别桶 model=null");
-assert.equal(calls[5].tokens, null, "零 usage 补记（s3 第二条 call）token 为 null");
+assert.equal(calls[4].interrupted, true, "s2 结算带 interrupted 标记");
+assert.equal(calls[4].provider, TREND_UNIDENTIFIED, "归属缺失 → TREND_UNIDENTIFIED 桶");
+assert.equal(calls[4].model, null, "未识别桶 model=null");
+assert.equal(calls[7].tokens, null, "零 usage 的 message 结算 token 为 null");
 assert.deepEqual(
   calls.map((c) => c.dir).sort(),
-  [TREND_UNIDENTIFIED, TREND_UNIDENTIFIED, TREND_UNIDENTIFIED, "proj-a", "proj-a", "proj-b", "proj-b"],
+  [TREND_UNIDENTIFIED, TREND_UNIDENTIFIED, TREND_UNIDENTIFIED, "proj-a", "proj-a", "proj-a", "proj-a", "proj-b", "proj-b"],
   "#633 目录归属两条线：合法 basename 与缺失归未识别均落盘",
 );
 

--- a/packages/dsh-provider-usage/test/unit/trend/unit-trend.test.ts
+++ b/packages/dsh-provider-usage/test/unit/trend/unit-trend.test.ts
@@ -57,7 +57,30 @@ const T0 = new Date(2026, 8, 4, 12, 0, 0).getTime();
 const DAY0 = dayKey(T0); // 2026-09-04
 const HOUR = 3600_000;
 
+/**
+ * 事件工厂。0.1.5 迁移适配：旧用例以 `assistant/chunk` + 内嵌 usage 表达「一次
+ * usage 到达」，而官方已移除该事件、usage 改由结算事件承载——这里把 usage chunk
+ * 形态映射为 assistant/message 结算形态（token 与时间语义不变），使下方用例的
+ * 断言继续在**原口径**上成立。非 usage 的 chunk（text-delta 等）在新形态下不构成
+ * 调用证据，映射为空 stream 的 assistant/attempt（collector 对无 usage attempt 不入账）。
+ */
 function ev(type, data, time, seq = 1) {
+  if (type === "assistant/chunk") {
+    if (data?.chunk?.type !== "usage") {
+      return { type: "assistant/attempt", seq, time, data: { turn: data?.turn, step: data?.step, stream: [] } };
+    }
+    return {
+      type: "assistant/message",
+      seq,
+      time,
+      data: {
+        turn: data.turn,
+        step: data.step,
+        usage: data.chunk.usage,
+        stream: [{ type: "chunk", time, chunk: data.chunk }],
+      },
+    };
+  }
   return { type, seq, time, data };
 }
 const HEADER = (provider = "deepseek", model = "deepseek-chat") => ({
@@ -109,33 +132,40 @@ const countersOf = (emitted) => emitted.filter((e) => e.type === "counter").map(
   assert.equal(emitted.filter((e) => e.type === "correct").length, 0, "text-delta 与首定稿不产生校正");
 }
 
-// ---------------------------------------------------------------- collector：重复 usage 校正
-// 不变量2：防双计（同 fold 键不重复记账、压实不二次累加）——同调用重复 usage 只校正 token、不重计调用。
+// ---------------------------------------------------------------- collector：结算事件防双计
+// 不变量2：防双计——(a) message 顶层 usage 与内嵌 stream usage 恒等，只取一处（P0 陷阱）；
+//          (b) 同 (turn,step) 多次结算按重试逐次入账（结算事件本身即一次尝试；0.1.2 的
+//              「重复 usage 走校正」路径随 assistant/chunk 移除而退役）。
 
 {
+  // (a) 两处 usage 同时在场 → 只记一份
   const { emitted, send } = makeCollector();
   const s = { id: "s1" };
+  const tokens = { inputTokens: 100, outputTokens: 50, cacheReadTokens: 0, cacheWriteTokens: 0 };
   send(s, ev("request/header", HEADER(), T0, 1));
-  send(s, ev("assistant/chunk", USAGE(100, 50), T0, 2));
-  send(s, ev("assistant/chunk", USAGE(200, 60), T0 + 10, 3));
+  send(s, ev("assistant/message", {
+    turn: 1,
+    step: 1,
+    message: { role: "assistant", source: { kind: "model", provider: "deepseek", model: "deepseek-chat" } },
+    usage: tokens,
+    stream: [{ type: "chunk", time: T0, chunk: { type: "usage", usage: tokens } }],
+  }, T0, 2));
   const calls = callsOf(emitted);
-  assert.equal(calls.length, 1, "同调用重复 usage 不重计调用");
-  const corr = correctsOf(emitted);
-  assert.equal(corr.length, 1, "重复 usage 产生校正");
-  assert.deepEqual(corr[0].tokens, { input: 200, output: 60, cacheRead: 0, cacheWrite: 0 }, "校正取后值");
-  assert.equal(corr[0].retry, 1, "校正命中同 fold 键");
+  assert.equal(calls.length, 1, "两处 usage 只记一次调用");
+  assert.deepEqual(calls[0].tokens, { input: 100, output: 50, cacheRead: 0, cacheWrite: 0 }, "token 不翻倍（须 ?? 二选一）");
 }
 
 // ---------------------------------------------------------------- collector：retry 逐次计
-// 不变量2：防双计——retry 复用同一 (turn,step)，新 header 边界后逐次独立入账（重试消耗不合并、不丢）。
+// 不变量2：重试复用同一 (turn,step)，retry = 该键结算序数（内生于结算事件，不依赖
+// request/header 边界，也不依赖可选重试插件的事件）。
 
 {
   const { emitted, send } = makeCollector();
   const s = { id: "s1" };
   send(s, ev("request/header", HEADER(), T0, 1));
   send(s, ev("assistant/chunk", USAGE(100, 50), T0, 2));
-  // retry：复用同一 (turn,step)，新 request/header 后再 usage
-  send(s, ev("request/header", HEADER(), T0 + 5000, 3));
+  // 中间夹一次无 usage 的失败 attempt：不构成调用证据，也不影响序数连续性
+  send(s, ev("assistant/attempt", { turn: 1, step: 1, stream: [] }, T0 + 3000, 3));
   send(s, ev("assistant/chunk", USAGE(70, 30), T0 + 6000, 4));
   const calls = callsOf(emitted);
   assert.equal(calls.length, 2, "重试消耗逐次独立入账");
@@ -180,14 +210,41 @@ const countersOf = (emitted) => emitted.filter((e) => e.type === "counter").map(
 }
 
 {
-  // 校正：已定稿后 message 到达仅校正不重记
+  // 同键「usage 结算 + message 结算」= 两次尝试；0.1.5 起结算自带完整 token，无校正路径
   const { emitted, send } = makeCollector();
   const s = { id: "s1" };
   send(s, ev("request/header", HEADER(), T0, 1));
   send(s, ev("assistant/chunk", USAGE(100, 50), T0, 2));
   send(s, ev("assistant/message", MESSAGE({ inputTokens: 120, outputTokens: 60 }), T0 + 50, 3));
-  assert.equal(callsOf(emitted).length, 1, "已定稿后 message 不重计");
-  assert.equal(correctsOf(emitted).length, 1, "message 校正产生");
+  const calls = callsOf(emitted);
+  assert.equal(calls.length, 2, "同键两次结算各自入账");
+  assert.equal(calls[1].retry, 2, "第二次结算 retry=2");
+  assert.equal(correctsOf(emitted).length, 0, "结算自带完整 token，无校正路径");
+}
+
+// ---------------------------------------------------------------- collector：attempt 口径（Q1/Q2）
+// Q1：有 usage 的失败/重试 attempt 计入（0.1.2 本来就计入，丢弃即丢真实计费 token）；
+// Q2：无 usage 的 attempt 不计（无调用证据，避免 calls 虚高）。
+
+{
+  // Q1：attempt 的 usage 只在 stream 里（无顶层 usage 字段）
+  const { emitted, send } = makeCollector();
+  const s = { id: "s1" };
+  send(s, ev("request/header", HEADER(), T0, 1));
+  const usage = { inputTokens: 12, outputTokens: 3 };
+  send(s, ev("assistant/attempt", { turn: 1, step: 1, stream: [{ type: "chunk", time: T0, chunk: { type: "usage", usage } }] }, T0, 2));
+  const calls = callsOf(emitted);
+  assert.equal(calls.length, 1, "有 usage 的 attempt 计入调用");
+  assert.deepEqual(calls[0].tokens, { input: 12, output: 3, cacheRead: null, cacheWrite: null }, "token 取自 stream 内裸 usage chunk");
+}
+
+{
+  // Q2：无 usage 的 attempt 不入账（packed run 形态也不承载 usage）
+  const { emitted, send } = makeCollector();
+  const s = { id: "s1" };
+  send(s, ev("request/header", HEADER(), T0, 1));
+  send(s, ev("assistant/attempt", { turn: 1, step: 1, stream: [{ type: "text-chunks", time0: T0, index: 0, dt: [], texts: ["hi"] }] }, T0, 2));
+  assert.equal(callsOf(emitted).length, 0, "无 usage 的 attempt 无调用证据");
 }
 
 // ---------------------------------------------------------------- collector：归属
@@ -245,47 +302,53 @@ const countersOf = (emitted) => emitted.filter((e) => e.type === "counter").map(
 }
 
 {
-  // turn/end 丢弃未定稿缓冲；定稿记忆保留——同 turn 乱序迟到 message 不双算
+  // turn/end 后同键迟到结算：仍是真实尝试 → 入账且序数连续
+  // （0.1.5 起无 fold 缓冲——结算事件自带完整证据，turn/end 不再需要「丢弃未定稿」）
   const { emitted, send } = makeCollector();
   const s = { id: "s1" };
   send(s, ev("request/header", HEADER(), T0, 1));
-  send(s, ev("assistant/chunk", USAGE(100, 50), T0, 2)); // 已定稿 → done 记忆
+  send(s, ev("assistant/chunk", USAGE(100, 50), T0, 2));
   send(s, ev("turn/end", { turn: 1, reason: { kind: "completed" } }, T0 + 1000, 3));
-  send(s, ev("assistant/message", MESSAGE({ inputTokens: 999, outputTokens: 999 }), T0 + 2000, 4)); // 乱序迟到
-  assert.equal(callsOf(emitted).length, 1, "turn/end 后迟到 message 不补记（防双算）");
-  assert.equal(correctsOf(emitted).length, 1, "迟到 message 走校正路径");
+  send(s, ev("assistant/message", MESSAGE({ inputTokens: 999, outputTokens: 999 }), T0 + 2000, 4));
+  const calls = callsOf(emitted);
+  assert.equal(calls.length, 2, "turn/end 后同键迟到结算仍入账");
+  assert.equal(calls[1].retry, 2, "序数记忆不按 turn 清，retry 连续");
+  assert.equal(countersOf(emitted).filter((c) => c.turns === 1).length, 1, "turn 计数独立不受影响");
 }
 
 // ---------------------------------------------------------------- collector：TTL 与销毁
-// 不变量2：防双计——fold/会话 TTL 回收后迟到 message 仍经 done 定稿记忆走校正路径（不双算）。
+// 不变量2：会话状态 TTL 回收前后，结算序数记忆决定 retry 连续性；回收后视为全新会话。
 
 {
+  // 会话状态未到龄：序数记忆保留 → retry 连续
   let nowMs = T0;
   const { emitted, send } = makeCollector(() => nowMs);
   const s = { id: "s1" };
   send(s, ev("request/header", HEADER(), T0, 1));
   send(s, ev("assistant/chunk", USAGE(100, 50), T0, 2));
-  nowMs = T0 + 11 * 60 * 1000; // 推进 11min：fold 缓冲 TTL 到龄（定稿记忆保留）
+  nowMs = T0 + 11 * 60 * 1000;
   send(s, ev("assistant/message", MESSAGE({ inputTokens: 42, outputTokens: 42 }), nowMs, 3));
-  assert.equal(callsOf(emitted).length, 1, "fold TTL 后迟到 message 仍不双算（done 记忆在会话级保留）");
-  assert.equal(correctsOf(emitted).length, 1, "走校正");
+  const calls = callsOf(emitted);
+  assert.equal(calls.length, 2, "TTL 内迟到结算照常入账");
+  assert.equal(calls[1].retry, 2, "retry 取序数记忆（连续）");
 }
 
 {
+  // 会话状态被清扫回收：序数记忆一并丢弃 → 同键结算视为全新会话，retry 重启
   let nowMs = T0;
   const { emitted, send } = makeCollector(() => nowMs);
   const s1 = { id: "s1" };
   send(s1, ev("request/header", HEADER(), T0, 1));
   send(s1, ev("assistant/chunk", USAGE(100, 50), T0, 2));
-  nowMs = T0 + 61 * 60 * 1000; // 会话级 TTL（60min）到龄
-  send(s1, ev("assistant/message", MESSAGE({ inputTokens: 7, outputTokens: 7 }), nowMs, 3));
-  assert.equal(callsOf(emitted).length, 1, "闲置 61min 后首条迟到 message 仍走校正（不双算优先）");
-  assert.equal(correctsOf(emitted).length, 1, "校正路径");
-  // 其他会话的事件触发全局清扫 → s1（真闲置 61min）被回收
-  send({ id: "s2" }, ev("assistant/chunk", USAGE(1, 1), nowMs, 4));
-  // s1 回收后的迟到 message：全新会话态补记（60min 窗口外不追溯，口径文档化）
-  send(s1, ev("assistant/message", MESSAGE({ inputTokens: 7, outputTokens: 7 }), nowMs, 5));
-  assert.equal(callsOf(emitted).length, 2, "状态回收后的迟到 message 视为全新会话补记");
+  assert.equal(callsOf(emitted).length, 1, "首条入账");
+  // 闲置 61min 后由**别的**会话触发全局清扫 → s1 被回收
+  nowMs = T0 + 61 * 60 * 1000;
+  send({ id: "s2" }, ev("assistant/chunk", USAGE(1, 1), nowMs, 3));
+  assert.equal(callsOf(emitted).length, 2, "s2 入账");
+  send(s1, ev("assistant/message", MESSAGE({ inputTokens: 7, outputTokens: 7 }), nowMs + 1000, 4));
+  const calls = callsOf(emitted);
+  assert.equal(calls.length, 3, "回收后的 s1 结算照常入账");
+  assert.equal(calls.at(-1).retry, 1, "回收后 retry 从 1 重启（60min 窗口外不追溯，口径文档化）");
 }
 
 {
@@ -795,54 +858,52 @@ function writeAggShardLine(row) {
   await tracker.dispose();
 }
 
-// ---------------------------------------------------------------- 评审修复：P2-2 补记定稿后 headerSeen 对称重置
-// 不变量2：防双计——message 补记定稿后对称重置 headerSeen（迟到 usage 不被误判为新调用双算）。
+// ---------------------------------------------------------------- 0.1.5 迁移：校正路径退役
+// 不变量2：0.1.2 的「补记定稿后迟到 usage 走校正」随 assistant/chunk 移除而退役——
+// 0.1.5 下同键两次结算即两次尝试，各自独立 token，双算由结算事件唯一性保证。
 
 {
-  // P2-2 双算反例：header → message（带 usage）补记定稿 → 同 (turn,step) 迟到 usage chunk。
-  // 修复前：补记定稿不重置 headerSeen → 迟到 usage 被误判为新调用（retry+1）重记 → 双算。
+  // message 结算 + 同键后续结算 = 两次尝试（token 不互相覆盖）
   const { emitted, send } = makeCollector();
   const agg = new TrendAggregator();
   const s = { id: "s1" };
   send(s, ev("request/header", HEADER(), T0, 1));
-  send(s, ev("assistant/message", MESSAGE({ inputTokens: 30, outputTokens: 20 }), T0 + 100, 2)); // 补记定稿
-  send(s, ev("assistant/chunk", USAGE(300, 150), T0 + 200, 3)); // 迟到 usage chunk
-  assert.equal(callsOf(emitted).length, 1, "补记定稿后迟到 usage 不重记（防双算）");
-  const corr = correctsOf(emitted);
-  assert.equal(corr.length, 1, "迟到 usage 走校正");
-  assert.deepEqual(corr[0].tokens, { input: 300, output: 150, cacheRead: 0, cacheWrite: 0 }, "token 为校正值");
-  // aggregator 端到端：correct 覆盖补记行 token，calls 仍 1
+  send(s, ev("assistant/message", MESSAGE({ inputTokens: 30, outputTokens: 20 }), T0 + 100, 2));
+  send(s, ev("assistant/chunk", USAGE(300, 150), T0 + 200, 3));
+  const calls = callsOf(emitted);
+  assert.equal(calls.length, 2, "同键两次结算各自入账");
+  assert.deepEqual(calls.map((c) => c.retry), [1, 2], "retry = 结算序数");
+  assert.deepEqual(calls.map((c) => c.tokens.input), [30, 300], "两次 token 各自保留");
+  assert.equal(correctsOf(emitted).length, 0, "结算自带完整 token，无校正事件");
   for (const e of emitted) agg.apply(e);
   const cell = agg.buckets().find((d) => d.day === DAY0).providers[0].cell;
-  assert.equal(cell.calls, 1, "aggregator calls=1（补记 1 + 校正不重计）");
-  assert.equal(cell.input, 300, "aggregator token 被校正覆盖");
+  assert.equal(cell.calls, 2, "aggregator calls=2（两次尝试累加）");
+  assert.equal(cell.input, 330, "aggregator token 求和");
 }
 
-// ---------------------------------------------------------------- 评审修复：P2-3 done 定稿记忆 Map 化
-// 不变量2：防双计——done 定稿记忆（retry 记忆 + TREND_DONE_MAX 淘汰）防乱序迟到 message 双算。
+// ---------------------------------------------------------------- done 记忆语义：结算序数
+// 不变量2：done 从「定稿记忆（防双算校正）」变为「结算序数记忆（retry 连续性）」；
+// 序数内生于结算事件，不依赖 request/header 边界。
 
 {
-  // P2-3(a)：retry=2 定稿后 folds 被 TTL 清空 → 迟到 message 校正的 retry
-  // 从 done 记忆取真实值 2（修复前兜底 1，会错改 retry=1 行的归属）。
+  // 序数记忆跨 header 与宽松 TTL 保持连续：三次同键结算 → retry 1/2/3
   let nowMs = T0;
   const { emitted, send } = makeCollector(() => nowMs);
   const s = { id: "s1" };
   send(s, ev("request/header", HEADER(), T0, 1));
-  send(s, ev("assistant/chunk", USAGE(100, 50), T0, 2)); // retry=1 定稿 → done["1:1"]=1
-  send(s, ev("request/header", HEADER(), T0 + 5000, 3)); // 重试边界
-  send(s, ev("assistant/chunk", USAGE(70, 30), T0 + 6000, 4)); // retry=2 定稿 → done["1:1"]=2
-  nowMs = T0 + 11 * 60 * 1000; // fold TTL 到龄：sweep 清 folds（done 记忆保留）
-  send(s, ev("tool/call", { turn: 1, step: 1, callId: "c", name: "bash", arguments: "{}" }, nowMs, 5)); // 触发 sweep
-  send(s, ev("assistant/message", MESSAGE({ inputTokens: 88, outputTokens: 66 }), nowMs, 6)); // 迟到校正
-  const corr = correctsOf(emitted);
-  assert.equal(corr.length, 1, "folds 清空后迟到 message 仍走校正（不双算）");
-  assert.equal(corr[0].retry, 2, "retry 从 done 记忆取真实值 2（非兜底 1）");
+  send(s, ev("assistant/chunk", USAGE(100, 50), T0, 2));
+  send(s, ev("assistant/chunk", USAGE(70, 30), T0 + 6000, 3));
+  nowMs = T0 + 11 * 60 * 1000;
+  send(s, ev("tool/call", { turn: 1, step: 1, callId: "c", name: "bash", arguments: "{}" }, nowMs, 4));
+  send(s, ev("assistant/message", MESSAGE({ inputTokens: 88, outputTokens: 66 }), nowMs, 5));
+  const calls = callsOf(emitted);
+  assert.equal(calls.length, 3, "三次同键结算各自入账");
+  assert.deepEqual(calls.map((c) => c.retry), [1, 2, 3], "retry 序数连续，不因 header/时间回落");
 }
 
 {
-  // P2-3(b)：done 超 TREND_DONE_MAX 按插入序淘汰最旧键（长命会话防无界增长）。
-  // 行为观测：每 turn 定稿 1 键 + turn/end 清 folds → done 累积 MAX+1 键 →
-  // 最旧键（turn=1）被淘汰（迟到 message 补记），最新键仍在（迟到 message 校正）。
+  // done 超 TREND_DONE_MAX 按插入序淘汰最旧键（长命会话防无界增长）。
+  // 序数语义下的可观测行为：被淘汰键的后续结算 retry 从 1 重启，未淘汰键继续递增。
   assert.equal(TREND_DONE_MAX, 200, "done 记忆上限常量");
   const { emitted, send } = makeCollector();
   const s = { id: "s1" };
@@ -851,13 +912,16 @@ function writeAggShardLine(row) {
     send(s, ev("assistant/chunk", usageAt(turn), T0, turn));
     send(s, ev("turn/end", { turn, reason: { kind: "completed" } }, T0, turn));
   }
-  send(s, ev("assistant/message", MESSAGE({ inputTokens: 9, outputTokens: 9 }), T0, 999)); // turn=1 step=1（被淘汰键）
-  assert.equal(callsOf(emitted).length, TREND_DONE_MAX + 2, "被淘汰键的迟到 message 走补记（无记忆可校正）");
+  const settled = callsOf(emitted).length;
+  assert.equal(settled, TREND_DONE_MAX + 1, "每 turn 一条结算");
+  // 被淘汰键（turn=1）再次结算 → 无记忆 → retry 重启为 1
+  send(s, ev("assistant/message", MESSAGE({ inputTokens: 9, outputTokens: 9 }), T0, 999));
+  assert.equal(callsOf(emitted).length, settled + 1, "被淘汰键的结算照常入账");
+  assert.equal(callsOf(emitted).at(-1).retry, 1, "被淘汰键 retry 重启为 1");
+  // 未淘汰键（turn=MAX+1）再次结算 → 序数递增为 2
   const late = { ...MESSAGE({ inputTokens: 8, outputTokens: 8 }), turn: TREND_DONE_MAX + 1 };
-  send(s, ev("assistant/message", late, T0, 1000)); // turn=MAX+1（最新键仍在记忆）
-  const corr = correctsOf(emitted);
-  assert.equal(corr.length, 1, "未淘汰键的迟到 message 走校正");
-  assert.equal(corr[0].turn, TREND_DONE_MAX + 1, "校正命中最新键");
+  send(s, ev("assistant/message", late, T0, 1000));
+  assert.equal(callsOf(emitted).at(-1).retry, 2, "未淘汰键 retry 递增");
 }
 
 // ---------------------------------------------------------------- 评审修复：P2-4 分片行校验补强
@@ -1980,13 +2044,12 @@ const A2_LEGACY_AGG = {
   await tracker.dispose();
 }
 
-// ---------------------------------------------------------------- #655 fold 清理后重复记账
-// 不变量2：防双计——fold 被 TTL 清理后迟到 usage 只校正不重记（done 记忆取真实 retry）。
+// ---------------------------------------------------------------- #655 口径变更（0.1.5）
+// 0.1.2 的「fold 被 TTL 清理后迟到 usage 只校正不重记」随 assistant/chunk 移除而退役：
+// 0.1.5 下同键多次结算按序数逐次入账（每次尝试一条结算事件，token 各自独立）。
 
 {
-  // fold 被 fold TTL 清理后，同一 fold 键的迟到 usage 不得重复记账（与 onMessage 对称）。
-  // 真实数据形态：同一 (session,turn,step) 的 usage 间隔 13~19 分钟陆续到达，
-  // token 从 0/0 递增到真实值——修复前每次 fold 重建都多记一次 call。
+  // 真实数据形态：同一 (session,turn,step) 的多次尝试陆续结算，token 各自入账
   let nowT = new Date(2026, 8, 8, 4, 22, 7).getTime();
   const { emitted, send } = makeCollector(() => nowT);
   const U = (input, output) => ev("assistant/chunk", { turn: 1, step: 9, chunk: { type: "usage", usage: { inputTokens: input, outputTokens: output } } }, nowT, 1);
@@ -1995,29 +2058,26 @@ const A2_LEGACY_AGG = {
   nowT += 13 * 60_000; send("s1", U(0, 0));
   nowT += 13 * 60_000; send("s1", U(0, 0));
   nowT += 12 * 60_000; send("s1", U(118593, 41240));
-  assert.equal(callsOf(emitted).length, 1, "同一 fold 键只记一次调用（fold 被 TTL 清理后不重记）");
-  const corrects = correctsOf(emitted);
-  assert.equal(corrects.length, 3, "后续迟到 usage 走校正（不重记调用）");
-  assert.deepEqual(
-    corrects[2].tokens,
-    { input: 118593, output: 41240, cacheRead: null, cacheWrite: null },
-    "最后一次校正带真实 token（token 收敛到最新值）",
-  );
+  const calls = callsOf(emitted);
+  assert.equal(calls.length, 4, "同键四次结算逐次入账（每次尝试独立）");
+  assert.deepEqual(calls.map((c) => c.retry), [1, 2, 3, 4], "retry = 结算序数，跨时间连续");
+  assert.deepEqual(calls.at(-1).tokens, { input: 118593, output: 41240, cacheRead: null, cacheWrite: null }, "末次 token 为真实值");
+  assert.equal(correctsOf(emitted).length, 0, "无校正路径");
 }
 
 {
-  // 反例防线：fold 被清理后若出现新 header，同键 usage 仍按重试递增（不误判为重复块）。
+  // 同键结算中途出现新 header：仍按结算序数递增（header 只影响归属，不影响序数）
   let nowT = T0;
   const { emitted, send } = makeCollector(() => nowT);
   const U = (input, output) => ev("assistant/chunk", { turn: 1, step: 9, chunk: { type: "usage", usage: { inputTokens: input, outputTokens: output } } }, nowT, 1);
   send("s1", ev("request/header", HEADER(), nowT, 0));
   send("s1", U(10, 5));
   nowT += 13 * 60_000;
-  send("s1", ev("request/header", HEADER(), nowT, 2)); // 重试边界：新 header
+  send("s1", ev("request/header", HEADER(), nowT, 2));
   send("s1", U(20, 6));
   const calls = callsOf(emitted);
-  assert.equal(calls.length, 2, "新 header 后的同键 usage 记为新一次调用（重试）");
-  assert.equal(calls[1].retry, 2, "retry 从定稿记忆递增为 2（不回落为 1 重号）");
+  assert.equal(calls.length, 2, "同键两次结算 = 两次尝试");
+  assert.equal(calls[1].retry, 2, "retry 取序数记忆递增（不回落为 1 重号）");
 }
 
 assert.equal(sumToken(null, 5), 5, "sumToken null+数字");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,32 +10,32 @@ catalogs:
       specifier: 4.0.2
       version: 4.0.2
     '@deepseek-ai/dsh-agent':
-      specifier: 0.1.2-rc.1
-      version: 0.1.2-rc.1
+      specifier: 0.1.5-rc.1
+      version: 0.1.5-rc.1
     '@deepseek-ai/dsh-client-ui-slots':
-      specifier: 0.1.2-rc.1
-      version: 0.1.2-rc.1
+      specifier: 0.1.5-rc.1
+      version: 0.1.5-rc.1
     '@deepseek-ai/dsh-host-webserver':
-      specifier: 0.1.2-rc.1
-      version: 0.1.2-rc.1
+      specifier: 0.1.5-rc.1
+      version: 0.1.5-rc.1
     '@deepseek-ai/dsh-llm':
-      specifier: 0.1.2-rc.1
-      version: 0.1.2-rc.1
+      specifier: 0.1.5-rc.1
+      version: 0.1.5-rc.1
     '@deepseek-ai/dsh-session':
-      specifier: 0.1.2-rc.1
-      version: 0.1.2-rc.1
+      specifier: 0.1.5-rc.1
+      version: 0.1.5-rc.1
     '@deepseek-ai/dsh-session-title':
-      specifier: 0.1.2-rc.1
-      version: 0.1.2-rc.1
+      specifier: 0.1.5-rc.1
+      version: 0.1.5-rc.1
     '@deepseek-ai/dsh-system-prompt':
-      specifier: 0.1.2-rc.1
-      version: 0.1.2-rc.1
+      specifier: 0.1.5-rc.1
+      version: 0.1.5-rc.1
     '@deepseek-ai/dsh-tools':
-      specifier: 0.1.2-rc.1
-      version: 0.1.2-rc.1
+      specifier: 0.1.5-rc.1
+      version: 0.1.5-rc.1
     '@deepseek-ai/dsh-user-approval':
-      specifier: 0.1.2-rc.1
-      version: 0.1.2-rc.1
+      specifier: 0.1.5-rc.1
+      version: 0.1.5-rc.1
 
 importers:
 
@@ -73,10 +73,10 @@ importers:
         version: 4.0.2
       '@deepseek-ai/dsh-client-ui-slots':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/dsh-host-webserver':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(supports-color@7.2.0)
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(supports-color@7.2.0)
       '@types/compression':
         specifier: ^1.7.5
         version: 1.8.1
@@ -109,19 +109,19 @@ importers:
         version: 4.0.2
       '@deepseek-ai/dsh-agent':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-util-values@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))
       '@deepseek-ai/dsh-client-ui-slots':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/dsh-host-webserver':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(supports-color@7.2.0)
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(supports-color@7.2.0)
       '@deepseek-ai/dsh-system-prompt':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))
       '@deepseek-ai/dsh-tools':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(cb0dbe8de145fa446d6c11c9727085c6)
+        version: 0.1.5-rc.1(6a2f57c8c1710b9a682bbcc128a57495)
       schemastery:
         specifier: ^3.18.0
         version: 3.18.0
@@ -133,22 +133,22 @@ importers:
         version: 4.0.2
       '@deepseek-ai/dsh-agent':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-util-values@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))
       '@deepseek-ai/dsh-client-ui-slots':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/dsh-host-webserver':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(supports-color@7.2.0)
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(supports-color@7.2.0)
       '@deepseek-ai/dsh-session':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/dsh-session-title':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-brand@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-util-values@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-brand@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))
       '@deepseek-ai/dsh-user-approval':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-brand@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-util-values@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-brand@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))
 
   packages/dsh-plugins-all:
     dependencies:
@@ -178,16 +178,16 @@ importers:
         version: 4.0.2
       '@deepseek-ai/dsh-client-ui-slots':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/dsh-host-webserver':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(supports-color@7.2.0)
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(supports-color@7.2.0)
       '@deepseek-ai/dsh-llm':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/dsh-session':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
       async-mutex:
         specifier: ^0.5.0
         version: 0.5.0
@@ -207,10 +207,10 @@ importers:
         version: 4.0.2
       '@deepseek-ai/dsh-client-ui-slots':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/dsh-host-webserver':
         specifier: 'catalog:'
-        version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(supports-color@7.2.0)
+        version: 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(supports-color@7.2.0)
       '@types/marked':
         specifier: ^6.0.0
         version: 6.0.0
@@ -457,105 +457,106 @@ packages:
   '@deepseek-ai/cosmokit@1.8.3':
     resolution: {integrity: sha512-qBo+ronVM6Eu2WNVJXi8JcMiqZ19T9BRIpV+5qJUFPXjGH/Z0QKcQMC/IZJ7L394YTOtJgcovbk9qP0w2GsBXQ==}
 
-  '@deepseek-ai/dsh-agent@0.1.2-rc.1':
-    resolution: {integrity: sha512-lfaqN34vUCWvbn1kJVHrhfJ6Dvt1HDHCm33ZCpmKkl07/5q6FxWqVv6rOdVX5QnM/9xz/uYiN0nQwUtBg4+Skg==}
+  '@deepseek-ai/dsh-agent@0.1.5-rc.1':
+    resolution: {integrity: sha512-obIPyTSjq1y0Yhasm3mLhK5BW6Ge0VQoRT8FBt0ooLsct2+pFAjgyd7GP3KzFaz7zaEhQJ/NNEmCaU0KOsYutg==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.2
-      '@deepseek-ai/dsh-invariants': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-llm': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-scope': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-session': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-session-projection': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-system-prompt': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-typert-protocol': ^0.1.2-rc.1
+      '@deepseek-ai/dsh-invariants': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-llm': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-scope': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-session': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-session-projection': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-system-prompt': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-typert-protocol': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-util-values': ^0.1.5-rc.1
 
-  '@deepseek-ai/dsh-brand@0.1.2-rc.1':
-    resolution: {integrity: sha512-y2RHIag3kzLdY8kTBuSUSTsKzWPscJrysNObXTiNM7stXLpa3jXpshsB1caqGzNx50vYcmHeN1gFVECgx3NZHg==}
-    peerDependencies:
-      '@deepseek-ai/cordis': ^4.0.2
-
-  '@deepseek-ai/dsh-client-ui-slots@0.1.2-rc.1':
-    resolution: {integrity: sha512-wcqn8xwb87RjurSQ0zPoI4K9eYhDyoBjQqg4bByDq8CNynvayHoBPnNWfiAQ8ngyOPE20teL3DMS0gbcfCTqbA==}
+  '@deepseek-ai/dsh-brand@0.1.5-rc.1':
+    resolution: {integrity: sha512-nfEsuSNghhrcvjMnjlPU55Z60K/5FjCRY4ZJtnc0SHR0PgoMl7N9I9+y4t2kDMe3rnEKlH2UgIGIZ/msGOYvpg==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.2
 
-  '@deepseek-ai/dsh-host-webserver@0.1.2-rc.1':
-    resolution: {integrity: sha512-QVcaf4qnIa1t215Y8TRiRhqkEz4Lu5/F+KqvWT+4sHOiyWmZr8g1JndqlwP6MBnMQEPmp0I/EKYJ7PWMV32gkA==}
+  '@deepseek-ai/dsh-client-ui-slots@0.1.5-rc.1':
+    resolution: {integrity: sha512-xBCdGmV1RdCwWFHCW5m6Y3FVAIHNRR6ppFNeZN4iRpn/osCvnYCF7L+MyjeWExyjC71Xl/Rh06Kj8/1gtbb/wg==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.2
 
-  '@deepseek-ai/dsh-llm@0.1.2-rc.1':
-    resolution: {integrity: sha512-7VYsha5AXsVLnsAwYJffWXz9bwUbElw8i5N8tlTSdai9Bupk3sMbsotzPf8ZbsuGAxQYErahMwQwgGEu4qZO6g==}
+  '@deepseek-ai/dsh-host-webserver@0.1.5-rc.1':
+    resolution: {integrity: sha512-5kOu9kb0AuRN60/zwPTRcki801ozgnWAFwS1QtQ4ZNgCYIbAiU8gwJHY1//qEpUOuHS+26k+Tqq5/WCJmLGE6Q==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.2
 
-  '@deepseek-ai/dsh-session-title@0.1.2-rc.1':
-    resolution: {integrity: sha512-hCffH0uZWEM9p3MPkOQOFUxpPwfV48N8KDc3hYX7zVOFgHBY93ylwkEEVVkWN+sNp2zJmFrZSya23jFVshDtQg==}
-    peerDependencies:
-      '@deepseek-ai/cordis': ^4.0.2
-      '@deepseek-ai/dsh-agent': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-brand': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-invariants': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-llm': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-session': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-session-projection': ^0.1.2-rc.1
-
-  '@deepseek-ai/dsh-session@0.1.2-rc.1':
-    resolution: {integrity: sha512-jRGNPTbQcvIx1F2MVmmkoiHLgpC3Btqo1wkl/3JDLlOWRVWKOuaC+5fQiMrFPOYfno6YiX/c2UvmA0td8qB92w==}
-    peerDependencies:
-      '@deepseek-ai/cordis': ^4.0.2
-      '@deepseek-ai/dsh-scope': ^0.1.2-rc.1
-
-  '@deepseek-ai/dsh-system-prompt@0.1.2-rc.1':
-    resolution: {integrity: sha512-7W93PZKIk4CHvjZGgLIxrrEKpk+6t8nQXje1vKR5vG73dfXH0t1MJ5WWH/fngadYc7c6KzM84ihQ66tJqJqyNQ==}
-    peerDependencies:
-      '@deepseek-ai/cordis': ^4.0.2
-      '@deepseek-ai/dsh-invariants': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-llm': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-scope': ^0.1.2-rc.1
-
-  '@deepseek-ai/dsh-timeout@0.1.2-rc.1':
-    resolution: {integrity: sha512-llz11yxWeJB8suKCa6hRLjNBWVaPn3Fbd0XoBS0bkZLhPFzO1mDorx/XMca2GhI7XF9A86CURQcDt+aGjjvqJA==}
+  '@deepseek-ai/dsh-llm@0.1.5-rc.1':
+    resolution: {integrity: sha512-KPKJFTNLjURphuF4NlS8DRK94CUYL/dKB8Hzg/22jtxAFO2paX3ifL0vhdPq9xPbcyplaF7LYlf0+3+pXFTnTg==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.2
 
-  '@deepseek-ai/dsh-tools@0.1.2-rc.1':
-    resolution: {integrity: sha512-W9kUio00s7WbM8kEwniyd4hfb3CeUxVczsjXbOcKtakfiTywNLeyRWkpx2fvwRAH2rBfg3qCgczVfS0DOw1csg==}
+  '@deepseek-ai/dsh-session-title@0.1.5-rc.1':
+    resolution: {integrity: sha512-Gz1qZ9rXiNzogz9StL4+oV3PilLvK6kCgtXSYJZeLIr7quliwDObCmP68+B4vncLPUeBpEaN5ozyE2ymFuzNPg==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.2
-      '@deepseek-ai/dsh-agent': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-code-runtime': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-invariants': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-llm': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-scope': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-session': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-system-prompt': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-user-approval': ^0.1.2-rc.1
+      '@deepseek-ai/dsh-agent': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-brand': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-invariants': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-llm': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-session': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-session-projection': ^0.1.5-rc.1
 
-  '@deepseek-ai/dsh-typert-protocol@0.1.2-rc.1':
-    resolution: {integrity: sha512-vBWD0NpriPd96ltbWaAw+iKeWFIEjiAcCWYtmqEcV1Ms+FaV02usjjm7LCmhSQhMZpBSBc7EZUX0spGlpjI1bA==}
+  '@deepseek-ai/dsh-session@0.1.5-rc.1':
+    resolution: {integrity: sha512-0YBBrzkCbVEJolS/OpD0DZMSozmYxUTZopiG76MXInjOFBW9J4ca1a8WUjJjqelP1nJTmWGKXp92HcvNEny0Dg==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.2
+      '@deepseek-ai/dsh-scope': ^0.1.5-rc.1
 
-  '@deepseek-ai/dsh-user-approval@0.1.2-rc.1':
-    resolution: {integrity: sha512-oYkLE4a/TwqVNi299pUf/QP1Yku6KScdUCTUyYbjaRBcN+/pXPpHikl2aoE2thH9D0uT/Kj6T2kz+wDDcFd9Xg==}
+  '@deepseek-ai/dsh-system-prompt@0.1.5-rc.1':
+    resolution: {integrity: sha512-RAdO9biQoga1vAVTQY9J7THexiOE1FOd1Nli021MQt+Zf73c83BSd2DwXb0WDilLaMeSxZPaIRRqoXpJlpmLIA==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.2
-      '@deepseek-ai/dsh-agent': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-brand': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-invariants': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-llm': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-scope': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-session': ^0.1.2-rc.1
-      '@deepseek-ai/dsh-system-prompt': ^0.1.2-rc.1
+      '@deepseek-ai/dsh-invariants': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-llm': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-scope': ^0.1.5-rc.1
 
-  '@deepseek-ai/dsh-util-crypto@0.1.2-rc.1':
-    resolution: {integrity: sha512-gE8FznQ1hkknw9QMrHNSlm3UEyRYuj3MLVvlJ6NyH1kmOsdjnbrVbSs+Pn72k2oIV4Fiyu3Umg0sLznUEcsiXw==}
+  '@deepseek-ai/dsh-timeout@0.1.5-rc.1':
+    resolution: {integrity: sha512-BcV4y/uCIm82VlIwuGsbLjAZXOxRBmjwusi637MV25hJhhGuWaKoMqAa0D/Lcfqu8hU+g3vgGJdpQvhHnG8sgQ==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.2
 
-  '@deepseek-ai/dsh-util-values@0.1.2-rc.1':
-    resolution: {integrity: sha512-FQdgoK+KYVR0pBQb9fTsajvGb3gzUxEzJQEYnFOt+Qdwc4nkxJOPwJJdIvXuqvZaQ33DaOoqpnpcr2p5HpLu4g==}
+  '@deepseek-ai/dsh-tools@0.1.5-rc.1':
+    resolution: {integrity: sha512-I5AUxKTqUrC0nvRO4UcpU+f65P+nKs5BUrS2nqZehhFZ2rVxhUAJ7YdORcY6pVkBTB15nPr5gK0WPgwyfS217w==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.2
+      '@deepseek-ai/dsh-agent': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-code-runtime': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-invariants': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-llm': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-scope': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-session': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-system-prompt': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-user-approval': ^0.1.5-rc.1
+
+  '@deepseek-ai/dsh-typert-protocol@0.1.5-rc.1':
+    resolution: {integrity: sha512-HBxnSnvjiYPlir6An+/W+66dTRQnwpbNUbtOH6e5LHuV4CcHL5yrimTbMI04olJM9w2U9FyfwDOzmW6uqWjAew==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.2
+
+  '@deepseek-ai/dsh-user-approval@0.1.5-rc.1':
+    resolution: {integrity: sha512-fSxEBvHQnozIh5HV31t2BNodYzyv7iE2srna7p5k0Y/3R9c6DdoZyQZ9momcN9gloraq8HK5+cvrYHzgc4LYPQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.2
+      '@deepseek-ai/dsh-agent': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-brand': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-invariants': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-llm': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-scope': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-session': ^0.1.5-rc.1
+      '@deepseek-ai/dsh-system-prompt': ^0.1.5-rc.1
+
+  '@deepseek-ai/dsh-util-crypto@0.1.5-rc.1':
+    resolution: {integrity: sha512-8ZosLrwbXdsWRlZ/0Yu85GMhKbFHqGD+ayiFzABXGb3sxfG6nbQQWKtv1sRr77wJ6wYvM2R9rPOg+EDWkGocqQ==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.2
+
+  '@deepseek-ai/dsh-util-values@0.1.5-rc.1':
+    resolution: {integrity: sha512-iHH62b+Mc0ueLHn1OQGLOC6+WMqjyK2+wxCkaiQGoGHBAyRGQBnBWiFAOGxp2xIElCXsc1mU1nrkN8D6jppYQg==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.2
 
@@ -2619,23 +2620,24 @@ snapshots:
 
   '@deepseek-ai/cosmokit@1.8.3': {}
 
-  '@deepseek-ai/dsh-agent@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))':
+  '@deepseek-ai/dsh-agent@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-util-values@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2
-      '@deepseek-ai/dsh-llm': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-session': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-system-prompt': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))
-      '@deepseek-ai/dsh-typert-protocol': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-llm': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-session': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-system-prompt': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-util-values': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
 
-  '@deepseek-ai/dsh-brand@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)':
-    dependencies:
-      '@deepseek-ai/cordis': 4.0.2
-
-  '@deepseek-ai/dsh-client-ui-slots@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)':
+  '@deepseek-ai/dsh-brand@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2
 
-  '@deepseek-ai/dsh-host-webserver@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(supports-color@7.2.0)':
+  '@deepseek-ai/dsh-client-ui-slots@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.2
+
+  '@deepseek-ai/dsh-host-webserver@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(supports-color@7.2.0)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2
       '@deepseek-ai/schemastery': 3.18.2
@@ -2644,76 +2646,76 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)':
+  '@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2
-      '@deepseek-ai/dsh-brand': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-timeout': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-typert-protocol': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-util-crypto': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-util-values': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-brand': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-timeout': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-typert-protocol': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-util-crypto': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-util-values': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/schemastery': 3.18.2
       zod: 4.5.4
 
-  '@deepseek-ai/dsh-session-title@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-brand@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))':
+  '@deepseek-ai/dsh-session-title@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-util-values@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-brand@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2
-      '@deepseek-ai/dsh-agent': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))
-      '@deepseek-ai/dsh-brand': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-llm': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-session': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-util-values': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-util-values@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))
+      '@deepseek-ai/dsh-brand': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-llm': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-session': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-util-values': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/schemastery': 3.18.2
       zod: 4.5.4
 
-  '@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)':
+  '@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2
-      '@deepseek-ai/dsh-brand': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-llm': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-util-values': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-brand': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-llm': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-util-values': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
 
-  '@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))':
+  '@deepseek-ai/dsh-system-prompt@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2
-      '@deepseek-ai/dsh-llm': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-llm': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/schemastery': 3.18.2
 
-  '@deepseek-ai/dsh-timeout@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)':
+  '@deepseek-ai/dsh-timeout@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2
 
-  '@deepseek-ai/dsh-tools@0.1.2-rc.1(cb0dbe8de145fa446d6c11c9727085c6)':
+  '@deepseek-ai/dsh-tools@0.1.5-rc.1(6a2f57c8c1710b9a682bbcc128a57495)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2
-      '@deepseek-ai/dsh-agent': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))
-      '@deepseek-ai/dsh-brand': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-llm': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-session': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-system-prompt': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))
-      '@deepseek-ai/dsh-user-approval': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-brand@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))
-      '@deepseek-ai/dsh-util-values': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-agent': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-util-values@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))
+      '@deepseek-ai/dsh-brand': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-llm': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-session': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-system-prompt': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))
+      '@deepseek-ai/dsh-user-approval': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-util-values@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-brand@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))
+      '@deepseek-ai/dsh-util-values': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
       '@deepseek-ai/schemastery': 3.18.2
 
-  '@deepseek-ai/dsh-typert-protocol@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)':
+  '@deepseek-ai/dsh-typert-protocol@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2
 
-  '@deepseek-ai/dsh-user-approval@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-brand@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))':
+  '@deepseek-ai/dsh-user-approval@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-util-values@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-brand@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2
-      '@deepseek-ai/dsh-agent': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))
-      '@deepseek-ai/dsh-brand': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-llm': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-session': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)
-      '@deepseek-ai/dsh-system-prompt': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))
+      '@deepseek-ai/dsh-agent': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-session@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-system-prompt@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)))(@deepseek-ai/dsh-typert-protocol@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-util-values@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))
+      '@deepseek-ai/dsh-brand': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-llm': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-session': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)
+      '@deepseek-ai/dsh-system-prompt': 0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2))
       '@deepseek-ai/schemastery': 3.18.2
 
-  '@deepseek-ai/dsh-util-crypto@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)':
+  '@deepseek-ai/dsh-util-crypto@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2
 
-  '@deepseek-ai/dsh-util-values@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)':
+  '@deepseek-ai/dsh-util-values@0.1.5-rc.1(@deepseek-ai/cordis@4.0.2)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,20 +11,20 @@ autoInstallPeers: false
 # 仅限 import type（编译期擦除），禁止任何运行时值导入（contract-check 有门禁）。
 catalog:
   '@deepseek-ai/cordis': 4.0.2
-  '@deepseek-ai/dsh-agent': 0.1.2-rc.1
-  '@deepseek-ai/dsh-client-connection': 0.1.2-rc.1
-  '@deepseek-ai/dsh-client-store': 0.1.2-rc.1
-  '@deepseek-ai/dsh-client-ui-slots': 0.1.2-rc.1
-  '@deepseek-ai/dsh-host-webserver': 0.1.2-rc.1
-  '@deepseek-ai/dsh-llm': 0.1.2-rc.1
-  '@deepseek-ai/dsh-session': 0.1.2-rc.1
-  '@deepseek-ai/dsh-session-title': 0.1.2-rc.1
-  '@deepseek-ai/dsh-settings': 0.1.2-rc.1
-  '@deepseek-ai/dsh-skill': 0.1.2-rc.1
-  '@deepseek-ai/dsh-skill-filesystem': 0.1.2-rc.1
-  '@deepseek-ai/dsh-system-prompt': 0.1.2-rc.1
-  '@deepseek-ai/dsh-tools': 0.1.2-rc.1
-  '@deepseek-ai/dsh-user-approval': 0.1.2-rc.1
+  '@deepseek-ai/dsh-agent': 0.1.5-rc.1
+  '@deepseek-ai/dsh-client-connection': 0.1.5-rc.1
+  '@deepseek-ai/dsh-client-store': 0.1.5-rc.1
+  '@deepseek-ai/dsh-client-ui-slots': 0.1.5-rc.1
+  '@deepseek-ai/dsh-host-webserver': 0.1.5-rc.1
+  '@deepseek-ai/dsh-llm': 0.1.5-rc.1
+  '@deepseek-ai/dsh-session': 0.1.5-rc.1
+  '@deepseek-ai/dsh-session-title': 0.1.5-rc.1
+  '@deepseek-ai/dsh-settings': 0.1.5-rc.1
+  '@deepseek-ai/dsh-skill': 0.1.5-rc.1
+  '@deepseek-ai/dsh-skill-filesystem': 0.1.5-rc.1
+  '@deepseek-ai/dsh-system-prompt': 0.1.5-rc.1
+  '@deepseek-ai/dsh-tools': 0.1.5-rc.1
+  '@deepseek-ai/dsh-user-approval': 0.1.5-rc.1
 
 allowBuilds:
   esbuild: true
@@ -33,25 +33,25 @@ allowBuilds:
 # 死配置；一旦全局启用 minimumReleaseAge（rc 包发布时间新、会超龄拦截），按此清单
 # 豁免官方 rc 包。升级锁版版本号时同步更新此处。
 minimumReleaseAgeExclude:
-  - '@deepseek-ai/dsh-agent@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-host-webserver@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-llm@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-session-title@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-session@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-skill@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-system-prompt@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-tools@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-user-approval@0.1.2-rc.1'
+  - '@deepseek-ai/dsh-agent@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-host-webserver@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-llm@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-session-title@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-session@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-skill@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-system-prompt@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-tools@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-user-approval@0.1.5-rc.1'
   - '@deepseek-ai/cordis@4.0.2'
   - '@deepseek-ai/cosmokit@1.8.3'
-  - '@deepseek-ai/dsh-brand@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-timeout@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-typert-protocol@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-util-crypto@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-util-values@0.1.2-rc.1'
+  - '@deepseek-ai/dsh-brand@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-timeout@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-typert-protocol@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-util-crypto@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-util-values@0.1.5-rc.1'
   - '@deepseek-ai/schemastery@3.18.2'
-  - '@deepseek-ai/dsh-client-ui-slots@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-client-store@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-client-connection@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-settings@0.1.2-rc.1'
-  - '@deepseek-ai/dsh-skill-filesystem@0.1.2-rc.1'
+  - '@deepseek-ai/dsh-client-ui-slots@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-client-store@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-client-connection@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-settings@0.1.5-rc.1'
+  - '@deepseek-ai/dsh-skill-filesystem@0.1.5-rc.1'


### PR DESCRIPTION
关联 #695。**基于 #696**（stacked PR，合并顺序：先 #696 再本 PR）。

## 上游破坏面（实测 `lib/` 逐包 diff + 官方 release notes）

| 包 | 变更 | 触达本仓 |
|---|---|---|
| `dsh-session` | **删除 `assistant/chunk`**；新增 `assistant/attempt`；`assistant/message` 增内嵌 `stream`；`SESSION_FORMAT_VERSION` 0→3 | **provider-usage** |
| `dsh-system-prompt` | `SECTION_ORDERS` 重排（`HARNESS_SOURCE` -900→10000、`WEB_SURFACE` -800→10100） | **mcp-manager** |
| `dsh-tools` | `tool/code-dispatch` → `tool/ptc-dispatch` | 无 |
| `dsh-agent` | 删 `ctx.agent`/`InboxNotifications`；`AgentSetup` 加参 | 无 |
| `dsh-host-webserver` / `dsh-session-title` / `dsh-user-approval` / `dsh-settings` / `dsh-client-store` / `dsh-skill-filesystem` | **lib 零差异** | 安全 |

> 官方 `conversation` Slot → `main` 的 key：本仓只注册 `settings.plugin.item` / `settings.section`，两 slot 新版仍有消费者，**不受影响**。
> 会话日志 V3：插件读写的是**自建** jsonl，不读 DSH 会话日志，**不适用**。

## 改动

### provider-usage（唯一编译期破坏点，跃迁后 6 处 TS 错误）

官方把逐 chunk 的 `assistant/chunk` 换成**结算事件**，采集状态机随之改写：

- **token 取值**：`assistant/message.usage ?? stream 内最后一条裸 usage chunk`，**二选一**——真实会话中 message 的两处 usage 恒等（实测 871/871），两处都取会翻倍。`assistant/attempt` 只在 `stream` 里可能带 usage
- **retry**：改为同 `(turn, step)` 内的**结算序数**，不再依赖 `request/header` 启发式（结算事件内生于每次尝试，永不缺失；可选插件产出的 `llm/retry` 实测 0 条，不作主路径）
- **删除**：`fold` 两阶段缓冲、`headerSeen`、`TREND_FOLD_TTL_MS`（含 `apply/index.ts` 的发布导出面，属公开 API 变更）
- **保留**：`TrendCorrectRecord` / `applyCorrect`（聚合层消费面不动，collector 不再产出 correct）
- **口径与 0.1.2 零变化**（维护者已拍板）：有 usage 的失败 attempt **计入**；无 usage 的 attempt **不计**；无 usage 的 message 计入且 token=null；`TREND_ROW_VERSION` **不递增**（递增会在载入时静默丢弃全部历史）

测试随迁：`unit-trend` / `unit-trend-ledger` / `unit-report` / `smoke` 的事件工厂做形态映射，**语义反转的用例按新口径重设计**（重复 usage 校正、fold TTL 不重记、headerSeen 对称重置三处机制已不存在），并新增 Q1/Q2 口径用例。

### mcp-manager

官方 `SECTION_ORDERS` 重排后，原先硬编码的 `order: 160` 相对 `HARNESS_SOURCE`/`WEB_SURFACE` 的位置翻转（该两段被官方移到 10000/10100）。核实后确认它与相邻段的相对位置**未变**（仍在 `DEPLOYMENT_PERSONA_PREFIX(0)` 与 `PLAN_POLICY(500)` 之间），故**不改数值**，改为具名常量 `MCP_SECTION_ORDER` + 注释说明依据，并补一条**分节顺序断言**（全仓此前 0 处断言该 order），防未来官方再重排时本段落静默贬值。

### 其它

- catalog 15 键 → `0.1.5-rc.1`（`cordis 4.0.2` 不动）+ `minimumReleaseAgeExclude` 同步 + lock 重生成
- 文档锚定 4 处（`README.md` / `README.en.md` / `AGENTS.md` / `docs/DEVELOPMENT.md`）
- 归档 `docs/archive/dsh-0.1.5-适配计划.md`（含口径决策与验收清单）

## 门禁

- [x] `pnpm build` / `pnpm test` / `pnpm contract` / `pnpm pack:check` / `pnpm typecheck` 全绿（typecheck 0 错误）
- [x] `export-surface-snapshot | PASS dsh-notifier 导出面与基线零 diff`
- [x] provider-usage 三套单测 + smoke 全绿

## 待办（本 PR 不含）

- [ ] 隔离环境（`dsh-verify-isolated`）真实会话实测：用量记账数值与旧版对拍（calls / retry / token 三元组）、MCP 目录注入、通知链路
- [ ] 浏览器实测：5 个客户端插件渲染 + 窄屏/双主题 + 官方新 rightbar 布局下浮动胶囊落点
- [ ] 发版 PR（版本号对齐 + `docs/release-notes/`）——按仓库红线另开 `chore(release):`

## 已知上游问题（不在本 PR 修）

`dsh-llm@0.1.5-rc.1` 的 `.d.ts` 引用 `@deepseek-ai/dsh-attachment`，但该包未列入其自身 `dependencies`（上游漏声明）。当前被仓库 `skipLibCheck: true` 掩盖，且本仓不使用相关 API，故不加 workaround 依赖（避免上游修复后变僵尸依赖）。
