### PR TITLE
feat(dsh-verify-isolated): 设备视口模拟替代无效的 resizeTo + 几何验证方法论（Part of #695）

### DIFF
--- a/packages/dsh-verify-isolated/README.en.md
+++ b/packages/dsh-verify-isolated/README.en.md
@@ -32,9 +32,14 @@ built-in skill and becomes available to all sessions in the profile (check with
   raw CDP, zero dependencies (only Node ≥22's built-in global WebSocket), launches an
   independent chromium (temp user-data-dir + a free debug port of its choosing + headless),
   atomic-operation CLI (snapshot / click / eval / fill / wait / screenshot / console /
-  quit), uniform `--json` output, instance info written to `browser.state`; a
-  three-platform kernel detection chain (`DSH_VERIFY_CHROME` env → ms-playwright cache →
-  PATH → common platform paths), fail-fast with install guidance when all are missing;
+  quit), uniform `--json` output, instance info written to `browser.state`; **device
+  emulation**: page commands accept `--width / --height / --dpr / --mobile` to verify
+  responsive layouts viewport by viewport — applied within the command and cleared before
+  it exits, so commands never affect each other (why it is not sticky state, see
+  `scripts/lib/emulation.mjs`: CDP's Emulation state is per session, so clearing across
+  connections silently fails and leaks the size); a three-platform kernel detection chain
+  (`DSH_VERIFY_CHROME` env → ms-playwright cache → PATH → common platform paths), fail-fast
+  with install guidance when all are missing;
 - **Minimal startup dependencies**: profile bundles contain `@deepseek-ai/dsh-base` +
   `@deepseek-ai/dsh-web-app` (built-in bundles are resolved by name from the dsh install
   directory, not via npm);
@@ -78,6 +83,7 @@ skills/dsh-verify-isolated/
   scripts/verify-isolated.mjs     # one-shot isolated verification script (Node, --dsh / --browser / --port 0 / --keep / --no-build / --evidence-dir / --audit / --audit-extra-dirs / --json)
   scripts/lib/verify-core.mjs     # shared base utilities (exit-code constants/poll/findFreePort/port parsing/C11 normalization)
   scripts/lib/audit.mjs           # B4 isolated-audit pure functions (scanSnapshot/diffAgainstWhitelist/checkSymlinkEscape/runAudit + versioned whitelist WHITELIST_V)
+  scripts/lib/emulation.mjs       # device-emulation pure functions (parseEmulationFlags / buildDeviceMetrics; CDP session semantics)
   scripts/browser-driver.mjs      # self-contained browser driver (raw CDP, zero deps, --json atomic CLI)
 cordis.patch.yml                  # reuses official dsh-skill-filesystem + bundledSkillDir
 lib/index.js                      # host gate export (name + empty apply)
@@ -123,6 +129,10 @@ prompt for an upgrade):
 node "$SKILL_BASE/scripts/browser-driver.mjs" snapshot --state "$DSH_HOME/browser.state" --url http://127.0.0.1:<port>
 node "$SKILL_BASE/scripts/browser-driver.mjs" click --state "$DSH_HOME/browser.state" --selector "button.start"
 node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/browser.state" --path shot.png
+# device emulation (available on every page command): verify responsive layouts
+# viewport by viewport; applied within the command and cleared when it exits
+node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/browser.state" --url http://127.0.0.1:<port> --width 375 --height 667 --path phone.png
+node "$SKILL_BASE/scripts/browser-driver.mjs" eval --state "$DSH_HOME/browser.state" --width 375 --height 667 --expression "innerWidth+'x'+innerHeight"
 ```
 
 ## Security model
@@ -132,6 +142,10 @@ node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/brow
 - The isolated `dsh web` binds explicitly to loopback (`--host 127.0.0.1`, reachable
   from this machine only) and explicitly disables telemetry
   (`DSH_TELEMETRY_DISABLED=1`, no test data leaves the machine);
+- Isolated verification covers the **loopback access shape** only (the script pins
+  `--host 127.0.0.1`). To verify LAN/mobile access, start it yourself with the official
+  `--trusted-host <authority>` and confirm the plugin under test authenticates as expected
+  in that shape;
 - It never stops/restarts the running main `dsh web` process (dedicated port);
 - The browser instance binds only to a loopback debug port
   (`--remote-debugging-address=127.0.0.1`), reachable from this machine only;

--- a/packages/dsh-verify-isolated/README.md
+++ b/packages/dsh-verify-isolated/README.md
@@ -27,8 +27,11 @@ dsh plugin --profile web add @wingsky-1/dsh-verify-isolated
   raw CDP 零依赖（仅 Node ≥22 内置全局 WebSocket），launch 独立 chromium
   （临时 user-data-dir + 自选空闲调试端口 + headless），原子操作 CLI
   （snapshot / click / eval / fill / wait / screenshot / console / quit），
-  统一 `--json` 输出，实例信息写入 `browser.state`；三平台内核探测链
-  （`DSH_VERIFY_CHROME` env → ms-playwright 缓存 → PATH → 平台常见路径），
+  统一 `--json` 输出，实例信息写入 `browser.state`；**设备模拟**：页面命令通用
+  `--width / --height / --dpr / --mobile` 逐档设定视口验证响应式布局——命令内生效、
+  结束即清除，命令之间互不影响（不做粘性状态的原因见 `scripts/lib/emulation.mjs`：
+  CDP 的 Emulation 状态按 session 归属，跨连接清除会静默失效并残留）；三平台内核
+  探测链（`DSH_VERIFY_CHROME` env → ms-playwright 缓存 → PATH → 平台常见路径），
   全缺失 fail-fast 打印安装指引；
 - **最小启动依赖**：profile bundles 含 `@deepseek-ai/dsh-base` +
   `@deepseek-ai/dsh-web-app`（内置 bundle 按名从 dsh 安装目录解析，不走 npm）；
@@ -61,6 +64,7 @@ skills/dsh-verify-isolated/
   scripts/verify-isolated.mjs     # 一键隔离验证脚本（node，--dsh / --browser / --port 0 / --keep / --no-build / --evidence-dir / --audit / --audit-extra-dirs / --json）
   scripts/lib/verify-core.mjs     # 共享基础工具（退出码常量/poll/findFreePort/端口解析/C11 归一化）
   scripts/lib/audit.mjs           # B4 隔离审计纯函数（scanSnapshot/diffAgainstWhitelist/checkSymlinkEscape/runAudit + 版本化白名单 WHITELIST_V）
+  scripts/lib/emulation.mjs       # 设备模拟参数纯函数（parseEmulationFlags / buildDeviceMetrics；CDP 会话语义依据）
   scripts/browser-driver.mjs      # 自带独立浏览器驱动（raw CDP 零依赖，--json 原子操作 CLI）
 cordis.patch.yml                  # 复用官方 dsh-skill-filesystem + bundledSkillDir
 lib/index.js                      # 宿主门禁出口（name + 空 apply）
@@ -99,6 +103,9 @@ WebSocket，更低版本会在连接时报错提示升级）：
 node "$SKILL_BASE/scripts/browser-driver.mjs" snapshot --state "$DSH_HOME/browser.state" --url http://127.0.0.1:<端口>
 node "$SKILL_BASE/scripts/browser-driver.mjs" click --state "$DSH_HOME/browser.state" --selector "button.start"
 node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/browser.state" --path shot.png
+# 设备模拟（页面命令通用）：逐档视口验证响应式布局；命令内生效、结束即清除
+node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/browser.state" --url http://127.0.0.1:<端口> --width 375 --height 667 --path phone.png
+node "$SKILL_BASE/scripts/browser-driver.mjs" eval --state "$DSH_HOME/browser.state" --width 375 --height 667 --expression "innerWidth+'x'+innerHeight"
 ```
 
 ## 安全模型
@@ -106,6 +113,9 @@ node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/brow
 - 隔离环境不携带真实凭据（临时 `DSH_HOME` 无 `~/.dsh` 数据）；
 - 隔离 `dsh web` 显式回环绑定（`--host 127.0.0.1`，仅本机可连）并显式禁用遥测
   （`DSH_TELEMETRY_DISABLED=1`，测试数据不外发）；
+- 隔离验证只覆盖**回环访问形态**（脚本固定 `--host 127.0.0.1`）。要验证局域网/
+  移动端访问形态，需自行用官方 `--trusted-host <authority>` 拉起，并自行确认被测
+  插件在该形态下的鉴权与围栏行为；
 - 不关闭/重启运行中的主 `dsh web` 进程（独立端口）；
 - 浏览器实例只绑定回环调试端口（`--remote-debugging-address=127.0.0.1`），
   仅本机可连；

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/SKILL.md
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/SKILL.md
@@ -208,6 +208,10 @@ node "$SKILL_BASE/scripts/browser-driver.mjs" quit --state "$DSH_HOME/browser.st
 - **显式回环 + 遥测禁用**：隔离实例一律 `--host 127.0.0.1`（当前 dsh 默认即回环，
   显式写死防上游默认变更）+ `DSH_TELEMETRY_DISABLED=1`（测试数据不外发遥测）；
   一键脚本已内置，手动拉起时也必须带上。
+- **非回环访问形态不在隔离默认内**：脚本固定显式回环绑定，故隔离验证只覆盖回环
+  访问形态。要验证局域网/移动端访问形态，dsh 0.1.5 起可自行用官方
+  `--trusted-host <authority>` 声明受信 authority；该形态下**被测插件自身路由的
+  鉴权与围栏行为需自行确认**，不要假定与回环形态一致。
 - **锚定 dsh 版本**：验证特定 dsh 版本的生态时用 `--dsh <path>` 指定入口，默认
   PATH 中的 `dsh` 会让验证结果随环境漂移、不可复现。
 - **不复制真实凭据**：隔离环境使用临时 `DSH_HOME`，不携带 `~/.dsh` 下的真实凭据、
@@ -303,6 +307,8 @@ node "$SKILL_BASE/scripts/browser-driver.mjs" wait   --state "$STATE" --selector
 # 截图（整页或元素）与 console 捕获
 node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$STATE" --url http://127.0.0.1:<端口> --path shot.png
 node "$SKILL_BASE/scripts/browser-driver.mjs" console   --state "$STATE" --url http://127.0.0.1:<端口> --wait-ms 2000
+# 视口档位（设备模拟；任一页面命令通用，详见 §6.4）
+node "$SKILL_BASE/scripts/browser-driver.mjs" snapshot --state "$STATE" --url http://127.0.0.1:<端口> --width 375 --height 667
 ```
 
 ### 6.3 核验改动
@@ -314,10 +320,70 @@ node "$SKILL_BASE/scripts/browser-driver.mjs" console   --state "$STATE" --url h
 3. **检查 Console**：`console` 命令捕获 `console.error`、未捕获异常、插件相关的
    `console.warn` 消息。挂载失败只应 `console.warn` 不应 throw。
 4. **双主题验证**：切换明/暗主题确认颜色引用正确，无硬编码固定色值。
-5. **窄屏验证**：`eval` 设置视口（如 `window.resizeTo(768,1024)`）后核验 pad
-   （768×1024）和 phone（375×667）尺寸下的响应式布局。
+5. **窄屏/响应式验证**：按 §6.4 的视口档位逐档设定后核验 pad（768×1024）与 phone
+   （375×667）布局。**不要用 `window.resizeTo`**——它高度不生效，理由见 §6.4。
 
-### 6.4 防 flake 纪律
+### 6.4 设备视口与几何验证
+
+响应式/窄屏改动必须**逐档设定视口**后核验。不要用 `window.resizeTo`：它只能改窗口
+宽度，高度不生效（实测 `resizeTo(768,1024)` 后 `innerHeight` 仍是默认值，pad/phone
+档的第二维根本无法验证），同一条 `eval` 表达式内也读不到改动结果。
+
+改用设备模拟 flag——**任一页面命令**（snapshot / click / eval / fill / wait /
+screenshot / console）均可携带，命令内生效、结束即清除，命令之间互不影响：
+`--width N` `--height N` `--dpr N`（设备像素比，默认 1）`--mobile`（见下方边界）。
+只给一维时另一维取当前视口值。
+
+**基线档（不带任何设备 flag）**：先记录默认视口（`--browser` 的 headless 内核通常为
+800x600）作为对照基准；逐档改视口之后，再用一条**不带 flag** 的命令回读——数值回到
+基线，即证明「命令结束即清除」成立、没有残留污染后续命令。这条回读既是残留自检，
+也是判定窄屏档是否**真的**生效的基准（否则无法区分「窄屏生效」与「参数没起作用」）：
+
+```bash
+STATE="$DSH_HOME/browser.state"
+# 基线档：不带设备 flag
+node "$SKILL_BASE/scripts/browser-driver.mjs" eval --state "$STATE" --expression "innerWidth+'x'+innerHeight"
+# 改档后回读：应回到基线值（否则说明有残留）
+node "$SKILL_BASE/scripts/browser-driver.mjs" eval --state "$STATE" --expression "innerWidth+'x'+innerHeight"
+```
+
+```bash
+# 两档视口各采一次证据（phone / pad）
+node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$STATE" --url http://127.0.0.1:<端口> --width 375 --height 667 --path phone.png
+node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$STATE" --url http://127.0.0.1:<端口> --width 768 --height 1024 --path pad.png
+# 高 DPI：元素截图（--selector）按 --dpr 输出物理像素（375x667 档 + --dpr 2 → 750x1334）；
+# 整页截图（不带 --selector）固定输出 CSS 像素尺寸，不随 --dpr 放大
+node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$STATE" --url http://127.0.0.1:<端口> --width 375 --height 667 --dpr 2 --selector "<css>" --path phone@2x.png
+# 自证视口生效（不要把「设了参数」当成「布局已按该档渲染」）
+node "$SKILL_BASE/scripts/browser-driver.mjs" eval --state "$STATE" --width 375 --height 667 \
+  --expression "innerWidth+'x'+innerHeight+' mq='+matchMedia('(max-width: 640px)').matches"
+```
+
+每档至少断言四项（用 `eval` 或 `snapshot --selector` 返回的 `rect`）：
+
+| 断言 | 表达式模板 | 判据 |
+|------|-----------|------|
+| 视口生效 | `innerWidth+'x'+innerHeight` | 等于设定档位 |
+| 无横向溢出 | `document.documentElement.scrollWidth <= innerWidth + 1` | true（+1 容差防亚像素） |
+| 关键元素在视口内 | `snapshot --selector <css>` 的 `rect` | `x >= 0 && x + rect.width <= innerWidth`，纵向可滚动到 |
+| 落点复核 | 改视口前后各取一次 `rect` | 位移方向与幅度符合预期（如锚定侧边的元素随视口收窄内移） |
+
+`position: fixed` 元素最容易在窄屏失效：除落点外，还要滚动到页面底部确认它仍可达、
+不被安全区或软键盘遮住。
+
+**能力边界（不要越界承诺）**：
+
+- `--mobile` 启用移动 layout viewport 语义：页面无 `<meta name="viewport">` 时
+  `innerWidth` **不再等于**设定宽度（实测 375 档会读回约 981）。要精确命中 CSS 断点
+  请保持 mobile 关闭；只有需要复现真机 layout viewport 行为时才加 `--mobile`。
+- **触控、软键盘、真实 UA、旋转、`dvh`/安全区不在本 skill 能力面内**：headless 内核
+  无法完整模拟（`maxTouchPoints` 可设，但 `ontouchstart` 不生效）。涉及触控手势、
+  软键盘弹出/收起、`visualViewport` 跟随的改动**必须真机验证**，不得以 headless
+  结果代替。
+- 视口模拟只覆盖布局维度；改视口的命令结束后状态即清除，不要把某一档的结论套用到
+  其它档。
+
+### 6.5 防 flake 纪律
 
 浏览器自动化验证**不得使用固定时间等待**（如 `setTimeout(resolve, 300)`），
 必须采用轮询等待机制：
@@ -328,7 +394,7 @@ node "$SKILL_BASE/scripts/browser-driver.mjs" console   --state "$STATE" --url h
 - 等待网络请求完成：轮询页面状态标志（如 `eval --expression "document.readyState"`）
   而非固定延时。
 
-### 6.5 截图采集
+### 6.6 截图采集
 
 - 截图只截插件 UI 本身（`screenshot --selector` 元素截图），不带浏览器整窗，
   避免泄露本机环境（文件路径、IP 地址、其他标签页）。
@@ -345,6 +411,9 @@ node "$SKILL_BASE/scripts/browser-driver.mjs" console   --state "$STATE" --url h
 - [ ] 若验证涉及插件持久化文件：已核对插件 DSH_HOME 感知（不感知按 §5.1 第 5 项处置）
 - [ ] 若做并行验证：四重隔离自检清单（§5.1）逐项通过，各任务浏览器 state 独立
 - [ ] 插件 UI 在隔离环境渲染正常（双主题 + 窄屏如适用）
+- [ ] 响应式/窄屏改动已按 §6.4 逐档设定视口核验（未用 `resizeTo`），四项断言
+      （视口生效/无横向溢出/元素在视口内/落点）逐档通过
+- [ ] 触控、软键盘、真机 UA 相关项已明确标注「仍需真机验证」或已真机复核
 - [ ] Console 无未处理错误（挂载失败仅 warn）
 - [ ] 截图已采集并按仓库规范归档（如适用）
 - [ ] 隔离实例已停止、浏览器实例已清理（`browser.state` 不再存在）、临时

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/browser-driver.mjs
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/browser-driver.mjs
@@ -9,6 +9,10 @@
  *
  * 命令/参数契约以 `--help` 输出为准（launch / quit / snapshot / click / eval / fill /
  * wait / screenshot / console，统一 --json 输出）。内核探测链见 detectChrome()。
+ *
+ * 页面命令（snapshot / click / eval / fill / wait / screenshot / console）可携带设备
+ * 模拟 flag（--width / --height / --dpr / --mobile）：命令内应用、结束前清除，命令
+ * 之间互不影响——不做成粘性状态的原因见 lib/emulation.mjs 头部（CDP 会话语义）。
  */
 import { spawn } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
@@ -16,6 +20,7 @@ import { homedir, platform, tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { createServer } from "node:net";
 import { get } from "node:http";
+import { buildDeviceMetrics, parseEmulationFlags } from "./lib/emulation.mjs";
 
 // --- 基础工具 ---
 
@@ -373,156 +378,204 @@ async function waitSelector(wsUrl, selector, timeoutMs) {
   if (!found) throw new Error(`等待选择器超时（${timeoutMs}ms）: ${selector}`);
 }
 
-async function cmdSnapshot(flags) {
+// --- 设备模拟（视口）---
+
+async function readViewport(ws) {
+  const r = await rpcRaw(ws, "Runtime.evaluate", {
+    expression: "JSON.stringify({ width: innerWidth, height: innerHeight, dpr: devicePixelRatio })",
+    returnByValue: true,
+  });
+  return JSON.parse(r.result.value);
+}
+
+/**
+ * 在设备模拟条件下执行页面操作；`run` 收到 `{ st, page }`（state 与页面 target）。
+ * `--state` / `--index` 与设备 flag 一样由本函数统一取参，页面命令不再各自重复。
+ *
+ * set / clear 必须走同一条长连接：CDP 的 Emulation 状态按 session 归属，跨连接清除
+ * 会静默失效并把尺寸残留给后续命令（依据见 lib/emulation.mjs 头部）。无设备 flag
+ * 时不建连接，保持零开销。
+ */
+async function withPageEmulation(flags, run) {
+  // 先解析再连浏览器：参数错误应优先于环境错误报出。
+  const parsed = parseEmulationFlags((name) => flags.get(name));
   const statePath = flag(flags, "state", "browser.state");
   const { st, page } = await connectPage(statePath, Number(flag(flags, "index", "0")));
-  const url = flag(flags, "url", null);
-  await navigateIfGiven(page.webSocketDebuggerUrl, url);
-  const title = await evalRaw(page.webSocketDebuggerUrl, "document.title");
-  const readyState = await evalRaw(page.webSocketDebuggerUrl, "document.readyState");
-  const pageUrl = await evalRaw(page.webSocketDebuggerUrl, "location.href");
-  const selector = flag(flags, "selector", null);
-  let bodyText = null;
-  let element = null;
-  if (selector) {
-    element = await evalRaw(page.webSocketDebuggerUrl, selExpr(selector, `
-      const r = el.getBoundingClientRect();
-      return { found: true, tag: el.tagName, text: (el.innerText || el.textContent || "").slice(0, 2000), rect: { x: r.x, y: r.y, width: r.width, height: r.height } };`));
-  } else {
-    bodyText = (await evalRaw(page.webSocketDebuggerUrl, "document.body ? document.body.innerText.slice(0, 2000) : ''") || "");
+  if (!parsed.active) return run({ st, page });
+  const emuWs = await openRawWs(page.webSocketDebuggerUrl, () => {});
+  let baseline = null;
+  try {
+    baseline = await readViewport(emuWs);
+    await rpcRaw(emuWs, "Emulation.setDeviceMetricsOverride", buildDeviceMetrics(parsed, baseline));
+    return await run({ st, page });
+  } finally {
+    // 清理必须可自证：残留会静默污染后续命令，而跨连接 clear 本就不生效，
+    // 故在设置它的这条连接上清除并回读核对；失败只警告不改变命令成败语义。
+    try {
+      await rpcRaw(emuWs, "Emulation.clearDeviceMetricsOverride", {});
+      const restored = await readViewport(emuWs);
+      const drifted = baseline && (restored.width !== baseline.width
+        || restored.height !== baseline.height || restored.dpr !== baseline.dpr);
+      if (drifted) {
+        process.stderr.write(`警告: 设备模拟清理后视口未复原（${restored.width}x${restored.height}@${restored.dpr}，期望 ${baseline.width}x${baseline.height}@${baseline.dpr}）——后续命令可能受残留影响，必要时 quit 重建实例\n`);
+      }
+    } catch (e) {
+      process.stderr.write(`警告: 设备模拟清理失败（${e.message}）——视口状态可能残留，必要时 quit 重建实例\n`);
+    }
+    try { emuWs.close(); } catch {}
   }
-  const pages = (await httpJson(`http://127.0.0.1:${st.port}/json/list`) || []).filter((t) => t.type === "page");
-  out(flags, { ok: true, title, url: pageUrl, readyState, tabCount: pages.length, bodyText, element });
+}
+
+async function cmdSnapshot(flags) {
+  const url = flag(flags, "url", null);
+  const selector = flag(flags, "selector", null);
+  await withPageEmulation(flags, async ({ st, page }) => {
+    await navigateIfGiven(page.webSocketDebuggerUrl, url);
+    const title = await evalRaw(page.webSocketDebuggerUrl, "document.title");
+    const readyState = await evalRaw(page.webSocketDebuggerUrl, "document.readyState");
+    const pageUrl = await evalRaw(page.webSocketDebuggerUrl, "location.href");
+    let bodyText = null;
+    let element = null;
+    if (selector) {
+      element = await evalRaw(page.webSocketDebuggerUrl, selExpr(selector, `
+        const r = el.getBoundingClientRect();
+        return { found: true, tag: el.tagName, text: (el.innerText || el.textContent || "").slice(0, 2000), rect: { x: r.x, y: r.y, width: r.width, height: r.height } };`));
+    } else {
+      bodyText = (await evalRaw(page.webSocketDebuggerUrl, "document.body ? document.body.innerText.slice(0, 2000) : ''") || "");
+    }
+    const pages = (await httpJson(`http://127.0.0.1:${st.port}/json/list`) || []).filter((t) => t.type === "page");
+    out(flags, { ok: true, title, url: pageUrl, readyState, tabCount: pages.length, bodyText, element });
+  });
 }
 
 async function cmdClick(flags) {
-  const statePath = flag(flags, "state", "browser.state");
-  const { page } = await connectPage(statePath, Number(flag(flags, "index", "0")));
   const url = flag(flags, "url", null);
   const selector = flag(flags, "selector", null);
   const timeoutMs = Number(flag(flags, "timeout", "10000"));
   if (!selector) fail("click 需要 --selector");
-  await navigateIfGiven(page.webSocketDebuggerUrl, url);
-  await waitSelector(page.webSocketDebuggerUrl, selector, timeoutMs);
-  const clicked = await evalRaw(page.webSocketDebuggerUrl, selExpr(selector, `
-    el.scrollIntoView({ block: "center" });
-    el.click();
-    return { found: true, clicked: true, tag: el.tagName };`));
-  out(flags, { ok: true, selector, clicked, url: url || undefined });
+  await withPageEmulation(flags, async ({ page }) => {
+    await navigateIfGiven(page.webSocketDebuggerUrl, url);
+    await waitSelector(page.webSocketDebuggerUrl, selector, timeoutMs);
+    const clicked = await evalRaw(page.webSocketDebuggerUrl, selExpr(selector, `
+      el.scrollIntoView({ block: "center" });
+      el.click();
+      return { found: true, clicked: true, tag: el.tagName };`));
+    out(flags, { ok: true, selector, clicked, url: url || undefined });
+  });
 }
 
 async function cmdEval(flags) {
-  const statePath = flag(flags, "state", "browser.state");
-  const { page } = await connectPage(statePath, Number(flag(flags, "index", "0")));
   const expression = flag(flags, "expression", null);
   if (!expression) fail("eval 需要 --expression");
-  const value = await evalRaw(page.webSocketDebuggerUrl, expression);
-  out(flags, { ok: true, value });
+  await withPageEmulation(flags, async ({ page }) => {
+    const value = await evalRaw(page.webSocketDebuggerUrl, expression);
+    out(flags, { ok: true, value });
+  });
 }
 
 async function cmdFill(flags) {
-  const statePath = flag(flags, "state", "browser.state");
-  const { page } = await connectPage(statePath, Number(flag(flags, "index", "0")));
   const selector = flag(flags, "selector", null);
   const value = flag(flags, "value", "");
   const timeoutMs = Number(flag(flags, "timeout", "10000"));
   if (!selector) fail("fill 需要 --selector");
-  await waitSelector(page.webSocketDebuggerUrl, selector, timeoutMs);
-  const filled = await evalRaw(page.webSocketDebuggerUrl, `(() => {
-    const el = document.querySelector(${JSON.stringify(selector)});
-    if (!el) return { found: false };
-    const tag = el.tagName.toLowerCase();
-    if (tag === "select") {
-      el.value = ${JSON.stringify(value)};
-      el.dispatchEvent(new Event("change", { bubbles: true }));
-    } else {
-      el.value = ${JSON.stringify(value)};
-      el.dispatchEvent(new Event("input", { bubbles: true }));
-      el.dispatchEvent(new Event("change", { bubbles: true }));
-    }
-    return { found: true, tag, value: el.value };
-  })()`);
-  out(flags, { ok: true, selector, value, filled });
+  await withPageEmulation(flags, async ({ page }) => {
+    await waitSelector(page.webSocketDebuggerUrl, selector, timeoutMs);
+    const filled = await evalRaw(page.webSocketDebuggerUrl, `(() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) return { found: false };
+      const tag = el.tagName.toLowerCase();
+      if (tag === "select") {
+        el.value = ${JSON.stringify(value)};
+        el.dispatchEvent(new Event("change", { bubbles: true }));
+      } else {
+        el.value = ${JSON.stringify(value)};
+        el.dispatchEvent(new Event("input", { bubbles: true }));
+        el.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+      return { found: true, tag, value: el.value };
+    })()`);
+    out(flags, { ok: true, selector, value, filled });
+  });
 }
 
 async function cmdWait(flags) {
-  const statePath = flag(flags, "state", "browser.state");
-  const { page } = await connectPage(statePath, Number(flag(flags, "index", "0")));
   const url = flag(flags, "url", null);
   const selector = flag(flags, "selector", null);
   const timeoutMs = Number(flag(flags, "timeout", "10000"));
   if (!selector) fail("wait 需要 --selector");
-  const started = Date.now();
-  await navigateIfGiven(page.webSocketDebuggerUrl, url);
-  await waitSelector(page.webSocketDebuggerUrl, selector, timeoutMs);
-  out(flags, { ok: true, selector, waitedMs: Date.now() - started });
+  await withPageEmulation(flags, async ({ page }) => {
+    const started = Date.now();
+    await navigateIfGiven(page.webSocketDebuggerUrl, url);
+    await waitSelector(page.webSocketDebuggerUrl, selector, timeoutMs);
+    out(flags, { ok: true, selector, waitedMs: Date.now() - started });
+  });
 }
 
 async function cmdScreenshot(flags) {
-  const statePath = flag(flags, "state", "browser.state");
-  const { st, page } = await connectPage(statePath, Number(flag(flags, "index", "0")));
   const url = flag(flags, "url", null);
   const selector = flag(flags, "selector", null);
   const outPath = flag(flags, "path", `screenshot-${Date.now()}.png`);
-  await navigateIfGiven(page.webSocketDebuggerUrl, url);
-  let clip = undefined;
-  if (selector) {
-    await waitSelector(page.webSocketDebuggerUrl, selector, 10000);
-    clip = await evalRaw(page.webSocketDebuggerUrl, selExpr(selector, `
-      const r = el.getBoundingClientRect();
-      // getBoundingClientRect 是 viewport 坐标；captureBeyondViewport 下 CDP 按文档
-      // 坐标解释 clip，须加 scrollX/scrollY 转换，否则页面滚动后截空白（PR #481 P1-2）
-      return { found: true, x: r.x + window.scrollX, y: r.y + window.scrollY, width: r.width, height: r.height, dpr: window.devicePixelRatio || 1 };`));
-    if (!clip || !clip.found) throw new Error(`截图元素未找到: ${selector}`);
-    clip = { x: clip.x, y: clip.y, width: clip.width, height: clip.height, scale: clip.dpr };
-  }
-  const shot = await rpc(page.webSocketDebuggerUrl, "Page.captureScreenshot", {
-    format: "png", captureBeyondViewport: true, fromSurface: true, clip,
+  await withPageEmulation(flags, async ({ page }) => {
+    await navigateIfGiven(page.webSocketDebuggerUrl, url);
+    let clip = undefined;
+    if (selector) {
+      await waitSelector(page.webSocketDebuggerUrl, selector, 10000);
+      clip = await evalRaw(page.webSocketDebuggerUrl, selExpr(selector, `
+        const r = el.getBoundingClientRect();
+        // getBoundingClientRect 是 viewport 坐标；captureBeyondViewport 下 CDP 按文档
+        // 坐标解释 clip，须加 scrollX/scrollY 转换，否则页面滚动后截空白（PR #481 P1-2）
+        return { found: true, x: r.x + window.scrollX, y: r.y + window.scrollY, width: r.width, height: r.height, dpr: window.devicePixelRatio || 1 };`));
+      if (!clip || !clip.found) throw new Error(`截图元素未找到: ${selector}`);
+      clip = { x: clip.x, y: clip.y, width: clip.width, height: clip.height, scale: clip.dpr };
+    }
+    const shot = await rpc(page.webSocketDebuggerUrl, "Page.captureScreenshot", {
+      format: "png", captureBeyondViewport: true, fromSurface: true, clip,
+    });
+    writeFileSync(outPath, Buffer.from(shot.data, "base64"));
+    const dims = clip ? { width: clip.width, height: clip.height } : null;
+    out(flags, { ok: true, path: outPath, bytes: Buffer.byteLength(shot.data, "base64"), clip: dims, url: url || undefined });
   });
-  writeFileSync(outPath, Buffer.from(shot.data, "base64"));
-  const dims = clip ? { width: clip.width, height: clip.height } : null;
-  out(flags, { ok: true, path: outPath, bytes: Buffer.byteLength(shot.data, "base64"), clip: dims, url: url || undefined });
 }
 
 async function cmdConsole(flags) {
-  const statePath = flag(flags, "state", "browser.state");
-  const { page } = await connectPage(statePath, Number(flag(flags, "index", "0")));
   const url = flag(flags, "url", null);
   const waitMs = Number(flag(flags, "wait-ms", "2500"));
-  const messages = [];
-  const collect = (ev) => {
-    if (!ev.data || typeof ev.data !== "string") return;
-    let m; try { m = JSON.parse(ev.data); } catch { return; }
-    if (!m || m.id) return;
-    if (m.method === "Runtime.consoleAPICalled") {
-      const args = (m.params.args || []).map((a) => a.value ?? a.description ?? a.type);
-      messages.push({ type: m.params.type, text: args.join(" "), url: m.params.url || null, line: m.params.lineNumber ?? null });
-    } else if (m.method === "Runtime.exceptionThrown") {
-      const d = m.params.exceptionDetails || {};
-      messages.push({ type: "exception", text: d.exception?.description || d.text || "未捕获异常", url: d.url || null, line: d.lineNumber ?? null });
-    } else if (m.method === "Log.entryAdded") {
-      const e = m.params.entry || {};
-      messages.push({ type: "log", level: e.level, text: e.text, url: e.url || null, line: e.lineNumber ?? null });
-    }
-  };
-  const ws = await openRawWs(page.webSocketDebuggerUrl, collect);
-  // domain enable 是会话级状态：须在事件收集的长连接上启用，短连接 enable 不生效
-  await rpcRaw(ws, "Runtime.enable", {});
-  await rpcRaw(ws, "Log.enable", {});
-  try {
-    if (url) {
-      await rpcRaw(ws, "Page.navigate", { url });
-      await poll(async () => {
-        try { return (await rpcRaw(ws, "Runtime.evaluate", { expression: "document.readyState", returnByValue: true })).result.value === "complete"; }
-        catch { return false; }
-      }, 15000, 200);
-    } else {
-      await rpcRaw(ws, "Page.reload", {});
-    }
-  } catch {}
-  await sleep(waitMs);
-  ws.close();
-  out(flags, { ok: true, messages, capturedMs: waitMs });
+  await withPageEmulation(flags, async ({ page }) => {
+    const messages = [];
+    const collect = (ev) => {
+      if (!ev.data || typeof ev.data !== "string") return;
+      let m; try { m = JSON.parse(ev.data); } catch { return; }
+      if (!m || m.id) return;
+      if (m.method === "Runtime.consoleAPICalled") {
+        const args = (m.params.args || []).map((a) => a.value ?? a.description ?? a.type);
+        messages.push({ type: m.params.type, text: args.join(" "), url: m.params.url || null, line: m.params.lineNumber ?? null });
+      } else if (m.method === "Runtime.exceptionThrown") {
+        const d = m.params.exceptionDetails || {};
+        messages.push({ type: "exception", text: d.exception?.description || d.text || "未捕获异常", url: d.url || null, line: d.lineNumber ?? null });
+      } else if (m.method === "Log.entryAdded") {
+        const e = m.params.entry || {};
+        messages.push({ type: "log", level: e.level, text: e.text, url: e.url || null, line: e.lineNumber ?? null });
+      }
+    };
+    const ws = await openRawWs(page.webSocketDebuggerUrl, collect);
+    // domain enable 是会话级状态：须在事件收集的长连接上启用，短连接 enable 不生效
+    await rpcRaw(ws, "Runtime.enable", {});
+    await rpcRaw(ws, "Log.enable", {});
+    try {
+      if (url) {
+        await rpcRaw(ws, "Page.navigate", { url });
+        await poll(async () => {
+          try { return (await rpcRaw(ws, "Runtime.evaluate", { expression: "document.readyState", returnByValue: true })).result.value === "complete"; }
+          catch { return false; }
+        }, 15000, 200);
+      } else {
+        await rpcRaw(ws, "Page.reload", {});
+      }
+    } catch {}
+    await sleep(waitMs);
+    ws.close();
+    out(flags, { ok: true, messages, capturedMs: waitMs });
+  });
 }
 
 // console 专用：原始 WebSocket 会话（长连接收事件）
@@ -559,10 +612,13 @@ rpcRaw.nextId = 0;
 
 // --- 入口 ---
 
-const USAGE = `用法: node browser-driver.mjs <command> [--flag value]... [--json] [--pretty]
+// 命令清单与通用段分开：`--help <command>` 是实际查参入口，必须一并带上通用段，
+// 否则设备模拟 flag 只在全局 help 可见，与文件头「契约以 --help 输出为准」的自述不符。
+const USAGE_HEAD = `用法: node browser-driver.mjs <command> [--flag value]... [--json] [--pretty]
 
-命令：
-  launch      启动独立浏览器实例并写入 state（--state <path> [--port N] [--user-data-dir <path>] [--chrome <path>]）
+命令：`;
+
+const USAGE_COMMANDS = `  launch      启动独立浏览器实例并写入 state（--state <path> [--port N] [--user-data-dir <path>] [--chrome <path>]）
   quit        优雅关闭实例并清理（--state <path>）
   snapshot    页面快照（[--url <url>] [--selector <css>] [--index N]）
   click       点击元素（--selector <css> [--url <url>] [--timeout ms] [--index N]）
@@ -570,17 +626,23 @@ const USAGE = `用法: node browser-driver.mjs <command> [--flag value]... [--js
   fill        填充表单（--selector <css> --value <v> [--timeout ms] [--index N]）
   wait        等待选择器（--selector <css> [--url <url>] [--timeout ms] [--index N]）
   screenshot  截图（[--url <url>] [--selector <css>] [--path <png>] [--index N]）
-  console     捕获 console/异常（[--url <url>] [--wait-ms N] [--index N]）
+  console     捕获 console/异常（[--url <url>] [--wait-ms N] [--index N]）`;
 
-通用：--state <path> 指定实例 state 文件（多会话并行必须各自独立）；
+const USAGE_COMMON = `通用：--state <path> 指定实例 state 文件（多会话并行必须各自独立）；
+设备模拟（页面命令通用）：--width N --height N [--dpr N] [--mobile]
+  逐档设定视口验证响应式布局；命令内生效、结束即清除，命令之间互不影响。
+  单给一维时另一维取当前视口值。--mobile 启用移动 layout viewport 语义（页面无
+  viewport meta 时 innerWidth 不再等于设定宽度）；触控/真机差异见 SKILL.md 能力边界。
 内核探测：DSH_VERIFY_CHROME env > ms-playwright 缓存 > PATH > 平台常见路径，全缺 fail-fast。
 环境要求：Node >= 22（页面操作依赖内置全局 WebSocket）；Chromium 系内核。
 详情见本文件头部注释。`;
 
+const USAGE = `${USAGE_HEAD}\n${USAGE_COMMANDS}\n\n${USAGE_COMMON}`;
+
 function printHelp(cmd) {
   if (!cmd) { process.stdout.write(USAGE + "\n"); return; }
-  const lines = USAGE.split("\n").filter((l) => l.includes(cmd) || l.startsWith("用法") || l.startsWith("命令"));
-  process.stdout.write(lines.join("\n") + "\n");
+  const lines = USAGE_COMMANDS.split("\n").filter((l) => l.includes(cmd));
+  process.stdout.write([USAGE_HEAD, ...lines, "", USAGE_COMMON].join("\n") + "\n");
 }
 
 async function main() {

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/emulation.mjs
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/emulation.mjs
@@ -1,0 +1,101 @@
+/**
+ * emulation.mjs — browser-driver 设备模拟参数的解析与 CDP 参数构造（纯函数，零依赖）。
+ *
+ * 抽成独立模块而非内联进 browser-driver.mjs：后者在 import 时即执行 main()，
+ * smoke 无法 import 其内部函数做行为断言（与 lib/verify-core.mjs 同一理由）。
+ *
+ * 契约形态由 CDP 会话语义实测决定（0.1.5-rc.1 + chromium headless shell）：
+ * - Emulation 域状态按 CDP session 归属：`setDeviceMetricsOverride` 的渲染效果在
+ *   session 断开后仍作用于 target，但 `clearDeviceMetricsOverride` 只能清掉「发它的
+ *   那个 session」所设的 override。故 set/clear 必须成对走同一条长连接——否则清除
+ *   静默失效，尺寸残留污染后续命令（实测：新 session 里 clear 后仍读回设定值）。
+ * - `touch` / `UserAgent` override 是纯 session 级的，断开即失效，无法跨命令生效；
+ *   模拟能力也不完整（maxTouchPoints 可设，但 ontouchstart 不生效）。故不提供，
+ *   触控与真机差异写入 SKILL.md 能力边界，避免给出虚假安全感。
+ *
+ * 因此设备模拟不做成「独立粘性命令」，而是每条页面命令都可携带的公共 flag：
+ * 命令内应用、命令结束前清除，命令之间互不影响。
+ */
+
+/** 视口尺寸上限：远超任何真实设备，取一个能挡住手误输入（如多敲几个 0）的上界。 */
+const MAX_VIEWPORT = 10000;
+/** DPR 上限：8 已是真实设备上界（部分安卓旗舰），再大只会是误输入。 */
+const MAX_DPR = 8;
+
+function parseViewport(raw, name) {
+  const invalid = () => new Error(`错误: --${name} 需要 1-${MAX_VIEWPORT} 的十进制整数: ${raw}`);
+  if (!/^\d+$/.test(raw)) throw invalid();
+  const n = Number(raw);
+  if (n < 1 || n > MAX_VIEWPORT) throw invalid();
+  return n;
+}
+
+function parseDpr(raw) {
+  // 文案与判据必须一致：下限是「大于 0」，写成「0-8」会让 0 被拒看起来像 bug
+  const invalid = () => new Error(`错误: --dpr 需要大于 0 且不超过 ${MAX_DPR} 的数（可带小数）: ${raw}`);
+  if (!/^\d+(\.\d+)?$/.test(raw)) throw invalid();
+  const n = Number(raw);
+  if (!(n > 0) || n > MAX_DPR) throw invalid();
+  return n;
+}
+
+/**
+ * 解析布尔 flag：省略值（parseArgs 存 "true"）/ `true` / `1` → true，`false` / `0` → false。
+ *
+ * 不采用「出现即启用」：那会让 `--mobile=false` 得到与字面相反的结果，也与 --dpr 的
+ * 取值风格不一致。其余取值一律报错，不做猜测。
+ */
+function parseBoolFlag(raw, name) {
+  if (raw === undefined) return false;
+  if (raw === "true" || raw === "1" || raw === "") return true;
+  if (raw === "false" || raw === "0") return false;
+  throw new Error(`错误: --${name} 只接受 true/false（省略值表示启用）: ${raw}`);
+}
+
+/**
+ * 解析设备模拟 flag。
+ *
+ * `get` 为取参函数（browser-driver 传 `(name) => flags.get(name)`）：未给出的返回
+ * undefined。任一设备 flag 出现即视为启用模拟；未给出的视口维度留 undefined，
+ * 由 buildDeviceMetrics 用页面当前视口补齐。
+ *
+ * @param {(name: string) => string | undefined} get - 取参函数。
+ * @returns {{ active: false } | { active: true, width?: number, height?: number, deviceScaleFactor: number, mobile: boolean }}
+ * @throws {Error} 参数非法（由 CLI 统一转错误 JSON + 非零退出）。
+ */
+export function parseEmulationFlags(get) {
+  const widthRaw = get("width");
+  const heightRaw = get("height");
+  const dprRaw = get("dpr");
+  const mobile = parseBoolFlag(get("mobile"), "mobile");
+  if (widthRaw === undefined && heightRaw === undefined && dprRaw === undefined && !mobile) {
+    return { active: false };
+  }
+  return {
+    active: true,
+    width: widthRaw === undefined ? undefined : parseViewport(widthRaw, "width"),
+    height: heightRaw === undefined ? undefined : parseViewport(heightRaw, "height"),
+    deviceScaleFactor: dprRaw === undefined ? 1 : parseDpr(dprRaw),
+    mobile,
+  };
+}
+
+/**
+ * 构造 `Emulation.setDeviceMetricsOverride` 参数（未指定的维度用当前视口补齐）。
+ *
+ * 注意 `mobile: true` 会启用移动 layout viewport 语义：页面无 viewport meta 时
+ * `innerWidth` 不再等于设定宽度（实测 375 → 981）。要精确命中 CSS 断点应保持
+ * mobile 关闭，此语义在 SKILL.md 中标为能力边界。
+ *
+ * @param {{ width?: number, height?: number, deviceScaleFactor: number, mobile: boolean }} parsed - parseEmulationFlags 结果。
+ * @param {{ width: number, height: number }} current - 页面当前 innerWidth / innerHeight。
+ * @returns {{ width: number, height: number, deviceScaleFactor: number, mobile: boolean }}
+ */
+export function buildDeviceMetrics(parsed, current) {
+  return {
+    width: parsed.width ?? current.width,
+    height: parsed.height ?? current.height,
+    deviceScaleFactor: parsed.deviceScaleFactor,
+    mobile: parsed.mobile,
+  };
+}

--- a/packages/dsh-verify-isolated/test/smoke.ts
+++ b/packages/dsh-verify-isolated/test/smoke.ts
@@ -99,6 +99,73 @@ try { execFileSync(process.execPath, [driverFile], { encoding: "utf8" }); }
 catch { noArgExitsNonZero = true; }
 assert.ok(noArgExitsNonZero, "browser-driver 无参数应非零退出（用法提示，不误启动浏览器）");
 
+// ---- 5b. 设备模拟（视口）：纯函数行为 + 参数错误退出码（离线，不启动浏览器） ----
+{
+  assert.ok(help.includes("--width") && help.includes("--height"), "browser-driver --help 声明视口尺寸 flag");
+  assert.ok(help.includes("--dpr"), "browser-driver --help 声明 --dpr");
+  assert.ok(help.includes("--mobile"), "browser-driver --help 声明 --mobile");
+  const emulationFile = join(SCRIPTS_DIR, "lib", "emulation.mjs");
+  assert.ok(existsSync(emulationFile), "设备模拟纯函数 lib/emulation.mjs 随 skill 分发");
+
+  const emu = await import(pathToFileURL(emulationFile).href);
+  const get = (obj: Record<string, string>) => (n: string) => obj[n];
+  assert.equal(emu.parseEmulationFlags(get({})).active, false,
+    "无设备 flag 不启用模拟（页面命令走零开销路径）");
+  assert.deepEqual(
+    emu.parseEmulationFlags(get({ width: "375", height: "667", dpr: "2", mobile: "true" })),
+    { active: true, width: 375, height: 667, deviceScaleFactor: 2, mobile: true },
+    "四个设备 flag 全部解析");
+  const widthOnly = emu.parseEmulationFlags(get({ width: "375" }));
+  assert.deepEqual(widthOnly, { active: true, width: 375, height: undefined, deviceScaleFactor: 1, mobile: false },
+    "只给 --width：height 留空待补齐、dpr 默认 1");
+  assert.deepEqual(emu.buildDeviceMetrics(widthOnly, { width: 800, height: 600 }),
+    { width: 375, height: 600, deviceScaleFactor: 1, mobile: false },
+    "缺省维度按页面当前视口补齐（不把 undefined 传给 CDP）");
+  // 非法值必须抛错：否则 NaN/undefined 直达 CDP，用户只会看到难懂的协议报错
+  for (const bad of [{ width: "0" }, { width: "abc" }, { height: "10001" }, { dpr: "0" }, { dpr: "abc" }, { dpr: "9" }]) {
+    assert.throws(() => emu.parseEmulationFlags(get(bad)), /错误: --(width|height|dpr)/,
+      `非法参数应抛可操作错误: ${JSON.stringify(bad)}`);
+  }
+
+  // 参数校验先于连浏览器：state 指向不存在的实例时也应报参数错误而非环境错误
+  let badCode = 0; let badOut = "";
+  try {
+    badOut = execFileSync(process.execPath, [
+      driverFile, "eval", "--state", join(tmpdir(), "nonexistent-browser.state"),
+      "--width", "0", "--expression", "1",
+    ], { encoding: "utf8" });
+  } catch (e) { badCode = e.status ?? -1; badOut = e.stdout ?? ""; }
+  assert.equal(badCode, 1, `视口参数非法应退出 1，实际 ${badCode}`);
+  assert.equal(JSON.parse(badOut.trim()).ok, false, "视口参数非法输出错误 JSON");
+  assert.ok(badOut.includes("--width"), "错误文案点名非法参数 --width");
+
+  // --mobile 取值语义：「出现即启用」会让 `--mobile=false` 得到与字面相反的结果
+  assert.equal(emu.parseEmulationFlags(get({ mobile: "true" })).mobile, true, "--mobile（省略值）启用移动语义");
+  assert.equal(emu.parseEmulationFlags(get({ mobile: "false" })).active, false, "--mobile=false 不启用模拟");
+  assert.equal(emu.parseEmulationFlags(get({ width: "375", mobile: "false" })).mobile, false,
+    "--mobile=false 不打开移动语义");
+  assert.throws(() => emu.parseEmulationFlags(get({ mobile: "maybe" })), /错误: --mobile/,
+    "--mobile 取值非法应报错（不猜测）");
+
+  // 逐命令 help 是实际查参入口：设备 flag 只在全局 help 可见即等于该入口失效
+  const evalHelp = execFileSync(process.execPath, [driverFile, "--help", "eval"], { encoding: "utf8" });
+  assert.ok(evalHelp.includes("--expression"), "逐命令 help 含该命令自身参数");
+  assert.ok(evalHelp.includes("--width") && evalHelp.includes("--dpr"), "逐命令 help 含设备模拟 flag");
+
+  // 七条页面命令都必须走设备模拟路径：任何一条改回直连 connectPage，都会让
+  // --width 等 flag 在该命令上静默失效（单命令回退的回归盲区）
+  const driverSrc = readFileSync(driverFile, "utf8");
+  for (const cmd of ["cmdSnapshot", "cmdClick", "cmdEval", "cmdFill", "cmdWait", "cmdScreenshot", "cmdConsole"]) {
+    const body = driverSrc.split(`async function ${cmd}(`)[1]?.split("\nasync function ")[0] ?? "";
+    assert.ok(body.includes("withPageEmulation("), `${cmd} 接入设备模拟（页面命令不得绕过 wrapper 直连）`);
+  }
+  assert.equal((driverSrc.match(/await connectPage\(/g) || []).length, 1,
+    "connectPage 只被 withPageEmulation 调用（设备模拟单点接入）");
+  // 清理静默失败会把视口残留给后续命令，两条告警路径都必须留在代码里
+  assert.ok(driverSrc.includes("设备模拟清理失败"), "清理抛错路径有可见警告");
+  assert.ok(driverSrc.includes("设备模拟清理后视口未复原"), "清理后回读核对是否复原");
+}
+
 // ---- 6. verify-isolated.mjs：lib import 行为断言 + 关键契约文本锚定 + 退出码实测 ----
 {
   // 6a. lib/verify-core.mjs import 行为断言（弃纯文本 grep 锁脚本细节）
@@ -289,6 +356,18 @@ assert.ok(raw.includes("--dsh"), "SKILL.md 含 --dsh 版本锚定用法");
 assert.ok(raw.includes("DSH_HOME 感知"), "SKILL.md 自检清单含插件 DSH_HOME 感知项（#510 盲区）");
 assert.ok(raw.includes("DSH_TELEMETRY_DISABLED=1"), "SKILL.md 含遥测禁用原则");
 assert.ok(raw.includes("--host 127.0.0.1"), "SKILL.md 含显式回环原则");
+// 视口验证能力：替代 resizeTo（高度不生效，实测无效）+ 防回退锁
+assert.ok(raw.includes("--width"), "SKILL.md 含视口档位 flag 用法");
+assert.ok(raw.includes("设备视口与几何验证"), "SKILL.md 含设备视口与几何验证章节");
+assert.ok(raw.includes("基线档"), "SKILL.md 含不带 flag 的基线档与残留回读方法");
+assert.ok(raw.includes("不要用 `window.resizeTo`"), "SKILL.md 明确标注 resizeTo 不可用（高度不生效）");
+// 防回退锁：resizeTo 只允许作为反例出现在正文，不得再出现在示例代码块里（否则会被照抄）
+const bashBlocks = raw.split("```bash").slice(1).map((b) => b.split("```")[0]);
+assert.ok(bashBlocks.length > 0, "SKILL.md 含 bash 示例块");
+assert.ok(bashBlocks.every((b) => !b.includes("resizeTo")), "SKILL.md 示例代码块不再出现 resizeTo");
+assert.ok(raw.includes("ontouchstart"), "SKILL.md 声明触控模拟能力边界（不越界承诺真机行为）");
+// 访问形态边界（隔离语义，与视口能力无关）：脚本默认只覆盖回环形态
+assert.ok(raw.includes("--trusted-host"), "SKILL.md 声明非回环访问形态的边界与官方选项");
 
 // ---- 8. README 同步新能力 ----
 const readme = readFileSync(join(PKG_ROOT, "README.md"), "utf8");
@@ -296,6 +375,8 @@ assert.ok(readme.includes("browser-driver.mjs"), "README 同步 browser-driver")
 assert.ok(readme.includes("--browser"), "README 同步 --browser 用法");
 assert.ok(readme.includes("四重隔离"), "README 同步四重隔离说明");
 assert.ok(readme.includes("verify-isolated.mjs"), "README 同步 node 版脚本名（升级路径）");
+assert.ok(readme.includes("emulation.mjs"), "README 同步设备模拟纯函数模块");
+assert.ok(readme.includes("--width"), "README 同步视口档位用法");
 assert.ok(!readme.includes("scripts/verify-isolated.sh"), "README 不再以旧 bash 脚本路径作为当前用法（升级路径说明除外）");
 
 // ---- 9. B4 隔离审计：lib/audit.mjs 纯函数行为断言 + 脚本契约锚定 + 退出码实测 ----


### PR DESCRIPTION
Part of #695（本 PR 增强 #695 验收所依赖的隔离验证工具，不关闭该 issue）

## 说明

复核 `dsh-verify-isolated` 在 dsh 0.1.5-rc.1 下的可用性：**兼容性无需破坏性适配**（端到端实跑通过了 dsh 入口识别 / profile 初始化 / bundle 注入 / link 挂载 / 就绪断言 / verdict / 浏览器实例 / 退出清理），但发现该 skill 教的窄屏验证手段 `window.resizeTo` **只能改窗口宽度、高度不生效**（实测 `resizeTo(768,1024)` 后 `innerHeight` 仍为默认 600），pad/phone 档的第二维根本无法验证——而 `#695` 验收正要求窄屏复核。本 PR 补上可信的视口能力与配套方法论。

## 改动

| 文件 | 变化 |
|---|---|
| `skills/dsh-verify-isolated/scripts/browser-driver.mjs` | 7 条页面命令新增公共设备 flag `--width/--height/--dpr/--mobile`；`--state`/`--index` 收敛到统一取参；`--help <command>` 一并输出通用段 |
| `skills/dsh-verify-isolated/scripts/lib/emulation.mjs`（新增） | `parseEmulationFlags` / `buildDeviceMetrics` 纯函数层 |
| `skills/dsh-verify-isolated/SKILL.md` | 新增 §6.4「设备视口与几何验证」；§6.3 第 5 条改指视口 flag；§4 补非回环访问形态边界 |
| `README.md` / `README.en.md` | 同步能力与包结构 |
| `test/smoke.ts` | 纯函数行为断言、参数错误退出码、逐命令 help 契约、单命令回退盲区断言、resizeTo 防回退锁 |

设计依据（实测）：CDP 的 Emulation 状态按 session 归属——跨连接 `clearDeviceMetricsOverride` 静默失效并把尺寸残留给后续命令；`touch`/`UA` override 相反，是 session 级、断开即失效。故设备模拟不做成独立粘性命令，而是每条命令自带、同一条长连接内成对 set/clear，清除后回读核对，失败或未复原写 stderr 告警。

已按两轴独立子 agent 复核（规范轴 / 规格轴）逐条处置：修复 `--dpr` 文案与判据矛盾、`--mobile=false` 反被当成启用、清理失败静默、逐命令 help 缺通用段、index 取参重复、smoke 单命令回退盲区；回退 §6.3 双主题一处的越界扩写。规格轴怀疑「整页截图随 `--dpr` 放大」与文档相反，经实测定案为推断有误（整页 375x667 不放大、元素截图 750x1334 放大，与文档一致）。

## 验证

门禁（worktree 内逐条实跑，全部 exit 0）：

```
pnpm build        pnpm test         pnpm contract
pnpm pack:check   pnpm typecheck    pnpm docs:check
pnpm test:src-tests   pnpm gate:homedir
```

- smoke 按 `docs/DEVELOPMENT.md` §5.1 连跑 **10 次**无 flake
- 隔离环境实测（dsh 0.1.5-rc.1 + 临时 `DSH_HOME` + 独立浏览器实例）：
  - 基线档 800x600；`--width 375 --height 667` → **375x667**（`mq640` true、`bodyW` 375、无横向溢出）；`--width 768 --height 1024` → **768x1024**
  - 改档后不带 flag 的命令回读 **800x600**（证明「结束即清除」、无残留）
  - `click` / `fill` / `wait` / `console` 带视口补测通过；`console` 的 reload 路径下 override 保持（捕获 `page-log w=375`）
  - 异常路径（等待选择器超时）后仍无残留（finally 清理生效）
  - 截图尺寸随档位 800x600 / 768x1024 / 375x667；phone 档人眼确认侧栏图标化、卡片满宽
  - `--mobile` 语义实测：启用时 375 档读回 981（移动 layout viewport），`--mobile=false` 不启用
- 退出后临时 `DSH_HOME` 已清理、`~/.dsh/profiles/` 无 `verify_*` 残留、仓库无运行时产物

边界与取舍：不纳入 `--touch`/`--ua`（headless 无法完整模拟，触控需真机）；非回环形态只写通用文档边界（官方 `--trusted-host`），不给脚本加 opt-in；skill 保持通用定位，不绑定任何具体仓库语义。不改包版本号、不新增依赖、不动宿主端 `src/index.ts` 与 `cordis.patch.yml`。

### 客户端改动截图证据（勾选式）

- [x] **不涉及客户端改动**（本包无 `src/client/**`；上文截图是视口能力的实测证据，非插件 UI 改动）
