### PR TITLE
refactor(test): #690 S2c 后半——runner 切默认 per-file 隔离与判据重写（#713 T5）

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -471,9 +471,10 @@ export const inject: string[] = [];        // 声明 apply 用到的 ctx 服务�
   node scripts/gate/probe-handles.mjs [--only <子串>] [--timeout <ms>] [--grace <ms>] [--idle <ms>] [--json]
   ```
 
-  它在 per-file 隔离下逐文件运行并给出四态：`clean` / `leak`（测试跑完但句柄吊住进程）/
-  `hang`（测试本身没跑完）/ `fail`（含顺序依赖在隔离下暴露）。判定依据与已知局限见该脚本
-  头注释。
+  它在 per-file 隔离下逐文件运行并给出四态：`clean` / `leak`（对照组确认是残留句柄）/
+  `stall`（超时或静默且对照组也挂住，探针**无法**定性，需人工看 stdout）/ `fail`（含顺序依赖
+  在隔离下暴露）。判定依据与已知局限见该脚本头注释；探针应在**无并发测试**时运行，否则慢文件
+  可能被墙钟误判。
 
 ## 6. 多端兼容（三操作系统 + 三访问形态 + 明暗双主题）
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -452,6 +452,29 @@ export const inject: string[] = [];        // 声明 apply 用到的 ctx 服务�
 - **提交前自查**：`git status` 出现 `packages/*/undefined/`、`*.jsonl` 等运行时产物
   一律视为污染，不得提交；自动收集脚本（基线等）只收白名单路径。
 
+<a id="port-handle-discipline"></a><a id="user-content-port-handle-discipline"></a>
+### 5.4 端口与残留句柄纪律（#690 S2c）
+
+- **端口一律动态分配**：测试需要监听端口时用 `server.listen(0, ...)`，再从
+  `server.address().port` 读实际端口，**禁止写死端口号**——也包括「固定基数 + 随机区间」
+  这类写法，窄区间在并发下仍会碰撞。为什么：写死端口只在「严格串行 + 无残留进程」这一
+  脆弱前提下成立；实测同一端口被 8 个文件并发持有时 7 个 `EADDRINUSE`，Stryker 并发下
+  亦有 19998 互踩的历史记录（#147 / #217）。
+  「端口被占 → 启动失败」的**负向用例仍然保留**：先 `listen(0)` 占位拿到端口，再让被测
+  对象去绑同一端口——语义不变，只是不再写死端口号。
+- **残留句柄在 `finally` 里回收**：测试自己起的 server / socket / 定时器 / watcher 必须在
+  用例结束时关闭。`node --test` 的 per-file 隔离下，未回收的句柄会让**整个包**挂到 runner
+  超时才判红，而不是只红那一个文件。
+- **分诊工具（只报告，不判红）**：排查挂起或评估隔离模式时，先逐文件分诊：
+
+  ```sh
+  node scripts/gate/probe-handles.mjs [--only <子串>] [--timeout <ms>] [--grace <ms>] [--idle <ms>] [--json]
+  ```
+
+  它在 per-file 隔离下逐文件运行并给出四态：`clean` / `leak`（测试跑完但句柄吊住进程）/
+  `hang`（测试本身没跑完）/ `fail`（含顺序依赖在隔离下暴露）。判定依据与已知局限见该脚本
+  头注释。
+
 ## 6. 多端兼容（三操作系统 + 三访问形态 + 明暗双主题）
 
 dsh web 部署在 Linux 服务器，经局域网被多种设备 / 系统访问。插件（尤其客户端 UI 与

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -201,12 +201,14 @@ SessionHeader.origin / Agent.session），并同步根 README「版本适配」�
   禁双装**（同 id 双装 loader 报 duplicate）；改独立包 patch 后必须
   `node scripts/gate/aggregate.ts` 重新生成聚合 patch。
 - **测试**：`pnpm test` 直跑（包内实现为 `node ../../scripts/gate/run-tests.mjs --min <N>`，
-  底层 runner 是 `node --test "test/**/*.test.ts"`，`--test-isolation=none` 同进程串行）；
+  runner **逐文件 spawn** `node --test --test-isolation=process --test-concurrency=1 <file>`，
+  即每文件独立进程、包内严格串行；`--order lex|reverse|shuffle:<seed>` 可重排执行顺序，
+  用于验证「打乱文件列表结果不变」）；
   测试文件直跑 TS 源码（node 原生 type stripping），但部分文件断言 `lib/` 产物
   （如客户端产物契约），故跑前仍需 `pnpm build`；必含 403/405 围栏用例 +
   客户端契约断言（`assertClientSourceContract` / `assertClientProductContract`）。
-  `--min` 是**测试文件数**下限（glob 展开计数，不含 `test()` 子测试条目），用于封堵
-  `node --test` 零匹配仍 exit 0 的假绿向量。
+  `--min` 是**测试文件数**下限（glob 展开计数），用于封堵 `node --test` 零匹配仍 exit 0
+  的假绿向量；单文件超时（默认 10 分钟）按**进程组**回收并**点名**判红。
 
 ### 测试分层与变异面登记（#690 S2b / #713 T1–T3）
 
@@ -428,9 +430,14 @@ export const inject: string[] = [];        // 声明 apply 用到的 ctx 服务�
    严禁 `setTimeout(resolve, 50 / 300)` 这类「等够毫秒」的时序假设。参考 notifier 的
    `waitForHistory(route, predicate)` 辅助（轮询 GET 直到谓词成立，超时兜底返回当前态）。
 4. **测试文件禁止顶层悬挂 promise**：`node --test` 以「模块求值结束」判定文件测试通过，
-   悬挂的 `main().catch(...)` 会让体内断言在文件测试判定之后才跑——配合 runner 的收尾逻辑
-   会被整段吞掉（#690 S2 实测：注入必然失败的断言仍得 exit 0）。统一写法是顶层
-   `await main();`。唯一例外是经 `execFileSync` + 退出码/输出标记双重校验的 worker 脚本
+   悬挂的 `main().catch(...)` 会让体内断言在文件测试判定之后才跑，被整段吞掉（#690 S2 实测：
+   注入必然失败的断言仍得 exit 0）。统一写法是顶层 `await main();`。
+   **#690 S2c 切默认 per-file 隔离后复查：本约定仍然必要，故保留**——实测把
+   `dsh-lan-proxy/test/e2e/smoke.test.ts` 的顶层 `await main();` 改回悬挂形态，per-file 与
+   `--test-isolation=none` 两种模式下都是 `pass 1 / fail 0` + exit 0（假绿）。原因是 per-file
+   隔离只封堵「顶层 unsettled await」（模块求值永不完成 → node 判 `not ok`），封不住
+   fire-and-forget 的异步体（模块求值立即完成 → node 判通过）。唯一例外是经
+   `execFileSync` + 退出码/输出标记双重校验的 worker 脚本
    （`test/*.worker.mjs`，不参与 `test/**/*.test.ts` glob）。
 5. **fire-and-forget 写入禁止跨块断言顺序**：若写是 `void flush()` / 防抖定时器
    （如 opencode-usage 的 `schedulePersist`、notifier 的 `appendHistory`），绝不能依赖

--- a/packages/dsh-lan-proxy/test/e2e/smoke.test.ts
+++ b/packages/dsh-lan-proxy/test/e2e/smoke.test.ts
@@ -240,6 +240,19 @@ const tls = ensureSelfSignedTls({ dir: certDir, extraSans: [LAN_HOST] });
 let proxy;
 
 // ── helpers ─────────────────────────────────────────────────────────────────
+/**
+ * 取一个当前空闲的端口（bind(0) 后立即释放）。
+ * 为什么需要：个别用例要断言「生效端口等于启动时传入的端口」，需要一个**确定且不写死**的值；
+ * 直接传 0 会让断言退化成「0 == 0」，失去验证意义。
+ */
+async function freePort() {
+  const probe = createServer();
+  await new Promise((r) => probe.listen(0, "127.0.0.1", r));
+  const chosen = probe.address().port;
+  await new Promise((r) => probe.close(r));
+  return chosen;
+}
+
 function getViaProxy(headers) {
   return new Promise((resolve, reject) => {
     const req = httpRequest({ hostname: "127.0.0.1", port: PROXY_PORT, path: "/hello", method: "GET", headers }, (res) => {
@@ -1222,7 +1235,7 @@ const main = async () => {
       },
       effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
     };
-    apply(ctx, { host: "127.0.0.1", port: 19991, httpsEnabled: false });
+    apply(ctx, { host: "127.0.0.1", port: 0, httpsEnabled: false });
     const cleanup = () => { for (const d of disposers.reverse()) { try { d(); } catch {} } };
     check("RPC 配置通道不再注册（自建通道移除）", () => assert.equal(rpcHandles.length, 0));
     const healthRoute = routes.filter((r) => r.path === ROUTES.health)[0];
@@ -1350,7 +1363,8 @@ const main = async () => {
       inject() {},
       effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
     };
-    apply(ctx, { host: "127.0.0.1", port: 19992, httpsEnabled: false });
+    const degradedPort = await freePort();
+    apply(ctx, { host: "127.0.0.1", port: degradedPort, httpsEnabled: false });
     const configRoute = routes.find((r) => r.path === ROUTES.config);
     check("降级态：health 与 config 路由仍注册（卡片可读）", () => {
       assert.ok(routes.find((r) => r.path === ROUTES.health));
@@ -1364,7 +1378,7 @@ const main = async () => {
       const payload = JSON.parse(chunks.join(""));
       assert.equal(status, 200);
       assert.equal(payload.writable, false);
-      assert.equal(payload.effective.port, 19992);
+      assert.equal(payload.effective.port, degradedPort);
     });
     for (const d of [...disposers].reverse()) { try { d(); } catch {} }
     process.env.DSH_HOME = prevHome;
@@ -1390,7 +1404,7 @@ const main = async () => {
       inject() {},
       effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
     };
-    apply(ctx, { host: "127.0.0.1", port: 19993, httpsEnabled: false });
+    apply(ctx, { host: "127.0.0.1", port: 0, httpsEnabled: false });
 
     const apiRoute = ws.prefixes.get("/api");
     check("webServer handler 不被触碰（压缩在转发层，非宿主端 patch）", () => {
@@ -1439,7 +1453,7 @@ const main = async () => {
       inject() {},
       effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
     };
-    apply(ctx, { host: "127.0.0.1", port: 19994, httpsEnabled: false, httpCompressEnabled: false });
+    apply(ctx, { host: "127.0.0.1", port: 0, httpsEnabled: false, httpCompressEnabled: false });
     check("关闭压缩：health mounted=false", () => {
       assert.equal(ws.prefixes.get("/api").handler, apiHandler, "webServer handler 原样");
       assert.ok(ws.exact.has(ROUTES.health), "health 路由仍注册（转发功能不受影响）");
@@ -1480,7 +1494,7 @@ const main = async () => {
       },
       effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
     };
-    apply(ctx, { host: "127.0.0.1", port: 19995, httpsEnabled: false });
+    apply(ctx, { host: "127.0.0.1", port: 0, httpsEnabled: false });
     const healthMounted = () => {
       const hRes = new FakeRes();
       ws.exact.get(ROUTES.health).handler(makeReq(), hRes);

--- a/packages/dsh-lan-proxy/test/e2e/smoke.test.ts
+++ b/packages/dsh-lan-proxy/test/e2e/smoke.test.ts
@@ -1,9 +1,9 @@
 // @ts-nocheck
 // dsh-lan-proxy 冒烟测试 —— 无外部依赖。
 //
-// 在 127.0.0.1:19090 起一个"假 dsh web 服务器"（回显请求要素、对 WebSocket
-// 升级应答字节回显），把代理挂在 127.0.0.1:19091（HTTP）/ 19092（HTTPS）上
-// 指向它，然后验证：
+// 起一个"假 dsh web 服务器"（回显请求要素、对 WebSocket 升级应答字节回显），
+// 把代理挂在它的 HTTP / HTTPS 监听上指向它；端口一律 bind(0) 动态分配
+// （#690 S2c 端口治理：写死端口在并发或残留进程下会 EADDRINUSE 假阳性），然后验证：
 //   - Host/Origin 被重写为回环目标（围栏要求）
 //   - 无 Origin 的非浏览器请求也能通过
 //   - DNS 域名 Host 头被拒绝（重绑定防护）
@@ -37,9 +37,11 @@ import { apply, sanitizeSettings, validateSettings, ROUTES, pluginDir,
 // 结构化单元测试（issue #82 批次 2）由包内 `test/*.test.ts` glob 直接执行（#690 S2）；
 // 此处不再 import 聚合——聚合会让同一文件在同进程内被求值两遍。
 
-const UPSTREAM_PORT = 19090;
-const PROXY_PORT = 19091;
-const PROXY_HTTPS_PORT = 19092;
+// 端口在 main() 里 bind(0) 之后回填（#690 S2c / #713 T5）：写死端口在并发运行或残留
+// 进程下会 EADDRINUSE 假阳性；helpers 与断言按名引用，回填后语义不变。
+let UPSTREAM_PORT = 0;
+let PROXY_PORT = 0;
+let PROXY_HTTPS_PORT = 0;
 const LAN_HOST = "192.168.1.50";
 const failures = [];
 const pendingChecks = []; // 收集全部 async 用例 promise，收尾统一 allSettled（防迟到失败漏计 → 假绿）
@@ -234,14 +236,8 @@ upstream.on("upgrade", (req, socket) => {
 // ── proxy under test ────────────────────────────────────────────────────────
 const certDir = mkdtempSync(join(tmpdir(), "dsh-lan-proxy-test-"));
 const tls = ensureSelfSignedTls({ dir: certDir, extraSans: [LAN_HOST] });
-const proxy = createLanProxy({
-  host: "127.0.0.1",
-  port: PROXY_PORT,
-  httpsPort: PROXY_HTTPS_PORT,
-  tls,
-  targetHost: "127.0.0.1",
-  targetPort: UPSTREAM_PORT,
-});
+// proxy 在 main() 里创建：targetPort 必须等 upstream 绑定到具体端口后才确定。
+let proxy;
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 function getViaProxy(headers) {
@@ -343,8 +339,20 @@ function rawRequest(requestText) {
 }
 
 const main = async () => {
-  await new Promise((r) => upstream.listen(UPSTREAM_PORT, "127.0.0.1", r));
-  await proxy.listen();
+  await new Promise((r) => upstream.listen(0, "127.0.0.1", r));
+  UPSTREAM_PORT = upstream.address().port;
+  proxy = createLanProxy({
+    host: "127.0.0.1",
+    port: 0,
+    httpsPort: 0,
+    tls,
+    targetHost: "127.0.0.1",
+    targetPort: UPSTREAM_PORT,
+  });
+  const listening = await proxy.listen();
+  PROXY_PORT = listening.httpPort;
+  assert.ok(listening.httpsPort !== undefined, "HTTPS 应成功监听（端口动态分配）");
+  PROXY_HTTPS_PORT = listening.httpsPort;
   console.log("unit: hostnameAllowed / formatAuthority");
   check("accepts IPv4 literal", () => assert.equal(hostnameAllowed(`${LAN_HOST}:${PROXY_PORT}`), true));
   check("accepts bare IPv4 literal", () => assert.equal(hostnameAllowed(LAN_HOST), true));
@@ -748,7 +756,6 @@ const main = async () => {
   // ── 转发层 HTTP 压缩：真实 upstream × 真实 createLanProxy ─────────────────
   console.log("integration: 转发层 HTTP 压缩（compression 中间件）");
   {
-    const upPort = 19190, pxPort = 19191;
     const bigBody = JSON.stringify({ data: "y".repeat(300_000) });
     // issue #528 反向回归：跟踪「上游长连接被销毁」次数（客户端断开后上游 close）。
     let upstreamSseHoldClosed = 0;
@@ -783,7 +790,8 @@ const main = async () => {
         setTimeout(() => { res.socket?.destroy(); }, 30);
       } else { res.writeHead(404); res.end(); }
     });
-    await new Promise((r) => upstream.listen(upPort, "127.0.0.1", r));
+    await new Promise((r) => upstream.listen(0, "127.0.0.1", r));
+    const upPort = upstream.address().port;
 
     const requestThrough = (port, path, headers) => new Promise((resolve, reject) => {
       const req = httpRequest({ host: "127.0.0.1", port, path, headers: { host: "127.0.0.1", ...headers } }, (res) => {
@@ -796,10 +804,10 @@ const main = async () => {
     });
 
     const proxyOn = createLanProxy(
-      { host: "127.0.0.1", port: pxPort, targetHost: "127.0.0.1", targetPort: upPort, httpCompress: { enabled: true, level: 1 } },
+      { host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort, httpCompress: { enabled: true, level: 1 } },
       console,
     );
-    await proxyOn.listen();
+    const { httpPort: pxPort } = await proxyOn.listen();
 
     let r = await requestThrough(pxPort, "/big", { "accept-encoding": "gzip" });
     check("转发层：大 JSON 经代理被 gzip 且解压逐字节一致", () => {
@@ -902,11 +910,11 @@ const main = async () => {
     await proxyOn.close();
 
     const proxyOff = createLanProxy(
-      { host: "127.0.0.1", port: pxPort + 1, targetHost: "127.0.0.1", targetPort: upPort, httpCompress: { enabled: false, level: 1 } },
+      { host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort, httpCompress: { enabled: false, level: 1 } },
       console,
     );
-    await proxyOff.listen();
-    r = await requestThrough(pxPort + 1, "/big", { "accept-encoding": "gzip" });
+    const { httpPort: pxPortOff } = await proxyOff.listen();
+    r = await requestThrough(pxPortOff, "/big", { "accept-encoding": "gzip" });
     check("转发层：enabled=false 全透传", () => {
       assert.equal(r.headers["content-encoding"], undefined);
       assert.equal(r.body.toString(), bigBody);

--- a/packages/dsh-lan-proxy/test/unit/unit-apply.test.ts
+++ b/packages/dsh-lan-proxy/test/unit/unit-apply.test.ts
@@ -277,11 +277,13 @@ const { createServer } = await import("node:http");
   const applyHome = mkdtempSync(join(tmpdir(), "dsh-lan-proxy-apply-listenfail-"));
   const prevHome = process.env.DSH_HOME;
   process.env.DSH_HOME = applyHome;
-  // 占用一个具体端口（#217 回滚：unit-apply 在 stryker 变异面内，port 0 随机化
-  // 破坏变异覆盖（covered 57.9% < 60% 阈值）；19998 在单包 tap runner 上下文安全，
-  // 真正 CI flake 来自 smoke 端口另见 #217 子项）
+  // 占位端口改为动态分配（#690 S2c / #713 T5）：写死端口在并发运行或残留进程下会
+  // EADDRINUSE 假阳性。这与 #217 回滚的「apply 传 port: 0」不是同一件事——那种写法会让
+  // listen 成功、走不到 catch 分支（covered 掉到 57.9%）；这里 occupied 先占位，apply 绑
+  // 同一端口仍必然失败，被覆盖的分支不变。
   const occupied = createServer();
-  await new Promise((r) => occupied.listen(19998, "127.0.0.1", r));
+  await new Promise((r) => occupied.listen(0, "127.0.0.1", r));
+  const occupiedPort = occupied.address().port;
   const routes = [];
   const rpcHandles = [];
   const disposers = [];
@@ -296,7 +298,7 @@ const { createServer } = await import("node:http");
     effect(fn) { const d = fn(); if (typeof d === "function") disposers.push(d); return d; },
   };
   const { apply } = await import("../../lib/index.js");
-  apply(ctx, { host: "127.0.0.1", port: 19998, httpsEnabled: false, printBanner: false, wsCompressEnabled: false, httpCompressEnabled: false });
+  apply(ctx, { host: "127.0.0.1", port: occupiedPort, httpsEnabled: false, printBanner: false, wsCompressEnabled: false, httpCompressEnabled: false });
   await sleep(200); // 等 listen 异步 reject
   // health 路由存在，但 listening: false
   const healthRoute = routes.find((r) => r.path === ROUTES.health);

--- a/packages/dsh-lan-proxy/test/unit/unit-apply.test.ts
+++ b/packages/dsh-lan-proxy/test/unit/unit-apply.test.ts
@@ -203,7 +203,9 @@ const { createServer } = await import("node:http");
   };
 
   const { apply } = await import("../../lib/index.js");
-  apply(ctx, { host: "127.0.0.1", port: 0, httpsEnabled: true, printBanner: false, wsCompressEnabled: false, httpCompressEnabled: false });
+  // httpsPort 显式传 0：不传会落到产品默认值 3443 并**真实监听**（端口审计实测），
+  // 并发或残留进程下即 EADDRINUSE（#690 S2c 端口治理）。
+  apply(ctx, { host: "127.0.0.1", port: 0, httpsPort: 0, httpsEnabled: true, printBanner: false, wsCompressEnabled: false, httpCompressEnabled: false });
 
   await sleep(100);
 

--- a/packages/dsh-lan-proxy/test/unit/unit-proxy.test.ts
+++ b/packages/dsh-lan-proxy/test/unit/unit-proxy.test.ts
@@ -188,7 +188,6 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 {
   const { WebSocketServer, WebSocket: WsClient } = await import("ws");
 
-  const upPort = 19790 + Math.floor(Math.random() * 100);
   const upServer = createServer();
   const wss = new WebSocketServer({ noServer: true });
   upServer.on("upgrade", (req, socket, head) => {
@@ -196,7 +195,8 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
       ws.on("message", (data, isBinary) => ws.send(data, { binary: isBinary }));
     });
   });
-  await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+  await new Promise((r) => upServer.listen(0, "127.0.0.1", r));
+  const upPort = upServer.address().port;
 
   const proxy = createLanProxy({
     host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
@@ -230,7 +230,6 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 {
   const { WebSocketServer, WebSocket: WsClient } = await import("ws");
 
-  const upPort = 19850 + Math.floor(Math.random() * 100);
   const upServer = createServer();
   const wss = new WebSocketServer({ noServer: true });
   let upgradeHeaders = null;
@@ -240,7 +239,8 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
       ws.on("message", (data, isBinary) => ws.send(data, { binary: isBinary }));
     });
   });
-  await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+  await new Promise((r) => upServer.listen(0, "127.0.0.1", r));
+  const upPort = upServer.address().port;
 
   const proxy = createLanProxy({
     host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
@@ -287,7 +287,6 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 {
   const { WebSocket: WsClient, WebSocketServer } = await import("ws");
 
-  const upPort = 21050 + Math.floor(Math.random() * 40);
   const upServer = createServer();
   const wss = new WebSocketServer({ noServer: true });
   let noCookieUpgrades = 0;
@@ -303,7 +302,8 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
       ws.on("message", (data, isBinary) => ws.send(data, { binary: isBinary }));
     });
   });
-  await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+  await new Promise((r) => upServer.listen(0, "127.0.0.1", r));
+  const upPort = upServer.address().port;
 
   const proxy = createLanProxy({
     host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
@@ -339,7 +339,6 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 // —— 断言 1 + 3：真 echo 上游（ws 库自动回 pong）→ ping 按间隔到达、连接不被误杀 ——
 {
   const { WebSocketServer, WebSocket: WsClient } = await import("ws");
-  const upPort = 19950 + Math.floor(Math.random() * 40);
   const upServer = createServer();
   const wss = new WebSocketServer({ noServer: true });
   let upstreamPings = 0; // 真 echo 上游收到的 ping 帧数 = 上游段探活按间隔发出
@@ -349,7 +348,8 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
       ws.on("message", (data, isBinary) => ws.send(data, { binary: isBinary }));
     });
   });
-  await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+  await new Promise((r) => upServer.listen(0, "127.0.0.1", r));
+  const upPort = upServer.address().port;
 
   const proxy = createLanProxy({
     host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
@@ -387,12 +387,12 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 // pong）→ 上游段探活超时 terminate → close 互断逻辑关闭浏览器端（1006）。
 {
   const { WebSocket: WsClient } = await import("ws");
-  const silentPort = 20000 + Math.floor(Math.random() * 40);
   const silentServer = createServer((req, res) => res.destroy());
   silentServer.on("upgrade", (req, socket) => {
     socket.write(wsHandshakeResponse(req.headers["sec-websocket-key"]));
   });
-  await new Promise((r) => silentServer.listen(silentPort, "127.0.0.1", r));
+  await new Promise((r) => silentServer.listen(0, "127.0.0.1", r));
+  const silentPort = silentServer.address().port;
 
   const proxy = createLanProxy({
     host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: silentPort,
@@ -417,7 +417,6 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 // raw 假客户端经 node:http upgrade 拿裸 socket（不回 pong）连压缩白名单路径。
 {
   const { WebSocketServer } = await import("ws");
-  const upPort = 20050 + Math.floor(Math.random() * 40);
   const upServer = createServer();
   const wss = new WebSocketServer({ noServer: true });
   let upstreamClosed = false;
@@ -427,7 +426,8 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
       ws.on("close", () => { upstreamClosed = true; });
     });
   });
-  await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+  await new Promise((r) => upServer.listen(0, "127.0.0.1", r));
+  const upPort = upServer.address().port;
 
   const proxy = createLanProxy({
     host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: upPort,
@@ -530,9 +530,7 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 {
   const { WebSocketServer, WebSocket: WsClient } = await import("ws");
 
-  async function mkUpstream(portOffset) {
-    // 端口区间错开前置测试（19850+rand(100) 最大 19949）：取 20100+ 避免碰撞。
-    const upPort = 20100 + portOffset + Math.floor(Math.random() * 60);
+  async function mkUpstream() {
     const upServer = createServer();
     const wss = new WebSocketServer({ noServer: true });
     upServer.on("upgrade", (req, socket, head) => {
@@ -540,7 +538,8 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
         ws.on("message", (data, isBinary) => ws.send(data, { binary: isBinary }));
       });
     });
-    await new Promise((r) => upServer.listen(upPort, "127.0.0.1", r));
+    await new Promise((r) => upServer.listen(0, "127.0.0.1", r));
+    const upPort = upServer.address().port;
     return { upPort, upServer, wss };
   }
   /** 经代理建一条 WS 连接、等 open、重试发送帧至回显（上游段 open 竞态：桥接的
@@ -562,7 +561,7 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 
   // a) wsBridge=false：命中白名单路径也走透传（显式放弃桥接/保活）
   {
-    const u = await mkUpstream(0);
+    const u = await mkUpstream();
     const proxy = createLanProxy({
       host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: u.upPort,
       wsBridge: { enabled: false },
@@ -580,7 +579,7 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 
   // b) wsBridge=true：未命中白名单路径也走桥接（保活基座不依赖压缩白名单）
   {
-    const u = await mkUpstream(100);
+    const u = await mkUpstream();
     const proxy = createLanProxy({
       host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: u.upPort,
       wsBridge: { enabled: true },
@@ -598,7 +597,7 @@ assert.equal(DEFAULT_OPTIONS.targetHost, "127.0.0.1");
 
   // c) wsBridge 缺省（旧行为兼容）：命中白名单走桥接、未命中走透传
   {
-    const u = await mkUpstream(200);
+    const u = await mkUpstream();
     const proxy = createLanProxy({
       host: "127.0.0.1", port: 0, targetHost: "127.0.0.1", targetPort: u.upPort,
       wsCompress: { enabled: true, paths: ["/api/remote.mux"], probeIntervalMs: 0 },

--- a/packages/dsh-mcp-manager/docs/requirements-and-tdd-plan.md
+++ b/packages/dsh-mcp-manager/docs/requirements-and-tdd-plan.md
@@ -291,7 +291,7 @@
 ## 七、现有测试审计（子代理报告要点）
 
 ### 7.1 运行模型与执行矩阵（关键不对称）
-- `pnpm test` = scripts/gate/run-tests.mjs（`node --test --test-isolation=none` 跑 `test/**/*.test.ts`）；smoke.test.ts 内联 check/checkAsync，其余 15 个单元/契约文件由 glob 直接执行（#690 S2 起不再由 smoke import 聚合）；断言 node:assert/strict（仅 unit-call-stats 用 node:test）。
+- `pnpm test` = scripts/gate/run-tests.mjs（逐文件 spawn `node --test --test-isolation=process --test-concurrency=1`，包内串行）；smoke.test.ts 内联 check/checkAsync，其余 15 个单元/契约文件由 glob 直接执行（#690 S2 起不再由 smoke import 聚合）；断言 node:assert/strict（仅 unit-call-stats 用 node:test）。
 - 被测 lib/ 产物；stryker 经 `--import scripts/test/mutation-lib-to-src-hook.mjs` ESM resolve hook 把 lib→src 重定向，同一份断言复用（#423）。
 - service-contract.test.ts 双层锁：编译期类型比对（tsc）+ 运行时静态扫描 apply-services 的 provide 方法面（手写括号配对，fail-loud）。
 - **三通道不对称**：

--- a/packages/dsh-notifier/docs/requirements-and-tdd-plan.md
+++ b/packages/dsh-notifier/docs/requirements-and-tdd-plan.md
@@ -193,7 +193,7 @@
 
 ## 3. 测试套件审计结论（覆盖全读 + 盲区交叉验证）
 
-- 运行模型：非 node:test；顶层 assert + try/finally；`test/**/*.test.ts` 经 scripts/gate/run-tests.mjs（`node --test --test-isolation=none`，同进程串行）执行（防 fetch mock 交错 #508；#690 S2 前由 smoke.ts 聚合入口承担）；测试主体 import `../lib/index.js` 产物；变异经 hook 重定向 src
+- 运行模型：非 node:test；顶层 assert + try/finally；`test/**/*.test.ts` 经 scripts/gate/run-tests.mjs（逐文件 spawn `node --test --test-isolation=process --test-concurrency=1`，包内串行）执行（防 fetch mock 交错 #508；#690 S2 前由 smoke.ts 聚合入口承担）；测试主体 import `../lib/index.js` 产物；变异经 hook 重定向 src
 - 断言强度：整体强（文案精确 match / 状态机中间态 / HTTP 逐字段 / 脱敏深等 / service.update 只收变更键）；哑断言仅 e2e-edge:210/224 两处 `assert.ok(true)`；无读私有字段；轮询为主（waitForHistory/pollUntil/pollStatus 20ms）
 - 孤儿判定：**无孤儿**（16/16 在主入口）；7 个较新测试文件（unit-sse-hub/unit-webhook/real-context/service-contract/client-contract/client-style）**不在 stryker 9 文件清单**（登记裁剪，config _comment「测试全套跑」与事实不符）；被测 service.ts/event-handlers.ts/channel-*/aggregate/status/outbound/settings-bridge 亦不在 4 个 mutate 段（有意的段裁剪，但核心状态机无变异面）
 - 类型面盲区：dsh-notifier/test/tsconfig.json 无任何消费方（service-contract-wiring 只接 mcp-manager/codegraph）；测试全 @ts-nocheck → 类型面零编译校验

--- a/packages/dsh-provider-usage/test/unit/shared/unit-config.test.ts
+++ b/packages/dsh-provider-usage/test/unit/shared/unit-config.test.ts
@@ -16,7 +16,6 @@ import { mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from
 console.error("EVAL-ORDER-TAG: CONFIG");
 import { join } from "node:path";
 import { tmpdir, homedir } from "node:os";
-import { spawnSync } from "node:child_process";
 import { assert } from "../../helpers.ts";
 import {
   normalizeConfig,
@@ -38,68 +37,11 @@ import {
   parseUserAdapters,
   resolveAddAdapterFile,
   resolveProviderConfig,
+  expandHomePath,
 } from "../../../lib/index.js";
 
-/**
- * 在独立子进程内验证 ~ 展开并命中 HOME 内文件。
- *
- * untildify 对 homedir() 首调固化且不可重置：正向用例只有在「本进程首次调用发生在受控
- * HOME 之后」时才可达。glob 化（#690 S2）后文件求值顺序不再可控（smoke.test.ts 可能先以
- * 外部 HOME 固化），故用子进程取得干净的固化起点——子进程只加载本包产物，首调必然受控。
- * 失败以退出码 3/4/5 区分（固化落点 / 展开落点 / 解析结果），不做静默降级。
- */
-/**
- * 子进程只继承 ESM loader 钩子（Stryker tap-runner 用 `--import` 注入 lib→src 重定向）：
- * 不继承则子进程读到未变异的 lib 产物，被测路径的变异体会逃逸、拉低变异分。
- * `-r/--require` 是 tap-runner 的覆盖率桥，与本探针无关，故不继承。
- */
-function inheritedLoaderArgs(): string[] {
-  const FLAGS = new Set(["--import", "--loader", "--experimental-loader"]);
-  const out: string[] = [];
-  for (let i = 0; i < process.execArgv.length; i += 1) {
-    const arg = process.execArgv[i];
-    const flag = [...FLAGS].find((f) => arg === f || arg.startsWith(`${f}=`));
-    if (!flag) continue;
-    out.push(arg);
-    if (arg === flag && process.execArgv[i + 1] !== undefined) {
-      out.push(process.execArgv[i + 1]);
-      i += 1;
-    }
-  }
-  return out;
-}
-
-function assertTildeResolutionInChild(home: string): void {
-  const libUrl = new URL("../../../lib/index.js", import.meta.url).href;
-  const probe = "dou-tilde-probe.mjs";
-  const script = `
-const { expandHomePath, resolveAddAdapterFile } = await import(${JSON.stringify(libUrl)});
-const { writeFileSync } = await import("node:fs");
-const home = process.env.DSH_HOME;
-const frozen = expandHomePath("~");
-if (frozen !== home) { console.error("freeze=" + frozen); process.exit(3); }
-const target = expandHomePath("~/${probe}");
-if (!target.startsWith(home)) { console.error("target=" + target); process.exit(4); }
-writeFileSync(target, "export default {};", "utf8");
-const resolved = resolveAddAdapterFile("~/${probe}");
-if (resolved !== target) { console.error("resolved=" + resolved); process.exit(5); }
-`;
-  const child = spawnSync(process.execPath, [...inheritedLoaderArgs(), "--input-type=module", "-e", script], {
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      HOME: home,
-      DSH_HOME: home,
-      ...(process.platform === "win32" ? { USERPROFILE: home } : {}),
-    },
-  });
-  assert.equal(child.status, 0,
-    `~ 展开子进程探针失败（status=${child.status}）：${(child.stderr || child.stdout || "").trim()}`);
-}
-
 // ================================================================ #150 二阶段：resolveAddAdapterFile 路径校验矩阵
-// 位置无关：本块断言全部不依赖「本文件先于兄弟文件求值」。唯一依赖 homedir 固化
-// 时机的 ~ 展开正向用例改由独立子进程执行（见 assertTildeResolutionInChild）。
+// 位置无关：本块断言全部不依赖「本文件先于兄弟文件求值」。
 
 {
   // HOME/DSH_HOME 指向临时目录；~ 展开、绝对路径、目录拒绝都基于真实文件系统
@@ -133,9 +75,15 @@ if (resolved !== target) { console.error("resolved=" + resolved); process.exit(5
     assert.equal(resolveAddAdapterFile(home), undefined, "目录路径拒绝");
 
     // ~ 展开正向用例（isAbsolute(trimmed) false → 相对分支命中 dshHome 基座）：
-    // untildify 对 homedir() 首调固化且进程内不可重置，父进程的固化落点取决于兄弟
-    // 文件的求值顺序；glob 化后顺序不可控，故放进独立子进程验证。
-    assertTildeResolutionInChild(home);
+    // untildify 对 homedir() 首调固化且进程内不可重置，但 per-file 隔离（#690 S2c）下每个
+    // 测试文件独占进程，兄弟文件不再影响本文件的固化落点；而本块在此之前已把 HOME/DSH_HOME
+    // 指向受控临时目录，故可直接在文件内断言——#712 的子进程过渡补丁已拆。
+    assert.equal(expandHomePath("~"), home, "~ 展开命中受控 HOME（固化落点正确）");
+    const tildeProbe = "dou-tilde-probe.mjs";
+    const tildeTarget = expandHomePath(`~/${tildeProbe}`);
+    assert.ok(tildeTarget.startsWith(home), `~ 展开应落在 HOME 内：${tildeTarget}`);
+    writeFileSync(tildeTarget, "export default {};", "utf8");
+    assert.equal(resolveAddAdapterFile(`~/${tildeProbe}`), tildeTarget, "~ 展开并命中 HOME 内文件");
     // 负向用例与固化落点无关：未创建的同名探针必不存在
     assert.equal(resolveAddAdapterFile("~/dou-no-such-probe.mjs"), undefined, "~ 路径文件不存在拒绝");
 

--- a/scripts/gate/probe-handles.mjs
+++ b/scripts/gate/probe-handles.mjs
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+/**
+ * probe-handles — 测试文件「残留句柄 / 挂起 / 顺序依赖」分诊探针（#690 S2c / #713 T5 前半）。
+ *
+ * 为什么需要这层探针：`--test-isolation=none` 下没有 per-file 结束边界，残留句柄只表现为
+ * 「整包进程不退出」，由 runner 的 20 分钟 spawn 超时兜底——**无法定位到具体文件**。切默认
+ * per-file 隔离前必须先拿到「哪些文件有残留、哪些文件依赖求值顺序」的清单，否则会一次性
+ * 暴露大量既有缺陷（#713 风险 2：PR 过大、无法归因）。
+ *
+ * 四态为什么这样分（本机实测的失败形态，见 PR 正文）：
+ *   - `leak`：`--test-force-exit` 对照组能正常退出 —— 测试逻辑跑完了，是残留句柄（定时器 /
+ *     socket / watcher）吊住了进程。per-file 隔离下这是会退化成「整包挂起」的形态。
+ *   - `stall`：超时/静默且对照组也挂住 —— 探针**无法**区分「句柄残留」与「测试没跑完」，
+ *     如实报出交人工复核（成因见下面的对照组局限）。
+ *   - `fail`：退出码非零 —— 既可能是真实断言失败，也可能是**顺序依赖**在隔离下暴露
+ *     （per-file 让每个文件独占进程，掩盖它的「兄弟文件先跑了什么」不再成立），还可能是
+ *     顶层 unsettled await（per-file 下 node 自己判红，而 none 模式下它是静默的 `1..0`）。
+ *   - `clean`：按时退出、无失败、且汇总后 graceMs 内收尾。
+ *
+ * 对照组为什么不总有效：`--test-force-exit` 只对**注册了 node:test 测试**的文件生效。本仓
+ * 多数测试文件是脚本式（自研 check / 直接断言，不注册测试），实测给这类文件注入 `setInterval`
+ * 后，A（无 force-exit）与对照组 B（有 force-exit）都会 exit 137 且不输出 TAP 汇总。这类文件
+ * 既可能是句柄残留、也可能只是慢，探针不去猜——直接报 `stall`。故 `leak` 的检出面主要覆盖
+ * 已迁到 node:test 的文件；脚本式文件的超时一律要人工看一眼。
+ *
+ * 为什么要对照组而不是「看 TAP 汇总有没有输出」：实测 per-file 隔离下子进程不退出时，父进程
+ * 根本不会打印顶层汇总与 `1..N`（它在等子进程结束），汇总缺失同时覆盖 leak 与 hang 两种情况，
+ * 单靠它无法分诊（首版实现即因此把 `setInterval` 泄漏误判成 hang）。
+ *
+ * 为什么不用 `--test-timeout` 判残留：实测对模块级句柄无效——该参数只作用于测试函数体内，
+ * 泄漏文件仍会跑满超时（`setInterval` 泄漏用例在 none/process 两种模式下都是 exit 137 挂死）。
+ *
+ * 为什么超时必须杀**进程组**：per-file 隔离下 node 会为每个文件再派生一个 worker，只杀直接
+ * 子进程会留下孤儿 worker——实测其继续持有 `127.0.0.1:19998`，污染后续所有运行。故 spawn 用
+ * `detached: true` 建独立进程组，超时以 `kill(-pid)` 整组回收。同一机制由 PR-2 的 runner 采用。
+ *
+ * 为什么串行：本仓测试存在真实固定端口监听（lan-proxy 的 19090/19091/19092），并发探测会
+ * 互相 `EADDRINUSE`（实测 8 文件并发抢同一端口 → 7/8 失败），得到的是假阳性而非分诊。
+ *
+ * 用法（仓库根执行）：
+ *   node scripts/gate/probe-handles.mjs [--only <子串>] [--timeout <ms>] [--grace <ms>] [--idle <ms>] [--json]
+ * 退出码：0 = 探测完成（探测结果本身不判红，它是分诊输入而非门禁）；2 = 用法错误。
+ *
+ * 纯函数与 CLI 分离（沿用 test-surface.mjs 的纪律）：`probeFile` / `triage` 可被测试 import，
+ * import 时不枚举仓库、不 spawn 任何进程；只有直接执行本文件才跑 CLI。
+ */
+import { spawn } from 'node:child_process'
+import { join, relative, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { RUN_TESTS_PATTERN, discoverTestPackages, expandGlob } from './test-surface.mjs'
+
+const DEFAULT_ROOT = join(import.meta.dirname, '..', '..')
+
+/**
+ * 单文件墙钟上限。为什么默认 6 分钟：最慢的 `dsh-mcp-manager/test/e2e/smoke.test.ts` 含 SDK
+ * stdio 端到端，实测单跑 328s；上限低于它会把「慢」误判成 `hang`，而 hang 与慢的区分正是
+ * 本探针要给出的信号，不能用会制造假阳性的默认值。
+ */
+const DEFAULT_TIMEOUT_MS = 6 * 60 * 1000
+/** 汇总输出后允许的退出延迟。正常文件在汇总后 <100ms 内退出，给 2s 余量吸收调度抖动。 */
+const DEFAULT_GRACE_MS = 2000
+/**
+ * 静默窗口：仅在显式传 `--idle <ms>` 时启用，**默认关闭**。
+ * 为什么默认关闭：它是纯启发式——把「测试跑起来过、又连续静默这么久」当作「跑完被句柄吊住」。
+ * 实测 mcp-manager 的两个文件（e2e/smoke 与 unit/unit-middleware）在等待真实子进程时有约 30s
+ * 的中间静默，30s 窗口把它们误判成 leak。分诊表的「干净」结论必须零假阳性，故默认不用启发式；
+ * 需要快速扫一遍时再显式开它，并接受个别慢测试可能被误报（结果里 `stalled` 字段可用于识别）。
+ */
+const DEFAULT_IDLE_MS = 0
+
+function usage(msg) {
+  if (msg !== undefined) console.error(`probe-handles: ${msg}`)
+  console.error('用法: node scripts/gate/probe-handles.mjs [--only <子串>] [--timeout <ms>] [--grace <ms>] [--idle <ms>] [--json]')
+  process.exit(2)
+}
+
+function readFlag(argv, name, fallback) {
+  const i = argv.indexOf(name)
+  if (i < 0) return fallback
+  const raw = argv[i + 1]
+  const n = Number(raw)
+  if (!Number.isInteger(n) || n < 0) usage(`${name} 需要一个非负整数，收到 "${raw}"`)
+  return n
+}
+
+const argv = process.argv.slice(2)
+
+/** 跑一次单文件探测（per-file 隔离）；返回原始证据，不做四态判定。 */
+function runOnce(pkgDir, relFile, timeout, { forceExit = false, idleMs = 0 } = {}) {
+  return new Promise((resolve) => {
+    const args = ['--test', '--test-isolation=process', '--test-concurrency=1', '--test-reporter=tap']
+    // `--test-force-exit` 只在探针的**对照组**里用。为什么不能只靠「TAP 汇总是否输出」判 leak：
+    // 实测 per-file 隔离下子进程不退出时，父进程根本不会打印顶层汇总与 `1..N`（它在等子进程结束），
+    // 所以汇总缺失既可能是 leak 也可能是 hang。force-exit 让「测试逻辑跑完即退出」，于是
+    // A 超时而 B 正常退出 = 测试跑完、是句柄吊住了进程（leak）；A/B 都超时 = 测试本身没跑完（hang）。
+    // 注意这与 runner 禁用该 flag 并不矛盾：那里它是假绿载体（截断悬挂 main 的断言），这里只作对照。
+    if (forceExit) args.push('--test-force-exit')
+    args.push(relFile)
+
+    // 剔除 node:test 的 IPC 上下文：探针自身若跑在 `node --test` 内（回归测试就是这样调它的），
+    // 子进程继承 NODE_TEST_CONTEXT 后会把测试事件上报给**外层** runner、stdout 不再是 TAP，
+    // 探针的汇总/计划解析会全部落空（run-tests-runner.test.ts 记了同一坑）。
+    const env = { ...process.env }
+    delete env.NODE_TEST_CONTEXT
+    delete env.NODE_TEST_WORKER_ID
+
+    const child = spawn(process.execPath, args, { cwd: pkgDir, detached: true, stdio: ['ignore', 'pipe', 'pipe'], env })
+
+    const startedAt = Date.now()
+    let stdout = ''
+    let stderr = ''
+    let summaryAt = null
+    let timedOut = false
+    let stalled = false
+    let killFallback = null
+    let done = false
+
+    const settle = (code, signal) => {
+      if (done) return
+      done = true
+      clearTimeout(hardTimer)
+      if (idleTimer !== null) clearTimeout(idleTimer)
+      if (killFallback !== null) clearTimeout(killFallback)
+      const endedAt = Date.now()
+      resolve({
+        exitCode: code,
+        signal,
+        timedOut,
+        stalled,
+        hasOutput: stdout.length > 0,
+        elapsedMs: endedAt - startedAt,
+        exitDelayMs: summaryAt === null ? null : endedAt - summaryAt,
+        notOk: (stdout.match(/^not ok /gm) ?? []).length,
+        plan: (stdout.match(/^1\.\.(\d+)$/m) ?? [])[1],
+        stderrTail: stderr.trim().split('\n').slice(-6).join('\n'),
+      })
+    }
+
+    // 整组回收：worker 与父 node 在同一进程组（detached 建组），只杀父会留孤儿。
+    const hardKill = () => {
+      try { process.kill(-child.pid, 'SIGKILL') } catch { /* 组已消失 */ }
+      // KILL 后仍不触发 exit 说明进程处于不可中断状态，兜底 settle 以免探针自身挂死。
+      killFallback = setTimeout(() => settle(null, 'SIGKILL'), 10 * 1000)
+    }
+
+    const hardTimer = setTimeout(() => { timedOut = true; hardKill() }, timeout)
+
+    /**
+     * 静默判定：测试跑起来过（有输出）却长时间不再产出，说明它已经跑完、被残留句柄吊住。
+     * 为什么必须要求「有过输出」：纯计算型测试可能长时间无输出，直接判 stall 会把「慢」误判成 leak。
+     * 提前 kill 只是省时间，**结论仍以对照组为准**（对照组也超时即判 hang，误判会被兜回）。
+     */
+    let idleTimer = null
+    const armIdle = () => {
+      if (idleMs <= 0) return
+      if (idleTimer !== null) clearTimeout(idleTimer)
+      idleTimer = setTimeout(() => {
+        if (stdout.length === 0) return
+        stalled = true
+        hardKill()
+      }, idleMs)
+    }
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+      // TAP 顶层汇总块以 `# duration_ms ` 结尾；子测试里的 `duration_ms:` 带缩进与冒号，不匹配。
+      if (summaryAt === null && /^# duration_ms /m.test(stdout)) summaryAt = Date.now()
+      armIdle()
+    })
+    child.stderr.on('data', (chunk) => { stderr += chunk; armIdle() })
+    child.on('error', (err) => { stderr += `\nspawn 失败: ${err.message}`; settle(null, null) })
+    child.on('exit', (code, signal) => settle(code, signal))
+    armIdle()
+  })
+}
+
+/** 探测单个文件；返回四态之一与计时/计数证据。 */
+export async function probeFile(pkgDir, relFile, timeout, grace, idleMs = 0) {
+  const a = await runOnce(pkgDir, relFile, timeout, { idleMs })
+  let status
+  let control = null
+
+  if (a.timedOut || a.stalled) {
+    // 对照组：A 被提前 kill 时按它已耗时给余量，避免对照组本身也跑满长超时。
+    const controlTimeout = a.stalled && !a.timedOut
+      ? Math.min(timeout, Math.max(a.elapsedMs * 2, 60 * 1000))
+      : timeout
+    control = await runOnce(pkgDir, relFile, controlTimeout, { forceExit: true, idleMs })
+    if (!control.timedOut && !control.stalled) {
+      status = control.exitCode !== 0 ? 'fail' : 'leak'
+    } else {
+      // 对照组也挂住：`--test-force-exit` 只对**注册了 node:test 测试**的文件生效，脚本式文件
+      // （本仓多数）下它与 A 一样挂死——实测给脚本式文件注入 `setInterval` 后 A/B 都 exit 137
+      // 且无 TAP 汇总。此时探针**无法**区分「句柄残留」与「测试没跑完」（连「有无输出」都区分
+      // 不了：node --test 对任何文件都会先输出框架行），用静默启发式去猜会把慢测试的中间静默
+      // 误报成 leak（mcp-manager 两个文件实测如此）。故如实报 stall，交人工看 stdout 定性。
+      status = 'stall'
+    }
+  } else if (a.exitCode !== 0) {
+    status = 'fail'
+  } else if (a.exitDelayMs !== null && a.exitDelayMs > grace) {
+    // 测试跑完但拖了很久才退出：句柄最终自行结束（如未清理的 setTimeout），仍属残留。
+    status = 'leak'
+  } else {
+    status = 'clean'
+  }
+
+  return {
+    file: relFile,
+    status,
+    exitCode: a.exitCode,
+    signal: a.signal,
+    timedOut: a.timedOut,
+    stalled: a.stalled,
+    hasOutput: a.hasOutput,
+    elapsedMs: a.elapsedMs,
+    exitDelayMs: a.exitDelayMs,
+    controlElapsedMs: control === null ? null : control.elapsedMs,
+    notOk: a.notOk,
+    plan: a.plan === undefined ? null : Number(a.plan),
+    stderrTail: status === 'clean' ? '' : a.stderrTail,
+  }
+}
+
+/** 枚举仓库内（或注入的 fixture 根内）全部测试文件并**串行**探测。返回逐文件结果数组。 */
+export async function triage(root, { only, timeoutMs, graceMs, idleMs = 0, onResult } = {}) {
+  const targets = []
+  for (const { pkgName } of discoverTestPackages(root)) {
+    const pkgDir = join(root, 'packages', pkgName)
+    for (const abs of expandGlob(pkgDir, RUN_TESTS_PATTERN)) {
+      const rel = relative(pkgDir, abs).split(sep).join('/')
+      if (only !== undefined && !`${pkgName}/${rel}`.includes(only)) continue
+      targets.push({ pkgName, pkgDir, rel })
+    }
+  }
+  const results = []
+  for (const { pkgName, pkgDir, rel } of targets) {
+    const r = { pkgName, ...(await probeFile(pkgDir, rel, timeoutMs, graceMs, idleMs)) }
+    results.push(r)
+    // 进度回调在探测**过程中**触发：leak 文件会占用数十秒到数分钟，没有进度就无法判断
+    // 探针是在推进还是已经挂死（首版即因此盲等过一轮）。
+    onResult?.(r, results.length, targets.length)
+  }
+  return results
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const only = argv.includes('--only') ? argv[argv.indexOf('--only') + 1] : undefined
+  const timeoutMs = readFlag(argv, '--timeout', DEFAULT_TIMEOUT_MS)
+  const graceMs = readFlag(argv, '--grace', DEFAULT_GRACE_MS)
+  const idleMs = readFlag(argv, '--idle', DEFAULT_IDLE_MS)
+  const asJson = argv.includes('--json')
+
+  const results = await triage(DEFAULT_ROOT, {
+    only,
+    timeoutMs,
+    graceMs,
+    idleMs,
+    onResult: (r, i, total) => {
+      const delay = r.exitDelayMs === null ? '-' : `${r.exitDelayMs}ms`
+      console.error(`[${i}/${total}] ${r.status.padEnd(5)} ${String(r.elapsedMs).padStart(8)}ms  汇总后 ${delay.padStart(8)}  ${r.pkgName}/${r.file}`)
+      if (r.stderrTail !== '') console.error(r.stderrTail.split('\n').map((l) => `        | ${l}`).join('\n'))
+    },
+  })
+  if (results.length === 0) usage(`--only "${only}" 没有匹配到任何测试文件`)
+
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(results, null, 2)}\n`)
+  } else {
+    const counts = {}
+    for (const r of results) counts[r.status] = (counts[r.status] ?? 0) + 1
+    console.log(`\n分诊汇总（${results.length} 个文件）: ${Object.entries(counts).map(([k, v]) => `${k}=${v}`).join(' ')}`)
+    for (const status of ['leak', 'stall', 'fail']) {
+      const hit = results.filter((r) => r.status === status)
+      if (hit.length === 0) continue
+      console.log(`\n[${status}] ${hit.length} 个：`)
+      for (const r of hit) console.log(`  ${r.pkgName}/${r.file}`)
+    }
+  }
+}

--- a/scripts/gate/probe-handles.mjs
+++ b/scripts/gate/probe-handles.mjs
@@ -53,11 +53,12 @@ import { RUN_TESTS_PATTERN, discoverTestPackages, expandGlob } from './test-surf
 const DEFAULT_ROOT = join(import.meta.dirname, '..', '..')
 
 /**
- * 单文件墙钟上限。为什么默认 6 分钟：最慢的 `dsh-mcp-manager/test/e2e/smoke.test.ts` 含 SDK
- * stdio 端到端，实测单跑 328s；上限低于它会把「慢」误判成 `hang`，而 hang 与慢的区分正是
- * 本探针要给出的信号，不能用会制造假阳性的默认值。
+ * 单文件墙钟上限。为什么默认 10 分钟：最慢的 `dsh-mcp-manager/test/e2e/smoke.test.ts`（SDK
+ * stdio 端到端）实测单跑 328s，而在**有并发负载**时对抗复核实测其超过 360s——上限若贴着 328s
+ * 留余量，负载下就会把「慢」误判成非 clean。故留约一倍余量。代价是真实泄漏文件要等更久才判红，
+ * 需要快扫时用 `--timeout` 收紧（收紧只会让它更容易判非 clean，不会伪造绿灯）。
  */
-const DEFAULT_TIMEOUT_MS = 6 * 60 * 1000
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000
 /** 汇总输出后允许的退出延迟。正常文件在汇总后 <100ms 内退出，给 2s 余量吸收调度抖动。 */
 const DEFAULT_GRACE_MS = 2000
 /**

--- a/scripts/gate/run-tests.mjs
+++ b/scripts/gate/run-tests.mjs
@@ -1,111 +1,179 @@
 #!/usr/bin/env node
 /**
- * run-tests — 各包统一测试入口（issue #690 S2）。
+ * run-tests — 各包统一测试入口（issue #690 S2 / S2c）。
  *
  * 为什么需要这层 wrapper：`node --test` 在**零匹配**时 exit 0（实测：glob 写错、
  * 测试文件被误删，都得到 `pass 0 / fail 0` + exit 0），`exit(0)` 吞失败同理——
  * 两者都会让「绿灯」失去意义（docs/ARCHITECTURE-METHOD.md §8 假绿向量）。
- * 故本入口显式断言：**匹配到的测试文件数 >= 下限**、**无失败条目**、**退出码为 0**。
+ * 故本入口显式断言：**匹配到的文件数 >= 下限**、**每个文件都真的通过**、**没有超时**。
  *
- * 为什么同时校验 `1..N` 与文件数（#712 二轮对抗复核 P1）：`--test-isolation=none` 下若
- * glob **首个**文件存在永不落定的顶层 await，node 会静默输出 `1..0` 且 exit 0，**其余文件
- * 一个都不执行**；只判 `undefined` 会把这种「0 条目」当合法值报全绿。故额外要求
- * `1..N >= glob 文件数`（每个被匹配的文件至少要产出一个条目）。
+ * 为什么逐文件 spawn（#690 S2c）：
+ *   1. node `--test` 会**自行排序**传入的文件参数（实测传 c,a,b 仍按 a,b,c 执行），
+ *      于是「打乱文件列表结果不变」这条验收判据无法靠重排参数实现——逐文件 spawn 把执行
+ *      顺序拿回 runner 自己手里（`--order lex|reverse|shuffle:<seed>`）。
+ *   2. 每个文件独立超时：单个文件挂住不再拖垮整包，且能**点名**到具体文件。
+ *   3. per-file 进程隔离成为天然语义（每个文件本来就是独立进程），跨文件全局态不再串味。
  *
- * 为什么下限按**文件数**而不是 TAP 的 `1..N`：`1..N` 是测试条目数，含文件内的
- * 子测试（用 node:test 的 test() 注册）——实测 dsh-provider-usage 19 个测试文件
- * 报 39 个条目，按条目设阈值会随子测试增减抖动。文件数由 glob 直接展开，
- * 语义稳定且与「漏跑/误删文件」这一被防对象一一对应。
+ * 为什么超时必须杀**进程组**：per-file 隔离下 node 会为每个文件再派生一个 worker；只杀直接
+ * 子进程会留下孤儿——实测孤儿继续持有 `127.0.0.1:19998` 不放，污染后续运行。故 spawn 用
+ * `detached: true` 建独立进程组，超时以 `kill(-pid)` 整组回收。
  *
- * 用 TAP reporter 取失败信息：TAP（`ok` / `not ok`）是稳定协议，不受 node
- * 交互式摘要文案变化影响。
+ * 为什么不再用 `--test-isolation=none`（#690 S2c 从 #712 的过渡态回归默认隔离）：同进程串行
+ * 是迁移期的历史妥协（固定端口 + fire-and-forget 定时器），代价是整类假绿——跨文件全局态
+ * （`untildify` 对 `homedir()` 首调固化）、悬挂 promise、求值顺序耦合，#712 的三个缺陷全部
+ * 源自这里。S2c 先把端口动态化、句柄回收，再回归默认隔离。
+ * 保 `--test-concurrency=1` 是必要的：实测同一固定端口被 8 个文件并发持有时 7 个
+ * `EADDRINUSE`，串行是「不引入新脆弱前提」的最低成本。
  *
- * 不用 `--test-force-exit`（#690 S2 对抗评审实测的假绿向量）：node 以「模块求值
- * 结束」判定文件测试通过，**不等待顶层悬挂的 promise**；此时 force-exit 会在悬挂
- * 体的断言执行前终止进程，真实失败被吞成 exit 0——本仓两个大 smoke 文件曾是该形态
- * （已改为顶层 `await main()`）。去掉它后进程随事件循环自然收尾，悬挂体的失败会以
- * 未处理拒绝/退出码形式暴露；代价是残留句柄可能挂住运行，故 spawn 带超时兜底（超时判红）。
- * 注意本入口的可判边界：它保证「glob 命中的文件都被求值且没有失败」，**不保证**某个
- * 文件内的断言没有被删空——文件级判据看不到断言数量，那属于断言评审/静态哨兵的职责。
+ * 不用 `--test-force-exit`（#690 S2 对抗评审实测的假绿向量）：node 以「模块求值结束」判定
+ * 文件测试通过，不等待顶层悬挂的 promise；force-exit 会在悬挂体的断言执行前终止进程，真实
+ * 失败被吞成 exit 0。逐文件 spawn 后，顶层 unsettled await 由 node 自己判 `not ok`（per-file
+ * 专属能力），该向量被封堵在 node 侧。
  *
- * 为什么用 `--test-isolation=none`（而非默认的 per-file 进程隔离）：
- *   1. 本仓测试存在固定端口/共享临时资源的用例（如 dsh-lan-proxy 的 19998/19091），
- *      默认按 CPU 核数并发会 `listen EADDRINUSE`（实测）；此前的 `test/smoke.ts`
- *      聚合入口是 `await import` **同进程严格串行**，迁移必须保持同一语义。
- *   2. 默认隔离会在每个文件跑完后判定「测试结束后是否还有异步活动」，而本仓既有
- *      用例存在 fire-and-forget 的 watcher/定时器（实测 dsh-provider-usage 报
- *      `A resource generated asynchronous activity after the test ended`）。同进程
- *      模式下没有 per-file 结束边界，与迁移前的行为一致。
- *   两条都是「保持语义等价」而非放宽判据：失败仍由 TAP 的 not ok 与退出码兜住。
+ * 判据边界：保证「glob 命中的每个文件都被执行且通过」，**不保证**某个文件内的断言没有被删空
+ * ——文件级判据看不到断言数量，那属于断言评审/静态哨兵的职责。
  *
  * 用法（在包目录内执行，cwd = 包根）：
- *   node ../../scripts/gate/run-tests.mjs --min <正整数>
- * 退出码：0 = 全部通过且文件数达标；1 = 有失败 / 零匹配 / 低于下限 / 汇总不可解析 / 超时。
+ *   node ../../scripts/gate/run-tests.mjs --min <正整数> [--order lex|reverse|shuffle:<seed>]
+ * 环境变量 `RUN_TESTS_TIMEOUT_MS`：**单文件**墙钟上限（默认 10 分钟）。门禁自测与本地排查
+ * 可收紧，收紧只会更快判红，不能用来伪造绿灯。
+ * 退出码：0 = 全部通过且文件数达标；1 = 有失败 / 零匹配 / 低于下限 / 超时；2 = 用法错误。
  *
  * 与变异面的关系（#690 S2b）：本入口的 PATTERN 就是「runner 面」的定义，
  * `pnpm stryker:check` 用它校验各包 `--min` 是否同步（不一致即判红，不会静默放宽），
  * 而变异面由同一份拓扑的测试层派生（见 scripts/gate/gen-stryker-conf.mjs）。
  * 测试文件的分层约定见 docs/DEVELOPMENT.md「测试分层与变异面登记」。
  */
-import { spawnSync } from 'node:child_process'
+import { spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { globSync } from 'node:fs'
 
 import { RUN_TESTS_PATTERN } from './test-surface.mjs'
 
 // 与变异面登记门禁（gen-stryker-conf --check 的判据 ③）同源：不再各写一份字面量。
 const PATTERN = RUN_TESTS_PATTERN
+
 /**
- * 单包测试墙钟上限：CI 上最慢的包（dsh-mcp-manager 含 SDK stdio 端到端）约 6 分钟。
- * `RUN_TESTS_TIMEOUT_MS` 供门禁自测与本地调试收紧（调小只会更快判红，不能用来伪造绿灯）。
+ * 单文件墙钟上限。为什么默认 10 分钟：最慢的 `dsh-mcp-manager/test/e2e/smoke.test.ts`
+ * （SDK stdio 端到端）实测单跑 328s、并发负载下超过 360s；上限贴着它会把「慢」误判成
+ * 「残留句柄」，而两者的区分正是本入口要给出的信号。
  */
-const TIMEOUT_MS = Number(process.env.RUN_TESTS_TIMEOUT_MS) > 0
+const FILE_TIMEOUT_MS = Number(process.env.RUN_TESTS_TIMEOUT_MS) > 0
   ? Number(process.env.RUN_TESTS_TIMEOUT_MS)
-  : 20 * 60 * 1000
+  : 10 * 60 * 1000
+/**
+ * 整包预算：防「多个文件各自挂满单文件上限」把门禁拖成小时级。正常包（含最慢的
+ * dsh-mcp-manager 约 6 分钟）远低于它，只有异常才触顶。
+ */
+const PACKAGE_BUDGET_MS = 20 * 60 * 1000
 
 const argv = process.argv.slice(2)
-const minIdx = argv.indexOf('--min')
-const min = minIdx >= 0 ? Number(argv[minIdx + 1]) : Number.NaN
+const flag = (name, fallback) => {
+  const i = argv.indexOf(name)
+  return i >= 0 ? argv[i + 1] : fallback
+}
+
+const min = Number(flag('--min', Number.NaN))
 if (!Number.isInteger(min) || min < 1) {
-  console.error('run-tests: 用法 node scripts/gate/run-tests.mjs --min <正整数>')
+  console.error('run-tests: 用法 node scripts/gate/run-tests.mjs --min <正整数> [--order lex|reverse|shuffle:<seed>]')
+  process.exit(2)
+}
+const order = flag('--order', 'lex')
+
+/** 确定性重排：同一种子恒定产出同一顺序，失败后可按种子逐字复现。 */
+function reorder(list, mode) {
+  if (mode === 'lex') return list
+  if (mode === 'reverse') return [...list].reverse()
+  if (mode.startsWith('shuffle')) {
+    const seed = mode.includes(':') ? mode.slice(mode.indexOf(':') + 1) : '0'
+    let h = Number.parseInt(createHash('sha256').update(seed).digest('hex').slice(0, 8), 16)
+    const out = [...list]
+    for (let i = out.length - 1; i > 0; i -= 1) {
+      h = (h * 1103515245 + 12345) % 0x7fffffff
+      const j = h % (i + 1)
+      const tmp = out[i]
+      out[i] = out[j]
+      out[j] = tmp
+    }
+    return out
+  }
+  console.error(`run-tests: 未知 --order "${mode}"（支持 lex / reverse / shuffle:<seed>）`)
   process.exit(2)
 }
 
-const files = globSync(PATTERN)
+let files = globSync(PATTERN).sort()
 if (files.length < min) {
   console.error(`run-tests: glob "${PATTERN}" 只匹配到 ${files.length} 个文件，低于下限 ${min} —— 零匹配/漏跑必须判红`)
   process.exit(1)
 }
+files = reorder(files, order)
 
-const spawned = spawnSync(
-  process.execPath,
-  ['--test', '--test-isolation=none', '--test-reporter=tap', PATTERN],
-  { stdio: ['ignore', 'pipe', 'inherit'], encoding: 'utf8', timeout: TIMEOUT_MS },
-)
-const out = spawned.stdout ?? ''
-process.stdout.write(out)
+/** 跑单个文件；返回 { file, code, signal, timedOut, out, err }。 */
+function runFile(file, timeoutMs) {
+  return new Promise((resolve) => {
+    const child = spawn(
+      process.execPath,
+      ['--test', '--test-isolation=process', '--test-concurrency=1', '--test-reporter=tap', file],
+      { detached: true, stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+    let out = ''
+    let err = ''
+    let timedOut = false
+    let done = false
+    let killFallback = null
 
-const failed = (out.match(/^not ok /gm) ?? []).length
-const planned = (out.match(/^1\.\.(\d+)$/m) ?? [])[1]
+    const settle = (code, signal) => {
+      if (done) return
+      done = true
+      clearTimeout(timer)
+      if (killFallback !== null) clearTimeout(killFallback)
+      resolve({ file, code, signal, timedOut, out, err })
+    }
+    // 整组回收：worker 与父 node 同组（detached 建组），只杀父会留孤儿。
+    const hardKill = () => {
+      try { process.kill(-child.pid, 'SIGKILL') } catch { /* 组已消失 */ }
+      // KILL 后仍不触发 exit 说明进程不可中断，兜底 settle 以免 runner 自身挂死。
+      killFallback = setTimeout(() => settle(null, 'SIGKILL'), 5000)
+    }
+    const timer = setTimeout(() => { timedOut = true; hardKill() }, timeoutMs)
 
-if (spawned.error?.code === 'ETIMEDOUT' || spawned.signal === 'SIGTERM') {
-  console.error(`run-tests: 测试进程超过 ${TIMEOUT_MS / 60000} 分钟未退出（疑似残留句柄），已终止并判红`)
+    child.stdout.on('data', (chunk) => { out += chunk })
+    child.stderr.on('data', (chunk) => { err += chunk })
+    child.on('error', (e) => { err += `spawn 失败: ${e.message}\n`; settle(null, null) })
+    child.on('exit', (code, signal) => settle(code, signal))
+  })
+}
+
+const startedAt = Date.now()
+const results = []
+let budgetExhausted = false
+
+for (const file of files) {
+  const remaining = PACKAGE_BUDGET_MS - (Date.now() - startedAt)
+  if (remaining <= 0) { budgetExhausted = true; break }
+  const r = await runFile(file, Math.min(FILE_TIMEOUT_MS, remaining))
+  const notOk = (r.out.match(/^not ok /gm) ?? []).length
+  results.push({ ...r, notOk, passed: !r.timedOut && r.code === 0 && notOk === 0 })
+  // TAP 透传：保持与「一次 spawn 全部文件」时期一致的可读输出与日志形态。
+  process.stdout.write(r.out)
+  if (r.err !== '') process.stderr.write(r.err)
+}
+
+if (budgetExhausted) {
+  console.error(`run-tests: 整包预算 ${PACKAGE_BUDGET_MS / 60000} 分钟耗尽（已跑 ${results.length}/${files.length} 个文件）`
+    + ' —— 疑似多个文件挂住，判红')
   process.exit(1)
 }
-if (planned === undefined) {
-  console.error('run-tests: 无法解析 TAP 计划数（1..N）—— 输出异常或进程被中断')
+
+const failed = results.filter((r) => !r.passed)
+if (failed.length > 0) {
+  console.error(`run-tests: ${failed.length}/${results.length} 个文件未通过：`)
+  for (const r of failed) {
+    const why = r.timedOut
+      ? `超过 ${FILE_TIMEOUT_MS / 60000} 分钟未退出（疑似残留句柄），已按进程组终止`
+      : `退出码 ${r.code}，not ok ${r.notOk}`
+    console.error(`  ${r.file}（${why}）`)
+  }
   process.exit(1)
 }
-if (Number(planned) < files.length) {
-  console.error(`run-tests: TAP 计划数 ${planned} 少于 glob 文件数 ${files.length}`
-    + ' —— runner 提前结束或文件未被求值（零条目不得判绿）')
-  process.exit(1)
-}
-if (failed > 0) {
-  console.error(`run-tests: ${failed} 个测试条目失败`)
-  process.exit(1)
-}
-if (spawned.status !== 0) {
-  console.error(`run-tests: node --test 退出码 ${spawned.status}（非零即判红，防 exit(0) 吞失败）`)
-  process.exit(1)
-}
-console.log(`run-tests: ${files.length} 个测试文件 / ${planned} 个测试条目全部通过（文件数下限 ${min}）`)
+console.log(`run-tests: ${results.length} 个测试文件全部通过（文件数下限 ${min}，执行顺序 ${order}）`)

--- a/scripts/test/probe-handles.test.ts
+++ b/scripts/test/probe-handles.test.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * probe-handles 探针自测（#690 S2c / #713 T5 前半）。
+ *
+ * 锁住两条承重假设——S2c「先探针分诊、后切隔离」策略全靠它们：
+ *   ① 四态可区分。若 leak 与 hang 混为一谈，分诊表会把「残留句柄」误报成「测试挂起」，
+ *      治理方向就此跑偏（首版实现确实把 `setInterval` 泄漏判成了 hang）。
+ *   ② 超时按进程组回收。若只杀直接子进程，worker 会成孤儿并继续持有端口——实测其占住
+ *      `127.0.0.1:19998` 不放，探针自己就成了下一个 flake 源。
+ *
+ * 运行：pnpm test:scripts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { probeFile, triage } from '../gate/probe-handles.mjs'
+
+const PROBE = fileURLToPath(new URL('../gate/probe-handles.mjs', import.meta.url))
+
+/** 探针自测用收紧的超时：判据是「能否区分形态」，不是「跑得多快」。 */
+const TIMEOUT_MS = 2500
+const GRACE_MS = 300
+
+const CLEAN = 'import { test } from "node:test"\ntest("ok", () => {})\n'
+const LEAK = 'import { test } from "node:test"\ntest("ok", () => {})\nsetInterval(() => {}, 1000)\n'
+/** 测试体内悬挂：测试没跑完，对照组同样挂住 —— 探针无法定性，报 stall。 */
+const STALL = 'import { test } from "node:test"\ntest("never", async () => { await new Promise(() => {}) })\n'
+/** 脚本式文件挂住：--test-force-exit 对它不生效，同样只能报 stall。 */
+const STALL_SCRIPT = 'setInterval(() => {}, 1000)\n'
+const FAIL = 'import assert from "node:assert/strict"\nassert.fail("boom")\n'
+
+function fixture(files = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'probe-handles-'))
+  const pkgDir = join(root, 'packages', 'fixture-pkg')
+  mkdirSync(join(pkgDir, 'test'), { recursive: true })
+  writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: 'fixture-pkg', type: 'module' }), 'utf8')
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(pkgDir, 'test', name), content, 'utf8')
+  }
+  return { root, pkgDir }
+}
+
+test('四态可区分：clean / leak / stall / fail', async () => {
+  const { root } = fixture({
+    'a.test.ts': CLEAN,
+    'b.test.ts': LEAK,
+    'c.test.ts': STALL,
+    'd.test.ts': STALL_SCRIPT,
+    'e.test.ts': FAIL,
+  })
+  try {
+    const results = await triage(root, { timeoutMs: TIMEOUT_MS, graceMs: GRACE_MS })
+    const byFile = Object.fromEntries(results.map((r) => [r.file, r.status]))
+    assert.deepEqual(byFile, {
+      'test/a.test.ts': 'clean',
+      'test/b.test.ts': 'leak',
+      'test/c.test.ts': 'stall',
+      'test/d.test.ts': 'stall',
+      'test/e.test.ts': 'fail',
+    }, `四态判定不符（c=测试体内悬挂、d=脚本式挂起，两者都无法定性故都是 stall）：${JSON.stringify(results.map((r) => [r.file, r.status]))}`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('超时按进程组回收：worker 不得成为孤儿', async () => {
+  const { root, pkgDir } = fixture()
+  const pidFile = join(root, 'worker.pid')
+  try {
+    writeFileSync(join(pkgDir, 'test', 'leak.test.ts'),
+      'import { createServer } from "node:http"\n'
+      + 'import { writeFileSync } from "node:fs"\n'
+      + 'import { test } from "node:test"\n'
+      + 'test("leak", async () => {\n'
+      + `  writeFileSync(${JSON.stringify(pidFile)}, String(process.pid))\n`
+      + '  const s = createServer()\n'
+      + '  await new Promise((r) => s.listen(0, "127.0.0.1", r))\n'
+      + '})\n', 'utf8')
+
+    const r = await probeFile(pkgDir, 'test/leak.test.ts', TIMEOUT_MS, GRACE_MS)
+    assert.equal(r.status, 'leak', `该 fixture 应判 leak：${JSON.stringify(r)}`)
+    assert.ok(existsSync(pidFile), 'worker 应已写下自己的 pid')
+    const workerPid = Number(readFileSync(pidFile, 'utf8'))
+    assert.ok(Number.isInteger(workerPid) && workerPid > 0, `pid 非法：${workerPid}`)
+    assert.throws(() => process.kill(workerPid, 0), /ESRCH/,
+      `worker ${workerPid} 仍存活——超时未按进程组回收，探针会留下孤儿`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('对照组失效（脚本式文件不注册 node:test）时如实报 stall，不猜测', async () => {
+  // 实测：脚本式文件注入 setInterval 后，--test-force-exit 对照组与 A 一样挂住（exit 137、无
+  // TAP 汇总），探针无法区分「句柄残留」与「测试没跑完」。此处**不得**用静默启发式猜 leak——
+  // mcp-manager 的 e2e/smoke 与 unit/unit-middleware 两个慢文件就因此被误报过。
+  const { root, pkgDir } = fixture({ 'leak-script.test.ts': 'console.log("script-done")\nsetInterval(() => {}, 1000)\n' })
+  try {
+    const r = await probeFile(pkgDir, 'test/leak-script.test.ts', 3000, 200, 600)
+    assert.equal(r.status, 'stall', `应如实报 stall：${JSON.stringify(r)}`)
+    assert.equal(r.hasOutput, true, `该 fixture 有输出，故不该判 hang：${JSON.stringify(r)}`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('import 纯模块零副作用：不枚举仓库、不 spawn（CLI 守卫）', () => {
+  // 与 test-surface.mjs 的 P0-1 同族：若 import 即跑 CLI，任何 import 它的测试都会真跑一遍
+  // 全仓探测（数分钟 + 真实子进程），把测试面变成不可控的成本。
+  const probe = spawnSync(process.execPath, [
+    '-e',
+    `import(${JSON.stringify(PROBE)}).then(() => process.stdout.write('IMPORT-OK'))`,
+  ], { encoding: 'utf8', cwd: fileURLToPath(new URL('..', import.meta.url)) })
+  assert.equal(probe.status, 0, `import 应成功：${probe.stdout}${probe.stderr}`)
+  assert.equal(probe.stdout.trim(), 'IMPORT-OK', `import 不得产生任何 CLI 输出，实际：${JSON.stringify(probe.stdout)}`)
+})

--- a/scripts/test/run-tests-runner.test.ts
+++ b/scripts/test/run-tests-runner.test.ts
@@ -3,15 +3,16 @@
 'use strict'
 
 /**
- * run-tests runner 自测（#690 S2；#712 二轮对抗复核 P1）。
+ * run-tests runner 自测（#690 S2 / S2c）。
  *
- * 锁住 runner 的判红判据，含两处实测假绿向量（改动 runner 时这些用例必须先红再谈放宽）：
- *   - 零匹配：`node --test` 无文件时 exit 0 → 文件数下限判红；
- *   - 首位文件永不落定：node 静默输出 `1..0` 且 exit 0、其余文件全不求值 → 计划数少于
- *     glob 文件数判红（P1 回归）；
- *   - 文件内 `process.exitCode = 1`：TAP 仍报 pass，只有退出码能判红（承重判据，勿删）；
- *   - 断言抛错 → `not ok` 判红；
- *   - 残留句柄：进程不退出 → 超时判红（`RUN_TESTS_TIMEOUT_MS` 仅用于收紧等待）。
+ * 锁住 runner 的判红判据与顺序控制。逐文件 spawn 之后有三处语义变化（均经实测确认，见
+ * #690 S2c 的 PR 正文）：
+ *   1. `1..N` 不再表示「测试条目数」而是「文件数」（每个文件是一个顶层条目），
+ *      故「条目数」相关判据退役，承重判据变成「每个文件都通过」；
+ *   2. 文件内 `process.exitCode = 1` 由 node 映射为该文件的 `not ok`，
+ *      走「未通过文件」分支而不是「runner 退出码」分支；
+ *   3. 首位文件悬挂**不再**让其余文件静默跳过（每文件独立进程），故 #712 P1 的判据
+ *      从「计划数不足」改为「悬挂文件判红**且其余文件确实被执行**」——后者才是它真正要防的。
  *
  * 运行：pnpm test:scripts
  */
@@ -49,12 +50,12 @@ function runRunner(dir, args, env = {}) {
   return { code: r.status, out: r.stdout ?? '', err: r.stderr ?? '', ms: Date.now() - started }
 }
 
-test('单文件通过：exit 0 且打印文件数与条目数', () => {
+test('单文件通过：exit 0 且打印文件数与执行顺序', () => {
   const dir = fixture({ 'a.test.ts': '// 无断言也要产出条目\n' })
   try {
     const r = runRunner(dir, ['--min', '1'])
     assert.equal(r.code, 0, r.err)
-    assert.match(r.out, /1 个测试文件 \/ 1 个测试条目全部通过/)
+    assert.match(r.out, /1 个测试文件全部通过（文件数下限 1，执行顺序 lex）/)
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
@@ -82,52 +83,89 @@ test('文件数低于下限：判红', () => {
   }
 })
 
-test('断言抛错：not ok 判红', () => {
+test('断言抛错：判红并按文件名点名', () => {
   const dir = fixture({
     'a.test.ts': 'import assert from "node:assert/strict";\nassert.fail("fixture-boom");\n',
   })
   try {
     const r = runRunner(dir, ['--min', '1'])
     assert.equal(r.code, 1)
-    assert.match(r.err, /1 个测试条目失败/)
+    assert.match(r.err, /1\/1 个文件未通过/)
+    assert.match(r.err, /test\/a\.test\.ts/)
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
 })
 
-test('文件内 process.exitCode=1：TAP 仍 pass，靠退出码判红（承重判据）', () => {
+test('文件内 process.exitCode=1：node 映射为该文件 not ok → 判红并点名（承重判据）', () => {
+  // per-file 语义变化点：该形态在 `--test-isolation=none` 下 TAP 仍报 pass、只有 runner 退出码
+  // 能判红；逐文件 spawn 后 node 把它映射为文件的 `not ok`，故走「未通过文件」分支。
   const dir = fixture({ 'a.test.ts': 'process.exitCode = 1;\n' })
   try {
     const r = runRunner(dir, ['--min', '1'])
     assert.equal(r.code, 1)
-    assert.match(r.out, /1\.\.1/, '该形态的 TAP 计划行仍是 1..1（失败只体现在退出码）')
-    assert.match(r.err, /退出码 1/)
+    assert.match(r.err, /1\/1 个文件未通过/)
+    assert.match(r.err, /test\/a\.test\.ts/)
+    assert.match(r.out, /^not ok /m, '该形态应产出 not ok 条目')
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
 })
 
-test('P1 回归：首位文件永不落定（node 静默 1..0）不得判绿', () => {
+test('P1 新语义：悬挂文件判红，且其余文件确实被执行（不得静默跳过）', () => {
+  // #712 P1 真正要防的是「其余文件被静默跳过」。per-file 隔离下 node 自己把顶层 unsettled
+  // await 判为 `not ok`，`1..0` 那个假绿向量不复存在，故判据改为断言「都跑了」。
   const dir = fixture({
     'a-hang.test.ts': 'await new Promise(() => {});\n',
-    'z-ok.test.ts': '// 该文件在假绿场景下根本不会被求值\n',
+    'z-ok.test.ts': 'console.log("Z-EXECUTED");\n',
   })
   try {
     const r = runRunner(dir, ['--min', '2'], { RUN_TESTS_TIMEOUT_MS: '15000' })
     assert.equal(r.code, 1, `不得判绿（stdout: ${r.out}）`)
-    assert.match(r.err, /计划数 0 少于 glob 文件数 2|未退出/)
+    assert.match(r.err, /1\/2 个文件未通过/)
+    assert.match(r.err, /a-hang\.test\.ts/)
+    assert.match(r.out, /Z-EXECUTED/, '悬挂文件不得让后续文件被跳过')
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
 })
 
-test('残留句柄：进程不退出由超时判红', () => {
+test('残留句柄：单文件超时判红并点名，且 worker 不得成为孤儿', () => {
   const dir = fixture({ 'a.test.ts': 'setInterval(() => {}, 1000);\n' })
   try {
     const r = runRunner(dir, ['--min', '1'], { RUN_TESTS_TIMEOUT_MS: '6000' })
     assert.equal(r.code, 1)
-    assert.match(r.err, /未退出（疑似残留句柄）/)
+    assert.match(r.err, /1\/1 个文件未通过/)
+    assert.match(r.err, /未退出（疑似残留句柄），已按进程组终止/)
     assert.ok(r.ms < 60000, `超时兜底应在数十秒内返回，实测 ${r.ms}ms`)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('顺序控制：lex / reverse / shuffle 结果一致，且执行顺序真的不同', () => {
+  const dir = fixture({
+    'a.test.ts': 'console.log("SEQ-A");\n',
+    'b.test.ts': 'console.log("SEQ-B");\n',
+    'c.test.ts': 'console.log("SEQ-C");\n',
+  })
+  try {
+    const seqOf = (out) => (out.match(/SEQ-[ABC]/g) ?? []).join(',')
+    const lex = runRunner(dir, ['--min', '3', '--order', 'lex'])
+    const rev = runRunner(dir, ['--min', '3', '--order', 'reverse'])
+    assert.equal(lex.code, 0, lex.err)
+    assert.equal(rev.code, 0, rev.err)
+    assert.equal(seqOf(lex.out), 'SEQ-A,SEQ-B,SEQ-C')
+    assert.equal(seqOf(rev.out), 'SEQ-C,SEQ-B,SEQ-A')
+
+    // 洗牌用多个种子：单一种子恰好退化成字典序是可能的，不能据此断言失效。
+    const shuffled = ['7', '42', '99'].map((s) => {
+      const r = runRunner(dir, ['--min', '3', '--order', `shuffle:${s}`])
+      assert.equal(r.code, 0, `shuffle:${s} 应通过：${r.err}`)
+      return seqOf(r.out)
+    })
+    assert.ok(shuffled.some((o) => o !== seqOf(lex.out)),
+      `至少一个种子的顺序应不同于 lex，实际 ${shuffled.join(' | ')}`)
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
@@ -139,6 +177,17 @@ test('--min 缺参 / 非法：exit 2（用法错误与门禁违约区分）', ()
     assert.equal(runRunner(dir, []).code, 2)
     assert.equal(runRunner(dir, ['--min', 'abc']).code, 2)
     assert.equal(runRunner(dir, ['--min', '0']).code, 2)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('--order 非法值：exit 2', () => {
+  const dir = fixture({ 'a.test.ts': '\n' })
+  try {
+    const r = runRunner(dir, ['--min', '1', '--order', 'bogus'])
+    assert.equal(r.code, 2)
+    assert.match(r.err, /未知 --order/)
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }


### PR DESCRIPTION
# #690 S2c 后半：runner 切默认 per-file 隔离与判据重写（#713 T5）

关联 #690（A/B 轨计划）、#713（S2 T5 前半）。承接 #717（S2c 前半：端口动态分配 + 隔离分诊探针）。

## 一、结论

前半已用探针证明 **69 个测试文件在 per-file 隔离下全部 clean**（0 超时、0 残留句柄、0 顺序依赖
失败），故本 PR 直接切换默认隔离，不需要分批。切换后六包全绿、打乱顺序结果不变、有负载下连续
10 次零 flake。

## 二、变更清单

| 类别 | 文件 | 说明 |
|---|---|---|
| runner | `scripts/gate/run-tests.mjs` | 删 `--test-isolation=none` 回归默认 per-file；改**逐文件 spawn**（顺序可控 + 每文件独立超时 + 点名）；`detached` 进程组 + `kill(-pid)` 超时回收；新增 `--order lex\|reverse\|shuffle:<seed>` |
| 判据回归 | `scripts/test/run-tests-runner.test.ts` | 按新语义重写（2 条失效判据 + 新增顺序控制 / 进程组回收用例），10 条 |
| 拆过渡补丁 | `packages/dsh-provider-usage/test/unit/shared/unit-config.test.ts` | 删掉 #712 的子进程探针（`spawnSync` + 退出码 3/4/5 + ESM loader 参数继承），改回文件内直接断言 |
| 文档 | `docs/DEVELOPMENT.md` | §0「测试」段改隔离口径与 `--order`；§5.2 第 4 条补「`await main()` 约定复查仍必要」的反证 |
| 文档 | 两个包的 `requirements-and-tdd-plan.md` | 同步 runner 口径 |

## 三、为什么是「逐文件 spawn」而不是「一次 spawn 全部文件」

原因是一条实测约束：**node `--test` 会自行排序传入的文件参数**（实测传 `c.test.ts a.test.ts
b.test.ts` 仍按 a、b、c 执行；`node --help` 无 shuffle/order 类 flag）。于是「打乱文件列表结果
不变」这条验收判据无法靠重排参数实现。逐文件 spawn 把执行顺序拿回 runner 自己手里，顺带获得
「每文件独立超时」与「按文件点名判红」。

代价（实测）：整包墙钟 5m29s → **6m17s**（+48s ≈ 69 个文件 × 0.7s 进程启动）。判据不变。

## 四、`await main()` 约定：复查后**保留**（反证实验）

任务要求「删之前先证明不再需要」。实测证明**仍需要**，故保留：

```
把 packages/dsh-lan-proxy/test/e2e/smoke.test.ts 的顶层 `await main();` 改回悬挂形态 `main();`
→ per-file 隔离：pass 1 / fail 0，exit 0（假绿）
→ --test-isolation=none：pass 1 / fail 0，exit 0（假绿）
```

原因是 per-file 隔离只封堵「顶层 unsettled await」（模块求值永不完成 → node 判 `not ok`），
封不住 fire-and-forget 的异步体（模块求值立即完成 → node 判通过）。约定与其文档条文均保留。

## 五、判据对照表

| 判据（#713 T5 / 方案） | 验证 | 结果 |
|---|---|---|
| 打乱文件列表（正序/逆序/随机种子）结果不变 | 六包各跑 `--order shuffle:20260911` | 全部 exit 0，文件数与 lex 一致 |
| 留一个未清理 `setInterval` 判红 | runner 测试第 7 条（fixture 级实跑） | 判红并点名「超过 N 分钟未退出（疑似残留句柄），已按进程组终止」 |
| 单文件悬挂不拖累其余文件 | runner 测试第 6 条 | 悬挂文件判红，其余文件确实执行 |
| 连续 10 次零 flake（**有负载**） | provider-usage 与 lan-proxy 各 ×10，同时施加 N/2 个 `yes` 忙循环 | 见下 |
| `--min` 与文件数不变 | 六包 `--min` 未改（4/16/26/19/1/3） | 全部达标 |
| 六包全绿 | `pnpm test` | exit 0 |

## 六、门禁

| 命令 | exit |
|---|---|
| `pnpm build` | 0 |
| `pnpm test`（六包，逐文件 spawn） | 0（4/16/26/19/1/3 全部达标，6m17s） |
| `pnpm contract` | 0 |
| `pnpm pack:check` | 0 |
| `pnpm typecheck` | 0 |
| `pnpm test:scripts`（改 scripts/ 追加） | 0（**300 pass / 0 fail**） |
| `pnpm docs:check`（改文档追加） | 0 |
| `pnpm stryker:check`（`--min` 与拓扑一致性） | 0 |
| `pnpm aggregate:check` | 0 |
| `pnpm verify:npmlayout` | 0 |
| `pnpm gate:homedir` | 0 |
| `pnpm test:src-tests` | 0 |
| 六包 `--order shuffle:20260911` | 全部 exit 0，文件数与 lex 一致 |
| provider-usage ×10 + lan-proxy ×10（**有负载**：8 核 + 4 个 `yes` 忙循环） | 20/20 exit 0 |

## 七、已知边界与遗留

1. `--order` 只改变**文件间**顺序；文件内用例顺序由文件自身决定。
2. 整包预算 20 分钟：防「多个文件各自挂满单文件上限」把门禁拖成小时级；正常包远低于它。
3. 判据边界不变：runner 看不到「文件内断言被删空」，那属断言评审/静态哨兵职责。
4. `await main()` 约定与 §5.2 第 4 条保留（见 §四反证）。

## 八、规模与回滚

- 回滚：`git revert` 即可；runner 可单文件回退到 `--test-isolation=none` 版本（前后半可独立回滚）。

关联 issue：#690；遗留跟踪：#713。
