### PR TITLE
refactor(test): #690 S2c 前半——端口动态分配与隔离分诊探针（#713 T5）

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -471,9 +471,10 @@ export const inject: string[] = [];        // 声明 apply 用到的 ctx 服务�
   node scripts/gate/probe-handles.mjs [--only <子串>] [--timeout <ms>] [--grace <ms>] [--idle <ms>] [--json]
   ```
 
-  它在 per-file 隔离下逐文件运行并给出四态：`clean` / `leak`（测试跑完但句柄吊住进程）/
-  `hang`（测试本身没跑完）/ `fail`（含顺序依赖在隔离下暴露）。判定依据与已知局限见该脚本
-  头注释。
+  它在 per-file 隔离下逐文件运行并给出四态：`clean` / `leak`（对照组确认是残留句柄）/
+  `stall`（超时或静默且对照组也挂住，探针**无法**定性，需人工看 stdout）/ `fail`（含顺序依赖
+  在隔离下暴露）。判定依据与已知局限见该脚本头注释；探针应在**无并发测试**时运行，否则慢文件
+  可能被墙钟误判。
 
 ## 6. 多端兼容（三操作系统 + 三访问形态 + 明暗双主题）
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -452,6 +452,29 @@ export const inject: string[] = [];        // 声明 apply 用到的 ctx 服务�
 - **提交前自查**：`git status` 出现 `packages/*/undefined/`、`*.jsonl` 等运行时产物
   一律视为污染，不得提交；自动收集脚本（基线等）只收白名单路径。
 
+<a id="port-handle-discipline"></a><a id="user-content-port-handle-discipline"></a>
+### 5.4 端口与残留句柄纪律（#690 S2c）
+
+- **端口一律动态分配**：测试需要监听端口时用 `server.listen(0, ...)`，再从
+  `server.address().port` 读实际端口，**禁止写死端口号**——也包括「固定基数 + 随机区间」
+  这类写法，窄区间在并发下仍会碰撞。为什么：写死端口只在「严格串行 + 无残留进程」这一
+  脆弱前提下成立；实测同一端口被 8 个文件并发持有时 7 个 `EADDRINUSE`，Stryker 并发下
+  亦有 19998 互踩的历史记录（#147 / #217）。
+  「端口被占 → 启动失败」的**负向用例仍然保留**：先 `listen(0)` 占位拿到端口，再让被测
+  对象去绑同一端口——语义不变，只是不再写死端口号。
+- **残留句柄在 `finally` 里回收**：测试自己起的 server / socket / 定时器 / watcher 必须在
+  用例结束时关闭。`node --test` 的 per-file 隔离下，未回收的句柄会让**整个包**挂到 runner
+  超时才判红，而不是只红那一个文件。
+- **分诊工具（只报告，不判红）**：排查挂起或评估隔离模式时，先逐文件分诊：
+
+  ```sh
+  node scripts/gate/probe-handles.mjs [--only <子串>] [--timeout <ms>] [--grace <ms>] [--idle <ms>] [--json]
+  ```
+
+  它在 per-file 隔离下逐文件运行并给出四态：`clean` / `leak`（测试跑完但句柄吊住进程）/
+  `hang`（测试本身没跑完）/ `fail`（含顺序依赖在隔离下暴露）。判定依据与已知局限见该脚本
+  头注释。
+
 ## 6. 多端兼容（三操作系统 + 三访问形态 + 明暗双主题）
 
 dsh web 部署在 Linux 服务器，经局域网被多种设备 / 系统访问。插件（尤其客户端 UI 与

--- a/packages/dsh-lan-proxy/test/e2e/smoke.test.ts
+++ b/packages/dsh-lan-proxy/test/e2e/smoke.test.ts
@@ -240,6 +240,19 @@ const tls = ensureSelfSignedTls({ dir: certDir, extraSans: [LAN_HOST] });
 let proxy;
 
 // ── helpers ─────────────────────────────────────────────────────────────────
+/**
+ * 取一个当前空闲的端口（bind(0) 后立即释放）。
+ * 为什么需要：个别用例要断言「生效端口等于启动时传入的端口」，需要一个**确定且不写死**的值；
+ * 直接传 0 会让断言退化成「0 == 0」，失去验证意义。
+ */
+async function freePort() {
+  const probe = createServer();
+  await new Promise((r) => probe.listen(0, "127.0.0.1", r));
+  const chosen = probe.address().port;
+  await new Promise((r) => probe.close(r));
+  return chosen;
+}
+
 function getViaProxy(headers) {
   return new Promise((resolve, reject) => {
     const req = httpRequest({ hostname: "127.0.0.1", port: PROXY_PORT, path: "/hello", method: "GET", headers }, (res) => {
@@ -1222,7 +1235,7 @@ const main = async () => {
       },
       effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
     };
-    apply(ctx, { host: "127.0.0.1", port: 19991, httpsEnabled: false });
+    apply(ctx, { host: "127.0.0.1", port: 0, httpsEnabled: false });
     const cleanup = () => { for (const d of disposers.reverse()) { try { d(); } catch {} } };
     check("RPC 配置通道不再注册（自建通道移除）", () => assert.equal(rpcHandles.length, 0));
     const healthRoute = routes.filter((r) => r.path === ROUTES.health)[0];
@@ -1350,7 +1363,8 @@ const main = async () => {
       inject() {},
       effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
     };
-    apply(ctx, { host: "127.0.0.1", port: 19992, httpsEnabled: false });
+    const degradedPort = await freePort();
+    apply(ctx, { host: "127.0.0.1", port: degradedPort, httpsEnabled: false });
     const configRoute = routes.find((r) => r.path === ROUTES.config);
     check("降级态：health 与 config 路由仍注册（卡片可读）", () => {
       assert.ok(routes.find((r) => r.path === ROUTES.health));
@@ -1364,7 +1378,7 @@ const main = async () => {
       const payload = JSON.parse(chunks.join(""));
       assert.equal(status, 200);
       assert.equal(payload.writable, false);
-      assert.equal(payload.effective.port, 19992);
+      assert.equal(payload.effective.port, degradedPort);
     });
     for (const d of [...disposers].reverse()) { try { d(); } catch {} }
     process.env.DSH_HOME = prevHome;
@@ -1390,7 +1404,7 @@ const main = async () => {
       inject() {},
       effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
     };
-    apply(ctx, { host: "127.0.0.1", port: 19993, httpsEnabled: false });
+    apply(ctx, { host: "127.0.0.1", port: 0, httpsEnabled: false });
 
     const apiRoute = ws.prefixes.get("/api");
     check("webServer handler 不被触碰（压缩在转发层，非宿主端 patch）", () => {
@@ -1439,7 +1453,7 @@ const main = async () => {
       inject() {},
       effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
     };
-    apply(ctx, { host: "127.0.0.1", port: 19994, httpsEnabled: false, httpCompressEnabled: false });
+    apply(ctx, { host: "127.0.0.1", port: 0, httpsEnabled: false, httpCompressEnabled: false });
     check("关闭压缩：health mounted=false", () => {
       assert.equal(ws.prefixes.get("/api").handler, apiHandler, "webServer handler 原样");
       assert.ok(ws.exact.has(ROUTES.health), "health 路由仍注册（转发功能不受影响）");
@@ -1480,7 +1494,7 @@ const main = async () => {
       },
       effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
     };
-    apply(ctx, { host: "127.0.0.1", port: 19995, httpsEnabled: false });
+    apply(ctx, { host: "127.0.0.1", port: 0, httpsEnabled: false });
     const healthMounted = () => {
       const hRes = new FakeRes();
       ws.exact.get(ROUTES.health).handler(makeReq(), hRes);

--- a/packages/dsh-lan-proxy/test/e2e/smoke.test.ts
+++ b/packages/dsh-lan-proxy/test/e2e/smoke.test.ts
@@ -1,9 +1,9 @@
 // @ts-nocheck
 // dsh-lan-proxy 冒烟测试 —— 无外部依赖。
 //
-// 在 127.0.0.1:19090 起一个"假 dsh web 服务器"（回显请求要素、对 WebSocket
-// 升级应答字节回显），把代理挂在 127.0.0.1:19091（HTTP）/ 19092（HTTPS）上
-// 指向它，然后验证：
+// 起一个"假 dsh web 服务器"（回显请求要素、对 WebSocket 升级应答字节回显），
+// 把代理挂在它的 HTTP / HTTPS 监听上指向它；端口一律 bind(0) 动态分配
+// （#690 S2c 端口治理：写死端口在并发或残留进程下会 EADDRINUSE 假阳性），然后验证：
 //   - Host/Origin 被重写为回环目标（围栏要求）
 //   - 无 Origin 的非浏览器请求也能通过
 //   - DNS 域名 Host 头被拒绝（重绑定防护）
@@ -37,9 +37,11 @@ import { apply, sanitizeSettings, validateSettings, ROUTES, pluginDir,
 // 结构化单元测试（issue #82 批次 2）由包内 `test/*.test.ts` glob 直接执行（#690 S2）；
 // 此处不再 import 聚合——聚合会让同一文件在同进程内被求值两遍。
 
-const UPSTREAM_PORT = 19090;
-const PROXY_PORT = 19091;
-const PROXY_HTTPS_PORT = 19092;
+// 端口在 main() 里 bind(0) 之后回填（#690 S2c / #713 T5）：写死端口在并发运行或残留
+// 进程下会 EADDRINUSE 假阳性；helpers 与断言按名引用，回填后语义不变。
+let UPSTREAM_PORT = 0;
+let PROXY_PORT = 0;
+let PROXY_HTTPS_PORT = 0;
 const LAN_HOST = "192.168.1.50";
 const failures = [];
 const pendingChecks = []; // 收集全部 async 用例 promise，收尾统一 allSettled（防迟到失败漏计 → 假绿）
@@ -234,14 +236,8 @@ upstream.on("upgrade", (req, socket) => {
 // ── proxy under test ────────────────────────────────────────────────────────
 const certDir = mkdtempSync(join(tmpdir(), "dsh-lan-proxy-test-"));
 const tls = ensureSelfSignedTls({ dir: certDir, extraSans: [LAN_HOST] });
-const proxy = createLanProxy({
-  host: "127.0.0.1",
-  port: PROXY_PORT,
-  httpsPort: PROXY_HTTPS_PORT,
-  tls,
-  targetHost: "127.0.0.1",
-  targetPort: UPSTREAM_PORT,
-});
+// proxy 在 main() 里创建：targetPort 必须等 upstream 绑定到具体端口后才确定。
+let proxy;
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 function getViaProxy(headers) {
@@ -343,8 +339,20 @@ function rawRequest(requestText) {
 }
 
 const main = async () => {
-  await new Promise((r) => upstream.listen(UPSTREAM_PORT, "127.0.0.1", r));
-  await proxy.listen();
+  await new Promise((r) => upstream.listen(0, "127.0.0.1", r));
+  UPSTREAM_PORT = upstream.address().port;
+  proxy = createLanProxy({
+    host: "127.0.0.1",
+    port: 0,
+    httpsPort: 0,
+    tls,
+    targetHost: "127.0.0.1",
+    targetPort: UPSTREAM_PORT,
+  });
+  const listening = await proxy.listen();
+  PROXY_PORT = listening.httpPort;
+  assert.ok(listening.httpsPort !== undefined, "HTTPS 应成功监听（端口动态分配）");
+  PROXY_HTTPS_PORT = listening.httpsPort;
   console.log("unit: hostnameAllowed / formatAuthority");
   check("accepts IPv4 literal", () => assert.equal(hostnameAllowed(`${LAN_HOST}:${PROXY_PORT}`), true));
   check("accepts bare IPv4 literal", () => assert.equal(hostnameAllowed(LAN_HOST), true));
@@ -748,7 +756,6 @@ const main = async () => {
   // ── 转发层 HTTP 压缩：真实 upstream × 真实 createLanProxy ─────────────────
   console.log("integration: 转发层 HTTP 压缩（compression 中间件）");
   {
-    const upPort = 19190, pxPort = 19191;
     const bigBody = JSON.stringify({ data: "y".repeat(300_000) });
     // issue #528 反向回归：跟踪「上游长连接被销毁」次数（客户端断开后上游 close）。
     let upstreamSseHoldClosed = 0;
@@ -783,7 +790,8 @@ const main = async () => {
         setTimeout(() => { res.socket?.destroy(); }, 30);
       } else { res.writeHead(404); res.end(); }
     });
-    await new Promise((r) => upstream.listen(upPort, "127.0.0.1", r));
+    await new Promise((r) => upstream.listen(0, "127.0.0.1", r));
+    const upPort = upstream.address().port;
 
     const requestThrough = (port, path, headers) => new Promise((resolve, reject) => {
       const req = httpRequest({ host: "127.0.0.1", port, path, headers: { host: "127.0.0.1", ...headers } }, (res) => {
@@ -796,10 +804,10 @@ const main = async () => {
     });
 
     const proxyOn = createLanProxy(
-      { host: "127.0.0.1", port: pxPort, targetHost: "127.0.0.1", targetPort: upPort, httpCompress: { enabled: true, level: 1 } },
+      { host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort, httpCompress: { enabled: true, level: 1 } },
       console,
     );
-    await proxyOn.listen();
+    const { httpPort: pxPort } = await proxyOn.listen();
 
     let r = await requestThrough(pxPort, "/big", { "accept-encoding": "gzip" });
     check("转发层：大 JSON 经代理被 gzip 且解压逐字节一致", () => {
@@ -902,11 +910,11 @@ const main = async () => {
     await proxyOn.close();
 
     const proxyOff = createLanProxy(
-      { host: "127.0.0.1", port: pxPort + 1, targetHost: "127.0.0.1", targetPort: upPort, httpCompress: { enabled: false, level: 1 } },
+      { host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort, httpCompress: { enabled: false, level: 1 } },
       console,
     );
-    await proxyOff.listen();
-    r = await requestThrough(pxPort + 1, "/big", { "accept-encoding": "gzip" });
+    const { httpPort: pxPortOff } = await proxyOff.listen();
+    r = await requestThrough(pxPortOff, "/big", { "accept-encoding": "gzip" });
     check("转发层：enabled=false 全透传", () => {
       assert.equal(r.headers["content-encoding"], undefined);
       assert.equal(r.body.toString(), bigBody);

--- a/packages/dsh-lan-proxy/test/unit/unit-apply.test.ts
+++ b/packages/dsh-lan-proxy/test/unit/unit-apply.test.ts
@@ -277,11 +277,13 @@ const { createServer } = await import("node:http");
   const applyHome = mkdtempSync(join(tmpdir(), "dsh-lan-proxy-apply-listenfail-"));
   const prevHome = process.env.DSH_HOME;
   process.env.DSH_HOME = applyHome;
-  // 占用一个具体端口（#217 回滚：unit-apply 在 stryker 变异面内，port 0 随机化
-  // 破坏变异覆盖（covered 57.9% < 60% 阈值）；19998 在单包 tap runner 上下文安全，
-  // 真正 CI flake 来自 smoke 端口另见 #217 子项）
+  // 占位端口改为动态分配（#690 S2c / #713 T5）：写死端口在并发运行或残留进程下会
+  // EADDRINUSE 假阳性。这与 #217 回滚的「apply 传 port: 0」不是同一件事——那种写法会让
+  // listen 成功、走不到 catch 分支（covered 掉到 57.9%）；这里 occupied 先占位，apply 绑
+  // 同一端口仍必然失败，被覆盖的分支不变。
   const occupied = createServer();
-  await new Promise((r) => occupied.listen(19998, "127.0.0.1", r));
+  await new Promise((r) => occupied.listen(0, "127.0.0.1", r));
+  const occupiedPort = occupied.address().port;
   const routes = [];
   const rpcHandles = [];
   const disposers = [];
@@ -296,7 +298,7 @@ const { createServer } = await import("node:http");
     effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
   };
   const { apply } = await import("../../lib/index.js");
-  apply(ctx, { host: "127.0.0.1", port: 19998, httpsEnabled: false, printBanner: false, wsCompressEnabled: false, httpCompressEnabled: false });
+  apply(ctx, { host: "127.0.0.1", port: occupiedPort, httpsEnabled: false, printBanner: false, wsCompressEnabled: false, httpCompressEnabled: false });
   await sleep(200); // 等 listen 异步 reject
   // health 路由存在，但 listening: false
   const healthRoute = routes.find((r) => r.path === ROUTES.health);

--- a/packages/dsh-lan-proxy/test/unit/unit-apply.test.ts
+++ b/packages/dsh-lan-proxy/test/unit/unit-apply.test.ts
@@ -203,7 +203,9 @@ const { createServer } = await import("node:http");
   };
 
   const { apply } = await import("../../lib/index.js");
-  apply(ctx, { host: "127.0.0.1", port: 0, httpsEnabled: true, printBanner: false, wsCompressEnabled: false, httpCompressEnabled: false });
+  // httpsPort 显式传 0：不传会落到产品默认值 3443 并**真实监听**（端口审计实测），
+  // 并发或残留进程下即 EADDRINUSE（#690 S2c 端口治理）。
+  apply(ctx, { host: "127.0.0.1", port: 0, httpsPort: 0, httpsEnabled: true, printBanner: false, wsCompressEnabled: false, httpCompressEnabled: false });
 
   await sleep(100);
 

--- a/packages/dsh-lan-proxy/test/unit/unit-proxy.test.ts
+++ b/packages/dsh-lan-proxy/test/unit/unit-proxy.test.ts
@@ -188,7 +188,6 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 {
   const { WebSocketServer, WebSocket: WsClient } = await import("ws");
 
-  const upPort = 19790 + Math.floor(Math.random() * 100);
   const upServer = createServer();
   const wss = new WebSocketServer({ noServer: true });
   upServer.on("upgrade", (req, socket, head) => {
@@ -196,7 +195,8 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
       ws.on("message", (data, isBinary) => ws.send(data, { binary: isBinary }));
     });
   });
-  await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+  await new Promise((r) => upServer.listen(0, "127.0.0.1", r));
+  const upPort = upServer.address().port;
 
   const proxy = createLanProxy({
     host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
@@ -230,7 +230,6 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 {
   const { WebSocketServer, WebSocket: WsClient } = await import("ws");
 
-  const upPort = 19850 + Math.floor(Math.random() * 100);
   const upServer = createServer();
   const wss = new WebSocketServer({ noServer: true });
   let upgradeHeaders = null;
@@ -240,7 +239,8 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
       ws.on("message", (data, isBinary) => ws.send(data, { binary: isBinary }));
     });
   });
-  await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+  await new Promise((r) => upServer.listen(0, "127.0.0.1", r));
+  const upPort = upServer.address().port;
 
   const proxy = createLanProxy({
     host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
@@ -287,7 +287,6 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 {
   const { WebSocket: WsClient, WebSocketServer } = await import("ws");
 
-  const upPort = 21050 + Math.floor(Math.random() * 40);
   const upServer = createServer();
   const wss = new WebSocketServer({ noServer: true });
   let noCookieUpgrades = 0;
@@ -303,7 +302,8 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
       ws.on("message", (data, isBinary) => ws.send(data, { binary: isBinary }));
     });
   });
-  await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+  await new Promise((r) => upServer.listen(0, "127.0.0.1", r));
+  const upPort = upServer.address().port;
 
   const proxy = createLanProxy({
     host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
@@ -339,7 +339,6 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 // —— 断言 1 + 3：真 echo 上游（ws 库自动回 pong）→ ping 按间隔到达、连接不被误杀 ——
 {
   const { WebSocketServer, WebSocket: WsClient } = await import("ws");
-  const upPort = 19950 + Math.floor(Math.random() * 40);
   const upServer = createServer();
   const wss = new WebSocketServer({ noServer: true });
   let upstreamPings = 0; // 真 echo 上游收到的 ping 帧数 = 上游段探活按间隔发出
@@ -349,7 +348,8 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
       ws.on("message", (data, isBinary) => ws.send(data, { binary: isBinary }));
     });
   });
-  await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+  await new Promise((r) => upServer.listen(0, "127.0.0.1", r));
+  const upPort = upServer.address().port;
 
   const proxy = createLanProxy({
     host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
@@ -387,12 +387,12 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 // pong）→ 上游段探活超时 terminate → close 互断逻辑关闭浏览器端（1006）。
 {
   const { WebSocket: WsClient } = await import("ws");
-  const silentPort = 20000 + Math.floor(Math.random() * 40);
   const silentServer = createServer((req, res) => res.destroy());
   silentServer.on("upgrade", (req, socket) => {
     socket.write(wsHandshakeResponse(req.headers["sec-websocket-key"]));
   });
-  await new Promise((r) => silentServer.listen(silentPort, "127.0.0.1", r));
+  await new Promise((r) => silentServer.listen(0, "127.0.0.1", r));
+  const silentPort = silentServer.address().port;
 
   const proxy = createLanProxy({
     host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: silentPort,
@@ -417,7 +417,6 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 // raw 假客户端经 node:http upgrade 拿裸 socket（不回 pong）连压缩白名单路径。
 {
   const { WebSocketServer } = await import("ws");
-  const upPort = 20050 + Math.floor(Math.random() * 40);
   const upServer = createServer();
   const wss = new WebSocketServer({ noServer: true });
   let upstreamClosed = false;
@@ -427,7 +426,8 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
       ws.on("close", () => { upstreamClosed = true; });
     });
   });
-  await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+  await new Promise((r) => upServer.listen(0, "127.0.0.1", r));
+  const upPort = upServer.address().port;
 
   const proxy = createLanProxy({
     host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
@@ -530,9 +530,7 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 {
   const { WebSocketServer, WebSocket: WsClient } = await import("ws");
 
-  async function mkUpstream(portOffset) {
-    // 端口区间错开前置测试（19850+rand(100) 最大 19949）：取 20100+ 避免碰撞。
-    const upPort = 20100 + portOffset + Math.floor(Math.random() * 60);
+  async function mkUpstream() {
     const upServer = createServer();
     const wss = new WebSocketServer({ noServer: true });
     upServer.on("upgrade", (req, socket, head) => {
@@ -540,7 +538,8 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
         ws.on("message", (data, isBinary) => ws.send(data, { binary: isBinary }));
       });
     });
-    await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+    await new Promise((r) => upServer.listen(0, "127.0.0.1", r));
+    const upPort = upServer.address().port;
     return { upPort, upServer, wss };
   }
   /** 经代理建一条 WS 连接、等 open、重试发送帧至回显（上游段 open 竞态：桥接的
@@ -562,7 +561,7 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 
   // a) wsBridge=false：命中白名单路径也走透传（显式放弃桥接/保活）
   {
-    const u = await mkUpstream(0);
+    const u = await mkUpstream();
     const proxy = createLanProxy({
       host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: u.upPort,
       wsBridge: { enabled: false },
@@ -580,7 +579,7 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 
   // b) wsBridge=true：未命中白名单路径也走桥接（保活基座不依赖压缩白名单）
   {
-    const u = await mkUpstream(100);
+    const u = await mkUpstream();
     const proxy = createLanProxy({
       host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: u.upPort,
       wsBridge: { enabled: true },
@@ -598,7 +597,7 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 
   // c) wsBridge 缺省（旧行为兼容）：命中白名单走桥接、未命中走透传
   {
-    const u = await mkUpstream(200);
+    const u = await mkUpstream();
     const proxy = createLanProxy({
       host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: u.upPort,
       wsCompress: { enabled: true, paths: ["/api/remote.mux"], probeIntervalMs: 0 },

--- a/scripts/gate/probe-handles.mjs
+++ b/scripts/gate/probe-handles.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+/**
+ * probe-handles — 测试文件「残留句柄 / 挂起 / 顺序依赖」分诊探针（#690 S2c / #713 T5 前半）。
+ *
+ * 为什么需要这层探针：`--test-isolation=none` 下没有 per-file 结束边界，残留句柄只表现为
+ * 「整包进程不退出」，由 runner 的 20 分钟 spawn 超时兜底——**无法定位到具体文件**。切默认
+ * per-file 隔离前必须先拿到「哪些文件有残留、哪些文件依赖求值顺序」的清单，否则会一次性
+ * 暴露大量既有缺陷（#713 风险 2：PR 过大、无法归因）。
+ *
+ * 四态为什么这样分（本机实测的失败形态，见 PR 正文）：
+ *   - `leak`：`--test-force-exit` 对照组能正常退出 —— 测试逻辑跑完了，是残留句柄（定时器 /
+ *     socket / watcher）吊住了进程。per-file 隔离下这是会退化成「整包挂起」的形态。
+ *   - `stall`：超时/静默且对照组也挂住 —— 探针**无法**区分「句柄残留」与「测试没跑完」，
+ *     如实报出交人工复核（成因见下面的对照组局限）。
+ *   - `fail`：退出码非零 —— 既可能是真实断言失败，也可能是**顺序依赖**在隔离下暴露
+ *     （per-file 让每个文件独占进程，掩盖它的「兄弟文件先跑了什么」不再成立），还可能是
+ *     顶层 unsettled await（per-file 下 node 自己判红，而 none 模式下它是静默的 `1..0`）。
+ *   - `clean`：按时退出、无失败、且汇总后 graceMs 内收尾。
+ *
+ * 对照组为什么不总有效：`--test-force-exit` 只对**注册了 node:test 测试**的文件生效。本仓
+ * 多数测试文件是脚本式（自研 check / 直接断言，不注册测试），实测给这类文件注入 `setInterval`
+ * 后，A（无 force-exit）与对照组 B（有 force-exit）都会 exit 137 且不输出 TAP 汇总。这类文件
+ * 既可能是句柄残留、也可能只是慢，探针不去猜——直接报 `stall`。故 `leak` 的检出面主要覆盖
+ * 已迁到 node:test 的文件；脚本式文件的超时一律要人工看一眼。
+ *
+ * 为什么要对照组而不是「看 TAP 汇总有没有输出」：实测 per-file 隔离下子进程不退出时，父进程
+ * 根本不会打印顶层汇总与 `1..N`（它在等子进程结束），汇总缺失同时覆盖 leak 与 hang 两种情况，
+ * 单靠它无法分诊（首版实现即因此把 `setInterval` 泄漏误判成 hang）。
+ *
+ * 为什么不用 `--test-timeout` 判残留：实测对模块级句柄无效——该参数只作用于测试函数体内，
+ * 泄漏文件仍会跑满超时（`setInterval` 泄漏用例在 none/process 两种模式下都是 exit 137 挂死）。
+ *
+ * 为什么超时必须杀**进程组**：per-file 隔离下 node 会为每个文件再派生一个 worker，只杀直接
+ * 子进程会留下孤儿 worker——实测其继续持有 `127.0.0.1:19998`，污染后续所有运行。故 spawn 用
+ * `detached: true` 建独立进程组，超时以 `kill(-pid)` 整组回收。同一机制由 PR-2 的 runner 采用。
+ *
+ * 为什么串行：本仓测试存在真实固定端口监听（lan-proxy 的 19090/19091/19092），并发探测会
+ * 互相 `EADDRINUSE`（实测 8 文件并发抢同一端口 → 7/8 失败），得到的是假阳性而非分诊。
+ *
+ * 用法（仓库根执行）：
+ *   node scripts/gate/probe-handles.mjs [--only <子串>] [--timeout <ms>] [--grace <ms>] [--idle <ms>] [--json]
+ * 退出码：0 = 探测完成（探测结果本身不判红，它是分诊输入而非门禁）；2 = 用法错误。
+ *
+ * 纯函数与 CLI 分离（沿用 test-surface.mjs 的纪律）：`probeFile` / `triage` 可被测试 import，
+ * import 时不枚举仓库、不 spawn 任何进程；只有直接执行本文件才跑 CLI。
+ */
+import { spawn } from 'node:child_process'
+import { join, relative, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { RUN_TESTS_PATTERN, discoverTestPackages, expandGlob } from './test-surface.mjs'
+
+const DEFAULT_ROOT = join(import.meta.dirname, '..', '..')
+
+/**
+ * 单文件墙钟上限。为什么默认 6 分钟：最慢的 `dsh-mcp-manager/test/e2e/smoke.test.ts` 含 SDK
+ * stdio 端到端，实测单跑 328s；上限低于它会把「慢」误判成 `hang`，而 hang 与慢的区分正是
+ * 本探针要给出的信号，不能用会制造假阳性的默认值。
+ */
+const DEFAULT_TIMEOUT_MS = 6 * 60 * 1000
+/** 汇总输出后允许的退出延迟。正常文件在汇总后 <100ms 内退出，给 2s 余量吸收调度抖动。 */
+const DEFAULT_GRACE_MS = 2000
+/**
+ * 静默窗口：仅在显式传 `--idle <ms>` 时启用，**默认关闭**。
+ * 为什么默认关闭：它是纯启发式——把「测试跑起来过、又连续静默这么久」当作「跑完被句柄吊住」。
+ * 实测 mcp-manager 的两个文件（e2e/smoke 与 unit/unit-middleware）在等待真实子进程时有约 30s
+ * 的中间静默，30s 窗口把它们误判成 leak。分诊表的「干净」结论必须零假阳性，故默认不用启发式；
+ * 需要快速扫一遍时再显式开它，并接受个别慢测试可能被误报（结果里 `stalled` 字段可用于识别）。
+ */
+const DEFAULT_IDLE_MS = 0
+
+function usage(msg) {
+  if (msg !== undefined) console.error(`probe-handles: ${msg}`)
+  console.error('用法: node scripts/gate/probe-handles.mjs [--only <子串>] [--timeout <ms>] [--grace <ms>] [--idle <ms>] [--json]')
+  process.exit(2)
+}
+
+function readFlag(argv, name, fallback) {
+  const i = argv.indexOf(name)
+  if (i < 0) return fallback
+  const raw = argv[i + 1]
+  const n = Number(raw)
+  if (!Number.isInteger(n) || n < 0) usage(`${name} 需要一个非负整数，收到 "${raw}"`)
+  return n
+}
+
+const argv = process.argv.slice(2)
+
+/** 跑一次单文件探测（per-file 隔离）；返回原始证据，不做四态判定。 */
+function runOnce(pkgDir, relFile, timeout, { forceExit = false, idleMs = 0 } = {}) {
+  return new Promise((resolve) => {
+    const args = ['--test', '--test-isolation=process', '--test-concurrency=1', '--test-reporter=tap']
+    // `--test-force-exit` 只在探针的**对照组**里用。为什么不能只靠「TAP 汇总是否输出」判 leak：
+    // 实测 per-file 隔离下子进程不退出时，父进程根本不会打印顶层汇总与 `1..N`（它在等子进程结束），
+    // 所以汇总缺失既可能是 leak 也可能是 hang。force-exit 让「测试逻辑跑完即退出」，于是
+    // A 超时而 B 正常退出 = 测试跑完、是句柄吊住了进程（leak）；A/B 都超时 = 测试本身没跑完（hang）。
+    // 注意这与 runner 禁用该 flag 并不矛盾：那里它是假绿载体（截断悬挂 main 的断言），这里只作对照。
+    if (forceExit) args.push('--test-force-exit')
+    args.push(relFile)
+
+    // 剔除 node:test 的 IPC 上下文：探针自身若跑在 `node --test` 内（回归测试就是这样调它的），
+    // 子进程继承 NODE_TEST_CONTEXT 后会把测试事件上报给**外层** runner、stdout 不再是 TAP，
+    // 探针的汇总/计划解析会全部落空（run-tests-runner.test.ts 记了同一坑）。
+    const env = { ...process.env }
+    delete env.NODE_TEST_CONTEXT
+    delete env.NODE_TEST_WORKER_ID
+
+    const child = spawn(process.execPath, args, { cwd: pkgDir, detached: true, stdio: ['ignore', 'pipe', 'pipe'], env })
+
+    const startedAt = Date.now()
+    let stdout = ''
+    let stderr = ''
+    let summaryAt = null
+    let timedOut = false
+    let stalled = false
+    let killFallback = null
+    let done = false
+
+    const settle = (code, signal) => {
+      if (done) return
+      done = true
+      clearTimeout(hardTimer)
+      if (idleTimer !== null) clearTimeout(idleTimer)
+      if (killFallback !== null) clearTimeout(killFallback)
+      const endedAt = Date.now()
+      resolve({
+        exitCode: code,
+        signal,
+        timedOut,
+        stalled,
+        hasOutput: stdout.length > 0,
+        elapsedMs: endedAt - startedAt,
+        exitDelayMs: summaryAt === null ? null : endedAt - summaryAt,
+        notOk: (stdout.match(/^not ok /gm) ?? []).length,
+        plan: (stdout.match(/^1\.\.(\d+)$/m) ?? [])[1],
+        stderrTail: stderr.trim().split('\n').slice(-6).join('\n'),
+      })
+    }
+
+    // 整组回收：worker 与父 node 在同一进程组（detached 建组），只杀父会留孤儿。
+    const hardKill = () => {
+      try { process.kill(-child.pid, 'SIGKILL') } catch { /* 组已消失 */ }
+      // KILL 后仍不触发 exit 说明进程处于不可中断状态，兜底 settle 以免探针自身挂死。
+      killFallback = setTimeout(() => settle(null, 'SIGKILL'), 10 * 1000)
+    }
+
+    const hardTimer = setTimeout(() => { timedOut = true; hardKill() }, timeout)
+
+    /**
+     * 静默判定：测试跑起来过（有输出）却长时间不再产出，说明它已经跑完、被残留句柄吊住。
+     * 为什么必须要求「有过输出」：纯计算型测试可能长时间无输出，直接判 stall 会把「慢」误判成 leak。
+     * 提前 kill 只是省时间，**结论仍以对照组为准**（对照组也超时即判 hang，误判会被兜回）。
+     */
+    let idleTimer = null
+    const armIdle = () => {
+      if (idleMs <= 0) return
+      if (idleTimer !== null) clearTimeout(idleTimer)
+      idleTimer = setTimeout(() => {
+        if (stdout.length === 0) return
+        stalled = true
+        hardKill()
+      }, idleMs)
+    }
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+      // TAP 顶层汇总块以 `# duration_ms ` 结尾；子测试里的 `duration_ms:` 带缩进与冒号，不匹配。
+      if (summaryAt === null && /^# duration_ms /m.test(stdout)) summaryAt = Date.now()
+      armIdle()
+    })
+    child.stderr.on('data', (chunk) => { stderr += chunk; armIdle() })
+    child.on('error', (err) => { stderr += `\nspawn 失败: ${err.message}`; settle(null, null) })
+    child.on('exit', (code, signal) => settle(code, signal))
+    armIdle()
+  })
+}
+
+/** 探测单个文件；返回四态之一与计时/计数证据。 */
+export async function probeFile(pkgDir, relFile, timeout, grace, idleMs = 0) {
+  const a = await runOnce(pkgDir, relFile, timeout, { idleMs })
+  let status
+  let control = null
+
+  if (a.timedOut || a.stalled) {
+    // 对照组：A 被提前 kill 时按它已耗时给余量，避免对照组本身也跑满长超时。
+    const controlTimeout = a.stalled && !a.timedOut
+      ? Math.min(timeout, Math.max(a.elapsedMs * 2, 60 * 1000))
+      : timeout
+    control = await runOnce(pkgDir, relFile, controlTimeout, { forceExit: true, idleMs })
+    if (!control.timedOut && !control.stalled) {
+      status = control.exitCode !== 0 ? 'fail' : 'leak'
+    } else {
+      // 对照组也挂住：`--test-force-exit` 只对**注册了 node:test 测试**的文件生效，脚本式文件
+      // （本仓多数）下它与 A 一样挂死——实测给脚本式文件注入 `setInterval` 后 A/B 都 exit 137
+      // 且无 TAP 汇总。此时探针**无法**区分「句柄残留」与「测试没跑完」（连「有无输出」都区分
+      // 不了：node --test 对任何文件都会先输出框架行），用静默启发式去猜会把慢测试的中间静默
+      // 误报成 leak（mcp-manager 两个文件实测如此）。故如实报 stall，交人工看 stdout 定性。
+      status = 'stall'
+    }
+  } else if (a.exitCode !== 0) {
+    status = 'fail'
+  } else if (a.exitDelayMs !== null && a.exitDelayMs > grace) {
+    // 测试跑完但拖了很久才退出：句柄最终自行结束（如未清理的 setTimeout），仍属残留。
+    status = 'leak'
+  } else {
+    status = 'clean'
+  }
+
+  return {
+    file: relFile,
+    status,
+    exitCode: a.exitCode,
+    signal: a.signal,
+    timedOut: a.timedOut,
+    stalled: a.stalled,
+    hasOutput: a.hasOutput,
+    elapsedMs: a.elapsedMs,
+    exitDelayMs: a.exitDelayMs,
+    controlElapsedMs: control === null ? null : control.elapsedMs,
+    notOk: a.notOk,
+    plan: a.plan === undefined ? null : Number(a.plan),
+    stderrTail: status === 'clean' ? '' : a.stderrTail,
+  }
+}
+
+/** 枚举仓库内（或注入的 fixture 根内）全部测试文件并**串行**探测。返回逐文件结果数组。 */
+export async function triage(root, { only, timeoutMs, graceMs, idleMs = 0, onResult } = {}) {
+  const targets = []
+  for (const { pkgName } of discoverTestPackages(root)) {
+    const pkgDir = join(root, 'packages', pkgName)
+    for (const abs of expandGlob(pkgDir, RUN_TESTS_PATTERN)) {
+      const rel = relative(pkgDir, abs).split(sep).join('/')
+      if (only !== undefined && !`${pkgName}/${rel}`.includes(only)) continue
+      targets.push({ pkgName, pkgDir, rel })
+    }
+  }
+  const results = []
+  for (const { pkgName, pkgDir, rel } of targets) {
+    const r = { pkgName, ...(await probeFile(pkgDir, rel, timeoutMs, graceMs, idleMs)) }
+    results.push(r)
+    // 进度回调在探测**过程中**触发：leak 文件会占用数十秒到数分钟，没有进度就无法判断
+    // 探针是在推进还是已经挂死（首版即因此盲等过一轮）。
+    onResult?.(r, results.length, targets.length)
+  }
+  return results
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const only = argv.includes('--only') ? argv[argv.indexOf('--only') + 1] : undefined
+  const timeoutMs = readFlag(argv, '--timeout', DEFAULT_TIMEOUT_MS)
+  const graceMs = readFlag(argv, '--grace', DEFAULT_GRACE_MS)
+  const idleMs = readFlag(argv, '--idle', DEFAULT_IDLE_MS)
+  const asJson = argv.includes('--json')
+
+  const results = await triage(DEFAULT_ROOT, {
+    only,
+    timeoutMs,
+    graceMs,
+    idleMs,
+    onResult: (r, i, total) => {
+      const delay = r.exitDelayMs === null ? '-' : `${r.exitDelayMs}ms`
+      console.error(`[${i}/${total}] ${r.status.padEnd(5)} ${String(r.elapsedMs).padStart(8)}ms  汇总后 ${delay.padStart(8)}  ${r.pkgName}/${r.file}`)
+      if (r.stderrTail !== '') console.error(r.stderrTail.split('\n').map((l) => `        | ${l}`).join('\n'))
+    },
+  })
+  if (results.length === 0) usage(`--only "${only}" 没有匹配到任何测试文件`)
+
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(results, null, 2)}\n`)
+  } else {
+    const counts = {}
+    for (const r of results) counts[r.status] = (counts[r.status] ?? 0) + 1
+    console.log(`\n分诊汇总（${results.length} 个文件）: ${Object.entries(counts).map(([k, v]) => `${k}=${v}`).join(' ')}`)
+    for (const status of ['leak', 'stall', 'fail']) {
+      const hit = results.filter((r) => r.status === status)
+      if (hit.length === 0) continue
+      console.log(`\n[${status}] ${hit.length} 个：`)
+      for (const r of hit) console.log(`  ${r.pkgName}/${r.file}`)
+    }
+  }
+}

--- a/scripts/gate/probe-handles.mjs
+++ b/scripts/gate/probe-handles.mjs
@@ -53,11 +53,12 @@ import { RUN_TESTS_PATTERN, discoverTestPackages, expandGlob } from './test-surf
 const DEFAULT_ROOT = join(import.meta.dirname, '..', '..')
 
 /**
- * 单文件墙钟上限。为什么默认 6 分钟：最慢的 `dsh-mcp-manager/test/e2e/smoke.test.ts` 含 SDK
- * stdio 端到端，实测单跑 328s；上限低于它会把「慢」误判成 `hang`，而 hang 与慢的区分正是
- * 本探针要给出的信号，不能用会制造假阳性的默认值。
+ * 单文件墙钟上限。为什么默认 10 分钟：最慢的 `dsh-mcp-manager/test/e2e/smoke.test.ts`（SDK
+ * stdio 端到端）实测单跑 328s，而在**有并发负载**时对抗复核实测其超过 360s——上限若贴着 328s
+ * 留余量，负载下就会把「慢」误判成非 clean。故留约一倍余量。代价是真实泄漏文件要等更久才判红，
+ * 需要快扫时用 `--timeout` 收紧（收紧只会让它更容易判非 clean，不会伪造绿灯）。
  */
-const DEFAULT_TIMEOUT_MS = 6 * 60 * 1000
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000
 /** 汇总输出后允许的退出延迟。正常文件在汇总后 <100ms 内退出，给 2s 余量吸收调度抖动。 */
 const DEFAULT_GRACE_MS = 2000
 /**

--- a/scripts/test/probe-handles.test.ts
+++ b/scripts/test/probe-handles.test.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * probe-handles 探针自测（#690 S2c / #713 T5 前半）。
+ *
+ * 锁住两条承重假设——S2c「先探针分诊、后切隔离」策略全靠它们：
+ *   ① 四态可区分。若 leak 与 hang 混为一谈，分诊表会把「残留句柄」误报成「测试挂起」，
+ *      治理方向就此跑偏（首版实现确实把 `setInterval` 泄漏判成了 hang）。
+ *   ② 超时按进程组回收。若只杀直接子进程，worker 会成孤儿并继续持有端口——实测其占住
+ *      `127.0.0.1:19998` 不放，探针自己就成了下一个 flake 源。
+ *
+ * 运行：pnpm test:scripts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { probeFile, triage } from '../gate/probe-handles.mjs'
+
+const PROBE = fileURLToPath(new URL('../gate/probe-handles.mjs', import.meta.url))
+
+/** 探针自测用收紧的超时：判据是「能否区分形态」，不是「跑得多快」。 */
+const TIMEOUT_MS = 2500
+const GRACE_MS = 300
+
+const CLEAN = 'import { test } from "node:test"\ntest("ok", () => {})\n'
+const LEAK = 'import { test } from "node:test"\ntest("ok", () => {})\nsetInterval(() => {}, 1000)\n'
+/** 测试体内悬挂：测试没跑完，对照组同样挂住 —— 探针无法定性，报 stall。 */
+const STALL = 'import { test } from "node:test"\ntest("never", async () => { await new Promise(() => {}) })\n'
+/** 脚本式文件挂住：--test-force-exit 对它不生效，同样只能报 stall。 */
+const STALL_SCRIPT = 'setInterval(() => {}, 1000)\n'
+const FAIL = 'import assert from "node:assert/strict"\nassert.fail("boom")\n'
+
+function fixture(files = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'probe-handles-'))
+  const pkgDir = join(root, 'packages', 'fixture-pkg')
+  mkdirSync(join(pkgDir, 'test'), { recursive: true })
+  writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: 'fixture-pkg', type: 'module' }), 'utf8')
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(pkgDir, 'test', name), content, 'utf8')
+  }
+  return { root, pkgDir }
+}
+
+test('四态可区分：clean / leak / stall / fail', async () => {
+  const { root } = fixture({
+    'a.test.ts': CLEAN,
+    'b.test.ts': LEAK,
+    'c.test.ts': STALL,
+    'd.test.ts': STALL_SCRIPT,
+    'e.test.ts': FAIL,
+  })
+  try {
+    const results = await triage(root, { timeoutMs: TIMEOUT_MS, graceMs: GRACE_MS })
+    const byFile = Object.fromEntries(results.map((r) => [r.file, r.status]))
+    assert.deepEqual(byFile, {
+      'test/a.test.ts': 'clean',
+      'test/b.test.ts': 'leak',
+      'test/c.test.ts': 'stall',
+      'test/d.test.ts': 'stall',
+      'test/e.test.ts': 'fail',
+    }, `四态判定不符（c=测试体内悬挂、d=脚本式挂起，两者都无法定性故都是 stall）：${JSON.stringify(results.map((r) => [r.file, r.status]))}`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('超时按进程组回收：worker 不得成为孤儿', async () => {
+  const { root, pkgDir } = fixture()
+  const pidFile = join(root, 'worker.pid')
+  try {
+    writeFileSync(join(pkgDir, 'test', 'leak.test.ts'),
+      'import { createServer } from "node:http"\n'
+      + 'import { writeFileSync } from "node:fs"\n'
+      + 'import { test } from "node:test"\n'
+      + 'test("leak", async () => {\n'
+      + `  writeFileSync(${JSON.stringify(pidFile)}, String(process.pid))\n`
+      + '  const s = createServer()\n'
+      + '  await new Promise((r) => s.listen(0, "127.0.0.1", r))\n'
+      + '})\n', 'utf8')
+
+    const r = await probeFile(pkgDir, 'test/leak.test.ts', TIMEOUT_MS, GRACE_MS)
+    assert.equal(r.status, 'leak', `该 fixture 应判 leak：${JSON.stringify(r)}`)
+    assert.ok(existsSync(pidFile), 'worker 应已写下自己的 pid')
+    const workerPid = Number(readFileSync(pidFile, 'utf8'))
+    assert.ok(Number.isInteger(workerPid) && workerPid > 0, `pid 非法：${workerPid}`)
+    assert.throws(() => process.kill(workerPid, 0), /ESRCH/,
+      `worker ${workerPid} 仍存活——超时未按进程组回收，探针会留下孤儿`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('对照组失效（脚本式文件不注册 node:test）时如实报 stall，不猜测', async () => {
+  // 实测：脚本式文件注入 setInterval 后，--test-force-exit 对照组与 A 一样挂住（exit 137、无
+  // TAP 汇总），探针无法区分「句柄残留」与「测试没跑完」。此处**不得**用静默启发式猜 leak——
+  // mcp-manager 的 e2e/smoke 与 unit/unit-middleware 两个慢文件就因此被误报过。
+  const { root, pkgDir } = fixture({ 'leak-script.test.ts': 'console.log("script-done")\nsetInterval(() => {}, 1000)\n' })
+  try {
+    const r = await probeFile(pkgDir, 'test/leak-script.test.ts', 3000, 200, 600)
+    assert.equal(r.status, 'stall', `应如实报 stall：${JSON.stringify(r)}`)
+    assert.equal(r.hasOutput, true, `该 fixture 有输出，故不该判 hang：${JSON.stringify(r)}`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('import 纯模块零副作用：不枚举仓库、不 spawn（CLI 守卫）', () => {
+  // 与 test-surface.mjs 的 P0-1 同族：若 import 即跑 CLI，任何 import 它的测试都会真跑一遍
+  // 全仓探测（数分钟 + 真实子进程），把测试面变成不可控的成本。
+  const probe = spawnSync(process.execPath, [
+    '-e',
+    `import(${JSON.stringify(PROBE)}).then(() => process.stdout.write('IMPORT-OK'))`,
+  ], { encoding: 'utf8', cwd: fileURLToPath(new URL('..', import.meta.url)) })
+  assert.equal(probe.status, 0, `import 应成功：${probe.stdout}${probe.stderr}`)
+  assert.equal(probe.stdout.trim(), 'IMPORT-OK', `import 不得产生任何 CLI 输出，实际：${JSON.stringify(probe.stdout)}`)
+})


### PR DESCRIPTION
# #690 S2c 前半：端口动态分配与隔离分诊探针（#713 T5）

关联 #690（A/B 轨计划）、#713（S2 T5 前半）。本 PR 是 S2c 的**第一块**（端口与句柄治理），
**不含**隔离切换与 runner 判据重写——那是 PR-2。

## 一、结论：分诊先行，实测推翻了「per-file 隔离会暴露大量既有缺陷」的预期

按 #713 T5 的顺序「先治理再切隔离」，本 PR 新增探针 `scripts/gate/probe-handles.mjs`，让 69 个
测试文件逐个在 **per-file 隔离**（`--test-isolation=process --test-concurrency=1`）下运行并分诊：

**结果：clean 69 / 69。0 超时、0 残留句柄、0 顺序依赖失败。**

这条结论直接改变 PR-2 的取舍：原计划担心「切换会一次暴露大量既有缺陷、导致 PR 过大」的前提
**不成立**，因此 PR-2 不需要分批切换。

> 口径说明：该结论在**无并发测试**的机器状态下取得。对抗复核实测 `dsh-mcp-manager/test/e2e/smoke.test.ts`
> 在有并发负载时会超过 6 分钟；本 PR 已把探针默认墙钟从 6 分钟提到 10 分钟以留余量。

## 二、变更清单

| 类别 | 文件 | 说明 |
|---|---|---|
| 新增探针 | `scripts/gate/probe-handles.mjs` | 逐文件分诊四态；`detached` 进程组 + `kill(-pid)` 超时回收；剔除 `NODE_TEST_CONTEXT` 防 IPC 串台；静默启发式默认关闭；默认墙钟 10 分钟 |
| 新增反证 | `scripts/test/probe-handles.test.ts` | 4 条：四态判定、超时按进程组回收、对照组失效时如实报 stall、import 零副作用 |
| 端口治理 | `packages/dsh-lan-proxy/test/e2e/smoke.test.ts` | 19090/19091/19092、19190/19191、**5 处 `apply({port:1999X})`** → `bind(0)`；新增 `freePort()` helper 供「断言生效端口」的用例取动态值 |
| 端口治理 | `packages/dsh-lan-proxy/test/unit/unit-apply.test.ts` | 占位端口 19998 → `bind(0)`（EADDRINUSE 负向语义保留）；**隐式默认 httpsPort 3443** → 显式 `httpsPort: 0` |
| 端口治理 | `packages/dsh-lan-proxy/test/unit/unit-proxy.test.ts` | 4 处「固定基数 + `Math.random()` 区间」→ `bind(0)`；`mkUpstream(portOffset)` 参数随之退役 |
| 文档 | `docs/DEVELOPMENT.md` | 新增 §5.4「端口与残留句柄纪律」 |

## 三、探针的关键机制（都是实测逼出来的，不是设计出来的）

1. **为什么需要对照组**：per-file 隔离下子进程不退出时，父进程**根本不会打印 TAP 汇总**（它在等
   子进程结束），「汇总缺失」同时覆盖 leak 与 hang，单靠它无法分诊。首版实现因此把 `setInterval`
   泄漏误判成 hang。
2. **对照组为什么不总有效**：`--test-force-exit` 只对**注册了 `node:test` 测试**的文件生效。本仓
   66/69 是脚本式文件（对抗复核实测），给这类文件注入 `setInterval` 后 A/B 都 `exit 137`。此时探针
   **无法**区分「句柄残留」与「测试没跑完」，故如实报 `stall` 而不是猜。
3. **为什么默认关闭静默启发式**：加 `--idle 30000` 那一轮，`dsh-mcp-manager` 的 `e2e/smoke.test.ts`
   （328s）与 `unit/unit-middleware.test.ts`（32s）因中间静默超过 30s 被误报成 `leak`。分诊表的
   「干净」结论必须零假阳性。
4. **超时必须杀进程组**：per-file 隔离下 node 会再派生 worker；只杀直接子进程会留下孤儿——实测
   孤儿继续持有 `127.0.0.1:19998` 不放。故用 `detached: true` 建组 + `kill(-pid)`。

## 四、对抗复核发现与修复（本 PR 内闭环）

复核用了一个我最初没想到的手段——**拦截 `net.Server.prototype.listen` 记录真实绑定**——抓出三处问题：

| 发现 | 证据 | 处置 |
|---|---|---|
| `e2e/smoke.test.ts` 漏 5 处 `apply(ctx,{port:1999X})` | 拦截实测 `listen(19991)` / `listen(19995)` 等；它们经 `apply → proxy.listen()` **真实监听**，而我最初的 grep 只找 `listen(` 与 `Math.random()`，漏掉了这种写法 | 5 处改 `port: 0`；其中一处断言 `effective.port` 的用例改用新增 `freePort()` 动态取值，避免断言退化成 `0 == 0` |
| `unit-apply.test.ts` 隐式监听产品默认 3443 | 拦截实测 `listen(3443)`；该处 `apply({httpsEnabled:true})` 未传 `httpsPort`，落到 `DEFAULT_OPTIONS.httpsPort`。**进一步实证：3443 正是本机 `dsh web` 常驻监听的端口**（`ss -ltnp` 指向 `node ... dsh web`）——即该用例此前一直在与生产进程抢端口，只是 HTTPS 降级路径（`https server failed → serving HTTP only`）把它吞成了绿 | 显式 `httpsPort: 0`；复验双次审计得 40679 / 33979，确认动态且 3443 消失 |
| `docs/DEVELOPMENT.md` §5.4 把第三态写成 `hang` | 探针实际产出 `stall`（`probe-handles.mjs` 内 `status = 'stall'`） | 文档改为 `stall`，并补「应在无并发测试时运行」告警 |

复核同时确认：探针四态与自述一致、超时按进程组回收有效（本轮零孤儿、零端口残留）、枚举完整
（`git ls-files` 69 == 探针分母 69）、`pnpm stryker:check` exit 0、端口治理未破坏 lan-proxy 测试。

未采纳的一条：复核指出「`exitDelayMs <= grace` 时，约 1 秒内自行结束的残留定时器会落 `clean`」——
属已知边界（这类文件仍会按时退出），不改变 69/69 的结论，已记入下方边界清单。

## 五、69 个测试文件分诊表
| # | 包 | 测试文件 | 探针状态 | 单跑耗时 | 机制信号 / 处置 |
|---|---|---|---|---|---|
| 1 | dsh-lan-proxy | `test/client/client-style.test.ts` | clean | 0.1s | 无固定端口 / 无残留句柄 |
| 2 | dsh-lan-proxy | `test/e2e/smoke.test.ts` | clean | 9.7s | 固定端口 19090/19091/19092 + 19190/19191 + 5 处 `apply({port:1999X})` → 全部 bind(0)；一处断言改用 `freePort()` 动态取值 |
| 3 | dsh-lan-proxy | `test/unit/unit-apply.test.ts` | clean | 3.4s | 占位端口 19998 → bind(0)（EADDRINUSE 负向语义保留）；`httpsEnabled:true` 未传 httpsPort 时隐式监听产品默认 3443 → 改为显式 `httpsPort: 0` |
| 4 | dsh-lan-proxy | `test/unit/unit-proxy.test.ts` | clean | 2.6s | 4 处「固定基数 + 随机区间」→ bind(0) |
| 5 | dsh-mcp-manager | `test/e2e/smoke.test.ts` | clean | 328.5s | 慢文件（真实子进程 / socket），无残留句柄 |
| 6 | dsh-mcp-manager | `test/integration/service-contract.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 7 | dsh-mcp-manager | `test/unit/unit-apply.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 8 | dsh-mcp-manager | `test/unit/unit-call-stats.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 9 | dsh-mcp-manager | `test/unit/unit-catalog.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 10 | dsh-mcp-manager | `test/unit/unit-hotspot.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 11 | dsh-mcp-manager | `test/unit/unit-manager.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 12 | dsh-mcp-manager | `test/unit/unit-manager2.test.ts` | clean | 12.6s | 慢文件（真实子进程 / socket），无残留句柄 |
| 13 | dsh-mcp-manager | `test/unit/unit-middleware.test.ts` | clean | 32.3s | 慢文件（真实子进程 / socket），无残留句柄 |
| 14 | dsh-mcp-manager | `test/unit/unit-pipeline.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 15 | dsh-mcp-manager | `test/unit/unit-routes-sse.test.ts` | clean | 0.8s | 无固定端口 / 无残留句柄 |
| 16 | dsh-mcp-manager | `test/unit/unit-shared.test.ts` | clean | 0.1s | 无固定端口 / 无残留句柄 |
| 17 | dsh-mcp-manager | `test/unit/unit-store.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 18 | dsh-mcp-manager | `test/unit/unit-supervisor.test.ts` | clean | 0.3s | 无固定端口 / 无残留句柄 |
| 19 | dsh-mcp-manager | `test/unit/unit-transport.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 20 | dsh-mcp-manager | `test/unit/unit-workspace.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 21 | dsh-notifier | `test/client/client-contract.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 22 | dsh-notifier | `test/client/client-style.test.ts` | clean | 0.1s | 无固定端口 / 无残留句柄 |
| 23 | dsh-notifier | `test/integration/consumer-types.test.ts` | clean | 0.1s | 无固定端口 / 无残留句柄 |
| 24 | dsh-notifier | `test/integration/e2e-approval.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 25 | dsh-notifier | `test/integration/e2e-done.test.ts` | clean | 2.8s | 无固定端口 / 无残留句柄 |
| 26 | dsh-notifier | `test/integration/e2e-edge.test.ts` | clean | 1.0s | 无固定端口 / 无残留句柄 |
| 27 | dsh-notifier | `test/integration/e2e-interrupt.test.ts` | clean | 0.8s | 无固定端口 / 无残留句柄 |
| 28 | dsh-notifier | `test/integration/e2e-outbound.test.ts` | clean | 3.2s | 无固定端口 / 无残留句柄 |
| 29 | dsh-notifier | `test/integration/e2e-question-turn.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 30 | dsh-notifier | `test/integration/migration.test.ts` | clean | 0.5s | 无固定端口 / 无残留句柄 |
| 31 | dsh-notifier | `test/integration/real-context.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 32 | dsh-notifier | `test/integration/routes.test.ts` | clean | 0.7s | 无固定端口 / 无残留句柄 |
| 33 | dsh-notifier | `test/integration/service-contract.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 34 | dsh-notifier | `test/unit/unit-aggregate.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 35 | dsh-notifier | `test/unit/unit-config-port.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 36 | dsh-notifier | `test/unit/unit-config.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 37 | dsh-notifier | `test/unit/unit-event-handlers.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 38 | dsh-notifier | `test/unit/unit-pipeline-contract.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 39 | dsh-notifier | `test/unit/unit-sanitize.test.ts` | clean | 0.4s | 无固定端口 / 无残留句柄 |
| 40 | dsh-notifier | `test/unit/unit-server-sse-bus.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 41 | dsh-notifier | `test/unit/unit-settings-bridge.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 42 | dsh-notifier | `test/unit/unit-sse-hub.test.ts` | clean | 0.5s | 无固定端口 / 无残留句柄 |
| 43 | dsh-notifier | `test/unit/unit-stores.test.ts` | clean | 1.3s | 无固定端口 / 无残留句柄 |
| 44 | dsh-notifier | `test/unit/unit-system-notifier.test.ts` | clean | 0.3s | 无固定端口 / 无残留句柄 |
| 45 | dsh-notifier | `test/unit/unit-text.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 46 | dsh-notifier | `test/unit/unit-webhook.test.ts` | clean | 0.1s | 无固定端口 / 无残留句柄 |
| 47 | dsh-provider-usage | `test/client/unit-detect.test.ts` | clean | 0.3s | 无固定端口 / 无残留句柄 |
| 48 | dsh-provider-usage | `test/client/unit-fetch-timeout.test.ts` | clean | 0.3s | 无固定端口 / 无残留句柄 |
| 49 | dsh-provider-usage | `test/client/unit-refresh-revalidate.test.ts` | clean | 0.5s | 无固定端口 / 无残留句柄 |
| 50 | dsh-provider-usage | `test/e2e/smoke.test.ts` | clean | 15.5s | 慢文件（真实子进程 / socket），无残留句柄 |
| 51 | dsh-provider-usage | `test/unit/adapters/unit-deepseek-official.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 52 | dsh-provider-usage | `test/unit/apply/unit-apply.test.ts` | clean | 1.0s | 无固定端口 / 无残留句柄 |
| 53 | dsh-provider-usage | `test/unit/common/unit-errsurf.test.ts` | clean | 0.3s | 无固定端口 / 无残留句柄 |
| 54 | dsh-provider-usage | `test/unit/history/unit-history.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 55 | dsh-provider-usage | `test/unit/pipeline/unit-signal-lock.test.ts` | clean | 0.3s | 无固定端口 / 无残留句柄 |
| 56 | dsh-provider-usage | `test/unit/pipeline/unit-stats-service.test.ts` | clean | 3.4s | 无固定端口 / 无残留句柄 |
| 57 | dsh-provider-usage | `test/unit/report/unit-report-executor.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 58 | dsh-provider-usage | `test/unit/report/unit-report.test.ts` | clean | 0.6s | 无固定端口 / 无残留句柄 |
| 59 | dsh-provider-usage | `test/unit/routes/unit-routes.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 60 | dsh-provider-usage | `test/unit/shared/unit-config.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 61 | dsh-provider-usage | `test/unit/shared/unit-contract.test.ts` | clean | 0.3s | 无固定端口 / 无残留句柄 |
| 62 | dsh-provider-usage | `test/unit/shared/unit-v1.test.ts` | clean | 0.8s | 无固定端口 / 无残留句柄 |
| 63 | dsh-provider-usage | `test/unit/trend/unit-trend-ledger.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 64 | dsh-provider-usage | `test/unit/trend/unit-trend-view.test.ts` | clean | 0.2s | 无固定端口 / 无残留句柄 |
| 65 | dsh-provider-usage | `test/unit/trend/unit-trend.test.ts` | clean | 0.3s | 无固定端口 / 无残留句柄 |
| 66 | dsh-verify-isolated | `test/e2e/smoke.test.ts` | clean | 8.0s | 无固定端口 / 无残留句柄 |
| 67 | dsh-web-file-preview | `test/client/client-contract.test.ts` | clean | 0.1s | 无固定端口 / 无残留句柄 |
| 68 | dsh-web-file-preview | `test/client/client-present-redirect.test.ts` | clean | 0.1s | 无固定端口 / 无残留句柄 |
| 69 | dsh-web-file-preview | `test/unit/unit-present-open.test.ts` | clean | 0.1s | 无固定端口 / 无残留句柄 |

## 六、判据对照表

| 判据（来源） | 验证方式 | 结果 |
|---|---|---|
| #713 T5「固定端口 → 动态分配」 | 拦截 `net.Server.prototype.listen` 全仓审计 + grep | 三处治理后，lan-proxy 四文件审计仅剩内核动态端口（双次运行号码不同） |
| 「端口被占用」负向用例保留 | `unit-apply.test.ts` 断言 `listening: false` | 保留（占位端口改为动态，被覆盖分支不变） |
| 被治理文件在最小集合内独立通过 | `node scripts/gate/probe-handles.mjs --only dsh-lan-proxy` | clean 4/4 |
| `pnpm test` 六包全绿 | `pnpm test` | exit 0（4/16/26/19/1/3 文件数全部达标） |
| 反向用例：未清理句柄必须判非 clean | 注入 `setInterval` 到脚本式文件跑探针 | 报 `stall`（非 clean）；注入已 `git checkout` 还原并经 md5 比对 |
| 反向用例：node:test 文件注入 → 定性为 leak | 注入 `unit-trend-view.test.ts` 跑探针 | 报 `leak`（对照组 211ms 退出，确认是句柄残留） |
| 产物零污染 | `git status --porcelain \| grep -E 'undefined/\|\.jsonl$'` | 无输出 |

## 七、门禁（逐条 exit code，本机实测）

| 命令 | exit |
|---|---|
| `pnpm build` | 0 |
| `pnpm test` | 0（六包 4/16/26/19/1/3，文件数全部达标） |
| `pnpm contract` | 0 |
| `pnpm pack:check` | 0 |
| `pnpm typecheck` | 0 |
| `pnpm test:scripts`（改 scripts/ 追加） | 0（**298 pass / 0 fail**；S2b 基线 282、#715 加 12、本次新增 4） |
| `pnpm docs:check`（改文档追加） | 0 |
| `pnpm stryker:check`（拓扑与 `--min` 一致性） | 0 |
| `pnpm aggregate:check` | 0 |
| `pnpm verify:npmlayout` | 0 |
| `pnpm gate:homedir` | 0 |
| `pnpm test:src-tests` | 0 |
| `node scripts/gate/probe-handles.mjs --json` | 0，**clean 69/69** |
| 全仓端口审计（拦截 `net.Server.prototype.listen`） | **写死嫌疑文件数 = 0**（仅 3 个文件有真实监听，端口号每次不同） |
| `git status --porcelain \| grep -E 'undefined/\|\.jsonl$'` | 无输出（零产物污染） |

## 八、连带面

- **测试文件未搬移**（全部同路径内改），不触发 Stryker 增量缓存的测试身份键变化，**不需要重建变异基线**；
- `--min` 未变（4 / 16 / 26 / 19 / 1 / 3），`pnpm stryker:check` 已覆盖校验；
- 新增 2 个 `scripts/` 文件，已由 `pnpm test:scripts` 纳入（`scripts/test/*.test.ts` glob）；
- 未改 `.github/`、未新增第三方依赖、未改包版本号、未推 `v*` tag。

## 九、已知边界与遗留

1. **`leak` 的检出面有限**：`--test-force-exit` 对照组只对已迁到 `node:test` 的文件生效（全仓仅 3/69），
   脚本式文件超时一律报 `stall`（无法定性），需人工看 stdout。根因治理属 #713 T4 的迁移。
2. **探针不判红**：它是分诊输入，未接入任何门禁，也不改变 runner 行为。
3. **`--idle` 默认关闭**：开启可加速，但会把慢测试的中间静默误报成 `leak`（实测 2 例），启用时必须
   人工复核 `stalled` 字段。
4. **探针应在无并发测试时运行**：`dsh-mcp-manager/test/e2e/smoke.test.ts` 单跑 328s，并发负载下会
   超过 6 分钟（默认墙钟已放宽到 10 分钟，但仍不是无限的）。
5. **残留定时器自行结束的假阴性边界**：`exitDelayMs <= grace(2s)` 时，约 1 秒内自行结束的未清理
   定时器会落 `clean`；这类文件仍按时退出，不影响 69/69 的结论，但说明探针不覆盖「短暂残留」。
6. **既有假绿面（非本 PR 引入，仅登记）**：`src/apply.ts` 的 `proxy.listen().catch(...)` 只记录
   错误不抛出，端口被占时相关用例仍可全绿。复核实测：占住 19991/19995 后跑 `smoke.test.ts` 仍
   `pass 1 / fail 0`。治理它需要改被测行为或用例增加「确实在监听」的断言，属独立议题。
7. **PR-2 待办**：runner 切默认 per-file 隔离、拆 #712 两处过渡补丁（`unit-config.test.ts` 子进程探针、
   `await main()` 约定）、按新语义重写 `run-tests-runner.test.ts` 判据、同步文档。

## 十、规模与回滚

- 2 个提交、6 个文件（2 新增 / 4 修改）。
- 回滚：`git revert` 两个提交即可；无数据迁移、无公共 API 行为变更、无新增依赖、未触碰 `.github/`。

关联 issue：#690；遗留跟踪：#713。
