### PR TITLE
docs(meta): PR/issue 贴图规范跟上 gh --attach——CLI 场景首选上传永久链接（#695 实证）

### DIFF
--- a/.dsh/skills/dsh-plugin-hub-dev/SKILL.md
+++ b/.dsh/skills/dsh-plugin-hub-dev/SKILL.md
@@ -111,7 +111,9 @@ pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck
   临时目录，不纳入发布包，**用完即弃**）。涉及界面行为的改动实测后将截图归档至
   `packages/dsh-<name>/docs/archive/<issue号>-<行为描述>.png`（headless element
   screenshot 只截插件 UI 本身、不带浏览器整窗；各包 files 白名单不含 `docs/`，
-  截图不入发布物 tarball），并在 PR 正文贴图引用该路径、issue 评论回链 PR。
+  截图不入发布物 tarball），并在 PR 正文贴图引用该路径、issue 评论回链 PR。正文嵌图
+  手段（`gh --attach` / commit-pin raw URL / 网页拖拽）与破图陷阱见
+  [dsh-plugin-hub-pr-review/references/pr-images.md](../dsh-plugin-hub-pr-review/references/pr-images.md)。
 - P0/P1 断言必须实测并标证据类型（curl / playwright / smoke）；检核表见
   [dsh-plugin-review/references/verify-checklist.md](../dsh-plugin-review/references/verify-checklist.md)。
 - 新配置键**四同步**：normalize 白名单 / 透传排除表 + 客户端渲染 + smoke 断言 +

--- a/.dsh/skills/dsh-plugin-hub-pr-review/references/pr-images.md
+++ b/.dsh/skills/dsh-plugin-hub-pr-review/references/pr-images.md
@@ -1,4 +1,4 @@
-# PR / issue 正文嵌图规范（#565 / #566 实证）
+# PR / issue 正文嵌图规范（#565 / #566 / #695 实证）
 
 隔离实测截图归档在 `packages/<pkg>/docs/archive/`，随 PR 分支提交（版本控制）；各包
 `files` 白名单不含 `docs/`，归档**不进发布物**。归档存储与正文引用是两个载体。
@@ -8,14 +8,32 @@
 GitHub 对 PR / issue 正文里的**相对路径图片按默认分支（main）解析**：文件只存在于 PR
 分支时必 404 破图（#566 初稿即踩坑）。跨包相对前缀（`../../other-pkg/...`）还会额外错乱。
 
-## 可用写法（二选一）
+## 可用写法（按优先级）
 
-### 首选：网页拖拽上传（人工场景）
+### 首选（agent / CLI 场景）：`gh --attach`
 
-网页编辑器里把 PNG 拖进正文，GitHub 转存为 `https://github.com/user-attachments/assets/...`
-永久链接——不受分支 / 删除影响，最稳。agent 自动化场景拖不了，走下一节。
+gh **≥ 2.99.0** 起，`issue|pr` 的 `create` / `edit` / `comment` 支持可重复的 `--attach`：
+上传后得到 `https://github.com/user-attachments/assets/...` 永久链接，与网页拖拽同源，
+不受分支删除 / 文件移动影响（#695 实证：gh 2.97.0 报 `unknown flag: --attach`，2.100.0
+上传成功并在页面正常渲染）。
 
-### CLI 场景：commit-pin raw URL
+```sh
+gh --version                        # 需 ≥ 2.99.0，旧版走下方备选
+# 评论 / 正文附图（可重复 --attach，单命令最多 50 个）
+gh issue comment 695 --attach './phone.png#phone 档 375x667'
+gh pr create --body-file /tmp/body.md --attach ./before.png --attach ./after.png
+gh issue comment 695 --edit-last --body-file /tmp/body.md --attach ./after.png
+```
+
+- alt 文本：`--attach '<file>#<alt>'`，省略则用文件名；视频不支持 alt
+- 正文里已用 Markdown 引用本地路径（如 `![x](./shot.png)`）时，gh 把该引用**重写**为
+  上传 URL；未被引用的附件追加到正文末尾
+- 仅 GitHub.com / GHE.com 可用，需 repo `WRITE` / `MAINTAIN` / `ADMIN` 权限；
+  GHES 与 GitHub App token 不支持
+
+### 备选：commit-pin raw URL
+
+gh 版本不足，或正文需要指向**仓库内归档文件**（`packages/<pkg>/docs/archive/*.png`）时使用：
 
 ```sh
 SHA=$(git rev-parse HEAD)          # 40 位 commit sha
@@ -25,6 +43,10 @@ curl -s -o /dev/null -w "%{http_code}\n" "<该 URL>"   # 逐张验 200 再发 PR
 
 pin **commit**（而非分支名）的理由：squash merge 后分支被删，分支名 raw URL 失效；commit
 对象仍可达，URL 长期有效。
+
+### 人工场景：网页拖拽
+
+网页编辑器里把 PNG 拖进正文，得到与 `--attach` 同款的 `user-attachments` 永久链接。
 
 ## 禁止的写法
 
@@ -36,5 +58,6 @@ pin **commit**（而非分支名）的理由：squash merge 后分支被删，�
 `pnpm docs:check` 只校验各包 README 的相对链接（见 `scripts/gate/verify-docs.ts`：
 `relLinks()` 跳过含 `#` 的锚点），**PR / issue 正文不在任何门禁覆盖内**。因此：
 
-1. 发 PR 前逐张 `curl -w "%{http_code}"` 确认 200；
-2. 提交后在 GitHub 页面上实际打开一次正文，确认渲染无破图。
+1. `--attach` / 网页拖拽：提交后读回正文确认附件 URL 已就位（`gh issue view <n> --json
+   comments`、`gh pr view <n> --json body`），再打开页面确认渲染无破图；
+2. commit-pin raw URL：发 PR 前逐张 `curl -w "%{http_code}"` 确认 200，同样打开页面复核。

--- a/.dsh/skills/oss-pipeline/SKILL.md
+++ b/.dsh/skills/oss-pipeline/SKILL.md
@@ -151,7 +151,10 @@ merge --auto --squash → 清理。保留 loop/building 单标签便于在途识
    断言**（judge 判据并入 qa 角色，不设独立 judge）。截图归档至
    `packages/dsh-<name>/docs/archive/<issue号>-<行为描述>.png`（element screenshot
    只截插件 UI 本身；`docs/` 不入发布物 tarball），PR 正文贴图引用路径、
-   issue 评论回链 PR（双向引用）。纯宿主逻辑且 hardener 断言已覆盖者豁免实测部分，
+   issue 评论回链 PR（双向引用）；正文嵌图手段（`gh --attach` / commit-pin raw URL /
+   网页拖拽）见
+   [dsh-plugin-hub-pr-review/references/pr-images.md](../dsh-plugin-hub-pr-review/references/pr-images.md)。
+   纯宿主逻辑且 hardener 断言已覆盖者豁免实测部分，
    但逐条断言不可豁免。断言分工明文：coder 在 PR 正文产出全量断言表；
    **全部 [硬性] 条目由 qa subagent 独立复跑复核**（上下文隔离于 coder）；仅当
    qa 通道不可用时允许主控复核替代，且须在 PR 正文记录选择理由。豁免判据统一为

--- a/docs/ISSUE-WORKFLOW.md
+++ b/docs/ISSUE-WORKFLOW.md
@@ -53,7 +53,10 @@
    `packages/dsh-<name>/docs/archive/<issue号>-<行为描述>.png`（如
    `37-basename-fallback-overlay.png`）；截图只截插件 UI 本身（headless element
    screenshot），不带浏览器整窗，避免泄露本机环境。归档后双向引用：PR 正文贴图并
-   引用文件路径，issue 评论回链 PR。发布边界已核实安全：各包 files 白名单不含
+   引用文件路径，issue 评论回链 PR；正文嵌图手段（`gh --attach` / commit-pin raw
+   URL / 网页拖拽）与破图陷阱见
+   [.dsh/skills/dsh-plugin-hub-pr-review/references/pr-images.md](../.dsh/skills/dsh-plugin-hub-pr-review/references/pr-images.md)。
+   发布边界已核实安全：各包 files 白名单不含
    `docs/`，截图不入 tarball，不破坏「发布物不含内部文档」约定。PR 模板已内置
    客户端截图证据清单，见 `.github/PULL_REQUEST_TEMPLATE.md`。纯宿主端 /
    文档改动可跳过本步。


### PR DESCRIPTION
## 说明

`references/pr-images.md` 的「CLI 场景」只写了 commit-pin raw URL——那是 gh **2.99.0 之前**唯一的 CLI 贴图手段，现在已经过时：

- gh 2.99.0（2026-09-01）起，`gh issue|pr` 的 `create` / `edit` / `comment` 支持可重复的 `--attach`，上传得到 `https://github.com/user-attachments/assets/...` 永久链接，**与网页拖拽同源**，不受分支删除 / 文件移动影响
- 实证（#695）：本机 gh 2.97.0 报 `unknown flag: --attach`；升级到 2.100.0 后上传成功并在页面正常渲染（[评论实例](https://github.com/wingsky-1/dsh-plugin-hub/issues/695#issuecomment-5619440363)）

## 改动

| 文件 | 变化 |
|---|---|
| `.dsh/skills/dsh-plugin-hub-pr-review/references/pr-images.md` | 「可用写法」重写为按优先级三层：`gh --attach`（首选，含 ≥ 2.99.0 版本前提与各项限制）→ commit-pin raw URL（降为备选）→ 网页拖拽（人工）；「无门禁兜底」的人工核步骤按手段分开 |
| `.dsh/skills/dsh-plugin-hub-dev/SKILL.md` §7 | 归档与双向引用要求不变，补指向 pr-images.md 的链接 |
| `.dsh/skills/oss-pipeline/SKILL.md` ④.5 | 同上 |
| `docs/ISSUE-WORKFLOW.md` 第 4 步 | 同上 |

**纪律未放松**：截图仍须归档到 `packages/<pkg>/docs/archive/`（版本控制内证据，分支删除/仓库迁移后仍可追溯）、仍禁相对路径（按 main 解析必破图）、仍禁只列文件名。本次只是把「正文怎么引用」的手段更新到当前工具能力。

## 验证

```
pnpm docs:check    exit 0（verify-docs：7 个包 + 根 README + 26 个 agent 规则文档，含 --strict-en）
pnpm build         exit 0
pnpm test          exit 0
pnpm contract      exit 0
pnpm pack:check    exit 0
pnpm typecheck     exit 0
```

三处新增交叉引用逐条 `realpath` 校验均解析到真实文件（`.dsh/skills/.../pr-images.md`）；无 emoji；不改代码、不改版本号、不动 `.github/`。

### 客户端改动截图证据（勾选式）

- [x] **不涉及客户端改动**（纯文档/规程改动）
