### PR TITLE
feat(dsh-verify-isolated): 首启弹窗默认跳过与访问令牌指导（skill 转主线+支线披露）

### DIFF
--- a/packages/dsh-verify-isolated/README.en.md
+++ b/packages/dsh-verify-isolated/README.en.md
@@ -23,6 +23,12 @@ built-in skill and becomes available to all sessions in the profile (check with
   [archify-dsh](https://github.com/tt-a1i/archify) pattern) — the official provider
   discovers and registers `skills/dsh-verify-isolated/SKILL.md`; no hand-written
   registration code needed;
+- **Main line plus branches**: `SKILL.md` carries only what every run needs (when to
+  use, quick path, the two hard preconditions, isolation self-check, verification and
+  the done checklist); branch material (script contracts, manual setup, kernel
+  troubleshooting, viewport-geometry methodology) lives in `references/`, each file
+  self-contained and pointed at by the main line with the condition for reading it —
+  a routine verification never loads the branches;
 - **Quadruple isolation**: `DSH_HOME=$(mktemp -d)` isolates credentials/sessions/home-level
   patches; a dedicated `verify_<8 random chars>` profile isolates the plugin composition
   stack; a dedicated port isolates the network surface; a **dedicated browser instance**
@@ -44,28 +50,32 @@ built-in skill and becomes available to all sessions in the profile (check with
   `@deepseek-ai/dsh-web-app` (built-in bundles are resolved by name from the dsh install
   directory, not via npm);
 - **One-shot script** `skills/dsh-verify-isolated/scripts/verify-isolated.mjs`
-  (Node implementation, requires Node ≥22; the old bash `.sh` was rewritten and
-  removed in #517 C8): validate the dsh entry and print its version (`--dsh` pins
-  the target dsh version) → create temp DSH_HOME → create profile (explicit
+  (Node implementation, requires Node ≥22; the historical bash `.sh` was removed
+  with no shim left behind): validate the dsh entry and print its version (`--dsh` pins
+  the target dsh version) → create temp DSH_HOME → **preset the first-run popup
+  skip** (writes the internal-testing notice version into the isolated
+  `settings.yaml`, see below) → create profile (explicit
   `plugin list` init) → inject web-app bundle → normalize plugin args (relative
   paths → absolute against cwd; package specs like `@scope/name` / git URLs pass
-  through; #517 C11 semantics built in) → build and link local plugins
+  through) → build and link local plugins
   (`--no-build` validates artifact presence + staleness warning) → (optionally
   `--browser`) launch a dedicated browser instance → start (explicit
   `--host 127.0.0.1` loopback + `DSH_TELEMETRY_DISABLED=1` telemetry off) →
-  readiness probe → unified cleanup on exit (dsh process + browser process +
-  user-data-dir + DSH_HOME, no leftovers); `--port 0` auto-detects the real free
-  port (no longer prints an invalid 0); **B6** writes a startup-self-check
-  verdict at `$DSH_HOME/verdict.json` after ready (mode 0o600, three-channel port
-  source, cleanup field finalized on exit); **B7** `--evidence-dir` defaults to
-  `$DSH_HOME/evidence/`, externalized as `<dir>/evidence-<profile>/` without ever
-  touching the external directory; **B4** optional isolated audit `--audit` — diffs
-  the isolated `$ISOLATED_HOME` write surface against a preset whitelist
-  (versioned `WHITELIST_V`, pure functions in `scripts/lib/audit.mjs`); additions/
-  deletions/modifications outside the whitelist plus escaping symlinks are
-  reported as "suspicious" and **do not block exit** (`--audit-extra-dirs <dir>`
-  adds extra audited dirs, must be a directory; limitation: real home is never
-  scanned; the whitelist covers dsh's own write surface (`.credentials.yaml` /
+  readiness probe → **parse and print the token-bearing access URL** (also
+  written to `browser.state.dshWebUrl`) → unified cleanup on exit (dsh process +
+  browser process + user-data-dir + DSH_HOME, no leftovers); `--port 0`
+  auto-detects the real free port (no longer prints an invalid 0); **B6** writes
+  a startup-self-check verdict at `$DSH_HOME/verdict.json` after ready (mode
+  0o600, three-channel port source, cleanup field finalized on exit); **B7**
+  `--evidence-dir` defaults to `$DSH_HOME/evidence/`, externalized as
+  `<dir>/evidence-<profile>/` without ever touching the external directory;
+  **B4** optional isolated audit `--audit` — diffs the isolated `$ISOLATED_HOME`
+  write surface against a preset whitelist (versioned `WHITELIST_V`, pure
+  functions in `scripts/lib/audit.mjs`); additions/deletions/modifications
+  outside the whitelist plus escaping symlinks are reported as "suspicious" and
+  **do not block exit** (`--audit-extra-dirs <dir>` adds extra audited dirs,
+  must be a directory; limitation: real home is never scanned; the whitelist
+  covers dsh's own write surface (`.credentials.yaml` / `settings.yaml` /
   `storages/**`) while version-drifted surfaces such as the official
   `profiles/node_modules/**` bundle links are captured by the post-readiness t0
   baseline — the audit surface is the incremental write surface of the runtime;
@@ -74,16 +84,45 @@ built-in skill and becomes available to all sessions in the profile (check with
   `audit` field aligned with the verdict); `--json` emits only the final verdict
   JSON on stdout. Exit-code contract: 0 OK / 1 startup-or-readiness failure /
   2 argument error / 130 SIGINT / 143 SIGTERM.
+- **First-run popups are skipped by default**: a brand-new DSH_HOME opens on two
+  **blocking** dialogs ("Internal Testing Notice" → "Add an API key to get
+  started"); both set `#root` to `inert`, so every click on the page silently
+  fails. Before startup the script presets `ui-onboarding.welcomeNoticeVersion`
+  in `settings.yaml` (the value is read from the dsh client artifact's
+  `WELCOME_NOTICE_VERSION` at run time rather than hardcoded — a stale value
+  after a dsh upgrade silently brings the dialog back) to remove the first one;
+  the API-key dialog cannot be preset away (its "Configure later" only holds for
+  the current page lifetime and reappears on every reload), so browser-driver
+  clicks through it after navigation. When no skip button is recognized it does
+  **not guess** (the dialog may also offer a side-effecting "Save and continue"),
+  reporting `onboardingBlocked` with a warning instead. `--no-skip-onboarding`
+  keeps the native first-run state for verifying onboarding itself, and
+  `--no-auto-dismiss` makes the browser side probe without clicking. The pure
+  functions and probe live in `scripts/lib/onboarding.mjs`.
+- **Access authentication (the token is mandatory)**: the dsh web GUI is
+  authenticated, and a bare port returns a 401 text page
+  (`dsh web authentication required`); since the readiness probe treats any
+  2xx-4xx as ready, a missing token lets verification keep running against that
+  401 page. The token exists only in the line dsh prints at startup; the script
+  parses it, prints it, and writes it to `browser.state.dshWebUrl` (0o600) for
+  browser-driver's reserved `--url state` value; the verdict records only the
+  token-free `web.url`, and every echoed URL is redacted (`token=***`), so the
+  token never reaches CI logs or evidence files.
 
 ## Package layout
 
 ```text
 skills/dsh-verify-isolated/
-  SKILL.md                        # skill definition (frontmatter name=dsh-verify-isolated)
-  scripts/verify-isolated.mjs     # one-shot isolated verification script (Node, --dsh / --browser / --port 0 / --keep / --no-build / --evidence-dir / --audit / --audit-extra-dirs / --json)
-  scripts/lib/verify-core.mjs     # shared base utilities (exit-code constants/poll/findFreePort/port parsing/C11 normalization)
+  SKILL.md                        # skill definition (frontmatter name=dsh-verify-isolated; main line: when to use / quick path / hard preconditions / self-check / verification / done checklist)
+  references/script-contracts.md  # branch: verdict fields, isolated-audit whitelist and timing, exit codes, Windows promise
+  references/manual-setup.md      # branch: manual isolated-environment setup (the script's steps, expanded)
+  references/browser-kernel.md    # branch: Chromium kernel detection chain, per-platform self-check and install
+  references/viewport-geometry.md # branch: per-viewport device emulation and geometry-assertion methodology
+  scripts/verify-isolated.mjs     # one-shot isolated verification script (Node, --dsh / --browser / --port 0 / --keep / --no-build / --evidence-dir / --audit / --audit-extra-dirs / --no-skip-onboarding / --json)
+  scripts/lib/verify-core.mjs     # shared base utilities (exit-code constants/poll/findFreePort/port and token-URL parsing/C11 normalization)
   scripts/lib/audit.mjs           # B4 isolated-audit pure functions (scanSnapshot/diffAgainstWhitelist/checkSymlinkEscape/runAudit + versioned whitelist WHITELIST_V)
   scripts/lib/emulation.mjs       # device-emulation pure functions (parseEmulationFlags / buildDeviceMetrics; CDP session semantics)
+  scripts/lib/onboarding.mjs      # first-run popup skip pure functions (version constant lookup / settings doc / overlay probe expression / token redaction)
   scripts/browser-driver.mjs      # self-contained browser driver (raw CDP, zero deps, --json atomic CLI)
 cordis.patch.yml                  # reuses official dsh-skill-filesystem + bundledSkillDir
 lib/index.js                      # host gate export (name + empty apply)
@@ -113,11 +152,14 @@ node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --evidence-dir /tmp/my-e
 # isolated audit (B4): changes outside the whitelist are reported as suspicious and do not block exit;
 # --keep writes $DSH_HOME/audit/audit.json
 node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --audit --keep <plugin-package-path>
+# keep the native first-run state (to verify the onboarding popups themselves;
+# the skip is preset by default, see SKILL.md §4.1)
+node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --no-skip-onboarding <plugin-package-path>
 ```
 
 Plugin arguments accept either **local plugin paths** (relative paths are resolved to
 absolute paths against the current cwd before mounting — dsh otherwise parses a
-non-absolute path as a git URL; #517 C11) or **package specs** (npm package names /
+non-absolute path as a git URL) or **package specs** (npm package names /
 git URLs pass through unchanged).
 
 Browser instance operations (instance info in `$DSH_HOME/browser.state`; the command
@@ -126,19 +168,37 @@ they rely on the built-in global WebSocket; older versions error at connect time
 prompt for an upgrade):
 
 ```bash
-node "$SKILL_BASE/scripts/browser-driver.mjs" snapshot --state "$DSH_HOME/browser.state" --url http://127.0.0.1:<port>
+# --url state: use the token-bearing URL from state (the GUI is authenticated;
+# a bare port only yields a 401 text page)
+node "$SKILL_BASE/scripts/browser-driver.mjs" snapshot --state "$DSH_HOME/browser.state" --url state
 node "$SKILL_BASE/scripts/browser-driver.mjs" click --state "$DSH_HOME/browser.state" --selector "button.start"
-node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/browser.state" --path shot.png
+node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/browser.state" --url state --path shot.png
 # device emulation (available on every page command): verify responsive layouts
 # viewport by viewport; applied within the command and cleared when it exits
-node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/browser.state" --url http://127.0.0.1:<port> --width 375 --height 667 --path phone.png
+node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/browser.state" --url state --width 375 --height 667 --path phone.png
 node "$SKILL_BASE/scripts/browser-driver.mjs" eval --state "$DSH_HOME/browser.state" --width 375 --height 667 --expression "innerWidth+'x'+innerHeight"
 ```
+
+Navigating commands automatically skip the first-run popups after navigation (the output
+records the clicked buttons under `dismissed`; when no skip button is recognized it
+reports `onboardingBlocked` with a warning). `--no-auto-dismiss` probes without clicking
+and `--overlay-wait <ms>` tunes the popup wait window (default 1500). `eval` / `fill` do
+not navigate and therefore do not trigger this logic.
 
 ## Security model
 
 - The isolated environment carries no real credentials (the temp `DSH_HOME` has no
-  `~/.dsh` data);
+  `~/.dsh` data); the first-run popup skip only writes the isolated
+  `$DSH_HOME/settings.yaml` (0o600) and clicks the dialog's own "Configure later"
+  button — it injects and copies **no API key**. The script inherits the launching
+  environment (`{...process.env}`, unchanged semantics), so provider credential
+  variables already present there take effect per dsh's official precedence; launch
+  from a shell without them if you need a fully clean credential surface;
+- **Minimal token exposure**: the token-bearing GUI URL is written only to the 0o600
+  `$DSH_HOME/browser.state` (`dshWebUrl`) and `$DSH_HOME/dsh.log`; every URL echoed by
+  the script and browser-driver is redacted (`token=***`), and the verdict records only
+  the token-free `web.url` — the token never reaches `--json` output, CI logs, or
+  evidence archives;
 - The isolated `dsh web` binds explicitly to loopback (`--host 127.0.0.1`, reachable
   from this machine only) and explicitly disables telemetry
   (`DSH_TELEMETRY_DISABLED=1`, no test data leaves the machine);

--- a/packages/dsh-verify-isolated/README.md
+++ b/packages/dsh-verify-isolated/README.md
@@ -19,6 +19,10 @@ dsh plugin --profile web add @wingsky-1/dsh-verify-isolated
   的 `bundledSkillDir` 配置，从包 manifest 解析本包 `skills/` 目录（参照
   [archify-dsh](https://github.com/tt-a1i/archify) 模式）——官方 provider 发现并
   注册 `skills/dsh-verify-isolated/SKILL.md`，无需自写注册代码；
+- **主线 + 支线披露**：`SKILL.md` 只放每次验证都要用的判据与步骤（何时用、快速路径、
+  两个硬前提、隔离自检、核验与完成检查），支线内容（脚本契约、手动步骤、内核排查、
+  视口几何方法论）下沉到 `references/`，各文件自包含、由主线按「读它的时机」指向——
+  一次常规验证不必加载支线，触发到对应分支时才读；
 - **四重隔离**：`DSH_HOME=$(mktemp -d)` 隔离凭据/会话/home 级 patch；独立
   `verify_<8位随机>` profile 隔离插件组合栈；独立端口隔离网络面；**独立浏览器
   实例**（`--browser`）隔离页面/tab/console——多会话并行互不可见，从结构上杜绝
@@ -36,12 +40,14 @@ dsh plugin --profile web add @wingsky-1/dsh-verify-isolated
 - **最小启动依赖**：profile bundles 含 `@deepseek-ai/dsh-base` +
   `@deepseek-ai/dsh-web-app`（内置 bundle 按名从 dsh 安装目录解析，不走 npm）；
 - **一键脚本** `skills/dsh-verify-isolated/scripts/verify-isolated.mjs`（node 实现，
-  需 Node ≥22；原 bash 版 `.sh` 已随 #517 C8 重写删除）：校验 dsh
-  入口并打印版本（`--dsh` 锚定目标 dsh 版本）→ 建临时 DSH_HOME → 建 profile
+  需 Node ≥22；历史 bash 版 `.sh` 已删除且不留 shim）：校验 dsh
+  入口并打印版本（`--dsh` 锚定目标 dsh 版本）→ 建临时 DSH_HOME → **预置首启弹窗
+  跳过**（写隔离 `settings.yaml` 的内测声明版本，见下）→ 建 profile
   （`plugin list` 显式初始化）→ 注入 web-app bundle → 构建并 link 本地插件
   （`--no-build` 时校验产物存在 + 陈旧警告）→ （可选 `--browser`）启动独立浏览器
   实例 → 启动（显式 `--host 127.0.0.1` 回环 + `DSH_TELEMETRY_DISABLED=1` 遥测
-  禁用）→ 就绪断言 → 退出统一清理（dsh 进程 + 浏览器进程 +
+  禁用）→ 就绪断言 → **解析并打印带访问令牌的 URL**（同时写入
+  `browser.state.dshWebUrl`）→ 退出统一清理（dsh 进程 + 浏览器进程 +
   user-data-dir + DSH_HOME 无残留）；`--port 0` 自动探测真实空闲端口（不再打印
   无效的 0）；**B6** 就绪后写 `$DSH_HOME/verdict.json` 启动自检（0o600，端口三通道
   source，退出终态更新 cleanup）；**B7** 证据目录 `--evidence-dir` 默认
@@ -50,21 +56,42 @@ dsh plugin --profile web add @wingsky-1/dsh-verify-isolated
   （版本化 `WHITELIST_V`，`scripts/lib/audit.mjs` 纯函数），白名单外新增/删除/修改
   与越界 symlink 报「可疑」、**不阻断退出**（`--audit-extra-dirs <dir>` 可加额外
   审计目录，必须是目录；局限：不扫真实 home；白名单含 dsh 自身写面
-  `.credentials.yaml`/`storages/**`，随版本漂移的官方 bundle link 由就绪后 t0
-  基线覆盖——审计面 = 就绪后运行期增量写面；`--keep` 落
+  `.credentials.yaml`/`settings.yaml`/`storages/**`，随版本漂移的官方 bundle link
+  由就绪后 t0 基线覆盖——审计面 = 就绪后运行期增量写面；`--keep` 落
   `$DSH_HOME/audit/audit.json`，否则随 `--json` 终态 verdict 输出 `audit` 字段）；
   `--json` 时 stdout 只出最终 verdict JSON。退出码
   契约：0 正常 / 1 启动或就绪失败 / 2 参数错误 / 130 SIGINT / 143 SIGTERM。
+- **首启弹窗默认跳过**：全新 DSH_HOME 的首屏是两个**阻断式**弹窗（「内测声明」→
+  「添加 API Key」），两者都把 `#root` 置为 `inert`，页面上一切点击静默失效。脚本
+  启动前预置 `settings.yaml` 的 `ui-onboarding.welcomeNoticeVersion`（值从 dsh
+  客户端产物 `WELCOME_NOTICE_VERSION` 现取，不硬编码——dsh 升级后旧值会让弹窗
+  重新出现且不报错）消掉第一个；「添加 API Key」无法预置消除（其「稍后配置」只在
+  当前页面生命周期内有效，刷新必重弹），由 browser-driver 在导航后自动点击跳过。
+  识别不到跳过按钮时**不猜**（弹窗内可能并列「保存并继续」这类有副作用的按钮），
+  只输出 `onboardingBlocked` 并警告。`--no-skip-onboarding` 保留原生首启态，
+  供验证 onboarding 本身；`--no-auto-dismiss` 让浏览器侧只探测不点击。
+  纯函数与探测逻辑见 `scripts/lib/onboarding.mjs`。
+- **访问鉴权（必须带令牌）**：dsh web 的 GUI 带鉴权，裸端口只返回 401 文本页
+  （`dsh web authentication required`），而就绪断言把 2xx-4xx 都算就绪，因此漏带
+  令牌会让验证在 401 页面上继续跑。令牌只在 dsh 启动打印的那一行里；脚本解析它并
+  打印、写入 `browser.state.dshWebUrl`（0o600）供 browser-driver 的保留取值
+  `--url state` 取用；verdict 只记不含令牌的 `web.url`，命令回显的 URL 恒去令牌
+  （`token=***`），令牌不进 CI 日志与证据文件。
 
 ## 包结构
 
 ```text
 skills/dsh-verify-isolated/
-  SKILL.md                        # skill 定义（frontmatter name=dsh-verify-isolated）
-  scripts/verify-isolated.mjs     # 一键隔离验证脚本（node，--dsh / --browser / --port 0 / --keep / --no-build / --evidence-dir / --audit / --audit-extra-dirs / --json）
-  scripts/lib/verify-core.mjs     # 共享基础工具（退出码常量/poll/findFreePort/端口解析/C11 归一化）
+  SKILL.md                        # skill 定义（frontmatter name=dsh-verify-isolated；主线：何时用/快速路径/硬前提/自检/核验/完成检查）
+  references/script-contracts.md  # 支线：verdict 字段、隔离审计白名单与时序、退出码、Windows 承诺
+  references/manual-setup.md      # 支线：手动搭建隔离环境（脚本的等价展开）
+  references/browser-kernel.md    # 支线：Chromium 内核探测链、三平台自查与安装
+  references/viewport-geometry.md # 支线：设备视口逐档核验与几何断言方法论
+  scripts/verify-isolated.mjs     # 一键隔离验证脚本（node，--dsh / --browser / --port 0 / --keep / --no-build / --evidence-dir / --audit / --audit-extra-dirs / --no-skip-onboarding / --json）
+  scripts/lib/verify-core.mjs     # 共享基础工具（退出码常量/poll/findFreePort/端口与带令牌 URL 解析/C11 归一化）
   scripts/lib/audit.mjs           # B4 隔离审计纯函数（scanSnapshot/diffAgainstWhitelist/checkSymlinkEscape/runAudit + 版本化白名单 WHITELIST_V）
   scripts/lib/emulation.mjs       # 设备模拟参数纯函数（parseEmulationFlags / buildDeviceMetrics；CDP 会话语义依据）
+  scripts/lib/onboarding.mjs      # 首启弹窗跳过纯函数（版本常量探测 / settings 文档 / 弹窗探针表达式 / 令牌脱敏）
   scripts/browser-driver.mjs      # 自带独立浏览器驱动（raw CDP 零依赖，--json 原子操作 CLI）
 cordis.patch.yml                  # 复用官方 dsh-skill-filesystem + bundledSkillDir
 lib/index.js                      # 宿主门禁出口（name + 空 apply）
@@ -89,10 +116,12 @@ node "$SKILL_BASE/scripts/verify-isolated.mjs" --dsh /opt/dsh-0.1.2-rc.1/bin/dsh
 node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --evidence-dir /tmp/my-evidence --json <插件包路径>
 # 隔离审计（B4）：白名单外变化报「可疑」不阻断退出；--keep 落 $DSH_HOME/audit/audit.json
 node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --audit --keep <插件包路径>
+# 保留原生首启态（验证 onboarding 弹窗本身时用；默认预置跳过，见 SKILL.md §3.2）
+node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --no-skip-onboarding <插件包路径>
 ```
 
 插件参数支持**本地插件路径**（相对路径基于当前 cwd 自动解析为绝对路径后挂载，
-规避 dsh 把非绝对路径当 git URL 解析——#517 C11）或**包规格**（npm 包名/git URL
+规避 dsh 把非绝对路径当 git URL 解析）或**包规格**（npm 包名/git URL
 原样透传）。
 
 浏览器实例操作（实例信息在 `$DSH_HOME/browser.state`；命令契约见
@@ -100,17 +129,31 @@ node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --audit --keep <插件�
 WebSocket，更低版本会在连接时报错提示升级）：
 
 ```bash
-node "$SKILL_BASE/scripts/browser-driver.mjs" snapshot --state "$DSH_HOME/browser.state" --url http://127.0.0.1:<端口>
+# --url state：用 state 里的带令牌 URL（GUI 带鉴权，裸端口只会得到 401 文本页）
+node "$SKILL_BASE/scripts/browser-driver.mjs" snapshot --state "$DSH_HOME/browser.state" --url state
 node "$SKILL_BASE/scripts/browser-driver.mjs" click --state "$DSH_HOME/browser.state" --selector "button.start"
-node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/browser.state" --path shot.png
+node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/browser.state" --url state --path shot.png
 # 设备模拟（页面命令通用）：逐档视口验证响应式布局；命令内生效、结束即清除
-node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/browser.state" --url http://127.0.0.1:<端口> --width 375 --height 667 --path phone.png
+node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$DSH_HOME/browser.state" --url state --width 375 --height 667 --path phone.png
 node "$SKILL_BASE/scripts/browser-driver.mjs" eval --state "$DSH_HOME/browser.state" --width 375 --height 667 --expression "innerWidth+'x'+innerHeight"
 ```
 
+导航命令在导航后会自动跳过首启弹窗（输出 `dismissed` 记录所点按钮；识别不到跳过
+按钮时输出 `onboardingBlocked` 并警告）；`--no-auto-dismiss` 只探测不点击，
+`--overlay-wait <ms>` 调整弹窗等待窗口（默认 1500）。`eval` / `fill` 不导航，
+不触发这套逻辑。
+
 ## 安全模型
 
-- 隔离环境不携带真实凭据（临时 `DSH_HOME` 无 `~/.dsh` 数据）；
+- 隔离环境不携带真实凭据（临时 `DSH_HOME` 无 `~/.dsh` 数据）；首启弹窗跳过只写
+  隔离 `$DSH_HOME/settings.yaml`（0o600）与点击弹窗自身的「稍后配置」按钮，**不注入
+  也不复制任何 API Key**；脚本继承启动环境（`{...process.env}`，与既有语义一致），
+  环境里已有的 provider 凭据变量会照 dsh 官方优先级生效——需要绝对干净的凭据面时
+  自行在无凭据变量的 shell 中启动；
+- **访问令牌最小暴露**：带令牌的 GUI URL 只落 0o600 的
+  `$DSH_HOME/browser.state`（`dshWebUrl`）与 `$DSH_HOME/dsh.log`；脚本与
+  browser-driver 回显的 URL 恒去令牌（`token=***`），verdict 只记不含令牌的
+  `web.url`——令牌不进 `--json` 输出、CI 日志与证据归档；
 - 隔离 `dsh web` 显式回环绑定（`--host 127.0.0.1`，仅本机可连）并显式禁用遥测
   （`DSH_TELEMETRY_DISABLED=1`，测试数据不外发）；
 - 隔离验证只覆盖**回环访问形态**（脚本固定 `--host 127.0.0.1`）。要验证局域网/

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/SKILL.md
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/SKILL.md
@@ -1,21 +1,18 @@
 ---
 name: dsh-verify-isolated
 description: >
-  DSH 插件开发的隔离环境浏览器验证 skill——**适用于任意 dsh 插件仓库**
-  （dsh-plugin-hub / xiaozhuge 等）。触发信号：需要对客户端 UI 改动（src/client/**
-  或宿主端 UI 渲染逻辑）做隔离浏览器实测、采集截图证据归档、验证不污染正在使用的
-  web profile。核心做法：临时 DSH_HOME + verify_<8位随机> 独立 profile + 独立端口 +
-  独立浏览器实例四重隔离，一键脚本 scripts/verify-isolated.mjs 拉起隔离 dsh web 与
-  自带浏览器实例（browser-driver.mjs，raw CDP 零依赖），退出自动清理。
-  Do NOT trigger for: 纯宿主端逻辑（不涉及 UI 渲染）、纯文档改动、普通单元/smoke
-  测试（那些走仓库自身 test 门禁）。
+  DSH 插件的隔离环境浏览器验证：对客户端 UI 改动（src/client/**、宿主端 UI 渲染逻辑、
+  窄屏/响应式布局）在临时 DSH_HOME + 独立 profile + 独立端口 + 独立浏览器实例里实测，
+  采集截图证据，全程不触碰用户正在使用的 ~/.dsh 与 web profile。
+  一键脚本 scripts/verify-isolated.mjs 负责搭建与清理，browser-driver.mjs 负责页面操作。
+  Do NOT trigger for: 纯宿主端逻辑（不涉及 UI 渲染）、纯文档改动、普通单元/smoke 测试。
 ---
 
 # dsh-verify-isolated — 隔离环境浏览器验证
 
 > 适用于任意 dsh 插件仓库的**客户端界面改动**（`src/client/**` 或宿主端 UI 渲染逻辑）
-> 的浏览器实测。本 skill 是可执行清单；仓库级细节（截图归档路径、PR 证据要求）以
-> 各仓库 AGENTS.md / docs 为准。
+> 的浏览器实测。本 skill 是可执行清单；仓库级约定（截图归档路径、PR 证据要求）以被测
+> 仓库自身为准。
 
 ## 0. 何时用
 
@@ -25,396 +22,197 @@ description: >
 - 宿主端涉及 UI 渲染逻辑的改动（如路由注入、URL 重写、overlay/Modal 渲染、双主题适配）
 - 涉及窄屏/响应式布局的调整
 
-**不需要**隔离验证的例外：纯文档改动、纯宿主端逻辑（不涉及 UI 渲染）、纯后端数据流变更。
+**不需要**的例外：纯文档改动、纯宿主端逻辑（不涉及 UI 渲染）、纯后端数据流变更。
 
-## 1. 四重隔离原理
-
-验证使用**全新临时 `DSH_HOME` + 独立 profile + 独立端口 + 独立浏览器实例**的四重
-隔离环境，与正在使用的真实 `~/.dsh`（含用户日常的 `web` profile）完全隔绝：
+## 1. 四重隔离
 
 | 隔离层 | 做法 | 隔离内容 |
 |--------|------|----------|
-| 第一层：临时 `DSH_HOME` | `DSH_HOME=$(mktemp -d)` | 凭据、会话、全部用户数据、home 级 `cordis.patch.yml` |
-| 第二层：独立 profile | `verify_<8位随机>`（非 `web`） | 插件组合栈（bundles）、profile 级 patch、插件依赖 |
-| 第三层：独立端口 | `--port` 自选/探测空闲端口 | 与运行中主 `dsh web` 及其它验证实例互不冲突 |
-| 第四层：独立浏览器实例 | `--browser` 拉起 skill 自带浏览器（独立 user-data-dir + 调试端口） | 页面/tab/console 完全独立，多会话并行互不可见 |
+| 一：临时 `DSH_HOME` | `DSH_HOME=$(mktemp -d)` | 凭据、会话、全部用户数据、home 级 `cordis.patch.yml` |
+| 二：独立 profile | `verify_<8位随机>`（非 `web`） | 插件组合栈（bundles）、profile 级 patch、插件依赖 |
+| 三：独立端口 | `--port` 自选/探测空闲端口 | 与运行中主 `dsh web` 及其它验证实例互不冲突 |
+| 四：独立浏览器实例 | `--browser` 拉起自带浏览器（独立 user-data-dir + 调试端口） | 页面/tab/console 完全独立，多会话并行互不可见 |
 
-只建独立 profile 不够：profile 共享 home 级的凭据与会话；只有同时把 `DSH_HOME`
-指向临时目录，才能做到与用户正在使用的环境完全隔离。验证结束后删除临时
-`DSH_HOME` 与 `verify_*` profile，不留残留。
+只建独立 profile 不够：profile 共享 home 级的凭据与会话；只有同时把 `DSH_HOME` 指向
+临时目录，才做到与用户正在使用的环境完全隔离。
 
-## 2. 一键脚本（推荐）
+隔离默认只覆盖**回环访问形态**（脚本固定 `--host 127.0.0.1`）。要验证局域网/移动端
+访问形态，用官方 `--trusted-host <authority>` 自行拉起，并自行确认被测插件在该形态下
+的鉴权与围栏行为（与回环形态可能不同）。
 
-脚本随本 skill 分发，相对本 skill 的**资源基础目录**恒为
-`scripts/verify-isolated.mjs`（node 实现，原 bash 版 `verify-isolated.sh` 已随
-#517 C8 重写删除，不留 shim；升级路径：`bash .../verify-isolated.sh ...` →
-`node .../verify-isolated.mjs ...`，参数与输出文案逐行对齐）。
-资源基础目录 = 加载本 skill 时系统注入的 `<skill_resources>` 块中
-`Base directory for this skill:` 一行的**绝对路径**（本 skill 所在目录，安装形态
-自适应：npm 副本安装、`link:` 开发态挂载、仓库 checkout 内浏览均自动指向 skill
-实际所在位置，跟随 `cordis.patch.yml` 的 `bundledSkillDir` 解析，不以路径拼接猜测）。
+## 2. 跑起来
 
 ```bash
-# 工作目录：worktree 根（非主 checkout）
+# 工作目录：被测插件所在的仓库（插件参数的相对路径按当前 cwd 绝对化）
 # SKILL_BASE 取注入的「Base directory for this skill:」后面的绝对路径：
-SKILL_BASE="<Base directory for this skill 一行的绝对路径，见上方 skill_resources>"
-node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 3456 <插件包路径>
-# 多包：... --port 3456 <包A路径> <包B路径>
-# 端口冲突：--port 0 让脚本自动探测真实空闲端口；--keep 保留临时环境便于排查
-# 跳过构建：--no-build（默认会先 pnpm build 各插件，保证 lib/ 或 dist/ 产物存在；
-#           产物缺失会报可操作错误，源码比产物新会给陈旧警告）
-# 浏览器验证：加 --browser 自动拉起 skill 自带独立浏览器实例（见 §5 多会话并行）
+SKILL_BASE="<Base directory for this skill 一行的绝对路径，见 skill_resources>"
+# 最小可用：起隔离实例（--port 0 自动探测空闲端口）
+node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 <插件包路径>
+# 要跑浏览器验证：加 --browser（自带独立浏览器实例，见 §4 并行约束）
 node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --browser <插件包路径>
-# 锚定 dsh 版本：验证特定 dsh 版本的生态时必须 --dsh 指定入口（默认用 PATH 中的
-# dsh——PATH 碰巧是什么版本就验什么，结果不可复现）
-node "$SKILL_BASE/scripts/verify-isolated.mjs" --dsh /opt/dsh-0.1.2-alpha.2/bin/dsh --port 0 <插件包路径>
-# 证据目录外部化（截图/快照归档到 <dir>/evidence-<profile>/，绝不动外部目录）：
-node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --evidence-dir /tmp/my-evidence <插件包路径>
-# 隔离审计（B4）：对比隔离 DSH_HOME 写面与预置白名单，白名单外变化报「可疑」、
-# 不阻断退出；--keep 时报告落 $DSH_HOME/audit/audit.json，否则并入 verdict 的 audit 字段
-node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --audit --keep <插件包路径>
-# 额外审计目录（插件写到隔离环境外的数据面，可重复；局限：不扫真实 home）：
-node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --audit --audit-extra-dirs /tmp/plugin-data <插件包路径>
+# 验证特定 dsh 版本生态：--dsh 锚定入口（PATH 里碰巧是什么版本就验什么，结果不可复现）
+node "$SKILL_BASE/scripts/verify-isolated.mjs" --dsh /opt/dsh-0.1.2-rc.1/bin/dsh --port 0 <插件包路径>
+# 排查用：--keep 保留临时 DSH_HOME；--no-build 跳过挂载前的 pnpm build
+node "$SKILL_BASE/scripts/verify-isolated.mjs" --port 0 --keep --no-build <插件包路径>
 ```
 
-插件参数（`--` 之后或直接位置参数）接受两种形态，脚本内建统一归一化
-（#517 C11 语义，随 C8 内建于 `lib/verify-core.mjs` 的 `resolvePkgArg`）：
+`--help` 是选项契约的唯一事实源（完整选项、退出码、verdict 字段、隔离审计细节都在
+那里）；脚本内部行为的解读见 [`references/script-contracts.md`](references/script-contracts.md)。
 
-- **本地插件路径**（推荐，worktree 根执行时写相对路径即可）：相对路径基于当前
+插件参数接受两种形态：
+
+- **本地插件路径**（推荐；在插件所在仓库根执行时写相对路径即可）：相对路径按当前
   cwd 解析为**绝对路径**后挂载——dsh 会把非绝对路径当 git URL 解析、报
-  `Repository not found` 迷惑错误，脚本已自动规避；绝对路径原样使用。
-- **包规格**（npm 包名 / git URL）：原样透传（仅适用 registry 可解析的包；
-  内置 bundle 如 `@deepseek-ai/dsh-web-app` 仍需按 §3 手动注入，不走 add）。
+  `Repository not found` 迷惑错误，脚本已自动规避。
+- **包规格**（npm 包名 / git URL）：原样透传（仅适用 registry 可解析的包；内置 bundle
+  如 `@deepseek-ai/dsh-web-app` 按 [`references/manual-setup.md`](references/manual-setup.md)
+  手动注入，不走 add）。
 
-若注入的 base 不可用或不确信，先自证脚本位置再执行
-（`ls "$SKILL_BASE/scripts/verify-isolated.mjs"`），或直接用 glob 全局搜索
-`verify-isolated.mjs` 取其真实绝对路径——脚本从任意 cwd 以绝对路径调用
-（自包含、不依赖自身位置）；`SKILL_BASE` 里的尖括号是占位说明，不是可执行值。
+脚本自动完成：建临时 `DSH_HOME` → 校验 dsh 入口 → 预置首启弹窗跳过 → 建
+`verify_<随机>` profile → 注入内置 web-app bundle → 构建并把插件 link 进 profile →
+（`--browser`）启动独立浏览器实例 → 启动隔离 `dsh web`（显式回环 + 遥测禁用）→
+就绪断言 → 打印带令牌 URL → 前台等待，`Ctrl+C` 退出时统一清理。dsh 直读插件的构建
+产物（`lib/` 或 `dist/`，见插件包 build 脚本），产物已就绪时 `--no-build` 可跳过构建。
 
-脚本自动完成：建临时 `DSH_HOME` → 校验 dsh 入口并打印版本（`--dsh` 锚定）→ 建
-`verify_<8位随机>` profile（`dsh plugin --profile <p> list` 显式初始化，失败即报
-可操作错误）→ 注入内置 `@deepseek-ai/dsh-web-app` bundle → **构建并**把本地插件
-link 进 profile（`--no-build` 时校验产物存在 + 陈旧警告；插件参数相对路径基于 cwd
-绝对化、npm 包名/git URL 原样透传）→ `--browser` 时启动独立浏览器实例（实例信息
-写入 `$DSH_HOME/browser.state`）→ 启动隔离 `dsh web`（显式 `--host 127.0.0.1`
-回环 + `DSH_TELEMETRY_DISABLED=1` 遥测禁用）→ **就绪断言**（轮询 HTTP 可达，
-2xx-4xx 就绪、15s 超时报可操作错误）→ 前台等待。`Ctrl+C` 退出时统一清理 dsh
-进程、浏览器实例、临时 `DSH_HOME` 与 profile（SIGINT/SIGTERM 透传退出码
-130/143）。
+`SKILL_BASE` 不可用或不确信时，先自证脚本位置（`ls "$SKILL_BASE/scripts/verify-isolated.mjs"`）
+或用 glob 搜 `verify-isolated.mjs` 取真实绝对路径——脚本自包含、可从任意 cwd 以绝对
+路径调用；尖括号是占位说明，不是可执行值。
 
-**B6 启动自检 verdict**：就绪后写 `$DSH_HOME/verdict.json`（0o600），退出终态更新
-cleanup 字段（`"done"`/`"kept"`）；端口实际绑定解析 dsh.log 端口行（parsed）→
-就绪断言端口（asserted）→ 探测端口（probed）三通道标注 source。可用
-`--json` 让 stdout 只出最终 verdict JSON（人类文案走 stderr）。
+## 3. 跑之前的两个硬前提
 
-**B7 证据目录**：默认 `$DSH_HOME/evidence/`（脚本会打印路径；退出随临时目录一并
-清理，`--keep` 保留）；显式 `--evidence-dir <dir>` 外部化时建
-`<dir>/evidence-<profile>/` 子目录，**绝不动外部目录**（不删、不覆盖）。
+全新 `DSH_HOME` 的隔离实例，首屏不是插件界面，而是两个**阻断式**弹窗；同时 GUI 带
+鉴权，裸端口访问拿不到界面。两者都会让「打开页面截图」看似成功、实则无效。
 
-**B4 隔离审计（`--audit`）**：可选开启，对比隔离 `$DSH_HOME` 写面与**预置白名单**
-（版本化 `WHITELIST_V`，模式数组随 `scripts/lib/audit.mjs` 分发、smoke 断言存在）：
-白名单外的新增/删除/修改报「可疑」（纯 stat 路径级，不读内容）；白名单内变化
-忽略（dsh 重写 settings 是常态）；未知顶层路径 → 可疑。白名单分工：
-`profiles/**`、`*.json/*.jsonl/*.log`、`.credentials.yaml`、`browser.state`、
-`browser-profile/**`（整树白名单 + 跳过深扫）、`evidence/**`、`audit/**`、
-`storages/**`（dsh 官方存储写面）、`dsh.log`、`verdict.json`；随 dsh 版本漂移的
-面（如 profiles/node_modules/** 官方 bundle link）由 **t0 动态基线**覆盖（见下）。
-**symlink 防逃逸**：快照 lstat 不跟随；`t1` 时**新增的**或**目标变化**且 resolve
-后在**所在扫描根**（`$ISOLATED_HOME` 或 `--audit-extra-dirs` 目录）外的 symlink
-报「越界 symlink」（防插件经 symlink 写回主 checkout），`t0` 已存在且目标未变的
-外部 symlink（`link:` 挂载点，合法）不报；防逃逸优先于白名单——`profiles/**` 内
-新增越界 symlink 同样报。**局限**：只扫 `$ISOLATED_HOME` 子树 +
-`--audit-extra-dirs <dir>`（可重复，相对路径基于 cwd 绝对化、必须是目录）指定的
-额外目录，**不扫真实 home**。时序：`t0` 基线在**就绪断言成功之后**（dsh 启动期
-自身写面与官方 bundle link 进基线——语义为「**就绪后运行期写面审计**」，审计面 =
-dsh 就绪后、退出前的增量写面；verdict 中间态在其后写入，先扫后写 + 白名单双
-保险）；审计插在退出清理序列「kill dsh → browser quit → **审计** → verdict 终态
-→ rm」之间，**不阻断退出**（审计是补充非门禁，退出码契约不变）；就绪前退出/
-超时路径不审计（`audit` 为 null）；`--keep` 时报告落 `$DSH_HOME/audit/audit.json`，
-否则随 `--json` 终态 verdict 输出（stdout `audit` 字段；错误路径错误 JSON 恒带
-`audit` 字段，与 verdict 对齐）。
+### 3.1 带令牌的访问 URL
 
-**退出码契约**：0 正常完成 / 1 启动或就绪失败（profile 初始化失败、add 失败、
-dsh 就绪前退出、15s 就绪超时）/ 2 参数错误（未知选项、缺参、找不到 dsh 入口、
---no-build 缺产物）/ 130 SIGINT（Ctrl+C）/ 143 SIGTERM。
-
-**Windows 承诺等级：试验性**——spawn .cmd 回退、无 POSIX 信号（taskkill /T 进程
-树清理）等兼容点在代码逐处注释标注，但未在 CI 实测；smoke 不启动 dsh，Windows
-行为走代码审查（见 verify-isolated.mjs 头部注释「Windows 三坑」）。
-
-> **构建说明**：dsh 直读构建产物（dsh-plugin-hub 各包的 `lib/`、xiaozhuge 的 `dist/`），
-> 脚本默认在挂载前 `pnpm build` 各插件，保证产物存在；产物已就绪时可 `--no-build` 跳过。
-
-## 3. 手动步骤（等价于脚本做的事）
+dsh web 的 GUI 带鉴权，**不带令牌只得到 401 文本页**
+（`dsh web authentication required; reopen the URL printed by dsh web.`）。就绪断言把
+2xx-4xx 都算就绪，所以漏带令牌时验证会在 401 页面上继续跑下去。令牌的唯一来源是 dsh
+启动打印的那一行：
 
 ```bash
-# 工作目录：worktree 根（非主 checkout）
-# 1. 第一层隔离：全新临时 DSH_HOME
-DSH_HOME=$(mktemp -d)
-export DSH_HOME
-
-# 2. 第二层隔离：独立 profile（verify_<8位随机>，避免与真实环境冲突）
-PROFILE="verify_$(node -e 'console.log(require("node:crypto").randomBytes(4).toString("hex"))')"
-dsh plugin --profile "$PROFILE" list >/dev/null   # 显式初始化 profile（含 dsh-base 模板；失败即停）
-
-# 3. 注入内置 web-app bundle：@deepseek-ai/dsh-base、@deepseek-ai/dsh-web-app 按名
-#    从 dsh 安装目录解析，不进 dependencies、不走 npm
-node -e '
-  const fs = require("fs");
-  const p = process.argv[1];
-  const j = JSON.parse(fs.readFileSync(p, "utf8"));
-  const b = j.dsh.profile.bundles;
-  if (!b.includes("@deepseek-ai/dsh-web-app")) {
-    b.splice(b.indexOf("@deepseek-ai/dsh-base") + 1, 0, "@deepseek-ai/dsh-web-app");
-  }
-  fs.writeFileSync(p, JSON.stringify(j, null, 2));
-' "$DSH_HOME/profiles/$PROFILE/package.json"
-
-# 4. 挂载本地插件（主 checkout 的 packages/*，link 进 profile）
-dsh plugin --profile "$PROFILE" add /path/to/main-checkout/packages/dsh-<name>
-
-# 5. 启动隔离 dsh web（指定不冲突端口；--port 0 让系统随机；显式回环 + 遥测禁用）
-DSH_TELEMETRY_DISABLED=1 dsh --profile "$PROFILE" --host 127.0.0.1 --port 3456 --no-open
-
-# 6. 就绪断言（对齐脚本 M2 行为）：轮询 HTTP 可达再开始验证（GUI 带鉴权，2xx-4xx
-#    均算就绪；连接拒绝继续等，15s 超时报错）
-node -e 'const t=Date.now();(async()=>{for(;;){try{const r=await fetch("http://127.0.0.1:3456/",{signal:AbortSignal.timeout(1500)});if(r.status<500)break}catch{}if(Date.now()-t>15000)throw new Error("15s 未就绪");await new Promise(r=>setTimeout(r,250))}})()'
+# 三种取法（等价，取其一）：
+# 1) 脚本启动时直接打印：`访问 URL（含访问令牌，GUI 鉴权必需）: http://127.0.0.1:<port>/?token=...`
+# 2) 从 dsh.log 取（与端口解析同一行）：
+grep -o 'dsh web: http://[^ ]*' "$DSH_HOME/dsh.log" | tail -1 | sed 's/^dsh web: //'
+# 3) 交给 browser-driver（--browser 时脚本已写入 browser.state.dshWebUrl）：
+node "$SKILL_BASE/scripts/browser-driver.mjs" snapshot --state "$DSH_HOME/browser.state" --url state
 ```
 
-需要浏览器实例时（第四层隔离，等价于脚本 `--browser`）：
+- `--url state` 是页面命令的保留取值：读 state 文件里的带令牌 URL，省掉手工拼接。
+  省略 `--url` 仍是**不导航**（保留上一条命令的页面状态，多步交互验证不受影响）。
+- **令牌是访问凭据**：命令回显的 URL 恒去令牌（`token=***`），真值只在 0o600 的
+  `browser.state` / `dsh.log` 里。截图与快照 JSON 进证据前确认其中没有 `token=` 明文；
+  手工传 `--url` 时同样用已脱敏的形态记录。
+- 鉴权是**会话级**的：同一浏览器实例先用带令牌 URL 打开过，后续裸端口也能进；全新
+  实例直接访问裸端口则必然 401。命中 401 文本页时命令输出 `authRequired` 并在 stderr
+  提示。
 
-```bash
-node "$SKILL_BASE/scripts/browser-driver.mjs" launch \
-  --state "$DSH_HOME/browser.state" --user-data-dir "$DSH_HOME/browser-profile"
-# 退出前清理（与脚本统一清理相同语义）：
-node "$SKILL_BASE/scripts/browser-driver.mjs" quit --state "$DSH_HOME/browser.state"
-```
+### 3.2 首启弹窗默认跳过
 
-## 4. 关键原则
+两个弹窗都把 `#root` 置为 `inert`，页面上一切点击静默失效——所以跳过必须是默认行为，
+而不是「记得点掉」：
 
-- **DSH_HOME 设到临时目录**：`$(mktemp -d)` 生成唯一临时目录，隔离凭据、会话与
-  home 级 patch，防止测试数据污染 `~/.dsh` 真实用户配置。
-- **独立 profile 命名 `verify_<8位随机>`**：不占用/不触碰用户正在使用的 `web`
-  profile；随机后缀避免多实例/多次验证间冲突。
-- **插件从主 checkout 的 `lib/` 加载**：`dsh plugin --profile <name> add` 指向主
-  checkout 的 `packages/*/`，以 `link:` 依赖挂载（符号链接，非复制），确保访问构建
-  后的成品（而非源文件）。
-- **最小启动依赖**：自定义 profile 要启动 web 界面，`dsh.profile.bundles` 必须含
-  `@deepseek-ai/dsh-base` + `@deepseek-ai/dsh-web-app`。这两个内置 bundle 从 dsh
-  安装目录按名解析，**不要**用 `dsh plugin add` 走 npm 安装（其依赖
-  `@deepseek-ai/dsh-frontend` 不在 registry，会 404）。
-- **独立端口**：`--port <n>` 选择与运行中主 `dsh web` 不冲突的端口（如 3456），
-  `--port 0` 自动探测真实空闲端口，**不要关闭或重启运行中的主 dsh web 进程**。
-- **显式回环 + 遥测禁用**：隔离实例一律 `--host 127.0.0.1`（当前 dsh 默认即回环，
-  显式写死防上游默认变更）+ `DSH_TELEMETRY_DISABLED=1`（测试数据不外发遥测）；
-  一键脚本已内置，手动拉起时也必须带上。
-- **非回环访问形态不在隔离默认内**：脚本固定显式回环绑定，故隔离验证只覆盖回环
-  访问形态。要验证局域网/移动端访问形态，dsh 0.1.5 起可自行用官方
-  `--trusted-host <authority>` 声明受信 authority；该形态下**被测插件自身路由的
-  鉴权与围栏行为需自行确认**，不要假定与回环形态一致。
-- **锚定 dsh 版本**：验证特定 dsh 版本的生态时用 `--dsh <path>` 指定入口，默认
-  PATH 中的 `dsh` 会让验证结果随环境漂移、不可复现。
-- **不复制真实凭据**：隔离环境使用临时 `DSH_HOME`，不携带 `~/.dsh` 下的真实凭据、
-  令牌、API 密钥等。若验证需要凭据，使用测试专用凭据或 mock 数据。
-- **验证完成后清理**：停止隔离 `dsh web` 进程后，删除临时 `DSH_HOME` 目录
-  （`rm -rf "$DSH_HOME"`），避免残留无用的 `verify_*` profile。
+| 顺序 | 弹窗 | 出现条件 | 默认处置 |
+|------|------|----------|----------|
+| 1 | 内测声明（`Continue` / `继续`） | `$DSH_HOME/settings.yaml` 的 `ui-onboarding.welcomeNoticeVersion` 与 dsh 客户端常量 `WELCOME_NOTICE_VERSION` **精确相等**才算已确认；全新 DSH_HOME 必然未确认 | 启动前预置该值（`--no-skip-onboarding` 关闭） |
+| 2 | 添加 API Key（`Configure later` / `稍后配置`） | 隔离环境无任何可用 provider；且「稍后配置」**只在当前页面生命周期内有效**，刷新/新标签必重弹 | browser-driver 导航后自动点击跳过 |
 
-## 5. 多会话并行（浏览器硬隔离）
+跳过是**双保险**：预置消掉弹窗 1，浏览器侧兜底消掉弹窗 2（顺带兜住 dsh 升级导致的
+版本漂移与 locale 文案变化）。要点：
 
-**强制规则：客户端 UI 验证一律走本 skill 自带浏览器实例（`--browser`），禁用
-工作区共享 MCP 浏览器**（`.dsh/mcp.json` 的 playwright / chrome-devtools 由
-dsh-mcp-manager 管理，**同一工作区的所有会话共享同一个 MCP server 子进程**——
-浏览器实例只有一份，`browser_snapshot/click` 等工具操作该 server 的「当前活动
-页」，多会话并行时 tab/页面互相漂移串扰，甚至漂到其他实例的用户页面。官方
-`--isolated` 只解「状态串」（每会话新 context），不解「操作面串」；`--browser`
-才是结构性硬隔离）。
+- **版本号现取，不硬编码**：脚本从 dsh 产物读常量（`scripts/lib/onboarding.mjs`）；
+  取不到只警告、不改判定，交给浏览器侧兜底——写死会在 dsh 升级后静默失效。
+- **识别不到跳过按钮时不猜**：弹窗里可能并列「保存并继续」这类有副作用的按钮，此时
+  只输出 `onboardingBlocked` 并在 stderr 警告，由人决定怎么处置。
+- **预置只写隔离环境**：目标是 `$DSH_HOME/settings.yaml`，不触碰真实 `~/.dsh`；脚本也
+  不注入任何凭据（弹窗 2 靠点击跳过，而不是伪造 API Key）。
+- **要验证 onboarding 本身**：加 `--no-skip-onboarding` 保留原生首启态；需要弹窗 2
+  也留着，再加 browser-driver 的 `--no-auto-dismiss`（只探测不点击）。
 
-每个验证任务**自带独立浏览器实例**：独立 user-data-dir + 自选空闲调试端口 +
-headless 内核，实例信息写入各任务自己的 `browser.state`（`--browser` 时在
-`$DSH_HOME/browser.state`，随 DSH_HOME 同生命周期），多会话并行互不可见、
-互不打断、tab 不漂移。
-
-### 5.1 四重隔离自检清单（并行验证前逐项核对）
+## 4. 隔离自检（并行验证前逐项核对）
 
 | # | 隔离项 | 自检命令 / 判据 |
 |---|--------|-----------------|
 | 1 | DSH_HOME | `echo $DSH_HOME` → 必须是本次验证的临时目录（mktemp 路径），**不得是** `~/.dsh` |
 | 2 | profile | 脚本输出 `profile=verify_<8位随机>`；`dsh plugin --profile web list` 不受影响 |
-| 3 | 端口 | dsh web 端口与主实例及其它并行实例互不相同；`--port 0` 时脚本会打印探测到的真实端口 |
-| 4 | 浏览器实例 | `browser.state` 的 `port`/`pid`/`userDataDir` 为本任务独有；并行任务各自的 state 文件路径不同（各在各自 DSH_HOME 下） |
-| 5 | 插件持久化隔离感知 | 验证涉及**读写插件自己的持久化文件**（通知记录、用量数据等）时，先确认该插件落盘路径 DSH_HOME 感知（hub 内查是否有 `process.env.DSH_HOME ?? homedir()/.dsh` 契约）。**不感知时的处置**：在验证记录中标注「该插件隔离盲区」→ 验证中避免触发会写持久化文件的操作（清理/发送测试类按钮）→ 提报 issue（先例 #510）。读面串同样算盲区，截图含真实数据时须说明 |
+| 3 | 端口 | dsh web 端口与主实例及其它并行实例互不相同；`--port 0` 时脚本打印真实端口 |
+| 4 | 浏览器实例 | `browser.state` 的 `port`/`pid`/`userDataDir` 为本任务独有；并行任务各自的 state 路径不同（各在各自 DSH_HOME 下） |
+| 5 | 插件持久化隔离感知 | 验证涉及**读写插件自己的持久化文件**（通知记录、用量数据等）时，先确认插件落盘路径 DSH_HOME 感知（查源码里是否有 `process.env.DSH_HOME ?? homedir()/.dsh` 这类契约）。**不感知时的处置**：在验证记录中标注「该插件隔离盲区」→ 验证中避免触发会写持久化文件的操作（清理/发送测试类按钮）→ 在验证结论中提报。读面串同样算盲区，截图含真实数据时须说明 |
 
-并行验证建议：每个任务**单独运行一个 `verify-isolated.mjs --port 0 --browser` 进程**
-（各自独立临时 DSH_HOME / profile / 端口 / 浏览器实例），不要在同一隔离环境内
-手拉多个浏览器。
+并行验证：每个任务**单独运行一个 `verify-isolated.mjs --port 0 --browser` 进程**
+（各自独立的临时 DSH_HOME / profile / 端口 / 浏览器实例）；同一隔离环境内手拉多个
+浏览器会让并行隔离失效。浏览器一律用本 skill 自带的 `--browser` 实例：工作区共享的
+浏览器 MCP 只有一份「当前活动页」，多会话并行时 tab 会互相漂移、甚至漂到其他实例的
+用户页面。
 
-## 6. 浏览器验证方法
+`--browser` 需要 Chromium 系内核（探测链、三平台自查与安装命令见
+[`references/browser-kernel.md`](references/browser-kernel.md)）。
 
-使用 skill 自带浏览器驱动（`browser-driver.mjs`，raw CDP 零依赖）在隔离环境内
-自动化验证；浏览器 MCP 仅限**非并行**的简单场景。
+## 5. 核验与证据
 
-### 6.1 前置检查：浏览器内核
+页面命令（snapshot / click / eval / fill / wait / screenshot / console）统一 `--json`
+输出，`--state` 指向本任务自己的 state 文件；完整参数见
+`node "$SKILL_BASE/scripts/browser-driver.mjs" --help`。
 
-`--browser` 需要 Chromium 系内核（Chrome / Edge / Chromium）。探测链（
-`browser-driver.mjs detectChrome()`，唯一收敛点）：
+### 5.1 核验步骤
 
-`DSH_VERIFY_CHROME` 环境变量 → ms-playwright 缓存 → PATH → 平台常见路径，
-全缺失时 fail-fast 并打印可执行安装指引。
+1. **导航到改动对应的路由/页面**：`snapshot --state "$STATE" --url state`。
+   判据：`bodyText` 里出现该页面的标志性文案，且输出无 `authRequired`。
+2. **验证 UI 呈现**：`snapshot --selector <css>` 断言目标元素 `found: true` 且 `rect`
+   非零；交互用 `click` / `fill` 后再 `eval` 读回状态。
+   判据：每个改动点都有一组「操作 + 读回」的成对输出，不靠目测。
+3. **检查 Console**：`console --state "$STATE" --url state --wait-ms 2000`。
+   判据：无 `type: "exception"`、无 `level: "error"`；插件挂载失败只应 `console.warn`。
+4. **双主题**：明/暗各采一张截图。
+   判据：两张都在，且暗色下无浅底浅字这类硬编码色值问题。
+5. **窄屏/响应式**（改动命中时）：按
+   [`references/viewport-geometry.md`](references/viewport-geometry.md)（设备视口与几何验证）
+   逐档设定视口核验，每档四项断言全过。
 
-| 平台 | ms-playwright 缓存目录 | 常见安装路径（PATH 之外兜底） |
-|------|------------------------|------------------------------|
-| Linux | `~/.cache/ms-playwright` | `/usr/bin/google-chrome`、`/usr/bin/chromium`、`/snap/bin/chromium` |
-| macOS | `~/Library/Caches/ms-playwright` | `/Applications/Google Chrome.app/.../Google Chrome`、`/Applications/Chromium.app/.../Chromium` |
-| Windows | `%LOCALAPPDATA%\ms-playwright` | `%ProgramFiles%\Google\Chrome\Application\chrome.exe`、`%ProgramFiles(x86)%\...`、`%LOCALAPPDATA%\Google\Chrome\Application\chrome.exe` |
+**穷尽要求**：本次改动涉及的每个 UI 触点（每个路由、每个交互状态）都要有对应证据；
+主路径正常不替代次要分支的核验。
 
-自查命令：
+### 5.2 截图与归档
 
-```bash
-# Linux / macOS：确认内核可执行文件存在
-ls ~/.cache/ms-playwright 2>/dev/null      # ms-playwright 缓存命中？
-command -v google-chrome chromium          # PATH 命中？
-# macOS 额外：
-ls "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" 2>/dev/null
-# Windows（PowerShell）：
-Test-Path "$env:LOCALAPPDATA\ms-playwright"          # ms-playwright 缓存
-Test-Path "$env:ProgramFiles\Google\Chrome\Application\chrome.exe"
-# 全部缺失时一键安装内核：
-#   Linux: sudo apt-get install -y chromium-browser   或   npx playwright install chromium
-#   macOS: brew install --cask google-chrome          或   npx playwright install chromium
-#   Windows: winget install Google.Chrome             或   npx playwright install chromium
-# 已装但探测不到时显式指定：
-#   DSH_VERIFY_CHROME=/path/to/chrome node "$SKILL_BASE/scripts/verify-isolated.mjs" --browser <pkg>
-```
-
-### 6.2 browser-driver 操作命令
-
-`--browser` 启动后（实例信息在 `$DSH_HOME/browser.state`），所有命令统一
-`--json` 输出、默认即 JSON；`--state` 必须指向本任务自己的 state 文件
-（并行任务各用各的，互不覆盖）。完整契约见 `browser-driver.mjs --help`：
-
-```bash
-# 先看帮助（契约唯一事实源）
-node "$SKILL_BASE/scripts/browser-driver.mjs" --help
-STATE="$DSH_HOME/browser.state"
-
-# 页面状态快照（导航 + title/readyState/body 文本/选择器元素）
-node "$SKILL_BASE/scripts/browser-driver.mjs" snapshot --state "$STATE" --url http://127.0.0.1:<端口>
-# 点击 / 填充 / 执行 JS / 等待元素（轮询，替代固定 sleep）
-node "$SKILL_BASE/scripts/browser-driver.mjs" click  --state "$STATE" --selector "button.start"
-node "$SKILL_BASE/scripts/browser-driver.mjs" fill   --state "$STATE" --selector "input[name=q]" --value "测试"
-node "$SKILL_BASE/scripts/browser-driver.mjs" eval   --state "$STATE" --expression "document.title"
-node "$SKILL_BASE/scripts/browser-driver.mjs" wait   --state "$STATE" --selector ".done" --timeout 10000
-# 截图（整页或元素）与 console 捕获
-node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$STATE" --url http://127.0.0.1:<端口> --path shot.png
-node "$SKILL_BASE/scripts/browser-driver.mjs" console   --state "$STATE" --url http://127.0.0.1:<端口> --wait-ms 2000
-# 视口档位（设备模拟；任一页面命令通用，详见 §6.4）
-node "$SKILL_BASE/scripts/browser-driver.mjs" snapshot --state "$STATE" --url http://127.0.0.1:<端口> --width 375 --height 667
-```
-
-### 6.3 核验改动
-
-1. **导航到改动对应的路由/页面**：打开 `http://127.0.0.1:<port>` 下的对应路径
-   （`--port 0` 时用脚本打印的真实端口）。
-2. **验证 UI 呈现**：`snapshot` 确认组件渲染正确、样式符合预期；`click`/`fill`/
-   `eval` 验证交互行为。
-3. **检查 Console**：`console` 命令捕获 `console.error`、未捕获异常、插件相关的
-   `console.warn` 消息。挂载失败只应 `console.warn` 不应 throw。
-4. **双主题验证**：切换明/暗主题确认颜色引用正确，无硬编码固定色值。
-5. **窄屏/响应式验证**：按 §6.4 的视口档位逐档设定后核验 pad（768×1024）与 phone
-   （375×667）布局。**不要用 `window.resizeTo`**——它高度不生效，理由见 §6.4。
-
-### 6.4 设备视口与几何验证
-
-响应式/窄屏改动必须**逐档设定视口**后核验。不要用 `window.resizeTo`：它只能改窗口
-宽度，高度不生效（实测 `resizeTo(768,1024)` 后 `innerHeight` 仍是默认值，pad/phone
-档的第二维根本无法验证），同一条 `eval` 表达式内也读不到改动结果。
-
-改用设备模拟 flag——**任一页面命令**（snapshot / click / eval / fill / wait /
-screenshot / console）均可携带，命令内生效、结束即清除，命令之间互不影响：
-`--width N` `--height N` `--dpr N`（设备像素比，默认 1）`--mobile`（见下方边界）。
-只给一维时另一维取当前视口值。
-
-**基线档（不带任何设备 flag）**：先记录默认视口（`--browser` 的 headless 内核通常为
-800x600）作为对照基准；逐档改视口之后，再用一条**不带 flag** 的命令回读——数值回到
-基线，即证明「命令结束即清除」成立、没有残留污染后续命令。这条回读既是残留自检，
-也是判定窄屏档是否**真的**生效的基准（否则无法区分「窄屏生效」与「参数没起作用」）：
-
-```bash
-STATE="$DSH_HOME/browser.state"
-# 基线档：不带设备 flag
-node "$SKILL_BASE/scripts/browser-driver.mjs" eval --state "$STATE" --expression "innerWidth+'x'+innerHeight"
-# 改档后回读：应回到基线值（否则说明有残留）
-node "$SKILL_BASE/scripts/browser-driver.mjs" eval --state "$STATE" --expression "innerWidth+'x'+innerHeight"
-```
-
-```bash
-# 两档视口各采一次证据（phone / pad）
-node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$STATE" --url http://127.0.0.1:<端口> --width 375 --height 667 --path phone.png
-node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$STATE" --url http://127.0.0.1:<端口> --width 768 --height 1024 --path pad.png
-# 高 DPI：元素截图（--selector）按 --dpr 输出物理像素（375x667 档 + --dpr 2 → 750x1334）；
-# 整页截图（不带 --selector）固定输出 CSS 像素尺寸，不随 --dpr 放大
-node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$STATE" --url http://127.0.0.1:<端口> --width 375 --height 667 --dpr 2 --selector "<css>" --path phone@2x.png
-# 自证视口生效（不要把「设了参数」当成「布局已按该档渲染」）
-node "$SKILL_BASE/scripts/browser-driver.mjs" eval --state "$STATE" --width 375 --height 667 \
-  --expression "innerWidth+'x'+innerHeight+' mq='+matchMedia('(max-width: 640px)').matches"
-```
-
-每档至少断言四项（用 `eval` 或 `snapshot --selector` 返回的 `rect`）：
-
-| 断言 | 表达式模板 | 判据 |
-|------|-----------|------|
-| 视口生效 | `innerWidth+'x'+innerHeight` | 等于设定档位 |
-| 无横向溢出 | `document.documentElement.scrollWidth <= innerWidth + 1` | true（+1 容差防亚像素） |
-| 关键元素在视口内 | `snapshot --selector <css>` 的 `rect` | `x >= 0 && x + rect.width <= innerWidth`，纵向可滚动到 |
-| 落点复核 | 改视口前后各取一次 `rect` | 位移方向与幅度符合预期（如锚定侧边的元素随视口收窄内移） |
-
-`position: fixed` 元素最容易在窄屏失效：除落点外，还要滚动到页面底部确认它仍可达、
-不被安全区或软键盘遮住。
-
-**能力边界（不要越界承诺）**：
-
-- `--mobile` 启用移动 layout viewport 语义：页面无 `<meta name="viewport">` 时
-  `innerWidth` **不再等于**设定宽度（实测 375 档会读回约 981）。要精确命中 CSS 断点
-  请保持 mobile 关闭；只有需要复现真机 layout viewport 行为时才加 `--mobile`。
-- **触控、软键盘、真实 UA、旋转、`dvh`/安全区不在本 skill 能力面内**：headless 内核
-  无法完整模拟（`maxTouchPoints` 可设，但 `ontouchstart` 不生效）。涉及触控手势、
-  软键盘弹出/收起、`visualViewport` 跟随的改动**必须真机验证**，不得以 headless
-  结果代替。
-- 视口模拟只覆盖布局维度；改视口的命令结束后状态即清除，不要把某一档的结论套用到
-  其它档。
-
-### 6.5 防 flake 纪律
-
-浏览器自动化验证**不得使用固定时间等待**（如 `setTimeout(resolve, 300)`），
-必须采用轮询等待机制：
-
-- 等待元素出现：用 `wait --selector <css> --timeout <ms>`（browser-driver 内置
-  轮询），或 `click`/`fill` 内部自带先等待；不要固定 sleep。
-- 等待 DOM 更新：轮询目标元素状态直到满足条件，设置合理超时兜底。
-- 等待网络请求完成：轮询页面状态标志（如 `eval --expression "document.readyState"`）
-  而非固定延时。
-
-### 6.6 截图采集
-
-- 截图只截插件 UI 本身（`screenshot --selector` 元素截图），不带浏览器整窗，
-  避免泄露本机环境（文件路径、IP 地址、其他标签页）。
+- 截图只截插件 UI 本身（`screenshot --selector` 元素截图），不带浏览器整窗，避免泄露
+  本机环境（文件路径、IP 地址、其他标签页）。
 - 格式：PNG；单张截图聚焦一个验证点，多场景拆多张。
-- 归档路径与 PR 证据要求以各仓库 AGENTS.md 为准（dsh-plugin-hub 归档至
-  `packages/dsh-<name>/docs/archive/`）。
+- 归档路径与 PR 证据要求以**被测仓库自身约定**为准（本 skill 不规定路径；没有约定时
+  放到 `docs/archive/` 之类的项目文档目录，并在结论里写明位置）。
 
-## 7. 完成检查
+### 5.3 等待一律轮询
 
-- [ ] 隔离 `dsh web` 实例已启动且不冲突主实例端口（`--port 0` 时打印真实端口；
-      脚本会做就绪断言，超时未就绪会给出可操作错误）
-- [ ] 隔离实例为显式回环 + 遥测禁用（脚本内置；手动拉起时核对 `--host` 与
+等待一律用轮询、超时兜底，这样慢机器上偶发失败、快机器上白等的情况都不会出现：
+
+- 元素出现/可点：`wait --selector <css> --timeout <ms>`，或直接用自带等待的 `click` / `fill`。
+- 页面状态：`eval` 轮询到目标值（如 `document.readyState`）。
+- 导航后异步挂载的组件（弹窗、懒加载区域）：轮询其存在性，而不是等固定时长。
+
+## 6. 完成检查
+
+- [ ] 隔离实例已启动且不冲突主实例端口（`--port 0` 时脚本打印真实端口，超时未就绪
+      会给可操作错误）
+- [ ] 隔离实例为显式回环 + 遥测禁用（脚本内置；手动拉起时核对 `--host 127.0.0.1` 与
       `DSH_TELEMETRY_DISABLED=1`）
-- [ ] 若验证涉及插件持久化文件：已核对插件 DSH_HOME 感知（不感知按 §5.1 第 5 项处置）
-- [ ] 若做并行验证：四重隔离自检清单（§5.1）逐项通过，各任务浏览器 state 独立
-- [ ] 插件 UI 在隔离环境渲染正常（双主题 + 窄屏如适用）
-- [ ] 响应式/窄屏改动已按 §6.4 逐档设定视口核验（未用 `resizeTo`），四项断言
-      （视口生效/无横向溢出/元素在视口内/落点）逐档通过
-- [ ] 触控、软键盘、真机 UA 相关项已明确标注「仍需真机验证」或已真机复核
+- [ ] 页面命令用的是**带令牌**的访问 URL（`--url state` 或脚本打印的 URL）：输出无
+      `authRequired`，body 可见插件界面
+- [ ] 首启弹窗已跳过、应用根非 inert：输出无 `onboardingBlocked`；必要时用 `eval` 复核
+      `document.getElementById('root').inert === false`
+- [ ] §4 自检清单逐项通过（含插件持久化 DSH_HOME 感知的核对或盲区标注）
+- [ ] §5.1 五个核验点按穷尽要求完成（每个 UI 触点都有成对的操作与读回证据）
+- [ ] 响应式/窄屏改动：`references/viewport-geometry.md` 的逐档核验与四项断言全过
+- [ ] 触控、软键盘、真机 UA 相关项已标注「仍需真机验证」或已真机复核
 - [ ] Console 无未处理错误（挂载失败仅 warn）
-- [ ] 截图已采集并按仓库规范归档（如适用）
-- [ ] 隔离实例已停止、浏览器实例已清理（`browser.state` 不再存在）、临时
-      `DSH_HOME` 与 `verify_*` profile 已清理
+- [ ] 截图已采集并按被测仓库约定归档，且证据内无 `token=` 明文
+- [ ] 隔离实例已停止、浏览器实例已清理（`browser.state` 不再存在）、临时 `DSH_HOME`
+      与 `verify_*` profile 已清理
+
+## 7. 参考文件
+
+| 文件 | 读它的时机 |
+|------|-----------|
+| [`references/script-contracts.md`](references/script-contracts.md) | 要解读 `verdict.json`、开隔离审计（`--audit`）、或启动/就绪失败要定位原因 |
+| [`references/manual-setup.md`](references/manual-setup.md) | 一键脚本不可用，或要理解/手工调整某一层隔离 |
+| [`references/browser-kernel.md`](references/browser-kernel.md) | `--browser` 报找不到 Chromium 系内核，或要确认命中了哪个内核 |
+| [`references/viewport-geometry.md`](references/viewport-geometry.md) | 改动涉及响应式/窄屏布局，要逐档核验几何表现 |

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/references/browser-kernel.md
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/references/browser-kernel.md
@@ -1,0 +1,43 @@
+# 浏览器内核：探测、自查与安装
+
+> 读它的时机：`--browser` 报「找不到 Chromium 系内核」，或要确认本机命中了哪个内核。
+> 内核正常时不需要本文件。
+
+`--browser` 需要 Chromium 系内核（Chrome / Edge / Chromium）。探测链
+（`browser-driver.mjs` 的 `detectChrome()`，唯一收敛点）：
+
+`DSH_VERIFY_CHROME` 环境变量 → ms-playwright 缓存 → `PATH` → 平台常见路径。
+全部缺失时 fail-fast，并打印可执行的安装指引。
+
+| 平台 | ms-playwright 缓存目录 | 常见安装路径（`PATH` 之外兜底） |
+|------|------------------------|------------------------------|
+| Linux | `~/.cache/ms-playwright` | `/usr/bin/google-chrome`、`/usr/bin/chromium`、`/snap/bin/chromium` |
+| macOS | `~/Library/Caches/ms-playwright` | `/Applications/Google Chrome.app/.../Google Chrome`、`/Applications/Chromium.app/.../Chromium` |
+| Windows | `%LOCALAPPDATA%\ms-playwright` | `%ProgramFiles%\Google\Chrome\Application\chrome.exe`、`%ProgramFiles(x86)%\...`、`%LOCALAPPDATA%\Google\Chrome\Application\chrome.exe` |
+
+自查命令：
+
+```bash
+# Linux / macOS：确认内核可执行文件存在
+ls ~/.cache/ms-playwright 2>/dev/null      # ms-playwright 缓存命中？
+command -v google-chrome chromium          # PATH 命中？
+# macOS 额外：
+ls "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" 2>/dev/null
+# Windows（PowerShell）：
+Test-Path "$env:LOCALAPPDATA\ms-playwright"          # ms-playwright 缓存
+Test-Path "$env:ProgramFiles\Google\Chrome\Application\chrome.exe"
+```
+
+装内核（任选其一）：
+
+```bash
+#   Linux:   sudo apt-get install -y chromium-browser   或   npx playwright install chromium
+#   macOS:   brew install --cask google-chrome          或   npx playwright install chromium
+#   Windows: winget install Google.Chrome               或   npx playwright install chromium
+```
+
+已装但探测不到时显式指定路径：
+
+```bash
+DSH_VERIFY_CHROME=/path/to/chrome node "$SKILL_BASE/scripts/verify-isolated.mjs" --browser <插件包路径>
+```

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/references/manual-setup.md
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/references/manual-setup.md
@@ -1,0 +1,64 @@
+# 手动搭建隔离环境（脚本的等价展开）
+
+> 读它的时机：一键脚本不可用（无法运行 node 脚本、dsh 入口异常）、要理解脚本每一步在
+> 做什么、或要手工调整某一层隔离。日常验证直接用 `scripts/verify-isolated.mjs`，
+> 见 SKILL.md §2。
+
+```bash
+# 工作目录：被测插件所在的仓库（SKILL_BASE 取注入的「Base directory for this skill:」绝对路径）
+# 1. 第一层隔离：全新临时 DSH_HOME
+DSH_HOME=$(mktemp -d)
+export DSH_HOME
+
+# 2. 第二层隔离：独立 profile（verify_<8位随机>，避免与真实环境冲突）
+PROFILE="verify_$(node -e 'console.log(require("node:crypto").randomBytes(4).toString("hex"))')"
+dsh plugin --profile "$PROFILE" list >/dev/null   # 显式初始化 profile（含 dsh-base 模板；失败即停）
+
+# 3. 注入内置 web-app bundle：@deepseek-ai/dsh-base、@deepseek-ai/dsh-web-app 按名
+#    从 dsh 安装目录解析，不进 dependencies、不走 npm
+node -e '
+  const fs = require("fs");
+  const p = process.argv[1];
+  const j = JSON.parse(fs.readFileSync(p, "utf8"));
+  const b = j.dsh.profile.bundles;
+  if (!b.includes("@deepseek-ai/dsh-web-app")) {
+    b.splice(b.indexOf("@deepseek-ai/dsh-base") + 1, 0, "@deepseek-ai/dsh-web-app");
+  }
+  fs.writeFileSync(p, JSON.stringify(j, null, 2));
+' "$DSH_HOME/profiles/$PROFILE/package.json"
+
+# 4. 挂载本地插件（被测插件目录，link 进 profile）
+dsh plugin --profile "$PROFILE" add /path/to/your-plugin-package
+
+# 5. 预置首启弹窗跳过（等价于脚本默认行为；要验证弹窗本身时跳过本步）：版本号取自
+#    dsh 客户端产物的 WELCOME_NOTICE_VERSION（精确相等才算已确认），故用脚本同源的
+#    探测函数现取——凭记忆写会在 dsh 升级后让弹窗重新出现，且不报任何错
+WELCOME_V=$(node -e 'import(process.argv[1]).then((m) => console.log(m.findWelcomeNoticeVersion(process.argv[2])?.version ?? ""))' \
+  "$SKILL_BASE/scripts/lib/onboarding.mjs" "$(command -v dsh)")
+test -n "$WELCOME_V" || echo "警告: 未取到版本号——内测声明弹窗由 browser-driver 兜底跳过"
+printf 'ui-onboarding:\n  welcomeNoticeVersion: %s\n' "$WELCOME_V" > "$DSH_HOME/settings.yaml"
+
+# 6. 启动隔离 dsh web（指定不冲突端口；--port 0 让系统随机；显式回环 + 遥测禁用）
+DSH_TELEMETRY_DISABLED=1 dsh --profile "$PROFILE" --host 127.0.0.1 --port 3456 --no-open
+
+# 7. 就绪断言（对齐脚本行为）：轮询 HTTP 可达再开始验证（GUI 带鉴权，2xx-4xx 均算就绪；
+#    连接拒绝继续等，15s 超时报错）
+node -e 'const t=Date.now();(async()=>{for(;;){try{const r=await fetch("http://127.0.0.1:3456/",{signal:AbortSignal.timeout(1500)});if(r.status<500)break}catch{}if(Date.now()-t>15000)throw new Error("15s 未就绪");await new Promise(r=>setTimeout(r,250))}})()'
+
+# 8. 取带访问令牌的访问 URL：dsh 启动打印的 `dsh web: http://...?token=...` 即 GUI 的
+#    唯一可用入口；裸端口只会返回 401 文本页
+DSH_WEB_URL=$(grep -o 'dsh web: http://[^ ]*' "$DSH_HOME/dsh.log" | tail -1 | sed 's/^dsh web: //')
+echo "$DSH_WEB_URL"   # 后续 browser-driver 命令用 --url "$DSH_WEB_URL"
+```
+
+需要浏览器实例时（第四层隔离，等价于脚本 `--browser`）：
+
+```bash
+node "$SKILL_BASE/scripts/browser-driver.mjs" launch \
+  --state "$DSH_HOME/browser.state" --user-data-dir "$DSH_HOME/browser-profile"
+# 退出前清理（与脚本统一清理相同语义）：
+node "$SKILL_BASE/scripts/browser-driver.mjs" quit --state "$DSH_HOME/browser.state"
+```
+
+收尾：停止隔离 `dsh web` 进程后删除临时目录（`rm -rf "$DSH_HOME"`），避免残留无用的
+`verify_*` profile。脚本模式会自动做这件事。

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/references/script-contracts.md
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/references/script-contracts.md
@@ -1,0 +1,93 @@
+# 脚本契约（`verify-isolated.mjs` 的内部行为）
+
+> 读它的时机：要解读 `verdict.json`、要开隔离审计（`--audit`）、或启动/就绪失败需要
+> 定位原因。日常跑一次隔离验证不需要本文件——`node .../verify-isolated.mjs --help`
+> 是选项契约的唯一事实源，选项冲突时以 `--help` 为准。
+
+## 脚本自动完成的链路
+
+建临时 `DSH_HOME` → 校验 dsh 入口并打印版本（`--dsh` 锚定）→ **预置首启弹窗跳过**
+（写隔离 `$DSH_HOME/settings.yaml` 的内测声明版本，见 SKILL.md「首启弹窗默认跳过」；
+`--no-skip-onboarding` 关闭）→ 建 `verify_<8位随机>` profile
+（`dsh plugin --profile <p> list` 显式初始化，失败即报可操作错误）→ 注入内置
+`@deepseek-ai/dsh-web-app` bundle → 构建并把本地插件 link 进 profile（`--no-build`
+时校验产物存在 + 陈旧警告）→ `--browser` 时启动独立浏览器实例（实例信息写入
+`$DSH_HOME/browser.state`）→ 启动隔离 `dsh web`（显式 `--host 127.0.0.1` 回环 +
+`DSH_TELEMETRY_DISABLED=1` 遥测禁用）→ 就绪断言（轮询 HTTP 可达，2xx-4xx 就绪、
+15s 超时报可操作错误）→ 打印带访问令牌的 URL 并写入 `browser.state.dshWebUrl` →
+前台等待。`Ctrl+C` 退出时统一清理 dsh 进程、浏览器实例、临时 `DSH_HOME` 与 profile
+（SIGINT/SIGTERM 透传退出码 130/143）。
+
+## B6 启动自检 verdict
+
+就绪后写 `$DSH_HOME/verdict.json`（0o600），退出终态更新 `cleanup` 字段
+（`"running"` → `"done"` / `"kept"`）。字段要点：
+
+| 字段 | 含义 |
+|------|------|
+| `port` | `{ requested, actual, source }`；`source` 三通道：`parsed`（解析 dsh 输出行）→ `asserted`（就绪断言端口）→ `probed`（`--port 0` 探测值） |
+| `web` | `{ url, tokenSource }`：**不含令牌**的访问 URL（verdict 会经 `--json` 进 CI 日志，令牌只落 0o600 的 `browser.state` / `dsh.log`） |
+| `onboarding` | 首启弹窗预置结果：`source` 为 `preset`（已预置）/ `unavailable`（未取到版本）/ `disabled`（`--no-skip-onboarding`）/ `existing` / `write-failed` |
+| `audit` | `--audit` 时的审计结果；否则 `null`（错误路径的错误 JSON 也恒带该字段） |
+| `ready` / `readyAt` | 就绪断言是否通过及其时刻 |
+
+`--json` 让 stdout 只出最终 verdict JSON，人类文案全部走 stderr。
+
+## B7 证据目录
+
+默认 `$DSH_HOME/evidence/`（脚本打印路径；退出随临时目录清理，`--keep` 保留）。
+显式 `--evidence-dir <dir>` 外部化时建 `<dir>/evidence-<profile>/` 子目录，
+**绝不动外部目录本体**（不删、不覆盖）。
+
+## B4 隔离审计（`--audit`）
+
+对比隔离 `$DSH_HOME` 的写面与**预置白名单**（`scripts/lib/audit.mjs` 的版本化
+`WHITELIST_V`）：白名单外的新增/删除/修改报「可疑」（纯 stat 路径级，不读内容）；
+白名单内变化忽略；未知顶层路径 → 可疑。**不阻断退出**——审计是补充证据，不是门禁，
+退出码契约不因它改变。
+
+白名单覆盖 dsh 自身写面：`profiles/**`、`*.json`、`*.jsonl`、`*.log`、
+`.credentials.yaml`、`settings.yaml`（官方设置文档：首启弹窗跳过会预置它，此后页面里
+改任何设置也由 dsh 重写）、`browser.state`、`browser-profile/**`（整树 + 跳过深扫）、
+`evidence/**`、`audit/**`、`storages/**`、`dsh.log`、`verdict.json`。
+随 dsh 版本漂移的面（如 `profiles/node_modules/**` 的官方 bundle link）由 **t0 动态
+基线**覆盖。
+
+**symlink 防逃逸**：快照 lstat 不跟随；`t1` 时**新增的**或**目标变化**、且 resolve 后
+落在**所在扫描根**之外的 symlink 报「越界 symlink」（防插件经 symlink 写到隔离环境
+之外的用户数据或仓库）；`t0` 已存在且目标未变的外部 symlink（`link:` 挂载点，合法）
+不报。防逃逸优先于白名单——`profiles/**` 内新增越界 symlink 同样报。
+
+**时序**：`t0` 基线在**就绪断言成功之后**扫描，语义是「**就绪后运行期写面审计**」——
+dsh 启动期的自身写面与官方 bundle link 进基线，审计面 = dsh 就绪后、退出前的增量写面。
+审计插在退出清理序列「kill dsh → browser quit → **审计** → verdict 终态 → rm」之间；
+就绪前退出/超时路径不审计（`audit` 为 `null`）。
+
+**局限**：只扫 `$ISOLATED_HOME` 子树 + `--audit-extra-dirs <dir>`（可重复，相对路径
+基于 cwd 绝对化、必须是目录）指定的额外目录，**不扫真实 home**——插件写到真实 `~/.dsh`
+的数据面不在判定面内（这类盲区按 SKILL.md「隔离自检」第 5 项处置）。`--keep` 时报告落
+`$DSH_HOME/audit/audit.json`，否则随 `--json` 终态 verdict 的 `audit` 字段输出。
+
+## 退出码契约
+
+| 码 | 含义 |
+|----|------|
+| 0 | 正常完成：启动 + 就绪 + 前台等待 dsh 退出，清理完毕 |
+| 1 | 启动或就绪失败：profile 初始化失败 / add 失败 / dsh 就绪前退出 / 15s 就绪超时 |
+| 2 | 参数错误：未知选项 / 缺参 / 找不到 dsh 入口 / `--no-build` 缺产物 |
+| 130 / 143 | SIGINT / SIGTERM：终态清理后透传 |
+
+就绪后 dsh 自身异常退出时，其退出码原样透传。
+
+## Windows 承诺等级：试验性
+
+`spawn`/`execFile` 对 `.cmd` 的回退、无 POSIX 信号（`taskkill /T` 进程树清理）等兼容点
+在代码里逐处标注，但未在 CI 实测。排查看 `verify-isolated.mjs` 头部注释的「Windows
+三坑」。
+
+## 构建说明
+
+dsh 直读插件的构建产物（随各仓约定为 `lib/` 或 `dist/`，见插件包 `package.json` 的
+build 脚本），脚本默认在挂载前 `pnpm build` 各插件以保证产物存在；产物已就绪时可用
+`--no-build` 跳过（此时脚本校验产物存在，源码比产物新会给陈旧警告——警告出现即意味着
+你可能在验证旧界面）。

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/references/viewport-geometry.md
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/references/viewport-geometry.md
@@ -1,0 +1,68 @@
+# 设备视口与几何验证
+
+> 读它的时机：改动涉及响应式/窄屏布局，需要逐档核验几何表现时。非响应式改动不需要
+> 本文件。
+
+## 逐档设定视口（用设备模拟 flag）
+
+响应式改动必须**逐档设定视口**后核验，而不是缩放窗口：`window.resizeTo` 只能改窗口
+宽度、高度不生效（实测 `resizeTo(768,1024)` 后 `innerHeight` 仍是默认值，pad/phone
+档的第二维根本无法验证），同一条 `eval` 表达式内也读不到改动结果。
+
+改用**设备模拟 flag**——任一页面命令（snapshot / click / eval / fill / wait /
+screenshot / console）均可携带，**视口档一次性生效**：命令内设定、结束即清除，命令
+之间互不影响。
+
+`--width N` `--height N` `--dpr N`（设备像素比，默认 1）`--mobile`（边界见下）。
+只给一维时另一维取当前视口值。
+
+## 基线档与残留自检
+
+先记录默认视口（`--browser` 的 headless 内核通常为 800x600）作为对照基准；逐档改视口
+之后，再用一条**不带 flag** 的命令回读——数值回到基线，即证明「命令结束即清除」成立、
+没有残留污染后续命令。这条回读既是残留自检，也是判定窄屏档是否**真的**生效的基准
+（否则无法区分「窄屏生效」与「参数没起作用」）：
+
+```bash
+STATE="$DSH_HOME/browser.state"
+# 基线档：不带设备 flag
+node "$SKILL_BASE/scripts/browser-driver.mjs" eval --state "$STATE" --expression "innerWidth+'x'+innerHeight"
+# 改档后回读：应回到基线值（否则说明有残留）
+node "$SKILL_BASE/scripts/browser-driver.mjs" eval --state "$STATE" --expression "innerWidth+'x'+innerHeight"
+```
+
+## 采证据
+
+```bash
+# 两档视口各采一次证据（phone / pad）；--url state 用带令牌 URL，见 SKILL.md 硬前提
+node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$STATE" --url state --width 375 --height 667 --path phone.png
+node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$STATE" --url state --width 768 --height 1024 --path pad.png
+# 高 DPI：元素截图（--selector）按 --dpr 输出物理像素（375x667 档 + --dpr 2 → 750x1334）；
+# 整页截图（不带 --selector）固定输出 CSS 像素尺寸，不随 --dpr 放大
+node "$SKILL_BASE/scripts/browser-driver.mjs" screenshot --state "$STATE" --url state --width 375 --height 667 --dpr 2 --selector "<css>" --path phone@2x.png
+# 自证视口生效（设了参数不等于布局已按该档渲染）
+node "$SKILL_BASE/scripts/browser-driver.mjs" eval --state "$STATE" --width 375 --height 667 \
+  --expression "innerWidth+'x'+innerHeight+' mq='+matchMedia('(max-width: 640px)').matches"
+```
+
+每档至少断言四项（用 `eval` 或 `snapshot --selector` 返回的 `rect`）：
+
+| 断言 | 表达式模板 | 判据 |
+|------|-----------|------|
+| 视口生效 | `innerWidth+'x'+innerHeight` | 等于设定档位 |
+| 无横向溢出 | `document.documentElement.scrollWidth <= innerWidth + 1` | true（+1 容差防亚像素） |
+| 关键元素在视口内 | `snapshot --selector <css>` 的 `rect` | `x >= 0 && x + rect.width <= innerWidth`，纵向可滚动到 |
+| 落点复核 | 改视口前后各取一次 `rect` | 位移方向与幅度符合预期（如锚定侧边的元素随视口收窄内移） |
+
+`position: fixed` 元素最容易在窄屏失效：除落点外，还要滚动到页面底部确认它仍可达、
+不被安全区或软键盘遮住。
+
+## 能力边界（越界承诺会误导真机判断）
+
+- `--mobile` 启用移动 layout viewport 语义：页面无 `<meta name="viewport">` 时
+  `innerWidth` **不再等于**设定宽度（实测 375 档会读回约 981）。要精确命中 CSS 断点
+  时保持 mobile 关闭；只有需要复现真机 layout viewport 行为时才加 `--mobile`。
+- **触控、软键盘、真实 UA、旋转、`dvh`/安全区不在本 skill 能力面内**：headless 内核
+  无法完整模拟（`maxTouchPoints` 可设，但 `ontouchstart` 不生效）。涉及触控手势、
+  软键盘弹出/收起、`visualViewport` 跟随的改动**必须真机验证**，以真机结果为准。
+- 视口模拟只覆盖布局维度；某一档的结论只对该档成立。

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/browser-driver.mjs
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/browser-driver.mjs
@@ -13,6 +13,15 @@
  * 页面命令（snapshot / click / eval / fill / wait / screenshot / console）可携带设备
  * 模拟 flag（--width / --height / --dpr / --mobile）：命令内应用、结束前清除，命令
  * 之间互不影响——不做成粘性状态的原因见 lib/emulation.mjs 头部（CDP 会话语义）。
+ *
+ * 导航命令（snapshot / click / wait / screenshot / console）的 `--url` 接受保留值
+ * `state`：改用 state 文件里 verify-isolated.mjs 写入的带令牌 URL（GUI 带鉴权，
+ * 裸端口只得到 401）。省略 `--url` 仍是**不导航**——自动导航会抹掉上一条命令的
+ * 页面状态，多步交互验证（点一下再读结果）就断了。
+ *
+ * 导航后自动跳过 dsh web 首启弹窗（--no-auto-dismiss 关闭）：内测声明与 API Key
+ * 弹窗把应用根置为 inert，若不跳过，页面命令的点击全部静默失效；成因与预置策略见
+ * lib/onboarding.mjs 头部。
  */
 import { spawn } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
@@ -21,10 +30,16 @@ import { delimiter, join } from "node:path";
 import { createServer } from "node:net";
 import { get } from "node:http";
 import { buildDeviceMetrics, parseEmulationFlags } from "./lib/emulation.mjs";
+import {
+  MAX_OVERLAY_ROUNDS, buildOverlayProbeExpression, redactToken,
+} from "./lib/onboarding.mjs";
 
 // --- 基础工具 ---
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** 首启弹窗等待窗口（弹窗异步挂载，探一次会漏检；见 settleOverlays）。 */
+const OVERLAY_WAIT_MS = 1500;
 
 async function poll(fn, timeoutMs, intervalMs = 200) {
   const deadline = Date.now() + timeoutMs;
@@ -278,7 +293,7 @@ async function cmdLaunch(flags) {
     wsUrl: version.webSocketDebuggerUrl,
     launchedAt: new Date().toISOString(),
   };
-  // 0o600：state 含调试 wsUrl/pid 等敏感信息，仅限本用户可读（PR #481 P3-3）
+  // 0o600：state 含调试 wsUrl/pid 等敏感信息，仅限本用户可读
   writeFileSync(statePath, JSON.stringify(state, null, 2), { mode: 0o600 });
   out(flags, { ok: true, ...state, stateFile: statePath });
 }
@@ -360,6 +375,98 @@ async function navigateIfGiven(wsUrl, url, timeoutMs = 15000) {
   await poll(async () => (await evalRaw(wsUrl, "document.readyState")) === "complete", timeoutMs, 200);
 }
 
+/**
+ * 解析导航目标：`--url state` 取 state 里的带令牌 URL（GUI 带鉴权，裸端口只会得到
+ * 401 文本页），其余原样。state 缺字段时给出可操作错误，而不是静默导航到一张空页。
+ * @returns 目标 URL；未给 `--url` 时 null（不导航）。
+ */
+function resolveTargetUrl(flags, st) {
+  const raw = flag(flags, "url", null);
+  if (raw === null || raw !== "state") return raw;
+  const url = st?.dshWebUrl;
+  if (!url) {
+    fail("--url state 需要 state 文件里存在 dshWebUrl（由 verify-isolated.mjs 写入）；手动拉起的 dsh web 请直接传带令牌的完整 URL");
+  }
+  return url;
+}
+
+/**
+ * 导航后一次性收尾：跳过首启弹窗 + 鉴权误用诊断。
+ *
+ * 弹窗由 React 在页面加载后异步挂载（实测晚于 readyState=complete，且时机会在
+ * 数百毫秒内波动），故按窗口轮询而不是探一次就下结论——漏检的代价不是「少一次
+ * 提示」，而是后续点击落在 inert 根上静默失效、验证结论假绿。等待窗口默认为
+ * OVERLAY_WAIT_MS，`--overlay-wait 0` 可退回单次探测（快，但可能漏检）。
+ *
+ * 两级弹窗（内测声明 → API Key）会无缝衔接：前一个卸载与后一个置位 inert 可能
+ * 落在同一帧，故**不能**用「等 inert 解除」判断弹窗已清空（必然超时误报），而是
+ * 直接推进到下一轮窗口轮询——没有下一个弹窗时，该轮窗口自然以「无弹窗」收尾。
+ *
+ * 识别不到跳过按钮时**不点**：弹窗内可能并列「保存并继续」这类有副作用的按钮，
+ * 点错会把验证流程变成一次误操作；此时只上报 blocked 交调用方处置。
+ */
+async function settleOverlays(wsUrl, flags) {
+  const result = { dismissed: [], authRequired: false, blocked: null };
+  const auto = !flags.has("no-auto-dismiss");
+  const waitMs = Math.max(0, Number(flag(flags, "overlay-wait", String(OVERLAY_WAIT_MS))) || 0);
+  const expr = buildOverlayProbeExpression({ click: auto });
+  for (let round = 0; round < MAX_OVERLAY_ROUNDS; round++) {
+    // 上一轮点过的弹窗需要一点时间卸载，否则本轮窗口会重复命中同一按钮
+    if (round > 0) await sleep(250);
+    let probe = null;
+    let seen = false;
+    const deadline = Date.now() + waitMs;
+    for (;;) {
+      try { probe = await evalRaw(wsUrl, expr); } catch { return result; }
+      if (!probe) return result;
+      if (probe.authRequired) result.authRequired = true;
+      if (probe.blocked) { seen = true; break; }
+      if (Date.now() >= deadline) break;
+      await sleep(150);
+    }
+    if (!seen) return result;
+    if (!probe.dismissed) { result.blocked = { reason: probe.reason, buttons: probe.buttons ?? [] }; return result; }
+    result.dismissed.push(probe.clicked);
+  }
+  return result;
+}
+
+/**
+ * 导航 + 导航后收尾，导航命令的统一入口。
+ * @returns `{ url, overlay }`；未给 `--url` 时 url 与 overlay 均为 null（保持
+ * 「省略即不导航」语义——自动导航会抹掉上一条命令的页面状态）。
+ */
+async function goto(wsUrl, flags, st) {
+  const url = resolveTargetUrl(flags, st);
+  if (url === null) return { url: null, overlay: null };
+  await navigateIfGiven(wsUrl, url);
+  const overlay = await settleOverlays(wsUrl, flags);
+  reportOverlay(overlay);
+  return { url, overlay };
+}
+
+/** 把导航后的异常状态报成可操作警告（stderr，不污染 stdout 的 JSON 契约）。 */
+function reportOverlay(overlay) {
+  if (!overlay) return;
+  if (overlay.authRequired) {
+    process.stderr.write("警告: 页面返回 dsh web 鉴权拒绝（缺访问令牌）——用 --url state 取 state 里的带令牌 URL；裸端口只会得到 401 文本页\n");
+  }
+  if (overlay.blocked) {
+    const detail = overlay.blocked.buttons.length ? `: ${overlay.blocked.buttons.join(" / ")}` : "";
+    process.stderr.write(`警告: 首启弹窗未跳过（${overlay.blocked.reason}${detail}）——应用根仍为 inert，随后点击不会生效\n`);
+  }
+}
+
+/** 输出附加字段：只在真的发生时出现，未命中的命令输出契约不变。 */
+function overlayFields(overlay) {
+  if (!overlay) return {};
+  const f = {};
+  if (overlay.dismissed.length) f.dismissed = overlay.dismissed;
+  if (overlay.authRequired) f.authRequired = true;
+  if (overlay.blocked) f.onboardingBlocked = overlay.blocked;
+  return f;
+}
+
 function selExpr(selector, extra) {
   return `(() => {
     const el = document.querySelector(${JSON.stringify(selector)});
@@ -370,7 +477,7 @@ function selExpr(selector, extra) {
 
 async function waitSelector(wsUrl, selector, timeoutMs) {
   // selExpr 未命中返回 { found:false }（对象恒 truthy），poll 必须显式判 found===true，
-  // 否则等待会立即「成功」（假绿，PR #481 P1-1）
+  // 否则等待会立即「成功」（假绿）
   const found = await poll(async () => {
     try { return (await evalRaw(wsUrl, selExpr(selector))).found === true; }
     catch { return false; }
@@ -427,10 +534,9 @@ async function withPageEmulation(flags, run) {
 }
 
 async function cmdSnapshot(flags) {
-  const url = flag(flags, "url", null);
   const selector = flag(flags, "selector", null);
   await withPageEmulation(flags, async ({ st, page }) => {
-    await navigateIfGiven(page.webSocketDebuggerUrl, url);
+    const nav = await goto(page.webSocketDebuggerUrl, flags, st);
     const title = await evalRaw(page.webSocketDebuggerUrl, "document.title");
     const readyState = await evalRaw(page.webSocketDebuggerUrl, "document.readyState");
     const pageUrl = await evalRaw(page.webSocketDebuggerUrl, "location.href");
@@ -444,23 +550,29 @@ async function cmdSnapshot(flags) {
       bodyText = (await evalRaw(page.webSocketDebuggerUrl, "document.body ? document.body.innerText.slice(0, 2000) : ''") || "");
     }
     const pages = (await httpJson(`http://127.0.0.1:${st.port}/json/list`) || []).filter((t) => t.type === "page");
-    out(flags, { ok: true, title, url: pageUrl, readyState, tabCount: pages.length, bodyText, element });
+    out(flags, {
+      ok: true, title, url: redactToken(pageUrl), readyState, tabCount: pages.length, bodyText, element,
+      ...overlayFields(nav.overlay),
+    });
   });
 }
 
 async function cmdClick(flags) {
-  const url = flag(flags, "url", null);
   const selector = flag(flags, "selector", null);
   const timeoutMs = Number(flag(flags, "timeout", "10000"));
   if (!selector) fail("click 需要 --selector");
-  await withPageEmulation(flags, async ({ page }) => {
-    await navigateIfGiven(page.webSocketDebuggerUrl, url);
+  await withPageEmulation(flags, async ({ st, page }) => {
+    const nav = await goto(page.webSocketDebuggerUrl, flags, st);
     await waitSelector(page.webSocketDebuggerUrl, selector, timeoutMs);
     const clicked = await evalRaw(page.webSocketDebuggerUrl, selExpr(selector, `
       el.scrollIntoView({ block: "center" });
       el.click();
       return { found: true, clicked: true, tag: el.tagName };`));
-    out(flags, { ok: true, selector, clicked, url: url || undefined });
+    out(flags, {
+      ok: true, selector, clicked,
+      url: nav.url ? redactToken(nav.url) : undefined,
+      ...overlayFields(nav.overlay),
+    });
   });
 }
 
@@ -499,31 +611,29 @@ async function cmdFill(flags) {
 }
 
 async function cmdWait(flags) {
-  const url = flag(flags, "url", null);
   const selector = flag(flags, "selector", null);
   const timeoutMs = Number(flag(flags, "timeout", "10000"));
   if (!selector) fail("wait 需要 --selector");
-  await withPageEmulation(flags, async ({ page }) => {
+  await withPageEmulation(flags, async ({ st, page }) => {
     const started = Date.now();
-    await navigateIfGiven(page.webSocketDebuggerUrl, url);
+    const nav = await goto(page.webSocketDebuggerUrl, flags, st);
     await waitSelector(page.webSocketDebuggerUrl, selector, timeoutMs);
-    out(flags, { ok: true, selector, waitedMs: Date.now() - started });
+    out(flags, { ok: true, selector, waitedMs: Date.now() - started, ...overlayFields(nav.overlay) });
   });
 }
 
 async function cmdScreenshot(flags) {
-  const url = flag(flags, "url", null);
   const selector = flag(flags, "selector", null);
   const outPath = flag(flags, "path", `screenshot-${Date.now()}.png`);
-  await withPageEmulation(flags, async ({ page }) => {
-    await navigateIfGiven(page.webSocketDebuggerUrl, url);
+  await withPageEmulation(flags, async ({ st, page }) => {
+    const nav = await goto(page.webSocketDebuggerUrl, flags, st);
     let clip = undefined;
     if (selector) {
       await waitSelector(page.webSocketDebuggerUrl, selector, 10000);
       clip = await evalRaw(page.webSocketDebuggerUrl, selExpr(selector, `
         const r = el.getBoundingClientRect();
         // getBoundingClientRect 是 viewport 坐标；captureBeyondViewport 下 CDP 按文档
-        // 坐标解释 clip，须加 scrollX/scrollY 转换，否则页面滚动后截空白（PR #481 P1-2）
+        // 坐标解释 clip，须加 scrollX/scrollY 转换，否则页面滚动后截空白
         return { found: true, x: r.x + window.scrollX, y: r.y + window.scrollY, width: r.width, height: r.height, dpr: window.devicePixelRatio || 1 };`));
       if (!clip || !clip.found) throw new Error(`截图元素未找到: ${selector}`);
       clip = { x: clip.x, y: clip.y, width: clip.width, height: clip.height, scale: clip.dpr };
@@ -533,14 +643,17 @@ async function cmdScreenshot(flags) {
     });
     writeFileSync(outPath, Buffer.from(shot.data, "base64"));
     const dims = clip ? { width: clip.width, height: clip.height } : null;
-    out(flags, { ok: true, path: outPath, bytes: Buffer.byteLength(shot.data, "base64"), clip: dims, url: url || undefined });
+    out(flags, {
+      ok: true, path: outPath, bytes: Buffer.byteLength(shot.data, "base64"), clip: dims,
+      url: nav.url ? redactToken(nav.url) : undefined,
+      ...overlayFields(nav.overlay),
+    });
   });
 }
 
 async function cmdConsole(flags) {
-  const url = flag(flags, "url", null);
   const waitMs = Number(flag(flags, "wait-ms", "2500"));
-  await withPageEmulation(flags, async ({ page }) => {
+  await withPageEmulation(flags, async ({ st, page }) => {
     const messages = [];
     const collect = (ev) => {
       if (!ev.data || typeof ev.data !== "string") return;
@@ -561,20 +674,24 @@ async function cmdConsole(flags) {
     // domain enable 是会话级状态：须在事件收集的长连接上启用，短连接 enable 不生效
     await rpcRaw(ws, "Runtime.enable", {});
     await rpcRaw(ws, "Log.enable", {});
+    let overlay = null;
     try {
-      if (url) {
-        await rpcRaw(ws, "Page.navigate", { url });
-        await poll(async () => {
-          try { return (await rpcRaw(ws, "Runtime.evaluate", { expression: "document.readyState", returnByValue: true })).result.value === "complete"; }
-          catch { return false; }
-        }, 15000, 200);
-      } else {
-        await rpcRaw(ws, "Page.reload", {});
-      }
+      // console 无 --url 时重载当前页（也算一次导航），故两条分支都等就绪后再收尾：
+      // 未就绪时探针读不到弹窗，会错过 inert 这一最关键的事实。
+      const readyExpr = "document.readyState";
+      const target = resolveTargetUrl(flags, st);
+      if (target) await rpcRaw(ws, "Page.navigate", { url: target });
+      else await rpcRaw(ws, "Page.reload", {});
+      await poll(async () => {
+        try { return (await rpcRaw(ws, "Runtime.evaluate", { expression: readyExpr, returnByValue: true })).result.value === "complete"; }
+        catch { return false; }
+      }, 15000, 200);
+      overlay = await settleOverlays(page.webSocketDebuggerUrl, flags);
+      reportOverlay(overlay);
     } catch {}
     await sleep(waitMs);
     ws.close();
-    out(flags, { ok: true, messages, capturedMs: waitMs });
+    out(flags, { ok: true, messages, capturedMs: waitMs, ...overlayFields(overlay) });
   });
 }
 
@@ -620,19 +737,29 @@ const USAGE_HEAD = `用法: node browser-driver.mjs <command> [--flag value]... 
 
 const USAGE_COMMANDS = `  launch      启动独立浏览器实例并写入 state（--state <path> [--port N] [--user-data-dir <path>] [--chrome <path>]）
   quit        优雅关闭实例并清理（--state <path>）
-  snapshot    页面快照（[--url <url>] [--selector <css>] [--index N]）
-  click       点击元素（--selector <css> [--url <url>] [--timeout ms] [--index N]）
+  snapshot    页面快照（[--url <url|state>] [--selector <css>] [--index N]）
+  click       点击元素（--selector <css> [--url <url|state>] [--timeout ms] [--index N]）
   eval        执行 JS（--expression <js> [--index N]）
   fill        填充表单（--selector <css> --value <v> [--timeout ms] [--index N]）
-  wait        等待选择器（--selector <css> [--url <url>] [--timeout ms] [--index N]）
-  screenshot  截图（[--url <url>] [--selector <css>] [--path <png>] [--index N]）
-  console     捕获 console/异常（[--url <url>] [--wait-ms N] [--index N]）`;
+  wait        等待选择器（--selector <css> [--url <url|state>] [--timeout ms] [--index N]）
+  screenshot  截图（[--url <url|state>] [--selector <css>] [--path <png>] [--index N]）
+  console     捕获 console/异常（[--url <url|state>] [--wait-ms N] [--index N]）`;
 
 const USAGE_COMMON = `通用：--state <path> 指定实例 state 文件（多会话并行必须各自独立）；
+导航与鉴权（snapshot / click / wait / screenshot / console）：--url <url> 显式 URL；
+  --url state 取 state 里 verify-isolated.mjs 写入的 dshWebUrl（带访问令牌——dsh web
+  GUI 带鉴权，裸端口只会得到 401 文本页）；省略 --url 即**不导航**（console 例外：
+  重载当前页），保留上一条命令的页面状态供多步交互验证。
+  命中 401 文本页时输出 authRequired 并在 stderr 给出可操作警告；回显 URL 恒去令牌。
+首启弹窗（导航后自动跳过）：dsh web 的「内测声明」「添加 API Key」弹窗把应用根置为
+  inert，不跳过则点击静默失效。命中跳过文案（Continue / Configure later / 继续 /
+  稍后配置）时自动点击，输出 dismissed 记录所点按钮；识别不到跳过按钮时**不猜**，
+  仅输出 onboardingBlocked。--no-auto-dismiss 关闭自动跳过（保留弹窗原状，只探测）。
+  弹窗异步挂载，故按 --overlay-wait <ms>（默认 1500）窗口轮询；设 0 退回单次探测。
 设备模拟（页面命令通用）：--width N --height N [--dpr N] [--mobile]
   逐档设定视口验证响应式布局；命令内生效、结束即清除，命令之间互不影响。
   单给一维时另一维取当前视口值。--mobile 启用移动 layout viewport 语义（页面无
-  viewport meta 时 innerWidth 不再等于设定宽度）；触控/真机差异见 SKILL.md 能力边界。
+  viewport meta 时 innerWidth 不再等于设定宽度）；触控/真机差异见 references/viewport-geometry.md 能力边界。
 内核探测：DSH_VERIFY_CHROME env > ms-playwright 缓存 > PATH > 平台常见路径，全缺 fail-fast。
 环境要求：Node >= 22（页面操作依赖内置全局 WebSocket）；Chromium 系内核。
 详情见本文件头部注释。`;

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/audit.mjs
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/audit.mjs
@@ -1,5 +1,5 @@
 /**
- * audit.mjs — 隔离审计核心（#517 B4：隔离审计白名单版）纯函数层。
+ * audit.mjs — 隔离审计核心（隔离审计白名单版）纯函数层。
  *
  * 供 verify-isolated.mjs 的 `--audit` 集成调用：t0 基线快照（dsh **就绪断言
  * 之后**——dsh 启动期自身写面与官方 bundle link 进基线，语义为「就绪后运行期
@@ -8,7 +8,7 @@
  * （lstat 不读文件内容），smoke 用 mkdtemp fixture 直接断言正反例行为
  * （见 test/smoke.ts）。
  *
- * ## 口径（#517 评论 B4 方案，实现注释说明）
+ * ## 口径（实现注释说明）
  *
  * 1. **范围硬绑定扫描根**：只扫传入的 root（$ISOLATED_HOME 子树 +
  *    --audit-extra-dirs 指定的额外目录），不扫真实 home——文档写明局限。
@@ -16,13 +16,13 @@
  *    symlink 只记录 linkTarget 不读目标内容（安全）；profile node_modules
  *    全 `link:` symlink 是挂载机制本身，**t0 已存在且目标未变的外部 symlink
  *    （link: 挂载点）合法不报**；t1 时**新增的**或**目标变化**且 resolve 后
- *    在**所在扫描根**外的 symlink 报「越界 symlink」（防插件经 symlink 写回
- *    主 checkout；extra dir 内部的 symlink 以其自身为越界基准）。防逃逸
+ *    在**所在扫描根**外的 symlink 报「越界 symlink」（防插件经 symlink 写到
+ *    隔离环境之外的用户数据或仓库；extra dir 内部的 symlink 以其自身为越界基准）。防逃逸
  *    优先于白名单忽略——白名单目录（profiles/** 等）内新增越界 symlink
  *    同样报可疑。
  * 3. **判定面 = 白名单模式外的新增/删除/修改**（路径级，不读内容）；
  *    白名单内变化忽略（dsh 重写 settings 是常态）。未知顶层路径 → 可疑。
- * 4. **首跑学习**（#517 方案：学习仅交叉校验 dsh 版本写面漂移）本模块不做
+ * 4. **首跑学习**（学习仅交叉校验 dsh 版本写面漂移）本模块不做
  *    判定源——判定面只有预置白名单，版本化 `WHITELIST_V` 随 skill 分发、
  *    smoke 断言存在。
  * 5. **browser-profile/** 整树白名单 + 跳过深扫**：chromium user-data-dir
@@ -36,7 +36,7 @@ import { lstatSync, readdirSync, readlinkSync } from "node:fs";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 
 /** 白名单版本（预置模式数组版本化；smoke 断言存在与格式）。 */
-export const WHITELIST_V = "v2";
+export const WHITELIST_V = "v3";
 
 /**
  * 预置白名单模式数组（判定面）：命中模式 = 预期写面，变化忽略；未命中 =
@@ -46,11 +46,13 @@ export const WHITELIST_V = "v2";
  *     下的任何文件都算可疑，贴合「未知顶层路径→可疑」）；
  *   - 其余：顶层精确文件名。
  *
- * dsh 自身写面分工（S1 修复，#540 复核）：
+ * dsh 自身写面分工：
  *   - **静态白名单**覆盖 dsh 固定写面：`.credentials.yaml`（首启凭据文件，
- *     就绪后初始化竞态窗口内落盘）与 `storages/**`（官方存储：workspace/
- *     settings 等，退出清理时也写）——无论何时写都是预期写面，不随 dsh
- *     版本漂移的顶层形态进白名单；
+ *     就绪后初始化竞态窗口内落盘）、`settings.yaml`（官方设置文档：首启弹窗
+ *     跳过会预置它，此后验证期间改动任何设置也由 dsh 自己重写——两种写入都是
+ *     预期写面，与 `.credentials.yaml` 同类）与 `storages/**`（官方存储：
+ *     workspace/settings 等，退出清理时也写）——无论何时写都是预期写面，不随
+ *     dsh 版本漂移的顶层形态进白名单；
  *   - **t0 动态基线**覆盖随 dsh 版本漂移的面：profiles/node_modules/** 官方
  *     bundle link（指向真实 dsh 安装目录、越界但 t0 已存在未变 → 合法挂载点
  *     不报），由 verify-isolated.mjs 在就绪断言后扫描进基线（见该文件 B4
@@ -62,6 +64,7 @@ export const WHITELIST = Object.freeze([
   "*.jsonl",
   "*.log",
   ".credentials.yaml",
+  "settings.yaml",
   "browser.state",
   "browser-profile/**",
   "evidence/**",

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/emulation.mjs
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/emulation.mjs
@@ -11,7 +11,7 @@
  *   静默失效，尺寸残留污染后续命令（实测：新 session 里 clear 后仍读回设定值）。
  * - `touch` / `UserAgent` override 是纯 session 级的，断开即失效，无法跨命令生效；
  *   模拟能力也不完整（maxTouchPoints 可设，但 ontouchstart 不生效）。故不提供，
- *   触控与真机差异写入 SKILL.md 能力边界，避免给出虚假安全感。
+ *   触控与真机差异写入 references/viewport-geometry.md 能力边界，避免给出虚假安全感。
  *
  * 因此设备模拟不做成「独立粘性命令」，而是每条页面命令都可携带的公共 flag：
  * 命令内应用、命令结束前清除，命令之间互不影响。

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/onboarding.mjs
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/onboarding.mjs
@@ -1,0 +1,149 @@
+/**
+ * onboarding.mjs — 隔离环境 dsh web 首启弹窗的默认跳过支持（纯函数 + 只读探测）。
+ *
+ * 两个阻断弹窗的成因（实测 dsh 0.1.5-rc.1，复现与对照见 SKILL.md
+ * 「首启弹窗默认跳过」）：
+ *   - 「内测声明」是否出现，取决于 settings.yaml 的
+ *     `ui-onboarding.welcomeNoticeVersion` 与客户端常量 WELCOME_NOTICE_VERSION
+ *     是否**精确相等**：预置该值即默认不弹。常量随 dsh 版本漂移（它按版本重新
+ *     告知），只能从 dsh 产物现取——硬编码会让跳过在 dsh 升级后静默失效。
+ *   - 「添加 API Key」由 provider 可用性决定，其「稍后配置」只在当前页面生命周期
+ *     内有效（刷新/新标签必重弹），预置消除不掉，只能导航后兜底点击。
+ * 两者都把应用根置为 inert（`#root.inert = true`），页面上一切点击静默失效——这
+ * 正是必须默认跳过、而不能只在文档里提醒「记得点掉」的原因。
+ *
+ * 本模块只做探测与表达式构造，不启动进程、不写隔离环境（预置由
+ * verify-isolated.mjs 落盘），以便 smoke 直接以纯函数 + fixture 断言。
+ */
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+
+/** 跳过语义的按钮文案（客户端 welcomeContinue / onboardingLater 的 en + zh）。 */
+export const SKIP_BUTTON_TEXTS = Object.freeze(["Continue", "Configure later", "继续", "稍后配置"]);
+
+/** 客户端产物里的须知版本常量；版本一变就会重新弹窗，故按 dsh 安装现取。 */
+export const WELCOME_NOTICE_VERSION_RE = /WELCOME_NOTICE_VERSION\s*=\s*"([^"]+)"/;
+
+/** 设置文档命名空间与字段（与客户端 onboarding-copy 常量对齐）。 */
+export const WELCOME_SETTINGS_NAMESPACE = "ui-onboarding";
+export const WELCOME_SETTINGS_FIELD = "welcomeNoticeVersion";
+
+/** 缺访问令牌时 GUI 的鉴权拒绝文案（页面命令据此给出可操作诊断而非空页假绿）。 */
+export const AUTH_REQUIRED_MARKER = "dsh web authentication required";
+
+/** 弹窗内可安全点击的跳过按钮上限轮数（实测最多两级：内测声明 → API Key）。 */
+export const MAX_OVERLAY_ROUNDS = 3;
+
+/**
+ * 从客户端产物源码提取须知版本。
+ * @param source - dsh-client-ui-settings-models 的 client.js 源码。
+ * @returns 版本字符串；未匹配（dsh 改了常量形态）返回 null，由调用方降级。
+ */
+export function extractWelcomeNoticeVersion(source) {
+  const m = WELCOME_NOTICE_VERSION_RE.exec(String(source ?? ""));
+  return m ? m[1] : null;
+}
+
+/**
+ * 构造预置的 settings.yaml 文档。
+ * @param version - 已确认的须知版本（原样落盘，加引号会改变解析结果，故不加）。
+ * @returns 设置文档文本。
+ */
+export function welcomeSettingsDocument(version) {
+  // 值来自 dsh 产物的字符串字面量，仍按白名单校验：settings.yaml 是要被 dsh 解析的
+  // 结构化文档，任何意外字符都可能改写命名空间结构而不是一个字段值。
+  if (!/^[A-Za-z0-9._-]+$/.test(String(version))) {
+    throw new Error(`内测声明版本含意外字符，拒绝写入 settings.yaml: ${version}`);
+  }
+  return `${WELCOME_SETTINGS_NAMESPACE}:\n  ${WELCOME_SETTINGS_FIELD}: ${version}\n`;
+}
+
+/**
+ * 解析 dsh 安装根：从入口 realpath 逐级向上找 name 匹配的 manifest。
+ * @param dshBinPath - dsh 可执行入口（可能是 bin 软链）。
+ * @returns 安装根绝对路径；解析不出返回 null（不猜 node_modules 布局）。
+ */
+export function dshRootOf(dshBinPath) {
+  let entry;
+  try { entry = realpathSync(dshBinPath); } catch { return null; }
+  let dir = dirname(entry);
+  for (let i = 0; i < 8; i++) {
+    try {
+      if (JSON.parse(readFileSync(join(dir, "package.json"), "utf8")).name === "@deepseek-ai/dsh") return dir;
+    } catch { /* 无 manifest / 非 JSON：继续向上 */ }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * 定位客户端产物：交给 Node 的解析算法从 dsh 安装根解析依赖，npm 提升布局与
+ * pnpm 软链布局都自洽（路径拼接会在其中一种布局下指向不存在的目录）。
+ * @param dshRoot - dsh 安装根。
+ * @returns client.js 绝对路径；解析失败返回 null。
+ */
+export function welcomeClientFileOf(dshRoot) {
+  try {
+    const req = createRequire(join(dshRoot, "package.json"));
+    const manifest = req.resolve("@deepseek-ai/dsh-client-ui-settings-models/package.json");
+    return join(dirname(manifest), "lib", "client.js");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 端到端解析须知版本（dsh 入口 → 安装根 → 客户端产物 → 常量）。
+ * @param dshBinPath - dsh 可执行入口。
+ * @returns `{ version, file }`；任一步失败返回 null。
+ */
+export function findWelcomeNoticeVersion(dshBinPath) {
+  const root = dshRootOf(dshBinPath);
+  if (!root) return null;
+  const file = welcomeClientFileOf(root);
+  if (!file || !existsSync(file)) return null;
+  const version = extractWelcomeNoticeVersion(readFileSync(file, "utf8"));
+  return version ? { version, file } : null;
+}
+
+/**
+ * 构造导航后的一次性探针表达式：同时给出鉴权误用诊断与弹窗状态。检测与点击放在
+ * 同一次往返里，避免弹窗在两次 CDP 调用之间被卸载/替换（那时点击会落空）。
+ *
+ * 识别不到跳过按钮时**不猜**：弹窗内可能并列「保存并继续」这类有副作用的按钮，
+ * 结构兜底（点第一个/最后一个）会把验证流程变成一次误操作，故只上报待人工处置。
+ * @param options - `click:false` 时只探测不点击（--no-auto-dismiss 的「保留原状」
+ *   必须真的不点：探针若照样点下去，关闭开关就成了只改输出文案的假开关）。
+ * @returns 在页面上下文执行的 JS 表达式。
+ */
+export function buildOverlayProbeExpression(options = {}) {
+  const allowClick = options.click !== false;
+  return `(() => {
+  const allowClick = ${allowClick ? "true" : "false"};
+  const skipTexts = ${JSON.stringify(SKIP_BUTTON_TEXTS)};
+  const authRequired = document.body ? document.body.innerText.includes(${JSON.stringify(AUTH_REQUIRED_MARKER)}) : false;
+  const root = document.getElementById("root");
+  const dialog = document.querySelector("[role=dialog]");
+  if (!root || root.inert !== true || !dialog) return { authRequired, blocked: false };
+  const label = (b) => (b.textContent || "").trim();
+  const buttons = [...dialog.querySelectorAll("button")].filter((b) => !b.disabled);
+  const target = buttons.find((b) => skipTexts.includes(label(b)));
+  if (!target) return { authRequired, blocked: true, dismissed: false, reason: "no-skip-button", buttons: buttons.map(label) };
+  if (!allowClick) return { authRequired, blocked: true, dismissed: false, reason: "auto-dismiss-off", buttons: buttons.map(label) };
+  target.click();
+  return { authRequired, blocked: true, dismissed: true, clicked: label(target) };
+})()`;
+}
+
+/**
+ * 输出脱敏：dsh web 的访问令牌是 GUI 鉴权凭据，命令回显的 URL 会随证据一起归档，
+ * 故回显恒去令牌（真值只在 0o600 的 browser.state / dsh.log 里）。
+ * @param url - 待回显的 URL。
+ * @returns 令牌替换为 `***` 的 URL；非字符串原样返回。
+ */
+export function redactToken(url) {
+  return typeof url === "string" ? url.replace(/([?&]token=)[^&#]*/gi, "$1***") : url;
+}

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/verify-core.mjs
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/lib/verify-core.mjs
@@ -1,13 +1,13 @@
 /**
  * verify-core.mjs — verify-isolated.mjs 的共享基础工具（零依赖，纯 Node 内置）。
  *
- * #517 C8 抽取：poll / findFreePort / jsonOut / 退出码常量给
+ * 抽取：poll / findFreePort / jsonOut / 退出码常量给
  * verify-isolated.mjs 复用（browser-driver.mjs 的 main/parseArgs/out/poll
  * 模式；fail 由 verify-isolated.mjs 内聚为 json 感知的 errorPayload 路径，
  * 本模块不导出死函数），另内建两段纯函数语义：
  *   - readDshPort：B6 verdict 端口实际绑定双通道之 parsed 通道（解析 dsh.log）；
- *   - resolvePkgArg：C11 插件参数归一化（相对路径绝对化 / 包规格透传），随 C8
- *     内建，不依赖 C11 的 resolve-pkg-paths.mjs 文件。
+ *   - resolvePkgArg：插件参数归一化（相对路径绝对化 / 包规格透传），内建，
+ *     不依赖独立文件。
  * browser-driver.mjs 保持独立 CLI 不动、不 import 本模块。
  */
 import { existsSync } from "node:fs";
@@ -75,8 +75,8 @@ export function jsonOut(obj, pretty = false) {
 //（0.1.2-rc.1 实测确认，注入 web-app bundle 后约 2s 内输出）；verdict 的
 // port.actual 三通道第一优先解析它。不匹配返回 null，由调用方回退
 // 就绪断言端口（asserted）/ 探测端口（probed）。
-// 行完整性（P2-6）：端口号后必须紧跟 `/` 或 `?`（真实 URL 形态），防 chunk
-// 截断 latch（如 chunk 尾部 `:34` 被当作完整端口锁定）；范围校验（P2-7）：
+// 行完整性：端口号后必须紧跟 `/` 或 `?`（真实 URL 形态），防 chunk
+// 截断 latch（如 chunk 尾部 `:34` 被当作完整端口锁定）；范围校验：
 // 1-65535 之外视为无匹配。
 export function readDshPort(text) {
   const m = /dsh web:\s*http:\/\/\S*?:(\d+)(?=\/|\?)/.exec(text || "");
@@ -85,17 +85,31 @@ export function readDshPort(text) {
   return p >= 1 && p <= 65535 ? p : null;
 }
 
-// --- C11 内建：插件参数归一化（原 resolve-pkg-paths.mjs 语义随 C8 内建） ---
+// --- 访问 URL 解析（GUI 鉴权令牌的唯一来源） ---
+// dsh web 的 GUI 带鉴权：不带令牌访问只得到 401 文本页，浏览器命令也拿不到界面。
+// 带令牌的完整 URL 只出现在 dsh 启动打印的这一行（同一行已由 readDshPort 解析
+// 端口），故整行取出而非「已知端口 + 猜令牌」。令牌是访问凭据：真值只落 0o600 的
+// browser.state / dsh.log，回显与 verdict 一律去令牌（防 CI 日志与 PR 证据归档）。
+// 完整性校验：必须是 host 之后带路径/查询的绝对 URL——截断的半个令牌比没有令牌更
+// 难排查（表现为 401 而非缺参数），故 shape 不符即返回 null 走可操作错误路径。
+export function readDshUrl(text) {
+  const m = /dsh web:\s*(https?:\/\/\S+)/.exec(text || "");
+  if (!m) return null;
+  const url = m[1].replace(/[.,;]+$/, "");
+  return /^https?:\/\/[^\s/]+\/\S*$/.test(url) ? url : null;
+}
+
+// --- 插件参数归一化 ---
 // dsh plugin add 同时接受本地路径 / npm 包名 / git URL 三种形态；相对路径必须
 // 基于当前 cwd 绝对化（dsh 会把非绝对路径当 git URL 解析、报 `Repository not
-// found` 迷惑错误，#517 C11），包规格（@scope/name、name@version、git URL）
+// found` 迷惑错误），包规格（@scope/name、name@version、git URL）
 // 原样透传。判定顺序敏感：
 //   1. 形态类路径（`.` `..` `/` `~` 开头）→ 绝对化；
 //   2. cwd 下存在该路径（目录或文件）→ 绝对化；
 //   3. 其余 → 视为包规格，原样透传。
 const PATH_LIKE = /^(\.{1,2}\/|\.{1,2}$|\/|~)/;
 // Windows 盘符绝对路径（C:\、C:/）不以 / 或 ~ 开头，PATH_LIKE 感知不到会误落
-// existsSync 分支：不存在的绝对路径被当成包规格透传（#517 C11 语义破坏）。
+// existsSync 分支：不存在的绝对路径被当成包规格透传。
 const WIN32_DRIVE_LIKE = /^[A-Za-z]:[\\/]/;
 
 function isPathLike(p) {

--- a/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/verify-isolated.mjs
+++ b/packages/dsh-verify-isolated/skills/dsh-verify-isolated/scripts/verify-isolated.mjs
@@ -2,7 +2,7 @@
 /**
  * verify-isolated.mjs — 隔离环境浏览器验证一键脚本（dsh-verify-isolated 插件包
  * 配套，随本 skill 分发）。原 `verify-isolated.sh`（bash + 内嵌 node -e）整体
- * 重写为纯 node 实现（#517 C8，需 Node >= 22），**不保留 shim**：skill 随包整体
+ * 重写为纯 node 实现（需 Node >= 22），**不保留 shim**：skill 随包整体
  * 发布，不存在新旧错配。升级路径：`bash .../verify-isolated.sh ...` →
  * `node .../verify-isolated.mjs ...`，参数与输出文案逐行对齐。
  *
@@ -21,12 +21,12 @@
  * 用法：
  *   node verify-isolated.mjs [--dsh <path>] [--port <port>] [--browser] [--keep]
  *                            [--no-build] [--evidence-dir <dir>] [--audit]
- *                            [--audit-extra-dirs <dir>] [--json]
- *                            [-- <pkg-path>...]
+ *                            [--audit-extra-dirs <dir>] [--no-skip-onboarding]
+ *                            [--json] [-- <pkg-path>...]
  *   --dsh <path>       指定 dsh 入口（默认 PATH 中的 dsh）。隔离实测必须锚定目标
- *                      dsh 版本——PATH 里碰巧存在的版本会让验证结果不可复现（#376 H1）。
+ *                      dsh 版本——PATH 里碰巧存在的版本会让验证结果不可复现。
  *   --port <port>      默认 3456；--port 0 自动探测真实空闲端口并打印（修复打印 0）。
- *                      探测块贴近 dsh 启动，防 EADDRINUSE 窗口（#481 P2-1）。
+ *                      探测块贴近 dsh 启动，防 EADDRINUSE 窗口。
  *   --browser          额外启动独立浏览器实例（browser-driver.mjs）：独立
  *                      user-data-dir + 自选空闲调试端口 + headless，实例信息写入
  *                      $ISOLATED_HOME/browser.state（与 DSH_HOME 同生命周期）。
@@ -47,10 +47,14 @@
  *                      额外审计目录（可重复）：相对路径基于 cwd 绝对化；局限
  *                      ——审计只扫 $ISOLATED_HOME 子树 + 本选项指定目录，**不扫
  *                      真实 home**（插件写真实 ~/.dsh 的数据面不在判定面内）。
+ *   --no-skip-onboarding
+ *                      不预置首启弹窗跳过（默认预置 settings.yaml 的
+ *                      ui-onboarding.welcomeNoticeVersion，使「内测声明」默认
+ *                      不弹）。要验证 onboarding 弹窗本身时用它保留原生首启态。
  *   --json             stdout 只出最终 verdict JSON（人类文案全部走 stderr）。
  *   --                 之后为要挂载的本地插件路径（相对路径基于当前 cwd 解析；
  *                      npm 包名 / git URL 原样透传，见 lib/verify-core.mjs
- *                      resolvePkgArg——C11 语义内建）。
+ *                      resolvePkgArg）。
  *   --help             显示本帮助。
  *
  * 退出码契约（显式表，smoke 锁定）：
@@ -89,7 +93,7 @@
  * checkSymlinkEscape / runAudit）外的新增/删除/修改 + 越界 symlink；
  * symlink 快照 lstat 不跟随，「t0 已存在且目标未变的外部 symlink（link:
  * 挂载点）合法不报」，「新增或目标变化且 resolve 后在**所在扫描根**外的
- * 报『越界 symlink』（防插件经 symlink 写回主 checkout）。时序：t0 基线
+ * 报『越界 symlink』（防插件经 symlink 写到隔离环境之外）。时序：t0 基线
  * 在**就绪断言成功之后**（dsh web 首启自建的 profiles/node_modules/** 官方
  * bundle link 与顶层 .credentials.yaml/storages/** 启动写面进基线——语义为
  * 「就绪后运行期写面审计」；verdict 中间态在其后写入，先扫后写 + 白名单
@@ -98,6 +102,20 @@
  * verdict JSON（audit 字段，--json 错误对象恒带 audit 字段与 verdict 对齐）。
  * 不阻断退出（审计异常仅警告，退出码契约不变）。就绪前退出/超时路径
  * auditBaseline 为 null → 审计跳过不报。
+ *
+ * 首启弹窗默认跳过（--no-skip-onboarding 关闭）：全新 DSH_HOME 的首屏是两个
+ * **阻断式**弹窗（「内测声明」→「添加 API Key」），二者都把 #root 置为 inert，
+ * 页面上的一切点击静默失效。内测声明由 settings.yaml 的
+ * ui-onboarding.welcomeNoticeVersion 与客户端常量精确相等决定，故启动前预置该
+ * 值即默认不弹——常量按 dsh 版本现取（lib/onboarding.mjs），取不到就只警告并
+ * 交给 browser-driver 导航后兜底，绝不用硬编码值伪造「已跳过」。「添加 API Key」
+ * 无法预置消除（其「稍后配置」只在当前页面生命周期内有效），由 browser-driver
+ * 在导航后自动点击跳过。弹窗成因、复现与对照见 SKILL.md 的硬前提（§3.2）。
+ *
+ * 访问 URL 与令牌：GUI 带鉴权，裸端口只得到 401 文本页，浏览器命令必须使用
+ * dsh 启动打印的带令牌 URL。脚本解析该行并：打印供直接使用、写入 browser.state
+ * 的 dshWebUrl（0o600，供 browser-driver 的 `--url state` 取用）；verdict 里只
+ * 记不含令牌的 web.url——verdict 会经 --json 进入 CI 日志，令牌不进日志。
  */
 import { spawn, spawnSync, execFileSync } from "node:child_process";
 import {
@@ -108,8 +126,11 @@ import { randomBytes } from "node:crypto";
 import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import {
-  EXIT, findFreePort, jsonOut, pidAlive, readDshPort, resolvePkgArg, waitPidExit,
+  EXIT, findFreePort, jsonOut, pidAlive, readDshPort, readDshUrl, resolvePkgArg, waitPidExit,
 } from "./lib/verify-core.mjs";
+import {
+  findWelcomeNoticeVersion, welcomeSettingsDocument,
+} from "./lib/onboarding.mjs";
 import {
   isInside, runAudit, scanSnapshot, SKIP_DEEP, WHITELIST_V,
 } from "./lib/audit.mjs";
@@ -118,9 +139,10 @@ const SCRIPT_DIR = import.meta.dirname; // Node >= 22 全程可用
 const DRIVER = join(SCRIPT_DIR, "browser-driver.mjs");
 const DEFAULT_PORT = 3456;
 const READY_TIMEOUT_MS = 15000;
+const URL_WAIT_MS = 5000; // 访问 URL 行晚于 HTTP 就绪的等待上限（见 9b 注释）
 const LOG_TAIL_LIMIT = 4096; // 防背压：收集缓冲限长（browser-driver stderrBuf 先例）
 
-const USAGE = `用法: node verify-isolated.mjs [--dsh <path>] [--port <port>] [--browser] [--keep] [--no-build] [--evidence-dir <dir>] [--audit] [--audit-extra-dirs <dir>] [--json] [-- <pkg-path>...]
+const USAGE = `用法: node verify-isolated.mjs [--dsh <path>] [--port <port>] [--browser] [--keep] [--no-build] [--evidence-dir <dir>] [--audit] [--audit-extra-dirs <dir>] [--no-skip-onboarding] [--json] [-- <pkg-path>...]
 
 选项：
   --dsh <path>         指定 dsh 入口（默认 PATH 中的 dsh；隔离实测必须锚定版本，防 PATH 漂移）
@@ -132,12 +154,17 @@ const USAGE = `用法: node verify-isolated.mjs [--dsh <path>] [--port <port>] [
   --audit              隔离审计：对比隔离 DSH_HOME 写面与预置白名单，白名单外变化报「可疑」，不阻断退出
   --audit-extra-dirs <dir>
                       额外审计目录（可重复；相对路径基于 cwd 绝对化；局限：不扫真实 home）
+  --no-skip-onboarding 不预置首启弹窗跳过（默认预置 settings.yaml 的内测声明版本，使其默认不弹）
   --json               stdout 只出最终 verdict JSON（人类文案走 stderr）
   --                   之后为要挂载的本地插件路径（相对路径基于 cwd 绝对化；npm 包名 / git URL 原样透传）
   --help               显示本帮助
 
 环境要求：Node >= 22（同 browser-driver）。
-退出码：0 正常 / 1 启动或就绪失败 / 2 参数错误 / 130 SIGINT / 143 SIGTERM。`;
+退出码：0 正常 / 1 启动或就绪失败 / 2 参数错误 / 130 SIGINT / 143 SIGTERM。
+
+访问 URL：dsh web 的 GUI 带鉴权，裸端口只得到 401 文本页。脚本启动后打印带令牌的
+访问 URL，并把它写入 browser.state 的 dshWebUrl（0o600）——browser-driver 页面命令
+用 \`--url state\` 取用即可；verdict 只记不含令牌的 web.url。`;
 
 // --- 全局运行态（cleanup / verdict / 信号多路共享） ---
 let flags = null;
@@ -157,16 +184,19 @@ let dshWebPort = 0; // 传给 dsh 的有效端口（--port 0 时为探测值）
 let browserPort = null;
 let readyOk = false;
 let readyIso = null;
-let childExitBeforeReady = null; // 就绪前 dsh 退出记录（P1 修复：#517 C8 复核）
+let childExitBeforeReady = null; // 就绪前 dsh 退出记录
 let exiting = null; // { code: number, signal: string|null } 退出请求
 let settling = false;
 let errorPayload = null; // --json 错误路径已输出的错误对象（settle 不再重复出 JSON）
 let auditBaseline = null; // B4：t0 基线快照 [{ root, snapshot }]（--audit 时）
 let auditResult = null; // B4：settle 审计输出（--audit 时；并入 verdict/audit.json）
 let auditExtraDirsAbs = []; // B4：绝对化后的 --audit-extra-dirs（settle 审计与 verdict 共用）
+let onboardingPreset = null; // 首启弹窗预置结果（--no-skip-onboarding 时为 disabled）
+let webUrl = null; // 带令牌的访问 URL（仅落 browser.state / 打印，不进 verdict）
+let webUrlBare = null; // 不含令牌的访问 URL（进 verdict，防 --json 日志泄漏令牌）
 
 // 人类文案输出：--json 时走 stderr（stdout 只出最终 JSON），普通模式走 stdout
-//（SKILL.md §5.1 自检清单依赖 `profile=verify_<随机>` / `DSH_HOME=…` 等可读行）。
+//（SKILL.md §4 自检清单依赖 `profile=verify_<随机>` / `DSH_HOME=…` 等可读行）。
 function out(msg) {
   (jsonMode ? process.stderr : process.stdout).write(msg + "\n");
 }
@@ -200,7 +230,7 @@ function parseCli(argv) {
   const f = {
     dsh: null, port: DEFAULT_PORT, browser: false, keep: false,
     noBuild: false, evidenceDir: null, audit: false, auditExtraDirs: [],
-    json: jsonMode, help: false,
+    skipOnboarding: true, json: jsonMode, help: false,
   };
   const pkgs = [];
   const bad = (msg) => { throw new CliError(msg, EXIT.USAGE); };
@@ -234,6 +264,7 @@ function parseCli(argv) {
         case "evidence-dir": f.evidenceDir = inline ?? val(i, "--evidence-dir"); if (inline === null) i++; break;
         case "audit": f.audit = true; break;
         case "audit-extra-dirs": f.auditExtraDirs.push(inline ?? val(i, "--audit-extra-dirs")); if (inline === null) i++; break;
+        case "no-skip-onboarding": f.skipOnboarding = false; break;
         case "json": {
           // --json=<v> 显式布尔（true/false），非法值参数错误
           if (inline !== null) {
@@ -256,7 +287,7 @@ function parseCli(argv) {
   return { flags: f, pkgs };
 }
 
-// --- dsh 入口校验与版本锚定（#376 H1） ---
+// --- dsh 入口校验与版本锚定 ---
 function checkExecutable(p) {
   try {
     const st = statSync(p);
@@ -353,6 +384,10 @@ function makeVerdict(mut) {
     ready: readyOk,
     readyAt: readyIso,
     evidenceDir: evidenceDir,
+    // 访问 URL 恒去令牌：verdict 会经 --json 进 CI 日志，令牌真值只落
+    // browser.state.dshWebUrl 与 dsh.log（均 0o600），tokenSource 指明去哪取。
+    web: { url: webUrlBare, tokenSource: webUrl ? "browser.state.dshWebUrl" : null },
+    onboarding: onboardingPreset,
     audit: auditResult, // B4：--audit 时 settle 审计结果；否则 null（--json 终态含同字段）
     cleanup: "running", // 中间态；终态由 writeVerdictTerminal 覆写为 done/kept
     ...mut,
@@ -377,7 +412,7 @@ function writeVerdictTerminal() {
   writeVerdict({ ok: done, ready: readyOk, readyAt: readyIso, cleanup: flags?.keep ? "kept" : "done" });
 }
 
-// --- 插件处理（C11 内建归一化 + 构建 / --no-build 校验 / add） ---
+// --- 插件处理（参数归一化 + 构建 / --no-build 校验 / add） ---
 function newestMtime(dir) {
   let m = 0;
   const walk = (d) => {
@@ -401,7 +436,7 @@ function hasBuildScript(pkgAbs) {
 
 function setupPlugins(pkgs) {
   if (pkgs.length === 0) return;
-  // 1. 归一化全部参数（C11 语义内建）：path → 绝对路径；spec → 原样透传
+  // 1. 归一化全部参数：path → 绝对路径；spec → 原样透传
   const items = pkgs.map(resolvePkgArg);
   for (const it of items) {
     const label = it.kind === "path" ? it.abs : it.input;
@@ -420,7 +455,7 @@ function setupPlugins(pkgs) {
           EXIT.USAGE,
         );
       }
-      // 陈旧警告（#376 L2）：src 比产物新 → 提示可能验证到旧版本
+      // 陈旧警告：src 比产物新 → 提示可能验证到旧版本
       const src = join(it.abs, "src");
       const s = existsSync(src) ? newestMtime(src) : 0;
       const p = Math.max(...prods.map(newestMtime));
@@ -442,7 +477,7 @@ function setupPlugins(pkgs) {
       out(`跳过构建（无 build 脚本）: ${it.abs}`);
     }
   }
-  // 2. add 统一用归一化结果（相对路径已在 dsh 侧被当 git URL，C11）
+  // 2. add 统一用归一化结果（相对路径已在 dsh 侧被当 git URL）
   const addArgs = items.map((it) => (it.kind === "path" ? it.abs : it.input));
   const add = runDsh(["plugin", "--profile", profile, "add", ...addArgs], true);
   if (add.status !== 0) {
@@ -453,7 +488,32 @@ function setupPlugins(pkgs) {
   }
 }
 
-// --- 就绪断言（#376 M2）：轮询 HTTP 可达 + 进程存活核对 ---
+// --- 首启弹窗默认跳过：预置 settings.yaml 的内测声明版本（见头部注释） ---
+// 预置失败不阻断启动：跳过失效只意味着首屏多一个弹窗（browser-driver 导航后仍会
+// 兜底），而把「dsh 改了客户端常量形态」升级成启动失败，会让验证在无关变更上停摆。
+function presetWelcomeNotice() {
+  const settingsPath = join(isolatedHome, "settings.yaml");
+  const found = findWelcomeNoticeVersion(dshAbs);
+  if (!found) {
+    outWarn("警告: 未能从 dsh 产物提取内测声明版本（布局或客户端常量变化？）——首启「内测声明」弹窗保留，由 browser-driver 导航后兜底跳过");
+    return { skip: true, source: "unavailable", version: null, settingsFile: settingsPath };
+  }
+  if (existsSync(settingsPath)) {
+    outWarn(`警告: ${settingsPath} 已存在，跳过预置（不覆盖既有设置文档）`);
+    return { skip: true, source: "existing", version: found.version, settingsFile: settingsPath };
+  }
+  try {
+    // 0o600：设置文档含用户偏好，与 verdict/browser.state/dsh.log 同级保护
+    writeFileSync(settingsPath, welcomeSettingsDocument(found.version), { mode: 0o600 });
+  } catch (e) {
+    outWarn(`警告: 首启弹窗预置写入失败（${e.message}）——首启「内测声明」弹窗保留，由 browser-driver 兜底跳过`);
+    return { skip: true, source: "write-failed", version: found.version, settingsFile: settingsPath, error: e.message };
+  }
+  out(`首启弹窗预置: 内测声明版本 ${found.version} → ${settingsPath}（--no-skip-onboarding 可关闭）`);
+  return { skip: true, source: "preset", version: found.version, clientFile: found.file, settingsFile: settingsPath };
+}
+
+// --- 就绪断言：轮询 HTTP 可达 + 进程存活核对 ---
 // 2xx-4xx 就绪（GUI 带鉴权，实测 401 即就绪）、5xx/拒绝继续等、
 // AbortSignal.timeout 1.5s、15s 超时、进程退出立即判失败。
 async function waitReady(port, pid) {
@@ -483,7 +543,7 @@ async function settle() {
   settling = true;
   try {
     // 1. kill dsh：与 bash trap 对齐，先 SIGTERM 优雅终止（5s 窗口），SIGKILL
-    //    仅作二次兜底（评审 P2-9：避免活体 dsh 被直接 SIGKILL 跳过清理钩子）
+    //    仅作二次兜底（避免活体 dsh 被直接 SIGKILL 跳过清理钩子）
     if (dshChild) {
       await waitPidExit(dshChild.pid, 5000);
       if (pidAlive(dshChild.pid)) killDsh(dshChild, "SIGTERM");
@@ -592,7 +652,7 @@ async function main() {
   const { flags: f, pkgs } = parseCli(process.argv.slice(2));
   flags = f;
   jsonMode = f.json;
-  // --json 时 USAGE 走 stderr（stdout 只出 JSON 的约束对 --help 同样生效，P2-8）
+  // --json 时 USAGE 走 stderr（stdout 只出 JSON 的约束对 --help 同样生效）
   if (f.help) {
     (jsonMode ? process.stderr : process.stdout).write(USAGE + "\n");
     process.exit(EXIT.OK);
@@ -646,7 +706,7 @@ async function main() {
     }
   }
   // dsh.log 含隔离实例访问 token（dsh web URL 行）——与 verdict/browser.state
-  // 一致 0o600 初始化（仅本用户可读，防同机其他用户窥探；P2-3）。
+  // 一致 0o600 初始化（仅本用户可读，防同机其他用户窥探）。
   try { writeFileSync(dshLogPath, "", { mode: 0o600 }); } catch {}
   // B7：证据目录默认 $ISOLATED_HOME/evidence/；显式 --evidence-dir 外部化时建
   // <dir>/evidence-<profile>/ 子目录（recursive 幂等，绝不动外部目录本体）
@@ -655,6 +715,12 @@ async function main() {
     : join(isolatedHome, "evidence");
   mkdirSync(evidenceDir, { recursive: true });
   out(`证据目录: ${evidenceDir}`);
+
+  // 1b. 首启弹窗默认跳过：预置内测声明版本，否则首屏是一张 inert 的阻断弹窗，
+  //     验证开始前必须先手工点掉（且刷新后重现）。--no-skip-onboarding 保留原生态。
+  onboardingPreset = f.skipOnboarding
+    ? presetWelcomeNotice()
+    : { skip: false, source: "disabled", version: null, settingsFile: join(isolatedHome, "settings.yaml") };
 
   // 2. 初始化独立 profile（显式 plugin list；失败 fail loudly 给可操作错误）
   const init = runDsh(["plugin", "--profile", profile, "list"], true);
@@ -672,7 +738,7 @@ async function main() {
   }
   writeFileSync(profilePkg, JSON.stringify(pj, null, 2));
 
-  // 4. 挂载本地插件（C11 归一化 + 构建 / --no-build 校验 + add）
+  // 4. 挂载本地插件（参数归一化 + 构建 / --no-build 校验 + add）
   setupPlugins(pkgs);
 
   // 5. 启动独立浏览器实例（--browser）：实例信息写入 browser.state。
@@ -696,7 +762,7 @@ async function main() {
     out(`浏览器实例就绪: state=${browserState}（操作命令见 browser-driver.mjs --help）`);
   }
 
-  // 6. 修复 --port 0：贴近 dsh 启动探测真实空闲端口再传给 dsh（#481 P2-1）
+  // 6. 修复 --port 0：贴近 dsh 启动探测真实空闲端口再传给 dsh
   dshWebPort = f.port;
   if (f.port === 0) {
     dshWebPort = await findFreePort();
@@ -749,7 +815,7 @@ async function main() {
   // EADDRINUSE / 插件加载失败 / 就绪前净退出）时若直接 requestExit 透传，
   // settle 会在微任务内抢先 process.exit，使下方 waitReady 的 dead 检测与
   // CliError 诊断整段不可达：stderr 空（无可操作诊断）且 dsh exit 0（就绪前
-  // 净退出）会静默假成功、非契约码（如 3）穿透契约表（#517 C8 复核 P1 复现）。
+  // 净退出）会静默假成功、非契约码（如 3）穿透契约表。
   // 故就绪前退出只记录，让 waitReady 的 pidAlive 检测返回 dead → 统一走
   // CliError(EXIT.FAIL) 路径（有诊断文案 + 契约退出码 1）。
   // **就绪后**：信号退出归一为 130/143，其余 dsh 异常退出码原样透传
@@ -763,7 +829,7 @@ async function main() {
 
   // 9. 就绪断言（轮询 HTTP + 进程存活核对，15s 超时可操作错误）。
   //    dead/timeout 诊断内联 logTail 尾部（内存滚动缓冲，非 --keep 时 dsh.log
-  //    随 ISOLATED_HOME 删除——引用文件路径用户按提示查看时已不存在，P2-4）。
+  //    随 ISOLATED_HOME 删除——引用文件路径用户按提示查看时已不存在）。
   const verdictPort = dshWebPort;
   const ready = await waitReady(verdictPort, dshChild.pid);
   if (ready === "dead") {
@@ -790,7 +856,7 @@ async function main() {
   readyOk = true;
   readyIso = new Date().toISOString();
   // 端口实际绑定三通道收口：parsed → asserted（就绪断言端口）→ probed。
-  // **无条件**以 dsh.log 全文重解析 parsed（P2-6：chunk 截断可能已 latch 错误
+  // **无条件**以 dsh.log 全文重解析 parsed（chunk 截断可能已 latch 错误
   // 端口——readDshPort 行完整性校验已防截断，此处双保险覆盖任何早到解析；
   // 无匹配则落 asserted/probed）。
   try {
@@ -802,6 +868,32 @@ async function main() {
     portSource = flags.port === 0 ? "probed" : "asserted";
   }
   out(`就绪断言通过: http://127.0.0.1:${actualPort} 已可达（pid=${dshChild.pid}）`);
+
+  // 9b. 访问 URL 与令牌：GUI 带鉴权，浏览器命令必须用带令牌的 URL（裸端口只得到
+  //     401 文本页）。令牌只从 dsh 打印行取真值，只落 0o600 的 browser.state 与
+  //     dsh.log，verdict 记去令牌形态——verdict 会经 --json 进 CI 日志。
+  webUrlBare = `http://127.0.0.1:${actualPort}/`;
+  // dsh 打印 URL 行的时刻晚于 HTTP 就绪（与端口 parsed 通道同源的既有实证），
+  // 就绪即读会稳定落空——那会把「必须带令牌」的引导降级成一句无用警告。
+  const urlDeadline = Date.now() + URL_WAIT_MS;
+  for (;;) {
+    try { webUrl = readDshUrl(readFileSync(dshLogPath, "utf8")); } catch {}
+    if (webUrl || Date.now() >= urlDeadline) break;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  if (!webUrl) {
+    outWarn(`警告: 未从 dsh 输出解析到带令牌的访问 URL（dsh.log 行格式变化？）——浏览器命令请自行从 ${dshLogPath} 取 URL`);
+  } else {
+    out(`访问 URL（含访问令牌，GUI 鉴权必需）: ${webUrl}`);
+  }
+  if (f.browser && existsSync(browserState)) {
+    try {
+      const st = JSON.parse(readFileSync(browserState, "utf8"));
+      if (webUrl) st.dshWebUrl = webUrl;
+      writeFileSync(browserState, JSON.stringify(st, null, 2));
+      if (webUrl) out("浏览器命令: 用 `--url state` 取该带令牌 URL（示例见 SKILL.md §3.1）");
+    } catch { /* state 解析失败不阻断启动 */ }
+  }
 
   // B4：t0 基线快照（--audit）——位置在**就绪断言成功之后**、verdict 中间态
   // 写入之前。语义为「**就绪后运行期写面审计**」：dsh web **首启**才自建的

--- a/packages/dsh-verify-isolated/test/smoke.ts
+++ b/packages/dsh-verify-isolated/test/smoke.ts
@@ -1,6 +1,6 @@
 /**
  * dsh-verify-isolated — smoke：skills 目录结构 + SKILL.md frontmatter + patch 配置
- * + 新增脚本参数契约（browser-driver.mjs / verify-isolated.mjs，node 重写 #517 C8）。
+ * + 新增脚本参数契约（browser-driver.mjs / verify-isolated.mjs）。
  *
  * 无网络、无真实凭据、**不真正启动 dsh / 浏览器**（防跨平台 flake，遵守
  * docs/DEVELOPMENT.md §5）。验证（参照 archify-dsh 的 bundledSkillDir 模式）：
@@ -14,22 +14,31 @@
  * 6. verify-isolated.mjs 关键契约：--dsh/--port 0/--browser/--keep/--no-build/
  *    --evidence-dir/verdict.json/dsh.log/退出码（0/1/2/130/143）文本锚定 +
  *    lib/verify-core.mjs import 行为断言（EXIT 常量 / poll / findFreePort /
- *    resolvePkgArg C11 归一化 / readDshPort parsed 通道）+ 子进程退出码实测
+ *    resolvePkgArg 归一化 / readDshPort parsed 通道）+ 子进程退出码实测
  *    （--help=0、--dsh 不存在=2、--json 错误=单 JSON）；
- * 7. SKILL.md 含多会话并行章节与三平台内核自查清单；
+ * 7. SKILL.md 主线 + references/ 支线（渐进式披露）：主线判据与约束（四重隔离 / 并行 /
+ *    DSH_HOME 感知 / 遥测 / 回环 / 版本锚定 / 访问形态边界）+ 每个 reference 都有指针
+ *    与「读它的时机」+ 主线体量上限（防支线内容回灌）+ 各 reference 自包含锚点；
  * 8. README 同步新能力。
  *
- * 9. B4 隔离审计（#517 B4，含 #540 复核修复）：lib/audit.mjs 纯函数行为断言
+ * 9. B4 隔离审计（含复核修复）：lib/audit.mjs 纯函数行为断言
  *    （WHITELIST_V 版本化、scanSnapshot/diffAgainstWhitelist/checkSymlinkEscape/
  *    runAudit）+ mkdtemp fixture 正反例（越界 symlink / 白名单外新增/删除/修改 /
  *    白名单内新增/删除/修改忽略 / link: 挂载点合法 / t1 无变化通过 / browser-profile
- *    跳过深扫 / M1 ctimeMs 参与修改判定 / 9f dsh 启动写面进基线干净运行 pass）+
+ *    跳过深扫 / ctimeMs 参与修改判定 / 9f dsh 启动写面进基线干净运行 pass）+
  *    脚本契约锚定（--audit / --audit-extra-dirs / 结论行 / audit.json / t0 位于
  *    就绪断言之后）+ 子进程退出码实测（--audit --help=0、--audit-extra-dirs 不存在
- *    或传文件=2、M6 t0 前错误 JSON 恒带 audit:null）+ 9g 假 dsh 端到端回归
+ *    或传文件=2、t0 前错误 JSON 恒带 audit:null）+ 9g 假 dsh 端到端回归
  *    （启动写面建模：干净运行 exit0+pass / 运行期写面 suspicious count=1）。
  *
- * 注（#517 C11 并入）：resolve-pkg-paths.mjs 独立文件随 C8 内建进
+ * 10. 首启弹窗跳过与访问令牌：lib/onboarding.mjs 纯函数（须知版本提取与降级 /
+ *    settings 文档形状与注入防护 / dsh 安装根与产物定位的 fixture 正反例 / 探针
+ *    表达式的 allowClick 真开关顺序 / 令牌脱敏 / 401 判据）+ readDshUrl 行完整性 +
+ *    脚本与 browser-driver 契约锚定（--no-skip-onboarding、--url state、
+ *    --no-auto-dismiss、导航命令接入 goto 而 eval/fill 不接入）+ SKILL/README 中英
+ *    四份文档的跳过与令牌指导锚点（前提性指导缺失会让执行者卡在 401/inert 页面）。
+ *
+ * 注：resolve-pkg-paths.mjs 的语义已内建进
  * lib/verify-core.mjs 的 resolvePkgArg（6a 行为断言覆盖原 6.5 段语义）。
  */
 import assert from "node:assert/strict";
@@ -54,12 +63,12 @@ const fm = parseFrontmatter(raw);
 assert.equal(fm.name, "dsh-verify-isolated", "SKILL.md frontmatter name");
 assert.match(fm.description ?? "", /隔离环境/, "description 含隔离环境");
 
-// 防回归（#428）：脚本定位必须走 skill 资源 base（注入的 Base directory），不得
+// 防回归：脚本定位必须走 skill 资源 base（注入的 Base directory），不得
 // 写死 npm 副本形态的 node_modules 路径——link:/checkout 形态下该路径不存在
 assert.ok(!raw.includes("node_modules/@wingsky-1"),
   "SKILL.md 不得写死 node_modules/@wingsky-1 路径（应经 skill 资源 base 定位）");
 
-// ---- 2. 一键脚本随 skill 分发（node 重写：#517 C8，删除 .sh 不留 shim） ----
+// ---- 2. 一键脚本随 skill 分发（node 实现，删除 .sh 不留 shim） ----
 const scriptFile = join(SCRIPTS_DIR, "verify-isolated.mjs");
 assert.ok(existsSync(scriptFile), "verify-isolated.mjs 随 skill 目录分发");
 assert.ok(!existsSync(join(SCRIPTS_DIR, "verify-isolated.sh")),
@@ -181,7 +190,7 @@ assert.ok(noArgExitsNonZero, "browser-driver 无参数应非零退出（用法�
   // findFreePort：127.0.0.1 上探测到真实空闲端口
   const fp = await core.findFreePort();
   assert.ok(Number.isInteger(fp) && fp > 0 && fp < 65536, `findFreePort 返回合法端口: ${fp}`);
-  // resolvePkgArg：C11 归一化语义内建（相对路径绝对化 / 包规格原样透传 / ~ 展开）
+  // resolvePkgArg：归一化语义内建（相对路径绝对化 / 包规格原样透传 / ~ 展开）
   //（cwd = 包根，smoke 由 pnpm -r 在各包目录执行）
   assert.equal(core.resolvePkgArg("skills").kind, "path", "cwd 存在的相对路径 → path");
   assert.equal(core.resolvePkgArg("./skills").kind, "path", "形态类路径 ./ → path");
@@ -198,13 +207,13 @@ assert.ok(noArgExitsNonZero, "browser-driver 无参数应非零退出（用法�
   // readDshPort：B6 parsed 通道（0.1.2-rc.1 实证格式）
   assert.equal(core.readDshPort("dsh web: http://127.0.0.1:34567/?token=abc"), 34567, "readDshPort 解析端口行");
   assert.equal(core.readDshPort("noise line\nsome other output"), null, "readDshPort 无端口行返回 null");
-  // P2-6/7：截断 chunk 尾部（无 / 或 ? 收尾）不 latch；端口范围 1-65535 外视为无匹配
+  // 截断 chunk 尾部（无 / 或 ? 收尾）不 latch；端口范围 1-65535 外视为无匹配
   assert.equal(core.readDshPort("dsh web: http://127.0.0.1:34"), null, "readDshPort 截断端口行不 latch（行完整性）");
   assert.equal(core.readDshPort("dsh web: http://127.0.0.1:70000/?token=abc"), null, "readDshPort 端口范围校验（>65535 → null）");
   assert.equal(core.readDshPort("dsh web: http://127.0.0.1:0/?token=abc"), null, "readDshPort 端口范围校验（0 → null）");
 
-  // 6b. 关键契约文本锚定（不锁脚本细节，锁对外契约面；#517 C11 归一化语义由
-  // 6a resolvePkgArg 行为断言覆盖——内建进 verify-core，不依赖 C11 独立文件）
+  // 6b. 关键契约文本锚定（不锁脚本细节，锁对外契约面；归一化语义由
+  // 6a resolvePkgArg 行为断言覆盖——内建进 verify-core，不依赖独立文件）
   const script = readFileSync(scriptFile, "utf8");
   for (const opt of ["--dsh", "--port 0", "--browser", "--keep", "--no-build", "--evidence-dir", "--json"]) {
     assert.ok(script.includes(opt), `脚本含 ${opt} 选项契约`);
@@ -220,7 +229,7 @@ assert.ok(noArgExitsNonZero, "browser-driver 无参数应非零退出（用法�
   ]) {
     assert.ok(script.includes(field), `verdict schema 含字段 ${field}`);
   }
-  // 四重隔离语义锚定（#376 加固面保留）：
+  // 四重隔离语义锚定：
   assert.ok(script.includes('"--host", "127.0.0.1"'), "隔离实例显式回环绑定（锚定启动行）");
   assert.ok(script.includes("DSH_TELEMETRY_DISABLED"), "隔离实例显式禁用遥测");
   assert.ok(script.includes("randomBytes(4)"), "verify_<随机> profile 走 node crypto");
@@ -233,9 +242,9 @@ assert.ok(noArgExitsNonZero, "browser-driver 无参数应非零退出（用法�
   assert.ok(script.includes("AbortSignal.timeout"), "就绪探测带超时（不裸连）");
   assert.ok(script.includes("--no-build 但缺少构建产物"), "--no-build 缺产物报可操作错误");
   assert.ok(script.includes("源码比构建产物新"), "--no-build 陈旧产物 mtime 警告");
-  // C11 语义注释在 lib/verify-core.mjs（resolvePkgArg 归属处）
+  // 归一化语义注释在 lib/verify-core.mjs（resolvePkgArg 归属处）
   const coreSrc = readFileSync(join(SCRIPTS_DIR, "lib", "verify-core.mjs"), "utf8");
-  assert.ok(coreSrc.includes("dsh 会把非绝对路径当 git URL 解析"), "脚本注释声明相对路径 git URL 陷阱（#517 C11）");
+  assert.ok(coreSrc.includes("dsh 会把非绝对路径当 git URL 解析"), "脚本注释声明相对路径 git URL 陷阱");
 }
 
 // ---- 6c. 子进程退出码实测（不启动 dsh / 浏览器，走 --dsh 不存在与 --help 路径） ----
@@ -254,7 +263,7 @@ assert.ok(noArgExitsNonZero, "browser-driver 无参数应非零退出（用法�
   // --dsh 不存在：参数错误退出码 2
   const bad = run(["--dsh", "/nonexistent/dsh"]);
   assert.equal(bad.code, 2, "--dsh 不存在退出码 2（找不到 dsh 入口）");
-  // --json --dsh 不存在：stdout **恰好 1 行** JSON（含 exitCode 2；P2-10 锁定
+  // --json --dsh 不存在：stdout **恰好 1 行** JSON（含 exitCode 2；锁定
   // stdout 只出 JSON 的约束，人类文案不得混入）
   const j = run(["--json", "--dsh", "/nonexistent/dsh"]);
   assert.equal(j.code, 2, "--json 错误路径退出码 2");
@@ -263,7 +272,7 @@ assert.ok(noArgExitsNonZero, "browser-driver 无参数应非零退出（用法�
   const parsed = JSON.parse(jLines[0]);
   assert.equal(parsed.ok, false, "--json 错误对象 ok=false");
   assert.equal(parsed.exitCode, 2, "--json 错误对象 exitCode=2");
-  // P1-1 回归：`--` 之后的 --json 是插件参数，不得误开全局 jsonMode
+  // 回归：`--` 之后的 --json 是插件参数，不得误开全局 jsonMode
   const afterDash = run(["--dsh", "/nonexistent/dsh", "--", "--json"]);
   assert.equal(afterDash.code, 2, "-- 之后 --json 仍按参数错误退出码 2");
   assert.ok(!afterDash.out.trim().startsWith("{"), "-- 之后的 --json 不误开 jsonMode（stdout 非 JSON）");
@@ -272,7 +281,7 @@ assert.ok(noArgExitsNonZero, "browser-driver 无参数应非零退出（用法�
   assert.equal(u.code, 2, "未知选项退出码 2");
 }
 
-// ---- 6d. P1 回归（#517 C8 复核）：dsh 就绪前退出 → 契约码 1 + 可操作诊断 ----
+// ---- 6d. 回归：dsh 就绪前退出 → 契约码 1 + 可操作诊断 ----
 // 复现路径：dsh web 启动即崩（端口被占 EADDRINUSE / 插件加载失败 / 就绪前净退出）。
 // 修复前：exit handler 抢先 requestExit 透传 dsh 退出码 → settle 抢先 process.exit
 // → waitReady 的 dead 检测与 CliError 诊断不可达（stderr 空），且 dsh exit 0 静默
@@ -340,34 +349,56 @@ process.exit(Number(process.env.FAKE_DH_EXIT ?? "0"));
     assert.equal(jparsed.ok, false, "--json 就绪前退出 ok=false");
     assert.equal(jparsed.exitCode, 1, "--json 就绪前退出 exitCode=1");
   } finally {
-    rmSync(tmp, { recursive: true, force: true }); // 零污染纪律（#218）
+    rmSync(tmp, { recursive: true, force: true }); // 零污染纪律
   }
 }
 
-// ---- 7. SKILL.md 含多会话并行章节与三平台内核自查 ----
-assert.ok(raw.includes("多会话并行"), "SKILL.md 含多会话并行章节");
+// ---- 7. SKILL.md 主线 + references/ 支线（渐进式披露：内容随分支下沉） ----
+// 断言跟随内容位置：主线判据留在 SKILL.md，支线（内核 / 视口 / 手动步骤 / 脚本契约）
+// 在各自的 reference 里自包含——把支线内容抄回正文以满足旧断言，会让披露重新退化。
+const REF_DIR = join(SKILL_DIR, "references");
+const REF_FILES = ["script-contracts.md", "manual-setup.md", "browser-kernel.md", "viewport-geometry.md"];
+for (const name of REF_FILES) {
+  assert.ok(existsSync(join(REF_DIR, name)), `支线参考 references/${name} 随 skill 分发`);
+}
+const refText = (name) => readFileSync(join(REF_DIR, name), "utf8");
+
+// 7a. 主线：每次触发都要用的判据与约束
 assert.ok(raw.includes("四重隔离"), "SKILL.md 含四重隔离说明");
-assert.ok(raw.includes("DSH_VERIFY_CHROME"), "SKILL.md 含 DSH_VERIFY_CHROME 内核指定");
-assert.ok(raw.includes("ms-playwright"), "SKILL.md 含 ms-playwright 缓存路径表");
-assert.ok(raw.includes("Google Chrome.app"), "SKILL.md 含 macOS 自查路径");
-assert.ok(raw.includes("ProgramFiles"), "SKILL.md 含 Windows 自查路径");
-// #376 配套：SKILL.md 含 --dsh 用法与隔离自检第 5 项（插件持久化 DSH_HOME 感知）
-assert.ok(raw.includes("--dsh"), "SKILL.md 含 --dsh 版本锚定用法");
-assert.ok(raw.includes("DSH_HOME 感知"), "SKILL.md 自检清单含插件 DSH_HOME 感知项（#510 盲区）");
+assert.ok(raw.includes("多会话并行"), "SKILL.md 含多会话并行约束");
+assert.ok(raw.includes("DSH_HOME 感知"), "SKILL.md 自检清单含插件 DSH_HOME 感知项");
 assert.ok(raw.includes("DSH_TELEMETRY_DISABLED=1"), "SKILL.md 含遥测禁用原则");
 assert.ok(raw.includes("--host 127.0.0.1"), "SKILL.md 含显式回环原则");
-// 视口验证能力：替代 resizeTo（高度不生效，实测无效）+ 防回退锁
-assert.ok(raw.includes("--width"), "SKILL.md 含视口档位 flag 用法");
-assert.ok(raw.includes("设备视口与几何验证"), "SKILL.md 含设备视口与几何验证章节");
-assert.ok(raw.includes("基线档"), "SKILL.md 含不带 flag 的基线档与残留回读方法");
-assert.ok(raw.includes("不要用 `window.resizeTo`"), "SKILL.md 明确标注 resizeTo 不可用（高度不生效）");
-// 防回退锁：resizeTo 只允许作为反例出现在正文，不得再出现在示例代码块里（否则会被照抄）
-const bashBlocks = raw.split("```bash").slice(1).map((b) => b.split("```")[0]);
-assert.ok(bashBlocks.length > 0, "SKILL.md 含 bash 示例块");
-assert.ok(bashBlocks.every((b) => !b.includes("resizeTo")), "SKILL.md 示例代码块不再出现 resizeTo");
-assert.ok(raw.includes("ontouchstart"), "SKILL.md 声明触控模拟能力边界（不越界承诺真机行为）");
-// 访问形态边界（隔离语义，与视口能力无关）：脚本默认只覆盖回环形态
+assert.ok(raw.includes("--dsh"), "SKILL.md 含 --dsh 版本锚定用法");
 assert.ok(raw.includes("--trusted-host"), "SKILL.md 声明非回环访问形态的边界与官方选项");
+
+// 7b. 指针：每个 reference 都要有指向它的入口，且声明读它的时机（否则等于不可达）
+for (const name of REF_FILES) assert.ok(raw.includes(name), `SKILL.md 指向 references/${name}`);
+assert.ok(raw.includes("唯一事实源"), "SKILL.md 声明 --help 为选项契约唯一事实源（正文不复述）");
+const skillLines = raw.split("\n").length;
+assert.ok(skillLines < 260, `SKILL.md 保持主线体量（实际 ${skillLines} 行，超限说明支线内容回灌正文）`);
+
+// 7c. 支线：各自的 reference 自包含
+const kernelRef = refText("browser-kernel.md");
+for (const anchor of ["DSH_VERIFY_CHROME", "ms-playwright", "Google Chrome.app", "ProgramFiles"]) {
+  assert.ok(kernelRef.includes(anchor), `references/browser-kernel.md 含内核锚点 ${anchor}`);
+}
+const vpRef = refText("viewport-geometry.md");
+for (const anchor of ["--width", "设备视口与几何验证", "基线档", "resizeTo", "ontouchstart"]) {
+  assert.ok(vpRef.includes(anchor), `references/viewport-geometry.md 含视口锚点 ${anchor}`);
+}
+assert.ok(vpRef.includes("高度不生效"), "references/viewport-geometry.md 保留 resizeTo 不可用的理由");
+// 防照抄锁：resizeTo 只作为「为何不用」的事实出现，示例代码块里不得再出现
+assert.ok(vpRef.split("```bash").slice(1).every((b) => !b.split("```")[0].includes("resizeTo")),
+  "references/viewport-geometry.md 示例代码块不出现 resizeTo");
+const manualRef = refText("manual-setup.md");
+for (const anchor of ["DSH_HOME=$(mktemp -d)", "WELCOME_NOTICE_VERSION", "DSH_WEB_URL", "browser-driver.mjs"]) {
+  assert.ok(manualRef.includes(anchor), `references/manual-setup.md 含手动步骤锚点 ${anchor}`);
+}
+const contractRef = refText("script-contracts.md");
+for (const anchor of ["WHITELIST_V", "verdict.json", "退出码", "symlink", "t0"]) {
+  assert.ok(contractRef.includes(anchor), `references/script-contracts.md 含契约锚点 ${anchor}`);
+}
 
 // ---- 8. README 同步新能力 ----
 const readme = readFileSync(join(PKG_ROOT, "README.md"), "utf8");
@@ -389,10 +420,11 @@ const SYMLINK_TYPE = process.platform === "win32" ? "junction" : "dir";
   const audit = await import(pathToFileURL(auditFile).href);
 
   // 9a. 白名单版本化 + 模式全集存在（预置模式数组，版本化 WHITELIST_V；
-  // v2 起含 dsh 自身写面 .credentials.yaml / storages/**——S1 修复分工）
+  // v2 起含 dsh 自身写面 .credentials.yaml / storages/**；
+  // v3 起含 settings.yaml——首启弹窗跳过会预置它，页面改设置也由 dsh 重写）
   assert.match(audit.WHITELIST_V, /^v\d+$/, `WHITELIST_V 版本化格式: ${audit.WHITELIST_V}`);
   for (const p of [
-    "profiles/**", "*.json", "*.jsonl", "*.log", ".credentials.yaml",
+    "profiles/**", "*.json", "*.jsonl", "*.log", ".credentials.yaml", "settings.yaml",
     "browser.state", "browser-profile/**", "evidence/**", "audit/**",
     "storages/**", "dsh.log", "verdict.json",
   ]) {
@@ -408,15 +440,15 @@ const SYMLINK_TYPE = process.platform === "win32" ? "junction" : "dir";
   assert.ok(script.includes("审计:通过"), "审计结论行通过文案");
   assert.ok(script.includes("项可疑"), "审计结论行可疑文案");
   assert.ok(script.includes("audit.json"), "审计报告落盘契约（--keep 落 $ISOLATED_HOME/audit/audit.json）");
-  // P0 S1 回归：t0 基线必须在**就绪断言通过之后**（dsh 启动写面与官方
+  // 回归：t0 基线必须在**就绪断言通过之后**（dsh 启动写面与官方
   // bundle link 进基线——语义「就绪后运行期写面审计」，源码位置锚定）
   assert.ok(
     script.indexOf("auditBaseline = [") > script.indexOf("就绪断言通过"),
-    "t0 基线快照位于就绪断言通过之后（S1 时序修复）",
+    "t0 基线快照位于就绪断言通过之后（时序）",
   );
 
   // 9c. 子进程退出码实测：--audit 不破坏退出码契约（0/2）；extra dir 不存在/
-  // 非目录 → 2；t0 前错误路径 --json 单 JSON 恒带 audit:null（M4/M6）
+  // 非目录 → 2；t0 前错误路径 --json 单 JSON 恒带 audit:null
   const run = (args) => {
     let code = 0;
     let out = "";
@@ -436,7 +468,7 @@ const SYMLINK_TYPE = process.platform === "win32" ? "junction" : "dir";
   const badFile = run(["--audit", "--audit-extra-dirs", plainFile]);
   assert.equal(badFile.code, 2, "--audit-extra-dirs 传文件退出码 2（必须是目录）");
   assert.ok(badFile.out.includes("必须是目录"), "--audit-extra-dirs 非目录报可操作错误");
-  // M6：t0 前错误（extra-dir 不存在）--json 单 JSON 恒带 audit:null（与 verdict 对齐）
+  // t0 前错误（extra-dir 不存在）--json 单 JSON 恒带 audit:null（与 verdict 对齐）
   const m6 = run(["--json", "--audit", "--audit-extra-dirs", join(tmpdir(), "dsh-verify-no-such-audit-dir-m6")]);
   assert.equal(m6.code, 2, "--json t0 前错误路径退出码 2");
   const m6Lines = m6.out.trim().split("\n").filter((l) => l.trim().length > 0);
@@ -445,10 +477,10 @@ const SYMLINK_TYPE = process.platform === "win32" ? "junction" : "dir";
   assert.ok(Object.prototype.hasOwnProperty.call(m6Parsed, "audit"), "error JSON 恒带 audit 字段");
   assert.equal(m6Parsed.audit, null, "t0 前错误 audit=null（未进入审计）");
 
-  // 9g. --audit 端到端回归（P1-1，随 S1 修）：假 dsh 就绪前建模 dsh 启动写面
+  // 9g. --audit 端到端回归：假 dsh 就绪前建模 dsh 启动写面
   // （官方 bundle link 指向外部 + .credentials.yaml + storages/**），验证：
   //   变体 A（干净运行）：exit 0 + 审计:通过 + verdict.audit pass + --keep 落盘
-  //   audit/audit.json（启动写面进 t0 基线 → 不误报，S1 修复核心回归）；
+  //   audit/audit.json（启动写面进 t0 基线 → 不误报，核心回归）；
   //   变体 B（运行期写面）：RUNTIME_WRITE → exit 0 + verdict.audit suspicious
   //   count=1（mystery.bin）——「就绪后运行期写面审计」语义仍生效。
   {
@@ -526,13 +558,13 @@ process.exit(1);
     assert.equal(bv.audit.conclusion, "suspicious", "变体B verdict.audit conclusion=suspicious");
     assert.equal(bv.audit.count, 1, "变体B count=1");
     assert.equal(bv.audit.suspicious[0].path, "mystery.bin", "变体B 可疑路径 mystery.bin");
-    // 零污染纪律（#218）：--keep 保留的隔离 home 由 smoke 显式清理
+    // 零污染纪律：--keep 保留的隔离 home 由 smoke 显式清理
     if (a.home) rmSync(a.home, { recursive: true, force: true });
     if (b.home) rmSync(b.home, { recursive: true, force: true });
     rmSync(tmp2, { recursive: true, force: true });
   }
 
-  // 9d. mkdtemp fixture 正反例（零污染纪律 #218：全部落在 mkdtemp 隔离目录）
+  // 9d. mkdtemp fixture 正反例（零污染纪律：全部落在 mkdtemp 隔离目录）
   const tmp = mkdtempSync(join(tmpdir(), "dsh-verify-audit-"));
   const outside = mkdtempSync(join(tmpdir(), "dsh-verify-audit-out-"));
   try {
@@ -589,7 +621,7 @@ process.exit(1);
       assert.ok(r.suspicious.some((s) => s.path === "mut.bin" && s.type === "修改"),
         "白名单外修改报可疑");
     }
-    // M1（复核 P1-2）：同 size 同 mtimeMs 快速重写经 ctimeMs 检出——直接构造
+    // 同 size 同 mtimeMs 快速重写经 ctimeMs 检出——直接构造
     // Entry（不依赖文件系统时间精度，验证 ctimeMs 参与修改判定逻辑本身）
     {
       const mk = (ctimeMs) => ({
@@ -654,7 +686,7 @@ process.exit(1);
       assert.ok(s.entries.has("browser-profile"), "browser-profile 目录条目在位");
       assert.ok(!s.entries.has("browser-profile/deep/file"), "browser-profile/** 跳过深扫");
     }
-    // 9f. dsh 启动写面回归（S1 修复，纯函数层）：t0 含官方 bundle link（指向
+    // 9f. dsh 启动写面回归（纯函数层）：t0 含官方 bundle link（指向
     // 扫描根外、t0 已存在未变 → 合法挂载点）+ .credentials.yaml + storages/**，
     // 干净运行 pass；运行期新增（白名单外）仍报——「就绪后运行期写面审计」语义
     {
@@ -675,9 +707,148 @@ process.exit(1);
       assert.equal(r2.suspicious[0].type, "新增", "运行期新增类型为新增");
     }
   } finally {
-    rmSync(tmp, { recursive: true, force: true }); // 零污染纪律（#218）
+    rmSync(tmp, { recursive: true, force: true }); // 零污染纪律
     rmSync(outside, { recursive: true, force: true });
   }
 }
 
-console.log("PASS: dsh-verify-isolated smoke（skills 结构 / frontmatter / patch / 路径解析 / verify-core 行为 / 脚本契约与退出码 / B4 审计纯函数与 fixture 正反例 / 文档同步）");
+// ---- 10. 首启弹窗跳过（onboarding）与访问令牌 ----
+{
+  const onboardingFile = join(SCRIPTS_DIR, "lib", "onboarding.mjs");
+  assert.ok(existsSync(onboardingFile), "首启弹窗跳过纯函数 lib/onboarding.mjs 随 skill 分发");
+  const ob = await import(pathToFileURL(onboardingFile).href);
+
+  // 10a. 须知版本提取：命中真实产物形态 / 未命中返回 null。降级而非抛错是契约——
+  // dsh 改了常量形态时应当「不预置 + 浏览器兜底」，而不是伪造版本来假装跳过
+  assert.equal(
+    ob.extractWelcomeNoticeVersion('const WELCOME_NOTICE_VERSION = "2026-08-13.1";'),
+    "2026-08-13.1", "从客户端产物提取须知版本");
+  assert.equal(ob.extractWelcomeNoticeVersion("nothing here"), null, "无版本常量返回 null（降级不抛）");
+  assert.equal(ob.extractWelcomeNoticeVersion(null), null, "null 输入返回 null");
+
+  // 10b. settings 文档形状 + 注入防护：settings.yaml 是 dsh 要解析的结构化文档，
+  // 意外字符会改写命名空间结构而不只是一个字段值
+  assert.equal(ob.welcomeSettingsDocument("2026-08-13.1"),
+    "ui-onboarding:\n  welcomeNoticeVersion: 2026-08-13.1\n", "settings 文档形状");
+  assert.throws(() => ob.welcomeSettingsDocument("bad\nvalue"), /意外字符/, "版本含换行被拒绝");
+
+  // 10c. dsh 安装根与产物定位（mkdtemp fixture 建模 npm 提升布局）
+  const fix = mkdtempSync(join(tmpdir(), "dsh-verify-onboarding-"));
+  const fixBare = mkdtempSync(join(tmpdir(), "dsh-verify-onboarding-bare-"));
+  try {
+    const dshRoot = join(fix, "node_modules", "@deepseek-ai", "dsh");
+    const clientDir = join(dshRoot, "node_modules", "@deepseek-ai", "dsh-client-ui-settings-models");
+    mkdirSync(join(dshRoot, "lib"), { recursive: true });
+    mkdirSync(join(clientDir, "lib"), { recursive: true });
+    writeFileSync(join(dshRoot, "package.json"), JSON.stringify({ name: "@deepseek-ai/dsh", version: "0.0.0" }));
+    writeFileSync(join(dshRoot, "lib", "bin.js"), "");
+    writeFileSync(join(clientDir, "package.json"), JSON.stringify({ name: "@deepseek-ai/dsh-client-ui-settings-models" }));
+    writeFileSync(join(clientDir, "lib", "client.js"), 'const WELCOME_NOTICE_VERSION = "2099-01-01.1";');
+    const bin = join(dshRoot, "lib", "bin.js");
+    assert.equal(ob.dshRootOf(bin), dshRoot, "dshRootOf 从入口向上解析安装根");
+    assert.equal(ob.welcomeClientFileOf(dshRoot), join(clientDir, "lib", "client.js"),
+      "welcomeClientFileOf 经 Node 解析算法定位产物");
+    assert.equal(ob.findWelcomeNoticeVersion(bin)?.version, "2099-01-01.1", "端到端解析版本");
+
+    // 负例用独立 fixture（依赖从一开始就不存在）：删除文件会被 require.resolve
+    // 的路径缓存挡住，测不出真实的「依赖缺失」路径
+    const rootBare = join(fixBare, "node_modules", "@deepseek-ai", "dsh");
+    mkdirSync(join(rootBare, "lib"), { recursive: true });
+    writeFileSync(join(rootBare, "package.json"), JSON.stringify({ name: "@deepseek-ai/dsh", version: "0.0.0" }));
+    writeFileSync(join(rootBare, "lib", "bin.js"), "");
+    assert.equal(ob.welcomeClientFileOf(rootBare), null, "依赖解析失败返回 null（降级不抛）");
+    assert.equal(ob.findWelcomeNoticeVersion(join(rootBare, "lib", "bin.js")), null,
+      "产物缺失时端到端返回 null（预置失败只警告）");
+  } finally {
+    rmSync(fix, { recursive: true, force: true }); // 零污染纪律
+    rmSync(fixBare, { recursive: true, force: true });
+  }
+
+  // 10d. 弹窗探针表达式：跳过文案集合（en + zh）+ click 必须是真的开关。
+  // 实测曾复现「--no-auto-dismiss 仍把弹窗点掉」——探针照样 click，开关退化成
+  // 只改输出文案的假开关，故此处锁死「禁止分支先于 target.click()」的顺序
+  assert.deepEqual([...ob.SKIP_BUTTON_TEXTS], ["Continue", "Configure later", "继续", "稍后配置"],
+    "跳过按钮文案含 en + zh（locale 变化不失效）");
+  const probeAuto = ob.buildOverlayProbeExpression();
+  const probeManual = ob.buildOverlayProbeExpression({ click: false });
+  assert.ok(/const allowClick = true/.test(probeAuto), "默认探针允许点击");
+  assert.ok(/const allowClick = false/.test(probeManual), "--no-auto-dismiss 探针禁止点击");
+  for (const expr of [probeAuto, probeManual]) {
+    assert.ok(expr.includes("target.click()"), "探针保留点击路径");
+    assert.ok(expr.indexOf("if (!allowClick) return") < expr.indexOf("target.click()"),
+      "禁止点击的分支先于 target.click()（防假开关回归）");
+    assert.ok(expr.includes("root.inert !== true"), "探针以应用根 inert 为阻断判据");
+    assert.ok(expr.includes(ob.AUTH_REQUIRED_MARKER), "探针携带鉴权拒绝文案判据");
+  }
+  assert.equal(ob.AUTH_REQUIRED_MARKER, "dsh web authentication required",
+    "401 判据与 dsh web 实际文案一致");
+
+  // 10e. 令牌脱敏：回显 URL 会随证据归档，真令牌只允许留在 0o600 的 state/log
+  assert.equal(ob.redactToken("http://127.0.0.1:41915/?token=abc123"), "http://127.0.0.1:41915/?token=***",
+    "回显去令牌");
+  assert.equal(ob.redactToken("http://127.0.0.1:1/a?x=1&token=abc&y=2"), "http://127.0.0.1:1/a?x=1&token=***&y=2",
+    "多参数下只替换令牌值");
+  assert.equal(ob.redactToken(undefined), undefined, "非字符串原样返回");
+
+  // 10f. 访问 URL 解析（令牌唯一来源）：只认 dsh 打印的完整 URL，截断即 null
+  const core2 = await import(pathToFileURL(join(SCRIPTS_DIR, "lib", "verify-core.mjs")).href);
+  assert.equal(core2.readDshUrl("dsh web: http://127.0.0.1:41915/?token=abc\n"),
+    "http://127.0.0.1:41915/?token=abc", "readDshUrl 取带令牌 URL");
+  assert.equal(core2.readDshUrl("dsh web: http://127.0.0.1:41915"), null,
+    "readDshUrl 拒绝截断行（半个令牌表现为 401，比缺参数更难排查）");
+  assert.equal(core2.readDshUrl("noise"), null, "readDshUrl 无行返回 null");
+
+  // 10g. verify-isolated 契约锚定：选项 / 预置步骤 / verdict 字段 / --help
+  const vScript = readFileSync(scriptFile, "utf8");
+  for (const opt of ["--no-skip-onboarding", "presetWelcomeNotice", "settings.yaml", "首启弹窗预置"]) {
+    assert.ok(vScript.includes(opt), `verify-isolated 含首启弹窗契约 ${opt}`);
+  }
+  for (const field of ["web:", "onboarding:", "tokenSource:"]) {
+    assert.ok(vScript.includes(field), `verdict schema 含字段 ${field}`);
+  }
+  assert.ok(vScript.includes("st.dshWebUrl = webUrl"), "带令牌 URL 写入 browser.state.dshWebUrl");
+  const viHelp = execFileSync(process.execPath, [scriptFile, "--help"], { encoding: "utf8" });
+  assert.ok(viHelp.includes("--no-skip-onboarding"), "--help 声明 --no-skip-onboarding");
+  assert.ok(viHelp.includes("令牌"), "--help 说明访问令牌（GUI 带鉴权）");
+
+  // 10h. browser-driver 契约锚定：--url state / 弹窗开关 / 导航命令接入 goto。
+  // eval 与 fill 不导航，故不得接入（要能检查弹窗本身，且不抹掉页面状态）
+  const dScript = readFileSync(driverFile, "utf8");
+  for (const opt of ["--no-auto-dismiss", "--overlay-wait", "dshWebUrl", "onboardingBlocked"]) {
+    assert.ok(dScript.includes(opt), `browser-driver 含 ${opt} 契约`);
+  }
+  for (const cmd of ["cmdSnapshot", "cmdClick", "cmdWait", "cmdScreenshot"]) {
+    const body = dScript.split(`async function ${cmd}(`)[1]?.split("\nasync function ")[0] ?? "";
+    assert.ok(body.includes("goto("), `${cmd} 接入导航收尾（弹窗跳过不得绕过）`);
+  }
+  // console 走长连接收事件（短连接的 goto 会丢事件），导航与收尾内联，但收尾必须在
+  {
+    const body = dScript.split("async function cmdConsole(")[1]?.split("\nasync function ")[0] ?? "";
+    assert.ok(body.includes("settleOverlays("), "cmdConsole 内联接入导航收尾（弹窗跳过不得绕过）");
+  }
+  for (const cmd of ["cmdEval", "cmdFill"]) {
+    const body = dScript.split(`async function ${cmd}(`)[1]?.split("\nasync function ")[0] ?? "";
+    assert.ok(!body.includes("goto(") && !body.includes("settleOverlays("),
+      `${cmd} 不导航、不触发弹窗跳过（设计契约）`);
+  }
+  const drvHelp = execFileSync(process.execPath, [driverFile, "--help"], { encoding: "utf8" });
+  assert.ok(drvHelp.includes("--url <url|state>"), "--help 声明 --url state 保留取值");
+  assert.ok(drvHelp.includes("--no-auto-dismiss"), "--help 声明 --no-auto-dismiss");
+
+  // 10i. 文档同步：跳过与令牌是「跑得起来」的前提，缺任一处都会让执行者卡在 401
+  // 或 inert 页面上（缺陷正是文档空白导致的）
+  const skillRaw = readFileSync(SKILL_FILE, "utf8");
+  for (const anchor of ["--url state", "首启弹窗", "401", "token=***", "--no-skip-onboarding", "inert"]) {
+    assert.ok(skillRaw.includes(anchor), `SKILL.md 含跳过/鉴权指导锚点 ${anchor}`);
+  }
+  const readmeZh = readFileSync(join(PKG_ROOT, "README.md"), "utf8");
+  for (const anchor of ["--no-skip-onboarding", "--url state", "token=***", "settings.yaml"]) {
+    assert.ok(readmeZh.includes(anchor), `README.md 含 ${anchor}`);
+  }
+  const readmeEn = readFileSync(join(PKG_ROOT, "README.en.md"), "utf8");
+  for (const anchor of ["--no-skip-onboarding", "--url state", "token=***", "onboarding.mjs"]) {
+    assert.ok(readmeEn.includes(anchor), `README.en.md 含 ${anchor}`);
+  }
+}
+
+console.log("PASS: dsh-verify-isolated smoke（skills 结构 / frontmatter / patch / 路径解析 / verify-core 行为 / 脚本契约与退出码 / B4 审计纯函数与 fixture 正反例 / 首启弹窗跳过与访问令牌 / 文档同步）");


### PR DESCRIPTION
无关联 issue（维护者直接指派的 skill 能力增强）

## 说明

复核 `dsh-verify-isolated` 在 dsh 0.1.5-rc.1 下的**首次可用性**：隔离环境首屏被两个阻断式弹窗占据，且 GUI 鉴权此前无任何指导。

- 「内测声明」：由 `settings.yaml` 的 `ui-onboarding.welcomeNoticeVersion` 与客户端常量 `WELCOME_NOTICE_VERSION` **精确相等**决定，全新 `DSH_HOME` 必然未确认
- 「添加 API Key」：隔离环境无可用 provider 时出现，其「稍后配置」**只在当前页面生命周期内有效**——刷新/新标签必重弹，而 browser-driver 的每条页面命令都带 `--url` 重新导航
- 两者都把 `#root` 置为 `inert`，页面上一切点击静默失效；同时 GUI 带鉴权，裸端口只返回 401 文本页，而就绪断言把 2xx-4xx 都算就绪

即：不处理这两件事，隔离验证会在一张点不动的页面或 401 文本页上「成功」跑完。

对照实验（三次独立启动，唯一变量）：

| settings.yaml 预置 | DEEPSEEK_API_KEY 占位 | 内测声明 | API Key | `root.inert` |
|---|---|---|---|---|
| 无 | 无 | 弹 | 弹 | `true` |
| 有 | 无 | 不弹 | 弹 | `true` |
| 有 | 有 | 不弹 | 不弹 | `false` |

按维护者裁决取「预置 settings + 浏览器侧兜底」：**不注入占位凭据、不改环境变量继承语义**（隔离实例仍 `{...process.env}`），凭据面保持原样。

## 改动

| 文件 | 变化 |
|---|---|
| `scripts/verify-isolated.mjs` | 启动前预置 `$DSH_HOME/settings.yaml` 的内测声明版本（从 dsh 产物现取，取不到只警告并交浏览器兜底）；`--no-skip-onboarding` 关闭；解析并打印带令牌 URL、写入 `browser.state.dshWebUrl`；verdict 增 `web`（去令牌）/ `onboarding` 字段 |
| `scripts/browser-driver.mjs` | `--url` 新增保留值 `state`（省掉手工拼令牌）；导航后自动跳过首启弹窗并输出 `dismissed`；识别不到跳过按钮时只报 `onboardingBlocked`（不猜，避免点到「保存并继续」）；401 文本页给 `authRequired` 诊断；回显 URL 恒去令牌；`--no-auto-dismiss` / `--overlay-wait` |
| `scripts/lib/onboarding.mjs`（新增） | 版本常量探测与降级、settings 文档构造（含注入防护）、弹窗探针表达式（含 `allowClick` 真开关）、令牌脱敏 |
| `SKILL.md` | 504 → 218 行：支线（脚本契约 / 手动搭环境 / 内核排查 / 视口几何）下沉 `references/`，主线按「读它的时机」指向并锁体量上限 |
| `references/*.md`（新增 4 个） | 各支线自包含（内核探测链、手动步骤、脚本契约、视口几何方法论） |
| `README.md` / `README.en.md` | 能力、包结构、安全模型（令牌最小暴露）同步 |
| `scripts/lib/audit.mjs` | `WHITELIST_V` v2 → v3（`settings.yaml` 属 dsh 官方写面） |
| `test/smoke.ts` | 纯函数行为断言（版本提取/降级/注入防护/脱敏/401 判据）+ 探针 `allowClick` 顺序锁（防假开关）+ 导航命令接入收尾而 `eval`/`fill` 不接入 + 文档锚点按内容位置重写 |

设计依据（实测）：

- **弹窗异步挂载晚于 `readyState=complete`**，单次探测会漏检——漏检的代价不是少一次提示，而是点击落在 inert 根上静默失效、结论假绿；故按 `--overlay-wait`（默认 1500ms）窗口轮询。等待全部用轮询而非固定时长。
- **两级弹窗无缝衔接**：前一个卸载与后一个置位 inert 可能同帧，故不能用「等 inert 解除」判断清空（必然超时误报），改为按轮推进窗口轮询。
- **`--no-auto-dismiss` 必须是真开关**：实测曾复现「关了开关弹窗仍被点掉」——探针在探测时就把按钮点了；现改为表达式级 `allowClick`，禁止分支先于 `target.click()`，并由 smoke 锁顺序防回归。
- **dsh 打印 URL 行晚于 HTTP 就绪**，就绪即读会稳定落空，故轮询等待。

## 验证

门禁（worktree 内逐条实跑，全部 exit 0）：

```
pnpm build        pnpm test         pnpm contract
pnpm pack:check   pnpm typecheck    pnpm test:scripts
pnpm docs:check
```

隔离环境实测（dsh 0.1.5-rc.1 + 临时 `DSH_HOME` + 独立端口 + 自带浏览器实例）：

- 默认路径：首屏 `dialogs: 0`、`#root.inert === false`，输出 `dismissed: ["Configure later"]`
- `--no-skip-onboarding`：`dismissed: ["Continue","Configure later"]`（两级连跳），落定后 `inert: false`
- `--no-auto-dismiss`：连跑 3 次稳定输出 `onboardingBlocked{reason:"auto-dismiss-off",buttons:["Configure later"]}`，弹窗保留（`inert: true`、`dialogs: 1`）
- 令牌：截图输出回显 `?token=***`；`verdict.web.url` 无令牌；`browser.state` / `dsh.log` / `verdict.json` / `settings.yaml` 均 0o600，`verdict` 内 `token=` 命中 0
- 清理：退出后无 `verify_*` profile 残留、无运行时产物（`git status` 干净）

## 边界与取舍

- 隔离环境**不注入凭据**（按维护者裁决），「添加 API Key」弹窗由浏览器侧在每次导航后跳过一次，输出里会看到 `dismissed`；需要模型能力的验证仍需自备凭据。
- skill 保持通用定位：已清除 `dsh-plugin-hub` / `xiaozhuge` 举例、「主 checkout」开发模型与 issue 编号，适配任意安装形态。
- 隔离实例仍继承启动环境（`{...process.env}`），凭据面语义未变；该现状已如实写入 README 安全模型。
- 不改包版本号、不新增依赖、不动宿主端 `src/index.ts` 与 `cordis.patch.yml`。

### 客户端改动截图证据（勾选式）

- [x] **不涉及客户端改动**（本包无 `src/client/**`；本 PR 改的是 skill 文档与验证脚本本身）
