### PR TITLE
feat(gate): S1 覆盖率口径修复与客户端产物标识符门禁（#690）

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -37,6 +37,14 @@ pnpm typecheck    # 全仓类型检查
 > （去 esbuild 内联 vendor 段与 `__` 运行时垫片后仅计自写函数），已接入 observe.yml
 > 夜间硬校验（`self-cov.mjs --check`，strict=true）；threshold=60 为当前硬阈值，
 > 80% 为阶段二目标。
+>
+> **两个覆盖口径并存**：`pnpm cov` 是 CI 判分口径（从 lib 产物采集，self-written
+> 派生依赖产物形态）；`pnpm cov:src` 是开发者/评审口径，经 lib→src resolve hook
+> 从 src 采集真实覆盖率（实测 `All files` 61.61% → 93.02%、`events/event-handlers.ts`
+> 27.24% → 96.91%、`server/routes.ts` 46.72% → 92.28%）。后者**不参与 CI 判分**：
+> 换成 src 口径后 self-cov 解析不到产物形态，逐包报 `self-written 函数覆盖 0%`
+> 而全区判红（已实测），且「覆盖率经源码镜像」属 refactor-plan §6 移出的仓库级项。
+> 细节见 `scripts/gate/cov.mjs` 头注释。
 
 ### 变异测试与增量链路（#178 / #187）
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "docs:check": "node scripts/gate/verify-docs.ts --strict-en",
     "typecheck": "pnpm -r --if-present run typecheck",
     "cov": "c8 --reporter=json --reporter=json-summary --reporter=text pnpm -r --filter !dsh-plugin-hub --if-present test",
+    "cov:src": "node scripts/gate/cov.mjs",
     "crap": "node scripts/gate/crap-check.mjs"
   },
   "keywords": [

--- a/scripts/gate/contract-check.ts
+++ b/scripts/gate/contract-check.ts
@@ -72,7 +72,7 @@ for (const p of pluginDirs) {
 
   checked++
   const code = readFileSync(clientPath, 'utf8')
-  const { ok, checks, error } = assertClientContract(pkg.name, code)
+  const { ok, checks, error, leaks } = assertClientContract(pkg.name, code)
   const allChecks = {
     ...checks,
     'dsh.client⇒exports["./client"]声明': clientExportOk,
@@ -82,6 +82,9 @@ for (const p of pluginDirs) {
   if (!okAll) failed++
   console.log(`${okAll ? 'PASS' : 'FAIL'} ${pkg.name} | ${Object.entries(allChecks).map(([k, v]) => `${k}=${v ? '✓' : '✗'}`).join(' ')}`)
   if (!okAll && error) console.log(`     执行错误: ${error.message}`)
+  // 宿主侧标识符泄漏单独列出：产物虽然「执行无异常」，但 node 全局在浏览器里会
+  // 直到运行时才炸，只有逐条打印才能定位是哪一个标识符进了产物。
+  if (leaks.length > 0) console.log(`     宿主侧标识符泄漏：${leaks.join('；')}`)
 }
 
 // 件数断言：凡 packages/dsh-* 目录都应被检查覆盖（防漏检）

--- a/scripts/gate/cov.mjs
+++ b/scripts/gate/cov.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * cov:src — **源码口径**覆盖率度量入口（issue #690 S1）。
+ *
+ * 为什么单独一个命令而不替换 `pnpm cov`：`pnpm cov` 是 CI mutation-verdict 的
+ * 覆盖率输入，其 self-written 派生（scripts/gate/self-cov.mjs）的口径绑定 **lib
+ * 产物形态**（靠 esbuild 边界注释 / 垫片过滤分段）。本脚本经 lib→src hook 让测试
+ * 从 src 加载，coverage 数据路径随之变为 `src/*.ts`，self-cov 解析不到产物形态 →
+ * 逐包报 `self-written 函数覆盖 0%` → PR 全红（已实测）。
+ * refactor-plan §6 也把「覆盖率经源码镜像」列为**移出**的仓库级项（破坏单包
+ * PR 可独立回滚），故这里的定位是**开发者/评审用的真实口径度量**，不动 CI 判分。
+ *
+ * 为什么需要它：`pnpm cov` 从产物入口采集时，src 行只统计「被产物直连加载」的
+ * 模块——实测 `All files 61.61%`、`events/event-handlers.ts` 27.24%、
+ * `server/routes.ts` 46.72%，是失真值。复用 Stryker 测试宿主既有的 lib→src
+ * resolve hook（scripts/test/mutation-lib-to-src-hook.mjs）把 `lib/*.js` 解析重定向
+ * 到同包 `src/*.ts` 后，真实口径为 `All files 93.02%`、`event-handlers.ts` 96.91%、
+ * `sdk/service.ts` 94.42%、`server/routes.ts` 92.28%。
+ *
+ * 为什么不写成 `NODE_OPTIONS="..." c8 ...` 放进 package.json：仓库无环境变量前缀
+ * 脚本先例，且该语法在 Windows cmd 下不成立；Node wrapper 用 file URL 传路径，
+ * 天然跨平台（也规避盘符与空格问题）。
+ *
+ * 约束：hook 只在本命令注入——`pnpm test` 与 `pnpm cov` 仍直跑产物，测试三层
+ * 口径与 CI 判分口径都不受影响。
+ * 前提：需要先有 lib 产物（与 `pnpm cov` 一致，CI 的 coverage job 先跑 pnpm build）。
+ *
+ * 用法：node scripts/gate/cov.mjs（或 pnpm cov:src）
+ * 退出码：透传 c8 的退出码（采集失败必须显式失败，不得吞掉）。
+ */
+import { spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const HOOK = join(ROOT, 'scripts', 'test', 'mutation-lib-to-src-hook.mjs')
+const nodeOptions = [process.env.NODE_OPTIONS, `--import=${pathToFileURL(HOOK).href}`].filter(Boolean).join(' ')
+
+// 直接以 node 执行 c8 的入口，而不是 `pnpm exec c8`：后者在 Windows 需要 shell 才能
+// 解析 pnpm.cmd，而 shell 化又会让 `--filter !dsh-plugin-hub` 的 `!` 被 cmd 当延迟
+// 扩展符解释。node + 解析出的绝对路径在两端都无歧义。
+const require = createRequire(import.meta.url)
+let c8Bin
+try {
+  c8Bin = require.resolve('c8/bin/c8.js')
+} catch {
+  c8Bin = join(ROOT, 'node_modules', 'c8', 'bin', 'c8.js')
+}
+
+const spawned = spawnSync(
+  process.execPath,
+  [
+    c8Bin,
+    '--reporter=json',
+    '--reporter=json-summary',
+    '--reporter=text',
+    'pnpm',
+    '-r',
+    '--filter',
+    '!dsh-plugin-hub',
+    '--if-present',
+    'test',
+  ],
+  { cwd: ROOT, stdio: 'inherit', env: { ...process.env, NODE_OPTIONS: nodeOptions } },
+)
+
+if (spawned.error) {
+  console.error(`cov: 启动 c8 失败：${spawned.error.message}`)
+  process.exit(1)
+}
+process.exit(spawned.status ?? 1)

--- a/scripts/lib/client-contract-lib.ts
+++ b/scripts/lib/client-contract-lib.ts
@@ -24,6 +24,10 @@
  * node:vm 不是安全边界（沙箱可达宿主 Function），不得用于执行不可信/第三方代码。
  */
 import vm from 'node:vm'
+import { builtinModules } from 'node:module'
+
+/** Node 内置模块名（裸名与 `node:` 前缀两种写法都要认）。 */
+const NODE_BUILTIN_NAMES = new Set([...builtinModules, ...builtinModules.map((m) => `node:${m}`)])
 
 /** 浏览器全局 stub（最小可执行集；每包独立沙箱隔离）。 */
 export function makeBrowserSandbox(calls, factories) {
@@ -108,18 +112,76 @@ export function materialize(factory) {
 }
 
 /**
- * 客户端契约断言（执行产物后）。返回 { ok, checks, error }。
+ * 客户端产物禁止泄漏的宿主侧标识符（issue #690 S1）。
+ *
+ * 为什么需要单独一道：`node:` 前缀依赖已被 build-client 的 browser 平台硬失败拦住，
+ * 但**只含 node 全局**的宿主值（`process.env` / `__dirname` / `Buffer`）会构建全绿并
+ * 进入产物，直到浏览器运行时才 ReferenceError——门禁必须在产物层兜住。
+ * 清单集中在此一处，避免各门禁各写一份导致口径漂移。
+ *
+ * 为什么 process/Buffer 不带 `\.` 限定：`process["env"]`、`const B = Buffer;`、
+ * `globalThis.process` 这类写法会绕开带点的匹配（已实测漏报）。产物里出现这些
+ * 标识符必然来自宿主全局，故按 fail-closed 只匹配名字本身。
+ */
+const FORBIDDEN_CLIENT_TOKENS = [
+  ['node: 内置模块', /\bnode:[a-z]/],
+  ['process 全局', /\bprocess\b/],
+  ['__dirname', /\b__dirname\b/],
+  ['__filename', /\b__filename\b/],
+  ['Buffer 全局', /\bBuffer\b/],
+]
+
+/**
+ * external 外壳：`require("<bare>")` 是构建器对宿主提供依赖（react 等）的合法形态。
+ * 三条约束缺一不可：
+ *   - lookbehind 排除标识符前缀——`__require("fs")` 这类别名不该被当外壳放行；
+ *   - 排除以 `.` / `/` 开头的 specifier——相对与绝对路径是真实依赖，不是宿主注入；
+ *   - 捕获 specifier 供 node 内置名二次判定——裸名 `require("fs")` 同样是宿主依赖
+ *     泄漏，不能因为「是 bare」就放行（构建器把顶层 bare import 一律当 external，
+ *     `node:` 前缀会被 browser 平台拦下，裸名不会）。
+ */
+const EXTERNAL_REQUIRE_RE = /(?<![A-Za-z0-9_$])require\(\s*['"]([^.'"/][^'"]*)['"]\s*\)/g
+
+/** 剥离 external 外壳后仍出现的 `require(`（含 `__require(` 等别名）即判红。 */
+const REMAINING_REQUIRE_RE = /require\s*\(/g
+
+/** 扫描客户端产物的宿主侧标识符泄漏，返回可读违例清单（空数组 = 干净）。 */
+export function findClientLeaks(code) {
+  const leaks = []
+  for (const [label, re] of FORBIDDEN_CLIENT_TOKENS) {
+    // 每次新建带 g 的正则：清单里的字面量正则复用会残留 lastIndex，且非全局
+    // 匹配拿不到真实命中次数（违例文案会恒报「1 处」而误导排查）。
+    const hit = code.match(new RegExp(re.source, 'g'))
+    if (hit) leaks.push(`${label}（${hit.length} 处，如 ${JSON.stringify(hit[0])}）`)
+  }
+  const externals = []
+  const withoutExternal = code.replace(EXTERNAL_REQUIRE_RE, (_m, spec) => {
+    externals.push(spec)
+    return ''
+  })
+  const req = withoutExternal.match(REMAINING_REQUIRE_RE)
+  if (req) leaks.push(`require( 非 external 形态（${req.length} 处）`)
+  for (const spec of externals) {
+    if (NODE_BUILTIN_NAMES.has(spec)) leaks.push(`external 外壳引用了 node 内置模块 ${JSON.stringify(spec)}`)
+  }
+  return leaks
+}
+
+/**
+ * 客户端契约断言（执行产物后）。返回 { ok, checks, error, leaks }。
  * checks 键：执行无异常 / load恰好一次 / load id === 完整包名(含scope) /
  *           factories可被arrive解析 / materialize后exports.apply为函数 /
- *           materialize后exports.inject为数组。
+ *           materialize后exports.inject为数组 / 无宿主侧标识符泄漏。
  */
 export function assertClientContract(pkgName, code) {
   const { calls, factories, error } = executeClient(code)
+  const leaks = findClientLeaks(code)
   const checks = {
     '执行无异常': error === null,
     'load恰好一次': calls.length === 1,
     'load id === 完整包名(含scope)': calls.length === 1 && calls[0].id === pkgName,
     'factories可被arrive解析': factories.has(pkgName),
+    '无宿主侧标识符泄漏': leaks.length === 0,
   }
   let applyOk = false
   let injectOk = false
@@ -131,5 +193,5 @@ export function assertClientContract(pkgName, code) {
   }
   checks['materialize后exports.apply为函数'] = applyOk
   checks['materialize后exports.inject为数组'] = injectOk
-  return { ok: Object.values(checks).every(Boolean), checks, error }
+  return { ok: Object.values(checks).every(Boolean), checks, error, leaks }
 }

--- a/scripts/test/client-leak-gate.test.ts
+++ b/scripts/test/client-leak-gate.test.ts
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * 客户端产物宿主侧标识符门禁回归测试（issue #690 S1）。
+ *
+ * 为什么存在：`node:` 前缀依赖已被 build-client 的 browser 平台硬失败拦住，但只含
+ * node **全局**的宿主值（`process.env` / `__dirname` / `Buffer`）会构建全绿并进产物，
+ * 浏览器运行时才炸。真实产物当前全部干净——「跑出 PASS」无法证明判红有效，故用
+ * 纯函数正反双向断言：泄漏形态逐项判红、external 外壳 `require("<bare>")` 放行。
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { assertClientContract, findClientLeaks } from '../lib/client-contract-lib.ts'
+
+test('宿主侧标识符门禁：external 外壳 require("<bare>") 不算泄漏', () => {
+  const code = 'var React = __toESM(require("react"), 1);\nvar X = require("react-dom");\n'
+  assert.deepEqual(findClientLeaks(code), [], '宿主提供依赖的 external 外壳必须放行')
+})
+
+test('宿主侧标识符门禁：node 全局与内置前缀逐项判红', () => {
+  const cases = [
+    ['node: 内置模块', 'const fs = require("node:fs");'],
+    ['process 全局', 'const mode = process.env.NODE_ENV;'],
+    ['__dirname', 'const p = __dirname + "/asset";'],
+    ['Buffer 全局', 'const buf = Buffer.from("x");'],
+  ]
+  for (const [label, snippet] of cases) {
+    const leaks = findClientLeaks(snippet)
+    assert.ok(leaks.length > 0, `${label} 应被判为泄漏：${snippet}`)
+    assert.ok(
+      leaks.some((l) => l.includes(label.split(' ')[0])),
+      `违例文案应点名字面量：${JSON.stringify(leaks)}`,
+    )
+  }
+})
+
+test('宿主侧标识符门禁：下标/别名/globalThis 等绕过写法同样判红', () => {
+  // 带 `\.` 限定的匹配会被这些写法绕开（实测漏报），故清单只匹配名字本身。
+  const bypasses = ['const e = process["env"];', 'const B = Buffer;', 'const p = globalThis.process;']
+  for (const snippet of bypasses) {
+    assert.ok(findClientLeaks(snippet).length > 0, `绕过写法应判红：${snippet}`)
+  }
+})
+
+test('宿主侧标识符门禁：非 external 形态 require( 判红，且与 external 可区分', () => {
+  assert.ok(findClientLeaks('const m = require("./local.js");').length > 0, '相对路径 require 应判红')
+  assert.ok(findClientLeaks('const m = require("node:path");').length > 0, 'node: require 应判红')
+  // 同一份产物里既有合法 external 又有泄漏时，仍必须报出泄漏。
+  const mixed = 'var React = __toESM(require("react"), 1);\nconst m = require("./local.js");\n'
+  assert.ok(findClientLeaks(mixed).length > 0, '混有 external 时不得整体放行')
+})
+
+test('宿主侧标识符门禁：干净产物零违例（防恒真）', () => {
+  const clean = [
+    'var React = __toESM(require("react"), 1);',
+    'var e = React.createElement("div", null, "hi");',
+    'function apply(ctx) { ctx.effect(() => () => {}); }',
+  ].join('\n')
+  assert.deepEqual(findClientLeaks(clean), [], '不含宿主标识符的产物必须零违例')
+})
+
+test('宿主侧标识符门禁：external 外壳不得成为绕过通道', () => {
+  // `node:` 前缀由 browser 平台构建期拦下，但裸内置名、别名 require、路径 require
+  // 都会进产物——它们不是「宿主注入 external」，必须逐项判红。
+  const bypasses = [
+    'require("fs")',
+    'require("child_process")',
+    'require("node:fs")',
+    '__require("fs")',
+    'require("/abs/x.js")',
+    'require("./rel.js")',
+  ]
+  for (const snippet of bypasses) {
+    assert.ok(findClientLeaks(snippet).length > 0, `应判红：${snippet}`)
+  }
+  assert.deepEqual(findClientLeaks('var React = require("react");'), [], '宿主注入依赖应放行')
+})
+
+test('宿主侧标识符门禁：__filename 判红，命中计数反映真实次数', () => {
+  assert.ok(findClientLeaks('var p = __filename;').length > 0, '__filename 应判红')
+  const many = Array.from({ length: 3 }, () => 'process.env.X').join(';\n')
+  const leaks = findClientLeaks(many)
+  assert.ok(
+    leaks.some((l) => l.includes('3 处')),
+    `违例文案应反映真实命中数（非恒为 1）：${JSON.stringify(leaks)}`,
+  )
+})
+
+test('宿主侧标识符门禁：泄漏让契约断言整体失败（接线有效，防写死 true）', () => {
+  // 与真实产物同构的最小外壳：注册 factory → materialize 后 apply/inject 合规。
+  const product = (body) =>
+    `window.__ModuleLoader__.load({ id: "@scope/test-pkg", factory: function (require) { ${body}; return { apply: function () {}, inject: [] } } });`
+  const clean = assertClientContract('@scope/test-pkg', product('var React = require("react")'))
+  assert.equal(clean.ok, true, `干净产物应整体通过：${JSON.stringify(clean.checks)}`)
+  assert.deepEqual(clean.leaks, [], '干净产物不应有违例')
+  // 泄漏写在**未执行的函数体**里：沙箱没有 process，直接求值会先抛 ReferenceError，
+  // 那样 ok=false 由「执行无异常」提供而非泄漏检查——接线被摘掉也测不出来（假绿）。
+  const leaky = assertClientContract('@scope/test-pkg', product('function inner() { return process.env.NODE_ENV }'))
+  assert.equal(leaky.checks['执行无异常'], true, '用例前提：产物本身可执行，判红必须来自泄漏检查')
+  assert.equal(leaky.ok, false, '泄漏必须让 ok 变成 false（否则门禁接线被摘掉也不会被发现）')
+  assert.ok(leaky.leaks.length > 0, '应给出非空违例清单')
+})


### PR DESCRIPTION
## 关联

- #690（A 轨 S1，refactor-plan §2 阶段表 S1 行）
- #710（S0 评审遗留项汇总：本 PR 核实其「度量完整性」一节与 S1-3 线索）

## 改动清单

| 文件 | 改动 |
|---|---|
| `scripts/gate/cov.mjs` | 新增：**源码口径**覆盖率度量（lib→src resolve hook 经 file URL 注入 `NODE_OPTIONS`） |
| `package.json` | 新增 `cov:src`；**`cov` 保持原命令不变**（见下节实测理由） |
| `scripts/lib/client-contract-lib.ts` | 新增 `findClientLeaks`；并入 `assertClientContract` 的 checks |
| `scripts/gate/contract-check.ts` | 打印 leaks 明细 |
| `scripts/test/client-leak-gate.test.ts` | 新增：客户端标识符门禁 8 例正反双向（含接线测试） |
| `docs/DEVELOPMENT.md` | 记录两个覆盖口径的差异与「不可替换」的原因 |

## S1-1 度量：新增 `pnpm cov:src`（实测推翻了「替换 `pnpm cov`」的原计划）

**问题**：`pnpm cov` 从产物入口采集时，src 行只统计「被产物直连加载」的模块——实测
`All files 61.63%`、`events/event-handlers.ts` 27.24%、`server/routes.ts` 46.72%，是失真值。

**修法**：复用 Stryker 测试宿主既有的 lib→src resolve hook（issue #423 方案 A）
把 `lib/*.js` 解析重定向到同包 `src/*.ts`，c8 即可采到真实口径。

### 为什么另立命令而不替换 `pnpm cov`（关键：原计划被 CI 实测否决）

本 PR 最初直接把 `pnpm cov` 指向该脚本，**CI 立即判红**：`mutation-verdict` 逐包报

```
mutation-gate [dsh-lan-proxy] 测试覆盖率: functions 0% vs threshold 60%（恒硬）
mutation-gate: FAIL —— self-written 函数覆盖 0% 低于下限 60%
...（5 个包全部 0%）
```

根因：`self-cov.mjs` 的 self-written 派生口径**绑定 lib 产物形态**（靠 esbuild 边界
注释 / 垫片过滤分段），换成 src 口径后它解析不到产物形态，派生为空。refactor-plan §6
也已把「**覆盖率经源码镜像**」列为**移出**的仓库级项（理由：破坏「单包 PR 可独立回滚」）。

故最终定位：`pnpm cov` **保持 CI 判分口径不变**，新增 `pnpm cov:src` 作为开发者/评审
口径，并在 `docs/DEVELOPMENT.md` 与 `scripts/gate/cov.mjs` 头注释记录该边界。

### 覆盖率前后对照（`pnpm cov:src` 实际输出）

| 文件 | `pnpm cov`（产物口径） | `pnpm cov:src`（源码口径） |
|---|---|---|
| **All files（Lines）** | 61.63% | **93.02%** |
| `events/event-handlers.ts` | 27.24% | **96.91%** |
| `server/routes.ts` | 46.72% | **92.28%** |
| `sdk/service.ts` | 口径内不可见 | **94.42%** |
| `server/config-routes.ts` | 口径内不可见 | **96.34%** |
| `stats-service.ts` | 70.31% | **99.21%** |

与 refactor-plan §0 F2（`event-handlers.ts 27.24→96.91`、`server/routes.ts 46.72→92.28`、
`sdk/service.ts →94.42`）逐字吻合。

### 实现细节

- 用 Node wrapper 而非把 `NODE_OPTIONS="..." c8 ...` 内联进 package.json：仓库无环境变量
  前缀脚本先例，且该语法在 Windows cmd 下不成立；file URL 同时规避盘符与空格。
- 直接以 node 执行解析出的 c8 入口，而非 `pnpm exec c8`：后者在 Windows 需 shell，
  而 shell 化会让 `--filter !dsh-plugin-hub` 的 `!` 被 cmd 当延迟扩展符解释。
- hook 只在本命令注入——`pnpm test` / `pnpm cov` 仍直跑产物，测试三层口径与 CI 判分口径
  均不受影响。
- 前提：需先有 lib 产物（与 `pnpm cov` 一致；CI 的 coverage job 明确先跑 `pnpm build`）。

## S1-2 客户端产物标识符门禁

`node:` 前缀依赖已被 build-client 的 browser 平台硬失败拦住，但**只含 node 全局**的宿主值
（`process.env` / `__dirname` / `Buffer`）会构建全绿并进产物，直到浏览器运行时才
`ReferenceError`。清单统一为一处（`FORBIDDEN_CLIENT_TOKENS`）：

- 判红：`node:[a-z]` / `process` / `__dirname` / `Buffer` / 非 external 形态 `require(`
- 放行：external 外壳 `require("<bare>")`（宿主提供依赖，如 `__toESM(require("react"))`）
  —— 构建器把 bare import 一律当 external，且裸 node 内置名在 `platform=browser` 下
  构建期即失败，故放行安全。

判定边界（独立对抗复核后收紧，逐条有反向变异验证）：

- `process` / `Buffer` **不带 `\.` 限定**：`process["env"]`、`const B = Buffer;`、
  `globalThis.process` 会绕开带点匹配（实测漏报）；产物里出现这些标识符必然来自宿主
  全局，按 fail-closed 只匹配名字本身。清单并补 `__filename`（与 `__dirname` 同类）。
- **external 外壳三条约束缺一不可**：lookbehind 排除标识符前缀（`__require("fs")` 不得
  被当外壳放行）、排除以 `.` / `/` 开头的 specifier（相对与绝对路径 `require` 是真实依赖）、
  对捕获到的 specifier 做 **node 内置名二次判定**——`require("fs")` / `require("child_process")`
  这类裸名同样是宿主依赖泄漏：构建器把顶层 bare import 一律当 external，而 `node:` 前缀
  会被 browser 平台在构建期拦下，裸名不会（此前仅靠 `node:` 令牌侥幸兜住）。
- 违例计数改用带 `g` 的正则：非全局 match 恒报「1 处」，会误导排查。
- 收紧后在 5 个真实产物上仍全 clean（external 仅 `react`）。

```
$ pnpm contract
PASS @wingsky-1/dsh-lan-proxy | ... 无宿主侧标识符泄漏=✓ ...
PASS @wingsky-1/dsh-mcp-manager | ... 无宿主侧标识符泄漏=✓ ...
PASS @wingsky-1/dsh-notifier | ... 无宿主侧标识符泄漏=✓ ...
PASS @wingsky-1/dsh-provider-usage | ... 无宿主侧标识符泄漏=✓ ...
PASS @wingsky-1/dsh-web-file-preview | ... 无宿主侧标识符泄漏=✓ ...
exit=0
```

## S1-3 配置段名漂移（文档债）：调研未定位到漂移点

已逐一核对全部候选，**均与实现一致**：

| 候选 | 核对结果 |
|---|---|
| `docs/DEVELOPMENT.md:43-44` 的 stryker 段名表述 | 与 `stryker.conf.d/` 实际文件名逐一一致；`dsh-lan-proxy-1..4` 的数字段已如实标注「待迁移功能段名」 |
| settings 命名空间（`SETTINGS_NS` vs notifier README） | 均为 `dsh-notifier` |
| 各包 README 配置段标题 vs `config-matrix` 提取器 | lan-proxy（`## 配置` 表格）、notifier（首个 ` ```json `）两形态匹配；pu 的 3 个配置段本就不在矩阵支持面内——属**能力缺口**（有门禁效力）而非文档漂移 |

该项在 refactor-plan 里标注为「零门禁效力」的文档债，本 PR 未找到可修正对象，已在提交
信息与本节说明，留 follow-up 待澄清（不擅自改动以凑数）。

## 验收判据逐条实测 exit code

```
$ pnpm cov          # CI 判分口径保持原样
All files                       |   61.63 |   76.67 |   47.46 |   61.63 |
exit=0

$ pnpm cov:src      # 新增：源码口径度量
All files                       |   93.02 |   85.11 |   88.26 |   93.02 |
exit=0

$ pnpm contract                     exit=0（5 包全 PASS，含新 check）
$ pnpm test:scripts                 exit=0（255 pass，改前 247）
$ pnpm docs:check                   exit=0（7 包 + 根 README + 26 个 agent 文档）
$ pnpm build / pnpm test / pnpm typecheck / pnpm pack:check / pnpm stryker:check   exit=0

$ git status --porcelain | grep -E 'undefined/|\.jsonl$'
（空）
```

## 回滚

单 PR 独立回滚：`git revert` 本提交即可（`cov:src` 与客户端标识符 check 一并回退，
`pnpm cov` 与 CI 判分口径自始至终未变）。
