### PR TITLE
fix(ci): 归档脚本二次修复——补变量声明与 fail-loud 恢复（#715 上线后实测暴露）

### DIFF
--- a/scripts/gate/overlay-baseline.mjs
+++ b/scripts/gate/overlay-baseline.mjs
@@ -151,6 +151,8 @@ async function main() {
   const tmpWork = mkdtempSync(join(tmpdir(), 'dsh-overlay-'));
   const baselineDir = join(tmpWork, 'baseline');
   const artifactsDir = join(tmpWork, 'artifacts');
+  const carriedForward = []; // 旧基线里带过来的段文件（对账用：区分「本次覆盖」与「沿用旧版」）
+  const overlaid = []; // 本次真正写入的段文件
   mkdirSync(baselineDir, { recursive: true });
   mkdirSync(artifactsDir, { recursive: true });
 
@@ -158,6 +160,15 @@ async function main() {
     // 5. 先恢复孤立分支的现存基线全量快照
     console.log(`[overlay-baseline] 恢复孤立分支 ${BRANCH} 现存基线...`);
     try {
+      // 先确认远端 ref 是否存在：`git fetch` 失败既可能是「分支尚不存在」（首夜，正常降级），
+      // 也可能是网络/权限瞬时故障——后者若被当成空分支，会把沿用中的基线整批丢掉
+      // （实测 2026-09-11 05:18 的 overlay 就出现过一次，日志显示「尚不可达或为空」）。
+      let remoteRefExists = false;
+      try {
+        remoteRefExists = runGh(['api', `repos/${repo}/git/ref/heads/${BRANCH}`]).length > 0;
+      } catch {
+        remoteRefExists = false;
+      }
       runCmd('git', ['fetch', '--depth=1', 'origin', `refs/heads/${BRANCH}`]);
       const treeOutput = runCmd('git', ['ls-tree', '-r', 'FETCH_HEAD']);
       for (const line of treeOutput.split('\n').filter(Boolean)) {
@@ -169,8 +180,12 @@ async function main() {
           if (BASELINE_FILE_RE.test(fileName)) carriedForward.push(fileName);
         }
       }
-    } catch {
-      console.log(`[overlay-baseline] 孤立分支 ${BRANCH} 尚不可达或为空，将基于当前产物构建全新快照`);
+    } catch (err) {
+      if (remoteRefExists) {
+        console.error(`[overlay-baseline] 孤立分支 ${BRANCH} 存在但恢复失败（fail-loud，拒绝以空快照覆盖）: ${err.message}`);
+        process.exit(1);
+      }
+      console.log(`[overlay-baseline] 孤立分支 ${BRANCH} 尚不存在（首夜），基于当前产物构建全新快照`);
     }
 
     // 6. 逐个下载增量产物并覆盖同名基线
@@ -188,19 +203,32 @@ async function main() {
       }
 
       const files = readdirSync(downloadPath).filter((f) => /^incremental-.+\.json$/.test(f));
+      if (files.length === 0) {
+        // 下载成功但目录里没有预期文件名：说明 upload 的 path 约定与这里不一致（段名/命名漂移），
+        // 静默跳过会让该段永远没有基线，故显式点名。
+        console.warn(`[overlay-baseline] 产物 ${art.name} 内无 incremental-*.json（实际: ${readdirSync(downloadPath).join(', ') || '空目录'}）`);
+        continue;
+      }
       for (const f of files) {
         const src = join(downloadPath, f);
         const dst = join(baselineDir, f);
+        let content;
         try {
-          const content = readFileSync(src, 'utf8');
-          JSON.parse(content); // 严格校验合法 JSON
-          writeFileSync(dst, content);
-          overlayCount++;
-          overlaid.push(f);
-          console.log(`[overlay-baseline] 差量覆盖: ${f}`);
-        } catch {
-          console.warn(`[overlay-baseline] 文件 ${f} 损坏或非有效 JSON，拒绝覆盖`);
+          content = readFileSync(src, 'utf8');
+        } catch (readErr) {
+          console.warn(`[overlay-baseline] 文件 ${f} 读取失败，拒绝覆盖: ${readErr.message}`);
+          continue;
         }
+        try {
+          JSON.parse(content); // 严格校验合法 JSON
+        } catch (parseErr) {
+          console.warn(`[overlay-baseline] 文件 ${f} 非有效 JSON（大小 ${content.length}B），拒绝覆盖: ${parseErr.message}`);
+          continue;
+        }
+        writeFileSync(dst, content);
+        overlayCount++;
+        overlaid.push(f);
+        console.log(`[overlay-baseline] 差量覆盖: ${f}`);
       }
     }
 


### PR DESCRIPTION
# 归档脚本二次修复：#715 上线后实测暴露的两个问题

## 背景

#715 的分页修复**已在 CI 上生效**——`34565422488` 的日志显示「artifact 分页取全：70 / total_count 70」
「发现 31 / 70 个增量产物」（修复前是 14）。但同一个 job 又暴露了两处新问题，导致这次归档
**没有推送任何东西**（归档分支仍是 `bf02d52`，29 段）。

## 问题与修复

### 1. `ReferenceError: overlaid is not defined`

`overlaid` / `carriedForward` 两个累加数组在脚本里**只有引用没有声明**（分页修复落地时漏了声明行），
对账代码一执行就抛错，整棵快照未推送。已在 `baselineDir` 之后补上声明。

### 2. 孤立分支恢复被静默降级

日志出现「孤立分支 baseline/mutation 尚不可达或为空」，而该分支**确实存在**：
本地用同一 refspec（`git fetch --depth=1 origin refs/heads/baseline/mutation`）实测成功。
按原逻辑，这次恢复失败会被当成「首夜空分支」，把沿用中的基线整批丢掉。
现在先经 API 判断远端 ref 是否存在：
- ref 存在但恢复失败 → **fail-loud exit 1**（拒绝以空快照覆盖）；
- ref 确实不存在（首夜） → 才降级为空快照。

### 3. 诊断信息细化（为下一次「31 个文件全报损坏」定位）

CI 上曾出现 31 个文件**全部**报「损坏或非有效 JSON」；但我用同一个 run 的产物在本地复刻
（31 个 artifact 全量下载 + 逐个 `JSON.parse`）结果是 **ok=31 / bad=0**，说明原因不在产物本身。
故把该分支拆成「读取失败」与「解析失败（带大小 + 原因）」，并新增
「产物内无 `incremental-*.json` 时点名实际文件名」——下次复现可一眼定位。

## 验证：本地裸仓库 + 假 gh 端到端真跑

不只是单测。搭建了本地 `origin`（裸仓库，预置 `baseline/mutation` 分支）+ 假 `gh`（回放
pulls/runs/artifacts/download/ref 五类响应），让脚本走完整路径（fetch → 下载 → 覆盖 → 对账 → 构建孤立
commit），只把最后一跳 `git push` 指向真实远端（用假 token，预期失败）：

| 场景 | 结果 |
|---|---|
| 旧基线缺多数段（3 段）+ 本次覆盖 2 段 | 「对账：期望 31 段，本次覆盖 2 段，沿用旧基线 3 段」+ **缺口 29 段点名** + 构建 6 个文件 |
| 旧基线完整（31 段）+ 本次覆盖 2 段 | 「对账：期望 31 / 覆盖 2 / 沿用 31」+ **不报缺口** + 构建 32 个文件 |
| 两场景的孤立分支恢复 | 均成功（不再出现「尚不可达或为空」） |

单测：`scripts/test/baseline-archive.test.ts` 12/12。

## 门禁

`pnpm build` / `pnpm test` / `pnpm contract` / `pnpm pack:check` / `pnpm typecheck` /
`pnpm test:scripts` / `pnpm stryker:check` / `pnpm docs:check` 全部 **exit 0**。

## 合并后的预期

main 上再有 push（含本次合并自身）时，归档 job 应：分页取全 → 恢复远端基线 → 覆盖本次产物 →
对账（若旧基线已由夜间班次补齐到 31 段，则缺口为空）→ 推送。若仍失败，fail-loud 会留下具体原因。

关联：#715、#714（发现于其合并后的归档核对）、#690（门禁纪律）。
