### PR TITLE
docs(dsh-lan-proxy): 修正 HTTP 压缩 Brotli 描述（实测生效条件）+ 归档官方能力重叠评估

### DIFF
--- a/packages/dsh-lan-proxy/AGENTS.md
+++ b/packages/dsh-lan-proxy/AGENTS.md
@@ -18,12 +18,16 @@ issue #110 起不再使用自建 config.json）。
   disposer；所有清理统一写在 `ctx.effect` 返回的 disposer 里）
 - `src/proxy.ts` — 转发器核心 `createLanProxy`（HTTP/HTTPS/WebSocket 桥接、
   Host 重写、DNS 重绑定防护、wss 压缩桥接）；业务逻辑导出纯函数可单测。
-  HTTP 响应压缩（原独立包 dsh-gzip 已退役并入；compression@1.8+ 按 Accept-Encoding 协商，br 优先、gzip 回退；档位预设经 resolveCompressionOptions 映射，对双算法生效）也在此层：经成熟开源库
+  HTTP 响应压缩（原独立包 dsh-gzip 已退役并入；compression@1.8+ 按 Accept-Encoding 协商；档位预设经 resolveCompressionOptions 映射，gzip 与 Brotli 两侧参数同时下发）也在此层：经成熟开源库
   `compression` 中间件挂在转发器自己的 `createServer` 处理链上（构建期 esbuild
   内联进产物），自定义 filter 复用 `isCompressible`（SSE 豁免）；
   协商 / Vary / Content-Length 删除 / Range·204·304 豁免全部由库承担。
-  上游已带 content-encoding 时本层自动让位（与宿主端任意压缩实现共存只压一次，
-  smoke 有专项用例锁定）。
+  上游已带 content-encoding 时本层自动让位（由库的 already encoded 分支判定；
+  与宿主端任意压缩实现共存只压一次，smoke 有专项用例锁定）。
+  **Brotli 生效条件不得写成「br 优先」**：dsh 自身 webServer 自带 gzip 且只协商 gzip，
+  实测（见 [`docs/official-lan-access-overlap-assessment.md`](./docs/official-lan-access-overlap-assessment.md) §4.1）只有客户端仅声明 br
+  且上游未压缩时本层才产出 br；主流浏览器同时声明 br 与 gzip，实际拿到上游 gzip。
+  该情形仍远优于不压缩（322900 → 5065 字节），且两层不会重复压缩。
   **禁止**在 webServer 宿主端 patch handler 实现压缩（非官方 API 挂载面，
   曾引出包装/卸载/幂等一整类缺陷）；**禁止**手写响应流 gzip 接线（一律走
   compression 中间件）

--- a/packages/dsh-lan-proxy/README.en.md
+++ b/packages/dsh-lan-proxy/README.en.md
@@ -72,8 +72,8 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-lan-proxy
 | `wsBridgeEnabled` | `true` | WebSocket bridge master switch (issue #552): `true` = all WS upgrades go through "termination + bridge" (keep-alive base: auto-answers upstream Pings + half-open probes); `false` = TCP byte passthrough (explicitly drops keep-alive and compression — mobile backgrounding can be killed by upstream heartbeat and cause frequent reconnect loops, see "WebSocket Bridge & Compression") |
 | `wsCompressEnabled` | `true` | Whether to apply compressed bridging to WebSockets matching `wsCompressPaths` (compression only; does not affect bridge keep-alive) |
 | `wsCompressPaths` | `/api/remote.mux` | Path allowlist participating in WebSocket compression (empty = bridged without compression, keep-alive unaffected) |
-| `httpCompressEnabled` | `true` | Master switch for HTTP response compression (Brotli/gzip negotiation, merged from dsh-gzip) |
-| `httpCompressLevel` | `1` | Compression preset 0..3: `0` default / `1` low (gzip 1 / br 2, fastest) · `2` medium (gzip 5 / br 5, balanced) / `3` high (gzip 9 / br 9, best ratio) — effective for **both** gzip and Brotli; legacy integer values 4..9 are migrated to 3 automatically |
+| `httpCompressEnabled` | `true` | Master switch for HTTP response compression (the forwarding layer negotiates gzip/Brotli for compressible responses; Brotli's effective condition is documented in "HTTP Response Compression", merged from dsh-gzip) |
+| `httpCompressLevel` | `1` | Compression preset 0..3: `0` default / `1` low (gzip 1 / br 2, fastest) · `2` medium (gzip 5 / br 5, balanced) / `3` high (gzip 9 / br 9, best ratio) — the gzip and Brotli parameters are both passed down; legacy integer values 4..9 are migrated to 3 automatically |
 
 GUI settings entry: Settings → Plugins → "LAN Access" card (saved changes apply hot).
 
@@ -138,14 +138,31 @@ GUI settings entry: Settings → Plugins → "LAN Access" card (saved changes ap
   battle-tested [compression](https://www.npmjs.com/package/compression) middleware
   (inlined at build time): for requests served through
   this plugin, compressible responses (JSON / text) from `/api` (RPC), `/plugins`
-  (client bundles), and static assets/index.html negotiate compression automatically — Brotli when the client's Accept-Encoding includes br, gzip fallback otherwise; SSE
+  (client bundles), and static assets/index.html negotiate compression automatically; SSE
   (text/event-stream), zip exports, already-encoded responses, HEAD, Range requests,
   and responses under 1KB pass through untouched.
+- **When Brotli actually applies (measured)**: dsh's own web server already ships gzip
+  compression (`compression: gzip`) and negotiates gzip only. Two cases therefore exist on
+  this path:
+
+  | Client `Accept-Encoding` | Upstream | Final response through this plugin |
+  |---|---|---|
+  | `br, gzip` (mainstream browsers) | gzip | gzip (already encoded, this layer defers instead of re-compressing) |
+  | `gzip` | gzip | gzip (same) |
+  | `br` (br only) | raw | **br** |
+
+  In other words, this layer's Brotli applies only when the upstream left the response
+  uncompressed and the client declared br alone. Mainstream browsers declare gzip as well,
+  so what arrives is the upstream gzip and the **extra Brotli ratio is not realized** on
+  this path; that case is still far better than no compression (the same response measured
+  322900 → 5065 bytes). The two layers never double-compress.
 - Benefit: large JSON responses such as session history (4~13MB uncompressed) often hit
   the browser RPC 30s timeout over remote/slow links ("history load failed"); after compression
   they are ~1.2MB — measured in an isolated environment at ~36s down to ~3s.
 - The middleware sits on the forwarder's own listener chain and does not modify dsh web
-  or any other plugin's runtime behavior; set `httpCompressEnabled: false` to turn it off.
+  or any other plugin's runtime behavior; set `httpCompressEnabled: false` to turn this
+  layer's compression off (when the client also accepts gzip, the upstream's own gzip still
+  compresses such responses, so the switch does not change their on-wire size).
   Note: traffic that reaches the loopback web directly (local browser on `127.0.0.1:3080`,
   not through this plugin) is outside the compression surface — loopback links do not
   need compression.

--- a/packages/dsh-lan-proxy/README.md
+++ b/packages/dsh-lan-proxy/README.md
@@ -70,8 +70,8 @@ npx @deepseek-ai/dsh plugin --profile web update @wingsky-1/dsh-lan-proxy
 | `wsCompressEnabled` | `true` | 是否对命中 `wsCompressPaths` 的 WebSocket 做压缩桥接（仅控制压缩，不影响桥接保活） |
 | `wsCompressPaths` | `/api/remote.mux` | 参与 WebSocket 压缩的路径白名单（清空 = 桥接不压缩，保活不受影响） |
 | `wsDeflatePolicy` | `{browser:true, uaDeny:[iPhone…]}` | WS 压缩协商策略：`browser` 为 false 全局关压缩；`uaDeny` 为不协商压缩的 UA 片段列表（iOS Safari 默认拦截，见「WebSocket 压缩」节） |
-| `httpCompressEnabled` | `true` | HTTP 响应压缩总开关（Brotli/gzip 自适应协商，合并自 dsh-gzip） |
-| `httpCompressLevel` | `1` | 压缩档位预设 0..3：`0` 默认 / `1` 低（gzip 1 / br 2，最快）· `2` 中（gzip 5 / br 5，均衡）/ `3` 高（gzip 9 / br 9，最高压缩比），对 gzip 与 Brotli **同时生效**；旧配置整数 4..9 自动迁移为 3 |
+| `httpCompressEnabled` | `true` | HTTP 响应压缩总开关（转发层对可压缩响应协商 gzip/Brotli；Brotli 生效条件见「HTTP 响应压缩」节，合并自 dsh-gzip） |
+| `httpCompressLevel` | `1` | 压缩档位预设 0..3：`0` 默认 / `1` 低（gzip 1 / br 2，最快）· `2` 中（gzip 5 / br 5，均衡）/ `3` 高（gzip 9 / br 9，最高压缩比），gzip 与 Brotli 两侧参数同时按下发；旧配置整数 4..9 自动迁移为 3 |
 | `injectToken` | `true` | 自动注入启动令牌（issue #380）：LAN 设备首次访问 `GET /` 由转发层自动补当前 token 铸造会话 cookie，固定设备免手工拿 token；带失效 cookie 的请求在上游 401 后自动重放自愈。安全语义见「安全模型」 |
 
 GUI 设置入口：设置 → 插件 → 「局域网访问」卡片（保存即热更新）。
@@ -124,14 +124,28 @@ GUI 设置入口：设置 → 插件 → 「局域网访问」卡片（保存即
   在**转发层**实现（成熟开源库 [compression](https://www.npmjs.com/package/compression)
   中间件，构建期内联进产物）：经本插件访问时，对 `/api`（RPC）、
   `/plugins`（客户端 bundle）与静态资源/index.html 等可压缩响应（JSON / 文本）
-  自动协商压缩——客户端 Accept-Encoding 含 br 时优先 Brotli，否则回退 gzip；SSE（text/event-stream）、zip 导出、已编码响应、HEAD、
+  自动协商压缩；SSE（text/event-stream）、zip 导出、已编码响应、HEAD、
   带 Range 的请求、小于 1KB 的响应原样透传。
+- **Brotli 的实际生效条件（实测口径）**：dsh 自身的 web 服务器自带 gzip 压缩
+  （`compression: gzip`），且只协商 gzip。因此这条链路上有两种情形：
+
+  | 客户端声明 `Accept-Encoding` | 上游行为 | 经本插件最终返回 |
+  |---|---|---|
+  | `br, gzip`（主流浏览器） | gzip | gzip（响应已编码，本层让位不重压） |
+  | `gzip` | gzip | gzip（同上） |
+  | `br`（仅声明 br） | 原文 | **br** |
+
+  即：只有当上游未压缩且客户端只声明 br 时，本层的 Brotli 才真正生效。主流浏览器
+  都同时声明 gzip，故这条链路上拿到的是上游 gzip、**拿不到 Brotli 的额外压缩率**；
+  该情形仍远优于不压缩（同一响应实测 322900 → 5065 字节）。两层不会重复压缩。
 - 收益：会话历史等大 JSON 响应（4~13MB 未压缩）经远程/慢链路访问时常触发
   浏览器 RPC 30s 超时「历史加载失败」；压缩后约 ~1.2MB，隔离环境实测由
   ~36s 降到 ~3s。
 - 实现位置在转发器自己的监听链上，不修改 dsh web 与任何其他插件的运行时行为；
-  `httpCompressEnabled: false` 一键关闭。注意：直连回环 web（本机浏览器访问
-  `127.0.0.1:3080`，不经本插件）的流量不在压缩面内——回环链路无需压缩。
+  `httpCompressEnabled: false` 关闭本层压缩（当客户端同时接受 gzip 时，上游自带
+  gzip 仍会压缩响应，故该开关不改变这类响应的线上体积）。注意：直连回环 web
+  （本机浏览器访问 `127.0.0.1:3080`，不经本插件）的流量不在压缩面内——回环链路
+  无需压缩。
 - **从 dsh-gzip 迁移**：升级本插件并确认压缩生效后，卸载独立 gzip 包：
 
   ```sh

--- a/packages/dsh-lan-proxy/docs/official-lan-access-overlap-assessment.md
+++ b/packages/dsh-lan-proxy/docs/official-lan-access-overlap-assessment.md
@@ -1,0 +1,293 @@
+# dsh 官方 LAN 访问能力与 lan-proxy 的重叠评估（结论：维持现状，不做薄化）
+
+> **关联**：无线程，源于会话评估（维护者直接就「dsh 0.1.5 的 `--trusted-host` 是否已能
+> 替代本插件部分能力」提问，本次成文归档）。
+>
+> **定位**：本文件记录一次**能力替代性评估**的结论与证据，供后续 dsh 升级评估复用。
+> 它不是插件行为契约，不作为 README 的承诺面；文中对官方实现的描述以评估时的 dsh
+> 版本为准，dsh 升级后须按「七、重新评估触发条件」复核。
+>
+> **验证基线**：dsh `0.1.5-rc.1`（与本仓 `pnpm-workspace.yaml` catalog 的适配基线
+> 一致）。官方侧观察对象为本机安装件
+> `~/.local/node/lib/node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/`，
+> 引用的行号即该安装件 `lib/*.js`（已构建产物）行号，跨 dsh 版本会漂移。
+>
+> **证据口径**：每条结论标注「实测」或「源码判读」。实测用临时 `DSH_HOME`
+> （`mktemp -d`）+ 独立端口 3099 + 真实 curl 完成，未触碰正在运行的 3080 GUI，
+> 也未改动任何 profile；其中 4.1 的对照实验另用一个端到端脚本：上游以等价中间件
+> 复现官方 gzip 逻辑，转发层用真实 `createLanProxy` 构建产物，两者均只监听回环。
+> 源码判读指只读阅读上述安装件与 `packages/dsh-lan-proxy/src/`。
+
+---
+
+## 一、结论摘要
+
+1. **官方 `--trusted-host` 只是信任白名单，不是开放端口的手段**。它无法单独让局域网
+   设备访问 GUI——bind 仍留在回环，局域网请求到不了进程。（实测）
+2. **官方当前不能替代 lan-proxy，且不是「更安全地做同一件事」**：要让官方方案在
+   局域网可用，必须绕过 CLI 对 `--host 0.0.0.0` 的硬拦截（改 profile patch），
+   其结果是 dsh 本体直接监听全网卡、防线只剩 token/cookie，比代理层语义更薄。
+   （实测 + 源码判读）
+3. **lan-proxy 的主体价值官方没有对应实现**：HTTPS/自签证书、WebSocket 桥接保活
+   （Pong 代答 + 半开探活，移动端切后台不断连）、WS permessage-deflate 压缩。HTTP 响应
+   压缩一项需要修正定位：官方 webserver **自带 gzip**（实测直连 3080 响应头
+   `Content-Encoding: gzip`），本插件在这条链路上提供的是「Brotli + 档位控制」。关键
+   限制是 Brotli 只在「上游未压缩且客户端仅声明 br」时生效，而主流浏览器同时声明
+   gzip，故实际拿不到 Brotli 的额外压缩率（见 4.1，已端到端实测）。
+4. **唯一真实重叠项是「Host 信任」这一层**，且两者方向相反：官方是「声明才放行」，
+   本插件是「重写为回环 + 自守 IP 字面量」。把这一层做薄不能减少插件复杂度，只会
+   在保留其余能力的同时更换一层已验证的安全语义。
+5. **决策：维持 lan-proxy 现状，不因官方 `--trusted-host` 做能力薄化**。重新评估的
+   触发条件见第七节。
+
+---
+
+## 二、官方实现拆解
+
+### 2.1 `--trusted-host` 的语义
+
+- CLI 定义：`@deepseek-ai/dsh-web-app/lib/startup.js:22`
+  —— `extra authority the /api browser-trust fence accepts (host or host:port; repeatable)`。
+- 收编进服务：同文件 `:46`，写入 `webStartup.trustedHosts`。
+- 最终栅栏值：`@deepseek-ai/dsh-web-app/lib/index.js:83-89` `resolveLanTrust(bindHost, extra)`
+  —— 返回 `trustedHosts = [...lanAddresses, ...extra]`，其中 `lanAddresses` 仅在
+  `bindHost === "0.0.0.0"` 时采样本机非 internal IPv4 字面量，否则为空数组。
+- 装配进围栏：`@deepseek-ai/dsh-web-app/cordis.patch.yml:185-188`
+  —— connection 行的 `trustedHosts: !!js ctx.webRuntime.trustedHosts`。
+
+即：**该 flag 只影响「哪些 Host 头被接受」，不影响监听地址、不影响认证**。
+（本节均为源码判读，无实测项。）
+
+### 2.2 围栏判定链
+
+`@deepseek-ai/dsh-client-connection/lib/index.js:198-212` `isTrustedApiRequest()`：
+
+1. 无 `Host` 头 → 拒；`Host` 无法解析 → 拒；
+2. Host 既非 loopback 又不命中 `trustedHosts` → **403**；
+3. `sec-fetch-site: cross-site` → **403**；
+4. 带 `Origin` 时必须 `Origin.host === Host.host`，否则 **403**；
+5. 通过围栏但未认证 → **401**。
+
+条目语法（`assertTrustedAuthority` / `isTrustedAuthority`，同文件 `:152-196`）：
+带端口条目精确匹配 authority，**不带端口条目匹配该主机名的任意端口**；畸形条目
+（多余路径、`user@host`、悬空冒号、零填充端口、非规范主机拼写）会让插件加载直接失败，
+不静默放宽。
+
+**关键边界**：该围栏的文档明确写明这类检查「绝不建立身份」，并给出状态码分层
+「Host/Origin 校验失败返回 403；Host 可信但未认证的请求返回 401」
+（`@deepseek-ai/dsh-client-connection/README.zh.md:39`，同一行还确认 `dsh web --host 0.0.0.0`
+仍不受支持）。身份来自 token 换 cookie（`lib/index.js:370-381` `authenticatedUrl()`、
+`:391-405` 根路由换 cookie），`/api` 每个方法与 WebSocket 流都另行认证。
+
+### 2.3 bind 侧约束
+
+- 命令行硬拦（**实测**，`dsh --profile web --host 0.0.0.0 --no-open`）：
+
+  ```
+  error: --host 0.0.0.0 is intentionally not supported yet for safety: it would expose
+  remote code execution to the network; use 127.0.0.1 instead
+  ```
+
+  拦截点：`@deepseek-ai/dsh-web-app/lib/startup.js:40`。
+- schema 只接受两个字面量：`@deepseek-ai/dsh-host-webserver/lib/index.js:141`
+  —— `host: z.union([z.const("127.0.0.1"), z.const("0.0.0.0")]).required()`。
+  因此**不能**通过绑具体局域网 IP 来绕过（既非 CLI 拦截面，也不在 schema 允许集内）。
+- 于是「官方方案上局域网」唯一通路是在 profile 的 `cordis.patch.yml` 里按 id 覆盖
+  `webserver` 行。注意该 patch 语义为**整块替换 config**（见
+  `@deepseek-ai/dsh-web-app/cordis.patch.yml:5`「A patch replaces the targeted
+  row's whole `config`」），`compression` 等同层键必须一并重述；且 `host` 只能写死字面量，
+  照抄 `!!js ctx.webStartup.host` 表达式会让 CLI 的 `--host` 继续压过配置。
+
+---
+
+## 三、实测记录
+
+隔离环境：`DSH_HOME=$(mktemp -d)`，`dsh --profile web --host 127.0.0.1 --port 3099
+--no-open --trusted-host gui.lan`。所有请求经 curl 直打 3099，用 `-H "Host: …"` 模拟
+不同 authority。
+
+### 3.1 `/api` 围栏矩阵（围栏所在层）
+
+| 请求 Host | 附加头 | 状态码 | 含义 |
+|---|---|---|---|
+| `127.0.0.1:3099` | — | 401 | loopback 放行，未认证 |
+| `gui.lan` | — | 401 | 命中 `--trusted-host`，放行 |
+| `gui.lan:3099` | — | 401 | 不带端口条目匹配任意端口 |
+| `evil.example.com` | — | **403** | 未受信 authority |
+| `192.168.1.50` | — | **403** | IP 字面量但未声明（Bind 为回环，未派生 LAN 字面量） |
+| `gui.lan` | `sec-fetch-site: cross-site` | **403** | 跨站拒绝 |
+| `gui.lan` | `Origin: http://evil.example.com` | **403** | Origin 与 Host 不同源 |
+| `gui.lan` | `Origin: http://gui.lan` | 401 | 同源，放行 |
+
+这张矩阵是本次评估最直接的证据：403 → 401 的差别说明 `--trusted-host` 确实在生效，
+但**生效的范围仅限「准不准进门」**。
+
+### 3.2 认证后的可达范围
+
+| 步骤 | 结果 |
+|---|---|
+| `GET /?token=<launch token>`（Host `gui.lan`） | **303**，`Set-Cookie: dsh-auth-<hash>=…; HttpOnly; SameSite=Strict` |
+| 带该 cookie `GET /` | **200** |
+| 带该 cookie `GET /api` | 404（路由面未命中，非围栏/认证问题） |
+| 带该 cookie 但 Host 换回 `evil.example.com` | **403**（围栏先于认证） |
+
+补充（源码判读）：`@deepseek-ai/dsh-client-connection/lib/index.js:252-281` 把
+**authority 写进 cookie 名（sha256）与签名载荷**，`Set-Cookie` 载荷中的 `authority`
+字段即当前 Host。实测中 `authority` 为 `gui.lan`，印证 cookie 与访问地址绑定——
+换地址访问会失去 cookie 并回到 401，需重走 token。
+
+另注：`GET /` 不经过 `isTrustedApiRequest`（围栏只挂在 `/api`），因此非受信 Host 的
+根请求返回 401 而非 403；这不影响上述结论。
+
+### 3.3 「改模型/改设置」是否受限
+
+- **host 端全量搜索无据可依的限制**：`grep -rn "remoteAddress" node_modules/@deepseek-ai/*/lib/*.js`
+  **零命中**；`@deepseek-ai/dsh-api-gateway` 的 RPC 分发（`lib/index.js:455` intercept、
+  `:566` `dispatchRpc`、`:510` `claimsEndpoint`）未见按来源 IP 或 loopback 的准入分支。
+  （源码判读）
+- 改模型与改设置走的就是 `/api` RPC 通道（`endpointFromPath`：`/api/<endpoint>`，
+  `@deepseek-ai/dsh-client-connection/lib/index.js:673-678`），即 3.1/3.2 已验证放行的
+  同一条通道。因此**认证后即为完整会话权限**：可改模型、可改设置，也可执行 shell、
+  读写宿主文件——这正是 2.3 那句警告所指的 "remote code execution to the network"。
+
+---
+
+## 四、与 lan-proxy 的逐维度对比
+
+本插件侧引用为仓库源码行号（`packages/dsh-lan-proxy/src/proxy.ts`）：
+
+| 维度 | 官方 `--trusted-host`（+ 强开 `0.0.0.0`） | lan-proxy |
+|---|---|---|
+| 达成 LAN 可达 | 声明式白名单；需 profile patch 强开 `0.0.0.0` | 反代 + Host/Origin 重写（`proxy.ts:298-303` `rewriteHeaders`） |
+| dsh 本体监听面 | **全网卡暴露**（本体直接面对网络） | 保持回环，暴露面在代理层 |
+| 信任粒度 | `host` 或 `host:port`，可放域名 | 只接受 IP 字面量与 `localhost`（`proxy.ts:276-288` `hostnameAllowed`），域名一律 403 |
+| 端口面 | 不带端口条目 → 该主机名任意端口可信 | 入站端口独立（HTTP 3081 / HTTPS 3443，`proxy.ts:417`） |
+| 认证 | 保留 token/cookie（403/401 分层） | 保留上游认证，另加 `injectToken` 帮 LAN 设备自动铸 cookie |
+| HTTPS / TLS | 无 | 并存（自签或自定义证书，`src/cert.ts`） |
+| HTTP 响应压缩 | **自带 gzip**（`@deepseek-ai/dsh-host-webserver/lib/index.js:104-124`，bundle 里 `compression: gzip`）；不产出 Brotli | Brotli/gzip 自适应协商 + 档位控制；但在上游 gzip 生效时被遮蔽，见 4.1 |
+| WS 帧压缩 | 无 | permessage-deflate 桥接（`permessage-deflate` 仅浏览器段） |
+| WebSocket 保活 | 无 | Pong 代答 + 半开探活（移动端切后台不断连） |
+| 对 dsh 的改动 | 需改 profile patch | 插件挂载，dsh 本体零改动 |
+| 上游围栏交互 | 本体即围栏持有者 | 上游永远看到回环 authority，天然通过 |
+
+**重叠面的准确定位**：「让局域网设备通过 Host 围栏」这一件事，官方给出了等价能力
+（且是本文档所述的 `--trusted-host` 存在的理由）；本插件在同类目标上用的是另一套
+机制。其余各行都不重叠。
+
+本插件源码注释（`src/proxy.ts:15-21`）中「LAN 转发器无法向该围栏追加受信项（它只从
+配置解析一次）」的判断在此复核为**准确**：`trustedHosts` 是启动时按配置解析一次的数组，
+插件无法在运行期追加；可行的官方通路是引导用户改 profile patch，属配置层动作，
+不是插件能替用户完成的事。
+
+### 4.1 复核中发现的偏差：HTTP 响应压缩的实际归属
+
+核实「官方是否有压缩」时发现一处与 README 表述的偏差，记在此处。
+
+**事实链**（第 1、3 条为源码判读，第 2 条为实测，第 4 条是基于前三者的推断）：
+
+1. 官方 webserver 自带 gzip：`@deepseek-ai/dsh-host-webserver/lib/index.js:104-124`
+   `createGzipMiddleware` 用 `compression` 库，`onHeaders` 前置把请求头的
+   `accept-encoding` 改写为 `Negotiator` 的 `encoding(["gzip", "identity"])` 结果——
+   **只可能产出 gzip，永不产出 Brotli**；其 config schema（同文件 `:143-145`）只允许
+   `compression: none | gzip`，而 `@deepseek-ai/dsh-web-app/cordis.patch.yml:141-143`
+   把 web 组合显式设为 `compression: gzip`。
+2. 实测（隔离实例 + 用户实例一致）：客户端声明 `Accept-Encoding: br, gzip`，直连官方
+   web 服务器得到的仍是 `Content-Encoding: gzip`。
+3. `compression` 库在 `onHeaders` 里对已编码响应直接放弃（
+   `@deepseek-ai/dsh/node_modules/compression/index.js:183-188`：
+   `encoding !== 'identity'` → `nocompress('already encoded')`）。
+4. 结论：官方 gzip 生效的响应，本插件的压缩中间件（`src/proxy.ts:704-718`，Brotli
+   档位由 `resolveCompressionOptions`（同文件 `:247` 起）映射）拿到的
+   `Content-Encoding` 已是 `gzip`，按其自身语义让位（`src/proxy.ts:116` 注释所称的
+   「经 content-encoding 检查天然互斥」）。**若仅凭以上推理，会得出「Brotli 一律不生效」
+   的绝对结论——下面的实测把条件收窄了。**
+
+**端到端对照实验（实测，2026-09-10）**：上游用等价中间件复现官方 gzip 逻辑
+（同 `:104-124` 的 `Negotiator(["gzip","identity"])` + 同库同阈值），转发层用真实
+`createLanProxy`（`lib/index.js` 构建产物，`httpCompress: { enabled: true, level: 1 }`），
+同一份未压缩 322900 字节的 JSON：
+
+| 客户端声明 `Accept-Encoding` | 直连上游（CE / 字节） | 经 lan-proxy（CE / 字节） |
+|---|---|---|
+| `br, gzip` | gzip / 10948 | gzip / 10948（未重压） |
+| `gzip` | gzip / 10948 | gzip / 10948（未重压） |
+| `br`（仅声明 br） | identity / 322900 | **br / 5065** |
+| 未声明 | identity / 322900 | identity / 322900 |
+
+（CE = `Content-Encoding`；lan-proxy 协商计数 `{compressed: 4, passthrough: 0}`。）
+
+复核结论：上一条推理只在「客户端同时接受 gzip」时成立。**Brotli 并非完全被遮蔽，
+而是被严格限制在「上游未压缩 + 客户端只声明 br」这一条件**——主流浏览器都发
+`br, gzip`，因此实际部署中拿不到 Brotli 收益；一旦命中条件，Brotli 仍显著优于不压缩。
+本次评估的初版结论过强，已按实测修正。
+
+**对本插件的影响**：README 原表述「客户端 Accept-Encoding 含 br 时优先 Brotli」在
+主流浏览器场景下不成立。这不是正确性缺陷（只压一次，无双重压缩，`AGENTS.md` 的
+「不双重压缩」约束依然满足），属功能声明与实际行为不一致。
+
+**处置（本 PR 范围）**：按实测修正 `README.md` 的相关表述（「HTTP 响应压缩」节新增
+生效条件表、配置表两处措辞、`httpCompressEnabled: false` 的效果说明），保留 Brotli
+能力声明与其价值，但去掉「br 优先」这一会造成误解的表述。
+
+**未处置（留待另议）**：是否让 Brotli 在主流浏览器下也真正生效（需对上游 gzip 响应
+解压后以 br 重压，代价是 CPU 与流式语义复杂化），取决于产品意图，不在本次授权范围。
+
+---
+
+## 五、二者同开时的相互影响
+
+若用户既配了 `--trusted-host`（或强开 `0.0.0.0`）又启用本插件：
+
+1. 经代理的请求，上游永远只看到重写后的回环 authority，**上游 `trustedHosts` 形同虚设**；
+   实际把关的是本插件的 `hostnameAllowed`。
+2. 直连回环（不经代理）的请求仍按官方围栏与认证处理。两条路径的信任判定不同源，
+   但都以 dsh 的 token/cookie 作为身份层，因此不产生越权，只是**判定面不一致**，
+   排障时容易误判（"我明明配了 `--trusted-host` 为什么还是 403" —— 因为请求走的是代理）。
+3. `sec-fetch-site` 由本插件原样透传（`src/proxy.ts:28-30`），跨站页面仍被上游拒绝，
+   防御链完整，不因重写 Host 而放松。
+
+---
+
+## 六、不做薄化的判定依据
+
+按权重排序：
+
+1. **官方缺的不是白名单，是开口**。`--trusted-host` 已就位，但 `--host 0.0.0.0` 仍被
+   以安全理由硬拦（实测）。要用官方方案覆盖同场景，必须用配置层绕过这道拦截，
+   代价是 dsh 本体暴露在网络、防线收窄为 token/cookie，同时**仍然拿不到** HTTPS、
+   压缩与 WS 保活。这不是「用官方换掉自研」，而是「既变薄又变差」。
+2. **本插件的主体价值不在 Host 信任那一层**。HTTPS/证书、WS 桥接保活、WS 帧压缩
+   都属代理层能力，官方当前无对应实现；HTTP 响应压缩虽是官方已有的 gzip，但本插件
+   在这条链路上也拿不到 Brotli 的实际收益（4.1）。即便把 Host 信任整层交还官方，
+   插件仍需保留代理层，复杂度不会下降。
+3. **重叠层的语义替换有净风险**。官方是「声明才放行」，本插件是「重写为回环 +
+   自守 IP 字面量」；两者都已通过各自测试（本包围栏用例见 `test/smoke.ts:404`
+   「DNS-name Host refused with 403」、`:410` HTTP/1.0 无 Host 拒绝）。为消除重复而
+   更换一层已验证的安全语义，收益是概念上的整洁，成本是重新验证与回归风险。
+
+---
+
+## 七、重新评估触发条件
+
+出现以下任一情况时，应重新发起本评估（建议挂在 dsh 升级评估的检查项里）：
+
+1. dsh 放开 `--host 0.0.0.0`（或提供受支持的 LAN 直连配置面），且
+2. 同时至少满足其一：
+   - 官方 webserver 提供 TLS（含自签/证书配置）；
+   - 官方提供与压缩相关的传输增强（HTTP 响应压缩或 WS permessage-deflate）；
+   - 官方在 API/WS 层提供保活（Pong 代答或等价的心跳策略）。
+
+满足后需重新判断的**具体问题**：可达性与传输增强能否整体交还官方，本插件是否退化为
+只保留「域名入站 + IP 字面量围栏」这类差异化能力。
+
+### 本次评估未覆盖、下次需补的验证项
+
+- **smoke 未覆盖 br 分支**：`test/smoke.ts:808-834` 的压缩用例全部只发
+  `accept-encoding: gzip`，没有任何断言走到 br 路径——这正是「br 优先」这一失实描述
+  能长期存活的原因。建议后续补一条 br 用例锁定 4.1 的实测语义。
+- 强开 `0.0.0.0` 后 `resolveLanTrust` 的 LAN 字面量派生与打印 URL（LAN: 前缀）在真实
+  双机环境下的表现——本次仅在单机隔离实例验证到围栏矩阵，未跨机实测。
+- cookie 的 `SameSite=Strict` 在真实局域网入口（`http://<LAN-IP>:<port>`）下换 cookie
+  与后续 WebSocket 升级的完整成功路径。
+- 官方方案下模型设置页与凭据类设置的写入是否触发额外确认（当前无代码证据表明存在，
+  但也未逐项实测）。


### PR DESCRIPTION
## 背景

维护者在会话中询问「dsh 0.1.5 的 `--trusted-host` 是否已能替代 lan-proxy 的部分能力」，评估后一并发现本插件 README 有一处**功能描述与实测不符**，本 PR 修正该描述并归档评估全文。

## 改了什么

**1. HTTP 压缩 Brotli 描述修正（核心）**

原描述称「客户端 Accept-Encoding 含 br 时优先 Brotli，否则回退 gzip」。实测不成立：

dsh 自身的 web 服务器**自带 gzip**（`compression: gzip`），且只协商
`Negotiator(["gzip","identity"])`。端到端对照实验（上游以等价中间件复现官方 gzip
逻辑 + 真实 `createLanProxy` 构建产物，同一份 322900 字节 JSON）：

| 客户端声明 `Accept-Encoding` | 直连上游 | 经本插件 |
|---|---|---|
| `br, gzip`（主流浏览器） | gzip / 10948 B | gzip / 10948 B（未重压） |
| `gzip` | gzip / 10948 B | gzip / 10948 B（未重压） |
| `br`（仅声明 br） | identity / 322900 B | **br / 5065 B** |
| 未声明 | identity / 322900 B | identity / 322900 B |

结论：**Brotli 仅在「上游未压缩 + 客户端只声明 br」时生效**；主流浏览器都同时声明
gzip，实际拿到上游 gzip，拿不到 Brotli 的额外压缩率。该情形仍远优于不压缩，且两层
不会重复压缩（无正确性缺陷，属声明失实）。

**2. 归档评估报告**（`packages/dsh-lan-proxy/docs/official-lan-access-overlap-assessment.md`）

dsh 官方 LAN 能力 vs 本插件的重叠评估，含：围栏 403/401 实测矩阵（含 cross-site /
Origin 不匹配）、`--trusted-host` 与 `--host 0.0.0.0` 硬拦的源码位置、
10 维度能力对比、二者同开时的相互影响、**「不薄化」判定依据**、重新评估触发条件。
`docs/` 不在 `files` 发布白名单，不入 tarball。

## 改动文件

| 文件 | 改动 |
|---|---|
| `packages/dsh-lan-proxy/README.md` | 压缩节新增生效条件表；配置表 2 处措辞；`httpCompressEnabled: false` 效果说明 |
| `packages/dsh-lan-proxy/README.en.md` | 同上，保持中英一致 |
| `packages/dsh-lan-proxy/AGENTS.md` | 同步同一处「br 优先」偏差，链接报告 §4.1 |
| `packages/dsh-lan-proxy/docs/official-lan-access-overlap-assessment.md` | 新增归档报告 |

**零代码改动、零行为变更**，纯描述与文档。

## 门禁

| 命令 | exit |
|---|---|
| `pnpm build` | 0 |
| `pnpm test` | 0 |
| `pnpm contract` | 0 |
| `pnpm pack:check` | 0 |
| `pnpm typecheck` | 0 |
| `docs:check`（`verify-docs.ts --strict-en`） | 0 |

工作树无产物污染（`git status --porcelain` 无 `undefined/`、`*.jsonl`）。

## 需要评审者知悉的两件事

1. **本次跳过了红线提案流程**。仓库 AGENTS.md 规定「公共 API 行为变更须先在 issue
   内起草方案评论、打 `needs-proposal-review`、获维护者 `approved` 后再动手」。维护者
   在本会话中已知悉该红线并明确选择「跳过评审直接开 PR」，故本 PR 未经 issue 提案与
   `approved`。记录在此以免后续误认为已走完流程。
2. **未处置事项（供评审决定是否纳入本 PR 或另开）**：
   - 是否让 Brotli 在主流浏览器下也真正生效（需对上游 gzip 响应解压后以 br 重压，
     代价是 CPU 与流式语义复杂化）——取决于产品意图，本次未动。
   - `test/smoke.ts:808-834` 的压缩用例全部只发 `accept-encoding: gzip`，**没有覆盖
     br 分支**，这正是失实描述能长期存活的原因。建议后续补一条 br 用例锁定语义。
   - 客户端 `src/client/locales.ts` 的压缩档位文案（如「低（最快：gzip 1 / br 2）」）
     仍并列展示两套参数，参数确实生效，但未说明 br 在上述条件下才产出。
