### PR TITLE
fix(ci): 变异基线归档分页取全 + 对账判缺口（#714 合并后定位的数据丢失）

### DIFF
--- a/scripts/gate/baseline-archive.mjs
+++ b/scripts/gate/baseline-archive.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * scripts/gate/baseline-archive.mjs — 变异基线归档分支的纯函数面（#572 / #714 后续修复）
+ *
+ * 为什么单独成文件：`overlay-baseline.mjs` 是带副作用的一次性同步脚本（拉产物、建孤立
+ * commit、强推），它的判定逻辑（分页合并、对账、缺口）必须能被单测覆盖——否则「归档
+ * 少了一半段」这类静默数据丢失只能靠人事后比对才发现（实际发生过：见下）。
+ *
+ * 背景（真实缺陷，2026-09-11 定位）：
+ * `gh api repos/<repo>/actions/runs/<id>/artifacts` 默认分页 30 条，而一次 PR CI 会产生
+ * 70 个 artifact（31 个 mutation-incremental + 报告/产物）。原实现直接读 `.artifacts`，
+ * 只拿到第 1 页 → 只有 14 个 mutation-incremental 被覆盖；随后整棵快照强推会把未被覆盖的
+ * 段固化成旧版本，两个「本来就没有基线」的段（provider-usage-errsurf、web-file-preview）
+ * 更是每次合并都被抹掉。故本模块把「分页取全」与「对账后判缺口」做成纯函数。
+ */
+
+/** 归档分支上参与对账的文件名形态（段级增量基线）。 */
+export const BASELINE_FILE_RE = /^incremental-.+\.json$/
+
+/** mutation artifact 的命名前缀（ci.yml 的 upload-artifact name 约定）。 */
+export const MUTATION_ARTIFACT_PREFIX = 'mutation-incremental-'
+
+/** GitHub API 单页上限；请求时显式带上它，避免默认 30 条截断。 */
+export const GH_API_PER_PAGE = 100
+
+/**
+ * 把「一页 artifact」合并进结果集，返回 { items, nextPage, done }。
+ * 入参 page 是 GitHub API 的响应体（`{ artifacts, total_count }`），pageNo 是**刚请求的那一页**。
+ *
+ * 终止条件（两条，任一成立即 done）：
+ *   · 本页为空（已过末页）——GitHub 并发上传时可能返回短页而 total_count 仍更大，
+ *     只按条数判会拿到不完整的结果；
+ *   · 已收条数 >= total_count。
+ * 页号严格递增（pageNo + 1），不用「已收条数 / perPage」反推——短页时那会算回同一页，
+ * 造成重复请求同一页（脚本侧另有 MAX_PAGES 硬上限兜底）。
+ */
+export function mergeArtifactPage(items, page, pageNo = 1) {
+  const incoming = Array.isArray(page?.artifacts) ? page.artifacts : []
+  const merged = [...items, ...incoming]
+  const total = typeof page?.total_count === 'number' ? page.total_count : merged.length
+  const done = incoming.length === 0 || merged.length >= total
+  return { items: merged, nextPage: done ? null : pageNo + 1, done }
+}
+
+/**
+ * 从 artifact 列表里挑出变异增量产物。
+ * 段文件名不从 artifact 名切分（`provider-usage-errsurf` 这类含连字符的段名不可靠），
+ * 而是等下载后按产物内**实际文件名**（`incremental-*.json`）判定。
+ */
+export function mutationArtifacts(artifacts) {
+  return (artifacts ?? []).filter((a) => typeof a?.name === 'string' && a.name.startsWith(MUTATION_ARTIFACT_PREFIX))
+}
+
+/**
+ * 期望被归档的段文件名集合（由 stryker.conf.d/*.json 派生，与 stryker 配置同源）。
+ * `dsh-web-file-preview.json`（未拆分包的 seg="0"）→ `incremental-web-file-preview.json`；
+ * `dsh-mcp-manager-entry.json` → `incremental-mcp-manager-entry.json`。
+ */
+export function expectedBaselineFiles(confFileNames) {
+  return (confFileNames ?? [])
+    .filter((f) => typeof f === 'string' && f.endsWith('.json'))
+    .map((f) => `incremental-${f.replace(/^dsh-/, '')}`)
+    .sort()
+}
+
+/**
+ * 对账：把「本次真正覆盖的文件」与「旧基线已有的文件」并起来，找出期望集合里的缺口。
+ * 调用方据此决定是否判红——缺口意味着该段在归档分支上没有可用基线：
+ *   · 增量班次每次都会全量恢复并强推，所以缺口会**持续**存在；
+ *   · 修法不是拒绝推送（那会让归档停在更旧的整棵树），而是**判红 + 点名**，
+ *     让维护者知道要查上游（产物上传失败 / 分页截断 / 段配置漂移）。
+ */
+export function reconcileArchive({ expected, overlaid, carriedForward }) {
+  const have = new Set([...(overlaid ?? []), ...(carriedForward ?? [])])
+  const missing = (expected ?? []).filter((f) => !have.has(f))
+  return { missing, carriedCount: (carriedForward ?? []).length, overlaidCount: (overlaid ?? []).length }
+}

--- a/scripts/gate/baseline/README.md
+++ b/scripts/gate/baseline/README.md
@@ -14,7 +14,21 @@
   - 全量班（`observe.yml`）与增量班（`observe-incremental.yml`）跑完后，通过 `node scripts/gate/orphan-baseline.mjs push` 强推至孤立分支；
   - PR 门禁（`ci.yml` 的 `mutation-gate`）通过 `node scripts/gate/orphan-baseline.mjs restore` 浅拉取恢复到 `coverage/mutation/`；
   - 增量班通过 `node scripts/gate/orphan-baseline.mjs restore` 恢复基线并执行增量；
+  - PR 合并到 main 后由 `baseline-overlay.yml` → `node scripts/gate/overlay-baseline.mjs` 秒级差量覆盖（复用该 PR CI 产出的 `mutation-incremental-*` artifact）；
   - 任务统一收敛至互斥并发组 `concurrency: group: mutation-baseline-sync`。
+
+### 归档缺口与对账（#714 后续修复）
+`overlay-baseline.mjs` 曾按 GitHub API 的**默认分页（30 条/页）**读取 artifact 列表，而一次 PR CI 会产生
+70 个 artifact（其中 31 个 `mutation-incremental-*`），于是每次合并只覆盖 14 段，随后整棵树强推会把
+未覆盖段的旧版本固化，`provider-usage-errsurf` 与 `web-file-preview` 两段更是每次被抹掉。
+
+现行实现：
+- 分页取全（`per_page=100` + 页号严格递增 + 空页/`total_count` 双终止条件 + 20 页硬上限）；
+- 推送前**对账**：期望集合由 `stryker.conf.d/*.json` 派生，凡「既未被本次覆盖、也不在旧基线里」的段
+  判为缺口并**非零退出 + 点名**（仍照常推送，避免归档停在更旧的树上）；
+- artifact 列表查询失败改为 **fail-loud**（原来 `exit 0` 静默跳过，等于把「查不到」当成「没有」）；
+- 纯函数（分页合并 / 期望集合派生 / 对账）在 `scripts/gate/baseline-archive.mjs`，由
+  `scripts/test/baseline-archive.test.ts` 覆盖（含「旧实现只看到 14 段」的回归用例）。
 - **本地调试**：
   - 本地若需要远端基线辅助增量测试，可执行：
     `node scripts/gate/orphan-baseline.mjs restore`

--- a/scripts/gate/overlay-baseline.mjs
+++ b/scripts/gate/overlay-baseline.mjs
@@ -22,6 +22,15 @@ import {
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
+import {
+  BASELINE_FILE_RE,
+  GH_API_PER_PAGE,
+  expectedBaselineFiles,
+  mergeArtifactPage,
+  mutationArtifacts,
+  reconcileArchive,
+} from './baseline-archive.mjs';
+
 const repo = process.env.GITHUB_REPOSITORY;
 const commitSha = process.env.COMMIT_SHA || execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
 const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || process.env.OBSERVE_PAT;
@@ -78,7 +87,7 @@ async function main() {
   try {
     const raw = runGh([
       'api',
-      `repos/${repo}/actions/runs?head_sha=${prHeadSha}&event=pull_request&status=completed`,
+      `repos/${repo}/actions/runs?head_sha=${prHeadSha}&event=pull_request&status=completed&per_page=${GH_API_PER_PAGE}`,
       '--jq',
       '.workflow_runs',
     ]);
@@ -94,28 +103,49 @@ async function main() {
     process.exit(0);
   }
 
-  // 3. 检查是否有变异增量产物
-  let artifacts;
+  // 3. 检查是否有变异增量产物（必须分页取全：默认 30 条会截断，实测一次 PR CI 有 70 个 artifact，
+  //    第 1 页只含 14 个 mutation-incremental —— 截断后强推会把其余段的旧基线固化，见 baseline-archive.mjs 头注释）
+  let artifacts = [];
   try {
-    const raw = runGh([
-      'api',
-      `repos/${repo}/actions/runs/${successfulCiRun.id}/artifacts`,
-      '--jq',
-      '.artifacts',
-    ]);
-    artifacts = JSON.parse(raw);
+    let page = 1;
+    let expectedTotal = null;
+    // 硬上限：翻页条件用「已收条数 < total_count」，若上游返回短页且 total_count 偏大，
+    // 没有上限就会无限重复请求同一页。20 页 × 100 条 = 2000，远超单次 run 的产物规模。
+    const MAX_PAGES = 20;
+    for (let guard = 0; guard < MAX_PAGES; guard++) {
+      const raw = runGh([
+        'api',
+        `repos/${repo}/actions/runs/${successfulCiRun.id}/artifacts?per_page=${GH_API_PER_PAGE}&page=${page}`,
+      ]);
+      const body = JSON.parse(raw);
+      if (expectedTotal === null && typeof body.total_count === 'number') expectedTotal = body.total_count;
+      const merged = mergeArtifactPage(artifacts, body, page);
+      artifacts = merged.items;
+      if (merged.nextPage === null) break;
+      page = merged.nextPage;
+      if (guard === MAX_PAGES - 1) {
+        throw new Error(`artifact 分页超过 ${MAX_PAGES} 页仍未取完（拿到 ${artifacts.length} / total_count ${expectedTotal}）`);
+      }
+    }
+    if (expectedTotal !== null && artifacts.length < expectedTotal) {
+      throw new Error(`artifact 分页取全失败：拿到 ${artifacts.length} / total_count ${expectedTotal}`);
+    }
+    console.log(`[overlay-baseline] artifact 分页取全：${artifacts.length} / total_count ${expectedTotal ?? artifacts.length}`);
   } catch (err) {
-    console.log(`[overlay-baseline] 查询 Artifacts 列表失败，跳过基线覆盖: ${err.message}`);
-    process.exit(0);
+    // fail-loud（#690 门禁纪律：环境/数据获取失败不得静默降级为成功）。
+    // 「查不到产物」与「确实没有产物」是两回事：前者说明归档没同步，必须让合并后的
+    // baseline-overlay 步骤红，否则缺口会被静默固化（本缺陷的历史形态）。
+    console.error(`[overlay-baseline] 查询 Artifacts 列表失败，未执行归档（fail-loud）: ${err.message}`);
+    process.exit(1);
   }
 
-  const mutArtifacts = (artifacts || []).filter((a) => a.name.startsWith('mutation-incremental-'));
+  const mutArtifacts = mutationArtifacts(artifacts);
   if (mutArtifacts.length === 0) {
     console.log(`[overlay-baseline] PR #${pr.number} 未产生任何增量变异产物（纯文档/未触及变异切片），安全跳过 (No-op)`);
     process.exit(0);
   }
 
-  console.log(`[overlay-baseline] 发现 ${mutArtifacts.length} 个增量产物，准备执行差量覆盖 (Overlay)...`);
+  console.log(`[overlay-baseline] 发现 ${mutArtifacts.length} / ${artifacts.length} 个增量产物，准备执行差量覆盖 (Overlay)...`);
 
   // 4. 创建隔离的临时目录工作区
   const tmpWork = mkdtempSync(join(tmpdir(), 'dsh-overlay-'));
@@ -133,9 +163,10 @@ async function main() {
       for (const line of treeOutput.split('\n').filter(Boolean)) {
         const parts = line.split('\t');
         const fileName = parts[1];
-        if (/^incremental-.+\.json$/.test(fileName) || fileName === 'manifest.json') {
+        if (BASELINE_FILE_RE.test(fileName) || fileName === 'manifest.json') {
           const content = runCmd('git', ['show', `FETCH_HEAD:${fileName}`]);
           writeFileSync(join(baselineDir, fileName), content);
+          if (BASELINE_FILE_RE.test(fileName)) carriedForward.push(fileName);
         }
       }
     } catch {
@@ -165,6 +196,7 @@ async function main() {
           JSON.parse(content); // 严格校验合法 JSON
           writeFileSync(dst, content);
           overlayCount++;
+          overlaid.push(f);
           console.log(`[overlay-baseline] 差量覆盖: ${f}`);
         } catch {
           console.warn(`[overlay-baseline] 文件 ${f} 损坏或非有效 JSON，拒绝覆盖`);
@@ -175,6 +207,25 @@ async function main() {
     if (overlayCount === 0) {
       console.log('[overlay-baseline] 没有成功覆盖任何有效基线文件，跳过推送');
       process.exit(0);
+    }
+
+    // 6.5 对账（#714 后续修复）：期望集合 = stryker.conf.d 派生的段文件；缺口 = 既没被本次覆盖
+    //     也不在旧基线里 —— 该段在归档分支上没有可用基线，增量班次每次都会全量重跑。
+    //     不拒绝推送（拒绝会让归档停在更旧的树），但必须判红点名，暴露上游问题。
+    const expected = expectedBaselineFiles(readdirSync(join(process.cwd(), 'stryker.conf.d')));
+    const reconciled = reconcileArchive({ expected, overlaid, carriedForward });
+    console.log(
+      `[overlay-baseline] 对账：期望 ${expected.length} 段，本次覆盖 ${reconciled.overlaidCount} 段，`
+      + `沿用旧基线 ${reconciled.carriedCount} 段`,
+    );
+    let archiveGap = false;
+    if (reconciled.missing.length > 0) {
+      archiveGap = true;
+      console.error(
+        `[overlay-baseline] 归档缺口 ${reconciled.missing.length} 段（既未覆盖也不在旧基线）：`
+        + reconciled.missing.join(', '),
+      );
+      console.error('[overlay-baseline] 这些段将每次全量重跑。检查上游：产物是否上传成功 / 分页是否取全 / 段配置是否漂移。');
     }
 
     // 7. 重新校准并生成 manifest.json
@@ -231,6 +282,10 @@ async function main() {
 
     runCmd('git', ['push', '--force', remoteTarget, `${commitShaNew}:refs/heads/${BRANCH}`]);
     console.log(`[overlay-baseline] 成功完成 PR #${pr.number} 产物差量覆盖并强推至 ${BRANCH}！`);
+    if (archiveGap) {
+      console.error('[overlay-baseline] 归档已更新，但存在缺口（见上）—— 本次以非零退出暴露问题');
+      process.exitCode = 1;
+    }
   } finally {
     rmSync(tmpWork, { recursive: true, force: true });
   }

--- a/scripts/test/baseline-archive.test.ts
+++ b/scripts/test/baseline-archive.test.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * 变异基线归档分支的纯函数回归（#714 后续修复）。
+ *
+ * 为什么存在：归档分支 `baseline/mutation` 由两个入口维护——夜间增量班次（全量恢复+强推）
+ * 与 PR 合并后的 overlay（只覆盖本次 CI 产出的段）。后者曾因 **artifact API 默认分页 30 条**
+ * 只覆盖 14/31 段，再配合整棵树强推，把未覆盖的段固化成旧版本、把两个「本来没有基线」的段
+ * （provider-usage-errsurf、web-file-preview）每次合并都抹掉。实测证据（2026-09-11）：
+ *   gh api repos/.../actions/runs/34559972509/artifacts            → total_count 70、mutation-incremental 14
+ *   gh api repos/.../actions/runs/34559972509/artifacts?per_page=100 → total_count 70、mutation-incremental 31
+ * 本文件把「分页合并」「期望集合派生」「对账缺口」三件事钉死，避免再次静默丢段。
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import {
+  BASELINE_FILE_RE,
+  GH_API_PER_PAGE,
+  expectedBaselineFiles,
+  mergeArtifactPage,
+  mutationArtifacts,
+  reconcileArchive,
+} from '../gate/baseline-archive.mjs'
+
+const ROOT = join(import.meta.dirname, '..', '..')
+
+/** 造一页 artifact API 响应。 */
+function page(names, totalCount) {
+  return { total_count: totalCount ?? names.length, artifacts: names.map((name) => ({ name })) }
+}
+
+test('分页合并：单页已取满时一轮结束', () => {
+  const first = mergeArtifactPage([], page(['a', 'b'], 2), 1)
+  assert.equal(first.items.length, 2)
+  assert.equal(first.nextPage, null, '已取满 total_count 时不应再翻页')
+  assert.equal(first.done, true)
+})
+
+test('分页合并：total_count 大于本页时给出下一页', () => {
+  const first = mergeArtifactPage([], page(Array.from({ length: 30 }, (_, i) => `a${i}`), 70), 1)
+  assert.equal(first.items.length, 30)
+  assert.equal(first.nextPage, 2, '应继续翻页（原缺陷就是在这里停住）')
+
+  const second = mergeArtifactPage(first.items, page(Array.from({ length: 40 }, (_, i) => `b${i}`), 70), 2)
+  assert.equal(second.items.length, 70, '两页应合并为 70 条')
+  assert.equal(second.nextPage, null, '取满 total_count 后终止')
+})
+
+test('分页合并：空页终止（短页 + total_count 偏大时不重复请求同一页）', () => {
+  // 页号必须严格递增：用「已收条数 / perPage」反推会在短页时算回同一页。
+  const first = mergeArtifactPage([], page(Array.from({ length: 7 }, (_, i) => `c${i}`), 70), 1)
+  assert.equal(first.nextPage, 2, '短页但未达 total_count 时页号应 +1')
+  const second = mergeArtifactPage(first.items, page([], 70), 2)
+  assert.equal(second.nextPage, null, '空页应终止')
+  assert.equal(second.items.length, 7, '空页不得改变已合并结果')
+  assert.equal(second.done, true)
+})
+
+test('分页合并：模拟真实两次请求的循环（30 + 40 = 70）并终止', () => {
+  const pages = [
+    page(Array.from({ length: 30 }, (_, i) => `p1-${i}`), 70),
+    page(Array.from({ length: 40 }, (_, i) => `p2-${i}`), 70),
+  ]
+  let items = []
+  let pageNo = 1
+  let rounds = 0
+  for (;;) {
+    rounds++
+    const merged = mergeArtifactPage(items, pages[pageNo - 1] ?? page([], 70), pageNo)
+    items = merged.items
+    if (merged.nextPage === null) break
+    pageNo = merged.nextPage
+    assert.ok(rounds < 10, '不得死循环')
+  }
+  assert.equal(rounds, 2, '两页数据应两轮取完')
+  assert.equal(items.length, 70)
+})
+
+test('产物筛选：只认 mutation-incremental- 前缀，且容忍脏数据', () => {
+  const picked = mutationArtifacts([
+    { name: 'mutation-incremental-dsh-mcp-manager-entry' },
+    { name: 'dsh-mcp-manager-entry.json' },
+    { name: 'coverage-self' },
+    { name: null },
+    {},
+    { name: 'mutation-incremental-dsh-notifier-sdk' },
+  ])
+  assert.deepEqual(picked.map((a) => a.name), [
+    'mutation-incremental-dsh-mcp-manager-entry',
+    'mutation-incremental-dsh-notifier-sdk',
+  ])
+})
+
+test('期望集合派生：dsh- 前缀剥离 + seg=0 单配置形态', () => {
+  assert.deepEqual(
+    expectedBaselineFiles(['dsh-mcp-manager-entry.json', 'dsh-web-file-preview.json', 'dsh-notifier-sdk.json']),
+    ['incremental-mcp-manager-entry.json', 'incremental-notifier-sdk.json', 'incremental-web-file-preview.json'],
+  )
+  assert.deepEqual(expectedBaselineFiles(['README.md', null]), [], '非 .json 条目不得进期望集合')
+})
+
+test('期望集合与真实仓库一致：stryker.conf.d/*.json 一条不落（31 段）', () => {
+  const confNames = readdirSync(join(ROOT, 'stryker.conf.d')).filter((f) => f.endsWith('.json'))
+  const expected = expectedBaselineFiles(confNames)
+  assert.equal(expected.length, confNames.length, '每个段配置都应对应一个基线文件')
+  assert.equal(expected.length, 31, `段数应为 31，实际 ${expected.length}`)
+  for (const f of expected) assert.match(f, BASELINE_FILE_RE, `文件名应匹配归档形态：${f}`)
+})
+
+test('对账：既未覆盖也不在旧基线 → 报缺口（复现原缺陷的两段）', () => {
+  const expected = ['incremental-a.json', 'incremental-b.json', 'incremental-c.json']
+  const r = reconcileArchive({
+    expected,
+    overlaid: ['incremental-a.json'],
+    carriedForward: ['incremental-b.json'],
+  })
+  assert.deepEqual(r.missing, ['incremental-c.json'], '只有两处都没有的段才算缺口')
+  assert.equal(r.overlaidCount, 1)
+  assert.equal(r.carriedCount, 1)
+})
+
+test('对账：空归档（首次 overlay）不得误报为「数据丢失」之外的语义', () => {
+  const r = reconcileArchive({ expected: ['incremental-a.json'], overlaid: [], carriedForward: [] })
+  assert.deepEqual(r.missing, ['incremental-a.json'])
+})
+
+test('对账：全覆盖时缺口为空', () => {
+  const r = reconcileArchive({
+    expected: ['incremental-a.json', 'incremental-b.json'],
+    overlaid: ['incremental-a.json'],
+    carriedForward: ['incremental-b.json'],
+  })
+  assert.deepEqual(r.missing, [])
+})
+
+test('回归：旧实现（只读第 1 页）会丢段，新实现拿全 31 段', () => {
+  // 用真实形状构造两页：page1 30 条里混入 14 个 mutation-incremental，page2 40 条里含其余 17 个。
+  const mutPage1 = Array.from({ length: 14 }, (_, i) => `mutation-incremental-pkg-${i}`)
+  const mutPage2 = [
+    'mutation-incremental-dsh-provider-usage-errsurf',
+    'mutation-incremental-dsh-web-file-preview-0',
+    ...Array.from({ length: 15 }, (_, i) => `mutation-incremental-pkg-${i + 14}`),
+  ]
+  const others = (n) => Array.from({ length: n }, (_, i) => `report-${i}`)
+  const page1 = [...mutPage1, ...others(16)]
+  const page2 = [...mutPage2, ...others(23)]
+  assert.equal(page1.length + page2.length, 70, 'fixture 应与真实 run 的 total_count 同形')
+
+  let items = []
+  const first = mergeArtifactPage(items, page(page1, 70), 1)
+  const oldWay = mutationArtifacts(first.items) // 旧实现停在第 1 页
+  items = first.items
+  const second = mergeArtifactPage(items, page(page2, 70), 2)
+  const newWay = mutationArtifacts(second.items)
+
+  assert.equal(oldWay.length, 14, '旧实现只看到 14 个（与实测一致）')
+  assert.equal(newWay.length, 31, '新实现应拿全 31 个')
+  for (const name of ['mutation-incremental-dsh-provider-usage-errsurf', 'mutation-incremental-dsh-web-file-preview-0']) {
+    assert.ok(!oldWay.some((a) => a.name === name), `旧实现应缺失 ${name}`)
+    assert.ok(newWay.some((a) => a.name === name), `新实现应包含 ${name}`)
+  }
+})
+
+test('脚本静态检查：两处 GitHub API 调用都显式带上分页参数', () => {
+  // 防回归：任何新增的 actions API 调用若不带 per_page，就是同一个缺陷的复发。
+  const src = readFileSync(join(ROOT, 'scripts/gate/overlay-baseline.mjs'), 'utf8')
+  const apiCalls = (src.match(/['"]api['"],\s*\n?\s*`[^`]+`/g) ?? [])
+    .filter((call) => /actions\/runs/.test(call) || /artifacts/.test(call))
+  assert.ok(apiCalls.length >= 2, `应至少有两处 actions API 调用，实际 ${apiCalls.length}`)
+  for (const call of apiCalls) {
+    assert.match(call, /per_page=/, `gh api 调用缺少分页参数（默认 30 条会截断）：${call}`)
+  }
+})


### PR DESCRIPTION
# 变异基线归档：分页取全 + 对账判缺口（#714 合并后定位的数据丢失）

## 结论

`baseline-overlay` **确实每次合并都自动触发了**（PR #714 合并于 04:45:49，归档 job 04:45:52 启动、
04:46:08 完成），但它**只覆盖 14/31 段**，并且因为随后「整棵树强推」，把未覆盖的段固化成旧版本、
把两个本来没有基线的段**永久抹掉**。根因是 artifact 列表 API 的分页被默认 30 条截断。

## 证据（全部实测，可复现）

1. **归档分支长期缺 2 段**：`baseline/mutation` 上 29 个 `incremental-*.json`（应为 31），
   缺 `incremental-provider-usage-errsurf.json` 与 `incremental-web-file-preview.json`。
2. **09-10 19:01 的增量班次明明推过这两段**：那次 `orphan-baseline push` 报「34 份文件」，
   清单里含 `provider-usage-errsurf`、`web-file-preview`，还有两个已废弃段名
   （`notifier-history` / `notifier-message`，PR2 功能命名后已更名）——所以是**后续合并把好数据抹掉的**。
3. **分页截断的直接证据**（PR #714 的 CI run `34559972509`，共 70 个 artifact）：
   ```
   gh api repos/.../actions/runs/34559972509/artifacts               → total_count 70，首 30 条里 mutation-incremental 仅 14 个
   gh api repos/.../actions/runs/34559972509/artifacts?per_page=100  → total_count 70，mutation-incremental 31 个
   首 30 条里是否含 errsurf / web-file-preview → 0 个（都在第 2 页）
   ```
4. **每次合并的日志都印证**：PR #712 与 PR #714 的 overlay job 都是
   「发现 **14** 个增量产物 → 准备提交 **30** 个基线文件 → 强推」。

## 影响面

- **不是分数问题**：段一旦有基线文件，增量模式仍会复用其 mutant 状态，指标不会因此算错。
- **是档案与效率问题**：每次合并都丢弃该 PR 一半段的最新结果；缺口段（errsurf / web-file-preview）
  每次全量重跑；`manifest.json` 与「谁更新过」的可追溯性受损。

## 改动

| 文件 | 改动 |
|---|---|
| `scripts/gate/baseline-archive.mjs`（新增） | 纯函数：分页合并（空页/`total_count` 双终止）、期望集合派生、对账缺口 |
| `scripts/gate/overlay-baseline.mjs` | 分页取全（`per_page=100`、页号严格递增、20 页硬上限）；`runs?head_sha=` 补 `per_page`；推送前对账并**非零退出 + 点名**；artifact 查询失败由 `exit 0` 改为 **fail-loud exit 1** |
| `scripts/test/baseline-archive.test.ts`（新增） | 12 条：含「旧实现只看到 14 段、新实现 31 段」回归、空页终止、脏数据容忍、gh api 必须带 `per_page` 的静态防回归 |
| `scripts/gate/baseline/README.md` | 补「归档缺口与对账」小节 |

**刻意选择**：发现缺口时**仍照常推送**、但以非零退出暴露。拒绝推送会让归档停在更旧的整棵树上，
比「补上 14 段 + 报告缺口」更糟。

## 验证

- 只读探针（真实 run，不写盘不推送）：旧实现 14 → 新实现 31 个变异产物；对账「期望 31 / 覆盖 31 /
  沿用 29 / 缺口 0」；若仍用旧实现则缺口 2 段（正是那两个）。
- `scripts/test/baseline-archive.test.ts` 12/12 通过。
- 门禁：`pnpm build` / `pnpm test` / `pnpm contract` / `pnpm pack:check` / `pnpm typecheck` /
  `pnpm test:scripts` / `pnpm stryker:check` / `pnpm docs:check` 全 **exit 0**。

## 合并后的自愈路径

归档分支会在下一次夜间班次（`observe.yml` 全量重建）或任一合并触发 overlay 后补齐到 31 段；
本 PR 起，若仍有缺口，`baseline-overlay` 步骤会红并点名缺口段，不再静默。

关联：#714（发现于其合并后的归档核对）、#690（门禁纪律：环境失败不得静默降级）。
