### PR TITLE
fix(ci): 归档链剩余两处静默降级改为 fail-loud（#718）

### DIFF
--- a/scripts/gate/baseline-archive.mjs
+++ b/scripts/gate/baseline-archive.mjs
@@ -103,8 +103,10 @@ export function classifyRemoteProbe({ ok, code }) {
  * 避免同一操作两份实现长期分叉。
  *
  * 已知边界（必须诚实记录）：`absent` 只能证明「本次广告里没有这条 ref」，**不能**证明
- * 「服务端上不存在」——服务端可用 `uploadpack.hideRefs` 隐藏某条 ref，此时探针与真·首夜
- * 完全同形。因此写路径的真正保障不在探针，而在**推送侧不得删段**（见 #718 方案评论）。
+ * 「服务端上不存在」——服务端可用 `uploadpack.hideRefs` 隐藏某条 ref，此时与真·首夜完全同形，
+ * 本函数无从区分。这一支上唯一实际生效的防护是 workflow 层 `mutation-suites` 的 outcome 门控
+ * （依赖 restore 非零退出，见 observe-incremental.yml）；**代码里并不存在「推送侧拒绝空/缺段
+ * 快照」的保护**，补该保护已登记在 #718 的方案中（并集入档），尚未实施。
  */
 export function decideRestoreOutcome({ probeStatus, fetchOk }) {
   if (fetchOk) return { action: 'restore' }

--- a/scripts/gate/baseline-archive.mjs
+++ b/scripts/gate/baseline-archive.mjs
@@ -77,25 +77,45 @@ export function reconcileArchive({ expected, overlaid, carriedForward }) {
 }
 
 /**
- * 恢复远端基线树的三态判定：`restore` / `bootstrap` / `fail`。
+ * 远端 ref 探针的三态分类（唯一判据，两个入口共用）。
+ *
+ * 用 `git ls-remote --exit-code --heads origin <ref>` 的退出码，而不是「stdout 是否为空」：
+ *   · 0 = 本次广告里**有**这条 ref；
+ *   · 2 = 本次广告里**没有**这条 ref（git 自己提供的语义，`--exit-code` 专为此设）；
+ *   · 其它（128 等）= 远端不可达 / 权限故障 / URL 不可解析 —— 属**环境故障**，可能瞬时，需重试。
+ * 「空 stdout」在这里不再承担判据职责，避免与「远端只广告了部分 ref」混淆。
+ */
+export function classifyRemoteProbe({ ok, code }) {
+  if (ok) return 'present'
+  if (code === 2) return 'absent'
+  return 'unreachable'
+}
+
+/**
+ * 恢复远端基线树的判定：`restore` / `bootstrap` / `fail`。
  *
  * 为什么不能只看「fetch 成不成功」：fetch 失败有两种完全相反的含义——
- *   · 远端可达但 ref 不存在 = 首夜，没有基线可恢复，降级为全量变异是正常的；
- *   · 远端不可达 / 权限故障 = 基线**可能存在但取不到**，此时若当成空分支继续，
- *     本班产物会被当成"全部内容"推回去，把沿用中的基线整批删掉。
- * 2026-09-11 05:18 的 overlay 就出现过后者（分支明明存在，日志却是"尚不可达或为空"），
- * 修复落在 overlay-baseline.mjs 一侧（#716）；本函数让 orphan-baseline.mjs 的 restore
- * 走同一判据，避免同一操作两份实现长期分叉。
+ *   · `absent` = 远端可达但这条 ref 不在广告里，没有基线可恢复，降级为全量变异是正常的（首夜）；
+ *   · `present` / `unreachable` = 基线**可能存在但取不到**，此时若当成空分支继续，本班产物会被
+ *     当成「全部内容」推回去，把沿用中的基线整批删掉。
+ * 2026-09-11 05:18 的 overlay 就出现过后者（分支明明存在，日志却是「尚不可达或为空」），
+ * 修复先落在 overlay-baseline.mjs（#716）；本函数让 orphan-baseline.mjs 走同一判据，
+ * 避免同一操作两份实现长期分叉。
  *
- * 判据因此是「远端可不可达 + ref 在不在」，而不是「fetch 有没有报错」。
+ * 已知边界（必须诚实记录）：`absent` 只能证明「本次广告里没有这条 ref」，**不能**证明
+ * 「服务端上不存在」——服务端可用 `uploadpack.hideRefs` 隐藏某条 ref，此时探针与真·首夜
+ * 完全同形。因此写路径的真正保障不在探针，而在**推送侧不得删段**（见 #718 方案评论）。
  */
-export function decideRestoreOutcome({ remoteReachable, refExists, fetchOk }) {
+export function decideRestoreOutcome({ probeStatus, fetchOk }) {
   if (fetchOk) return { action: 'restore' }
-  if (!remoteReachable) {
-    return { action: 'fail', reason: '远端不可达，无法判定是否存在基线（拒绝以空基线继续）' }
-  }
-  if (refExists) {
+  if (probeStatus === 'present') {
     return { action: 'fail', reason: '远端基线分支存在但拉取失败（拒绝以空基线覆盖）' }
   }
-  return { action: 'bootstrap', reason: '远端基线分支尚不存在，本次安全降级为全量变异' }
+  if (probeStatus === 'unreachable') {
+    return { action: 'fail', reason: '远端不可达，无法判定是否存在基线（拒绝以空基线继续）' }
+  }
+  if (probeStatus === 'absent') {
+    return { action: 'bootstrap', reason: '远端基线分支尚不存在，本次安全降级为全量变异' }
+  }
+  return { action: 'fail', reason: `未知的探针状态 ${String(probeStatus)}（拒绝以空基线继续）` }
 }

--- a/scripts/gate/baseline-archive.mjs
+++ b/scripts/gate/baseline-archive.mjs
@@ -75,3 +75,27 @@ export function reconcileArchive({ expected, overlaid, carriedForward }) {
   const missing = (expected ?? []).filter((f) => !have.has(f))
   return { missing, carriedCount: (carriedForward ?? []).length, overlaidCount: (overlaid ?? []).length }
 }
+
+/**
+ * 恢复远端基线树的三态判定：`restore` / `bootstrap` / `fail`。
+ *
+ * 为什么不能只看「fetch 成不成功」：fetch 失败有两种完全相反的含义——
+ *   · 远端可达但 ref 不存在 = 首夜，没有基线可恢复，降级为全量变异是正常的；
+ *   · 远端不可达 / 权限故障 = 基线**可能存在但取不到**，此时若当成空分支继续，
+ *     本班产物会被当成"全部内容"推回去，把沿用中的基线整批删掉。
+ * 2026-09-11 05:18 的 overlay 就出现过后者（分支明明存在，日志却是"尚不可达或为空"），
+ * 修复落在 overlay-baseline.mjs 一侧（#716）；本函数让 orphan-baseline.mjs 的 restore
+ * 走同一判据，避免同一操作两份实现长期分叉。
+ *
+ * 判据因此是「远端可不可达 + ref 在不在」，而不是「fetch 有没有报错」。
+ */
+export function decideRestoreOutcome({ remoteReachable, refExists, fetchOk }) {
+  if (fetchOk) return { action: 'restore' }
+  if (!remoteReachable) {
+    return { action: 'fail', reason: '远端不可达，无法判定是否存在基线（拒绝以空基线继续）' }
+  }
+  if (refExists) {
+    return { action: 'fail', reason: '远端基线分支存在但拉取失败（拒绝以空基线覆盖）' }
+  }
+  return { action: 'bootstrap', reason: '远端基线分支尚不存在，本次安全降级为全量变异' }
+}

--- a/scripts/gate/baseline/README.md
+++ b/scripts/gate/baseline/README.md
@@ -44,11 +44,15 @@
 |---|---|---|
 | `present`（exit 0） | 本次广告里有 `baseline/mutation` | 拉取；拉取失败 → **fail-loud** |
 | `absent`（exit 2） | 本次广告里没有该 ref | **唯一**允许降级为全量的情形（首夜，`::notice::`） |
-| `unreachable`（其它/无退出码） | 远端不可达 / 权限故障 / URL 不可解析 | **fail-loud**（无法判定基线是否存在） |
+| `unreachable`（其它/无退出码） | 远端不可达 / 权限故障 / URL 不可解析 | 不跳过 fetch；拉取仍失败 → **fail-loud** |
 
 另有两条同类收紧：远端树里有 blob 却**无任何基线文件**（命名漂移）在写路径上判 fail-loud
 （继续会用本班产物覆盖这些未知文件）；overlay 的「查询关联 PR」「查询 Workflow Runs」
 两处失败也改为 fail-loud——**「查不了」与「查不到（空数组）」是两件事**，后者仍是正常 no-op。
+
+表里 `unreachable` 只决定「是否跳过 fetch」，不单独决定最终动作：`decideRestoreOutcome` 把
+`fetchOk` 放在第一位，所以**探针三连失败但 fetch 反而成功时，判为恢复而非判红**（探针假阴性
+被救回）；只有 fetch 也失败才 fail-loud。`absent` 是唯一的确定结论——它直接跳过 fetch 并降级。
 
 **已知边界（不要误读为强保证）**：`absent` 只能证明「本次广告里没有这条 ref」，**不能**证明
 服务端上不存在——服务端可用 `uploadpack.hideRefs` 隐藏某条 ref，此时与真·首夜完全同形，

--- a/scripts/gate/baseline/README.md
+++ b/scripts/gate/baseline/README.md
@@ -51,8 +51,14 @@
 两处失败也改为 fail-loud——**「查不了」与「查不到（空数组）」是两件事**，后者仍是正常 no-op。
 
 **已知边界（不要误读为强保证）**：`absent` 只能证明「本次广告里没有这条 ref」，**不能**证明
-服务端上不存在——服务端可用 `uploadpack.hideRefs` 隐藏某条 ref，此时与真·首夜完全同形。
-写路径的真正保障不在探针，而在**推送侧不得删段**（见 #718 方案评论）。
+服务端上不存在——服务端可用 `uploadpack.hideRefs` 隐藏某条 ref，此时与真·首夜完全同形，
+客户端无从区分。这一支上**唯一实际生效**的防护是 workflow 层 `mutation-suites` 的 outcome
+门控（`observe-incremental.yml` 的 push 步骤要求它非 `skipped`，而它依赖 restore 非零退出）；
+**代码里没有「推送侧拒绝空/缺段快照」的保护**，补该保护已登记在 #718 的方案中（并集入档），尚未实施。
+
+**两条路径的有意差异**：orphan 侧在「远端树里有 blob 却无基线文件」时**拒绝继续**（fail-loud）；
+overlay 侧没有这个检查，而是由 `reconcileArchive` 以 `archiveGap` 判红、**仍照常推送**——
+因为 overlay 是差量覆盖，拒绝推送会让归档停在更旧的树上。两处语义不同是有意的，不要当作不一致。
 
 > 注：`.github/workflows/ci.yml`（「首夜/基线缺失时天然降级为全量变异，门禁语义不变仅变慢」等）
 > 与 `observe-incremental.yml` 的对应注释**尚未同步**。`.github/` 属红线，须在 issue 内取得

--- a/scripts/gate/baseline/README.md
+++ b/scripts/gate/baseline/README.md
@@ -32,3 +32,28 @@
 - **本地调试**：
   - 本地若需要远端基线辅助增量测试，可执行：
     `node scripts/gate/orphan-baseline.mjs restore`
+  - 注意：本地若没有可用的 `origin`（或远端不可达），该命令会**非零退出**，不再静默降级（见下节）。
+
+### 恢复与查询失败的三态语义（#718）
+
+`orphan-baseline.mjs restore` 与 `overlay-baseline.mjs` 的远端探针**共用同一判据**
+（`baseline-archive.mjs` 的 `classifyRemoteProbe` / `decideRestoreOutcome`），用
+`git ls-remote --exit-code` 的**退出码**分三态，不再用「stdout 是否为空」反推：
+
+| 探针结果 | 含义 | 动作 |
+|---|---|---|
+| `present`（exit 0） | 本次广告里有 `baseline/mutation` | 拉取；拉取失败 → **fail-loud** |
+| `absent`（exit 2） | 本次广告里没有该 ref | **唯一**允许降级为全量的情形（首夜，`::notice::`） |
+| `unreachable`（其它/无退出码） | 远端不可达 / 权限故障 / URL 不可解析 | **fail-loud**（无法判定基线是否存在） |
+
+另有两条同类收紧：远端树里有 blob 却**无任何基线文件**（命名漂移）在写路径上判 fail-loud
+（继续会用本班产物覆盖这些未知文件）；overlay 的「查询关联 PR」「查询 Workflow Runs」
+两处失败也改为 fail-loud——**「查不了」与「查不到（空数组）」是两件事**，后者仍是正常 no-op。
+
+**已知边界（不要误读为强保证）**：`absent` 只能证明「本次广告里没有这条 ref」，**不能**证明
+服务端上不存在——服务端可用 `uploadpack.hideRefs` 隐藏某条 ref，此时与真·首夜完全同形。
+写路径的真正保障不在探针，而在**推送侧不得删段**（见 #718 方案评论）。
+
+> 注：`.github/workflows/ci.yml`（「首夜/基线缺失时天然降级为全量变异，门禁语义不变仅变慢」等）
+> 与 `observe-incremental.yml` 的对应注释**尚未同步**。`.github/` 属红线，须在 issue 内取得
+> 维护者 `approved` 后单独修改；在同步之前，以本节与脚本头部注释为准。

--- a/scripts/gate/orphan-baseline.mjs
+++ b/scripts/gate/orphan-baseline.mjs
@@ -169,14 +169,16 @@ if (action === 'push') {
     }
   }
 
-  // ref 不在广告里就是首夜，直接降级——不必为一个取不到的 ref 白跑一轮 fetch 重试。
-  // ref 存在才拉取；拉取失败说明基线确实在、只是取不到，交由 decideRestoreOutcome 判 fail。
+  // 只有「探针明确说广告里没有这条 ref」才跳过 fetch（为首夜白跑一轮注定失败的重试没有意义）。
+  // 探针结果不确定（unreachable）时仍要尝试 fetch：拉取成功说明基线确实在、能正常恢复，
+  // 不该因探针的假阴性把「可恢复」判成「判红」——decideRestoreOutcome 把 fetchOk 放在第一位。
   let fetched = false;
-  if (probeStatus === 'present') {
+  if (probeStatus !== 'absent') {
     for (let attempt = 1; attempt <= PROBE_ATTEMPTS; attempt++) {
       const res = runGit(
         ['fetch', '--depth=1', 'origin', `refs/heads/${BRANCH}`],
-        { ignoreError: true },
+        // 与探针一致：无 TTY 时不让 git 挂起等待凭据输入。
+        { ignoreError: true, env: { GIT_TERMINAL_PROMPT: '0' } },
       );
       if (res !== null) {
         fetched = true;

--- a/scripts/gate/orphan-baseline.mjs
+++ b/scripts/gate/orphan-baseline.mjs
@@ -14,9 +14,10 @@
  *     - 强制推送到 refs/heads/baseline/mutation
  *
  *   node scripts/gate/orphan-baseline.mjs restore
- *     - 从 refs/heads/baseline/mutation 浅拉取（fetch --depth=1，带 3 次退避重试）
+ *     - 先 ls-remote 判「远端可不可达」与「ref 在不在」，再浅拉取（fetch --depth=1，带 3 次退避重试）
  *     - 将 incremental-*.json 与 manifest.json 恢复到 coverage/mutation/
- *     - 分支不存在或拉取失败时输出 notice 并以退出码 0 安全降级全量
+ *     - 仅在「远端可达且 ref 不存在」时输出 notice 并以退出码 0 降级全量（首夜）；
+ *       远端不可达、或 ref 存在但拉取失败，一律 fail-loud 退出（拒绝以空基线继续，见 #718）
  */
 import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
@@ -29,6 +30,8 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
+
+import { decideRestoreOutcome } from './baseline-archive.mjs';
 
 const action = process.argv[2];
 const BRANCH = 'baseline/mutation';
@@ -125,6 +128,12 @@ if (action === 'push') {
 } else if (action === 'restore') {
   mkdirSync(TARGET_DIR, { recursive: true });
 
+  // 先问「远端有没有这条 ref」，再 decide 怎么处置。判据不能只看 fetch 成不成功：
+  // 「取不到」与「不存在」是两件事，前者若被当成空分支，会把沿用中的基线整批丢掉。
+  const lsRemote = runGit(['ls-remote', '--heads', 'origin', `refs/heads/${BRANCH}`], {
+    ignoreError: true,
+  });
+
   // 带有退避重试的 fetch 机制（抵御 Runner 网络突发抖动）
   let fetched = false;
   for (let attempt = 1; attempt <= 3; attempt++) {
@@ -142,8 +151,18 @@ if (action === 'push') {
     }
   }
 
-  if (!fetched) {
-    console.log(`::notice::孤立分支 refs/heads/${BRANCH} 不可达或暂无基线，本次安全降级为全量变异`);
+  const outcome = decideRestoreOutcome({
+    remoteReachable: lsRemote !== null,
+    refExists: typeof lsRemote === 'string' && lsRemote.length > 0,
+    fetchOk: fetched,
+  });
+
+  if (outcome.action === 'fail') {
+    console.error(`[orphan-baseline] ${outcome.reason}（fail-loud）`);
+    process.exit(1);
+  }
+  if (outcome.action === 'bootstrap') {
+    console.log(`::notice::${outcome.reason}`);
     process.exit(0);
   }
 

--- a/scripts/gate/orphan-baseline.mjs
+++ b/scripts/gate/orphan-baseline.mjs
@@ -14,10 +14,11 @@
  *     - 强制推送到 refs/heads/baseline/mutation
  *
  *   node scripts/gate/orphan-baseline.mjs restore
- *     - 先 ls-remote 判「远端可不可达」与「ref 在不在」，再浅拉取（fetch --depth=1，带 3 次退避重试）
- *     - 将 incremental-*.json 与 manifest.json 恢复到 coverage/mutation/
- *     - 仅在「远端可达且 ref 不存在」时输出 notice 并以退出码 0 降级全量（首夜）；
- *       远端不可达、或 ref 存在但拉取失败，一律 fail-loud 退出（拒绝以空基线继续，见 #718）
+ *     - 探针 `ls-remote --exit-code` 判三态：广告里有该 ref / 广告里没有 / 环境故障（每态均带退避重试）
+ *     - 仅在「广告里没有该 ref」时输出 notice 并以退出码 0 降级全量（首夜）
+ *     - 远端不可达、或 ref 存在但拉取失败、或树里有 blob 却无任何基线文件，一律 fail-loud 退出
+ *       （拒绝以空基线继续——写路径上这意味着删段，见 #718）
+ *     - 取到后浅拉取（fetch --depth=1）并把 incremental-*.json 与 manifest.json 恢复到 coverage/mutation/
  */
 import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
@@ -31,12 +32,15 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 
-import { decideRestoreOutcome } from './baseline-archive.mjs';
+import { classifyRemoteProbe, decideRestoreOutcome } from './baseline-archive.mjs';
 
 const action = process.argv[2];
 const BRANCH = 'baseline/mutation';
 const TARGET_DIR = join(process.cwd(), 'coverage', 'mutation');
 const MAX_BUFFER = 64 * 1024 * 1024; // 64MB，防止巨型基线 JSON 突破 Node 默认 1MB maxBuffer
+const PROBE_ATTEMPTS = 3;
+// 环境故障（远端不可达）可能瞬时，按与 fetch 同规格的退避重试；测试用 0 秒避免拖慢套件。
+const RETRY_DELAY_MS = Number(process.env.ORPHAN_BASELINE_RETRY_DELAY_MS ?? 2000);
 
 function runGit(args, options = {}) {
   const { input, env, ignoreError = false } = options;
@@ -52,6 +56,29 @@ function runGit(args, options = {}) {
     if (ignoreError) return null;
     const stderr = err.stderr ? String(err.stderr).trim() : '';
     throw new Error(`git ${args.join(' ')} failed: ${stderr || err.message}`);
+  }
+}
+
+/**
+ * 需要**退出码**的 git 调用：探针靠 exit 2 区分「无匹配 ref」与「环境故障」，
+ * 而 `ignoreError` 会把两者都压成 null，丢掉这个信息。
+ */
+function runGitProbe(args) {
+  try {
+    const stdout = execFileSync('git', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: MAX_BUFFER,
+      // 无 TTY 时凭据缺失会让 git 挂起等待输入，显式关掉交互提示。
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    }).trim();
+    return { ok: true, code: 0, stdout };
+  } catch (err) {
+    return {
+      ok: false,
+      code: typeof err.status === 'number' ? err.status : null,
+      stdout: err.stdout ? String(err.stdout).trim() : '',
+    };
   }
 }
 
@@ -128,37 +155,44 @@ if (action === 'push') {
 } else if (action === 'restore') {
   mkdirSync(TARGET_DIR, { recursive: true });
 
-  // 先问「远端有没有这条 ref」，再 decide 怎么处置。判据不能只看 fetch 成不成功：
-  // 「取不到」与「不存在」是两件事，前者若被当成空分支，会把沿用中的基线整批丢掉。
-  const lsRemote = runGit(['ls-remote', '--heads', 'origin', `refs/heads/${BRANCH}`], {
-    ignoreError: true,
-  });
-
-  // 带有退避重试的 fetch 机制（抵御 Runner 网络突发抖动）
-  let fetched = false;
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    const res = runGit(
-      ['fetch', '--depth=1', 'origin', `refs/heads/${BRANCH}`],
-      { ignoreError: true },
-    );
-    if (res !== null) {
-      fetched = true;
-      break;
-    }
-    if (attempt < 3) {
-      console.warn(`[orphan-baseline] Fetch 孤立分支失败，第 ${attempt}/3 次重试（等待 2s）...`);
-      sleep(2000);
+  // 探针：`--exit-code` 让 git 自己给出三态（0=广告里有这条 ref / 2=广告里没有 / 其它=环境故障）。
+  // 不能用「stdout 是否为空」反推「ref 不存在」——服务端隐藏 ref 时两者同形，见 decideRestoreOutcome。
+  // 环境故障可能瞬时，探针必须和 fetch 一样带退避重试：探针比它保护的操作更脆就本末倒置了。
+  let probeStatus = 'unreachable';
+  for (let attempt = 1; attempt <= PROBE_ATTEMPTS; attempt++) {
+    const res = runGitProbe(['ls-remote', '--exit-code', '--heads', 'origin', `refs/heads/${BRANCH}`]);
+    probeStatus = classifyRemoteProbe({ ok: res.ok, code: res.code });
+    if (probeStatus !== 'unreachable') break;
+    if (attempt < PROBE_ATTEMPTS) {
+      console.warn(`[orphan-baseline] ls-remote 探测基线分支失败，第 ${attempt}/${PROBE_ATTEMPTS} 次重试...`);
+      sleep(RETRY_DELAY_MS);
     }
   }
 
-  const outcome = decideRestoreOutcome({
-    remoteReachable: lsRemote !== null,
-    refExists: typeof lsRemote === 'string' && lsRemote.length > 0,
-    fetchOk: fetched,
-  });
+  // ref 不在广告里就是首夜，直接降级——不必为一个取不到的 ref 白跑一轮 fetch 重试。
+  // ref 存在才拉取；拉取失败说明基线确实在、只是取不到，交由 decideRestoreOutcome 判 fail。
+  let fetched = false;
+  if (probeStatus === 'present') {
+    for (let attempt = 1; attempt <= PROBE_ATTEMPTS; attempt++) {
+      const res = runGit(
+        ['fetch', '--depth=1', 'origin', `refs/heads/${BRANCH}`],
+        { ignoreError: true },
+      );
+      if (res !== null) {
+        fetched = true;
+        break;
+      }
+      if (attempt < PROBE_ATTEMPTS) {
+        console.warn(`[orphan-baseline] Fetch 孤立分支失败，第 ${attempt}/${PROBE_ATTEMPTS} 次重试...`);
+        sleep(RETRY_DELAY_MS);
+      }
+    }
+  }
+
+  const outcome = decideRestoreOutcome({ probeStatus, fetchOk: fetched });
 
   if (outcome.action === 'fail') {
-    console.error(`[orphan-baseline] ${outcome.reason}（fail-loud）`);
+    console.error(`[orphan-baseline] ${outcome.reason}（fail-loud，本次未执行变异测试）`);
     process.exit(1);
   }
   if (outcome.action === 'bootstrap') {
@@ -189,7 +223,12 @@ if (action === 'push') {
   if (restored > 0) {
     console.log(`[orphan-baseline] 成功恢复 ${restored} 份基线文件至 ${TARGET_DIR}`);
   } else {
-    console.log('::notice::孤立分支中未发现基线文件，本次安全降级为全量变异');
+    // 树里有 blob 却一个都不符合基线命名 = 归档形状漂移。写路径若继续，会用本班产物覆盖这些
+    // 未知文件，所以按 fail-loud 处理——与「树为空」（真·空归档，首夜语义）区分开。
+    console.error(
+      `[orphan-baseline] 远端树含 ${lines.length} 个条目但无任何基线文件（命名漂移？），拒绝继续（fail-loud）`,
+    );
+    process.exit(1);
   }
 
 } else {

--- a/scripts/gate/overlay-baseline.mjs
+++ b/scripts/gate/overlay-baseline.mjs
@@ -37,6 +37,9 @@ const commitSha = process.env.COMMIT_SHA || execSync('git rev-parse HEAD', { enc
 const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || process.env.OBSERVE_PAT;
 const BRANCH = 'baseline/mutation';
 const MAX_BUFFER = 64 * 1024 * 1024; // 64MB
+const PROBE_ATTEMPTS = 3;
+// 与 orphan-baseline.mjs 共用同一退避口径（测试置 0 避免拖慢套件）。
+const RETRY_DELAY_MS = Number(process.env.ORPHAN_BASELINE_RETRY_DELAY_MS ?? 2000);
 
 function runCmd(cmd, args = [], options = {}) {
   return execFileSync(cmd, args, {
@@ -49,6 +52,38 @@ function runCmd(cmd, args = [], options = {}) {
 
 function runGh(args) {
   return runCmd('gh', args, { env: token ? { GH_TOKEN: token } : {} });
+}
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * 远端基线 ref 的三态探针——与 orphan-baseline.mjs 同一判据、同一重试规格。
+ * 两入口若各写一套，就会重演「同一操作两份实现」的老问题（#718 的成因之一）。
+ * `absent` 是确定结论，不再重试；只有环境故障才值得退避重试。
+ */
+function probeArchiveRef() {
+  for (let attempt = 1; attempt <= PROBE_ATTEMPTS; attempt++) {
+    try {
+      runCmd('git', ['ls-remote', '--exit-code', '--heads', 'origin', `refs/heads/${BRANCH}`], {
+        // 无 TTY 时凭据缺失会让 git 挂起等待输入，显式关掉交互提示。
+        env: { GIT_TERMINAL_PROMPT: '0' },
+      });
+      return 'present';
+    } catch (err) {
+      const status = classifyRemoteProbe({
+        ok: false,
+        code: typeof err.status === 'number' ? err.status : null,
+      });
+      if (status !== 'unreachable') return status;
+      if (attempt < PROBE_ATTEMPTS) {
+        console.warn(`[overlay-baseline] ls-remote 探测基线分支失败，第 ${attempt}/${PROBE_ATTEMPTS} 次重试...`);
+        sleepSync(RETRY_DELAY_MS);
+      }
+    }
+  }
+  return 'unreachable';
 }
 
 async function main() {
@@ -163,24 +198,13 @@ async function main() {
   try {
     // 5. 先恢复孤立分支的现存基线全量快照
     console.log(`[overlay-baseline] 恢复孤立分支 ${BRANCH} 现存基线...`);
+    // 探针必须声明在 try 之外：catch 要靠它区分「首夜」与「探针没能给出否定结论」。
+    // 上一版把声明放进 try、又在 catch 引用，命中即 ReferenceError——守卫成了死代码（#716 也是同一写法）。
+    const probeStatus = probeArchiveRef();
     try {
-      // 与 orphan-baseline.mjs 共用**同一个探针与同一套分类**（判据只允许一处实现）：
-      // `ls-remote --exit-code` 的 0 / 2 / 其它 分别是「广告里有这条 ref」/「广告里没有」/「环境故障」。
-      // 这里原本用 `gh api .../git/ref/heads/<branch>`，其失败被裸 catch 吞成「首夜」——
-      // 正是 2026-09-11 05:18 事故的原始形态；#716 只修了「探针成功但 fetch 失败」那一半。
-      let probeStatus = 'unreachable';
-      try {
-        runCmd('git', ['ls-remote', '--exit-code', '--heads', 'origin', `refs/heads/${BRANCH}`], {
-          env: { GIT_TERMINAL_PROMPT: '0' },
-        });
-        probeStatus = 'present';
-      } catch (probeErr) {
-        probeStatus = classifyRemoteProbe({
-          ok: false,
-          code: typeof probeErr.status === 'number' ? probeErr.status : null,
-        });
-      }
-      runCmd('git', ['fetch', '--depth=1', 'origin', `refs/heads/${BRANCH}`]);
+      runCmd('git', ['fetch', '--depth=1', 'origin', `refs/heads/${BRANCH}`], {
+        env: { GIT_TERMINAL_PROMPT: '0' },
+      });
       const treeOutput = runCmd('git', ['ls-tree', '-r', 'FETCH_HEAD']);
       for (const line of treeOutput.split('\n').filter(Boolean)) {
         const parts = line.split('\t');
@@ -194,9 +218,10 @@ async function main() {
     } catch (err) {
       // 只有「广告里确实没有这条 ref」才是首夜；探针没能给出否定结论时一律拒绝以空快照覆盖。
       if (probeStatus !== 'absent') {
-        console.error(
-          `[overlay-baseline] 无法确认孤立分支 ${BRANCH} 是否存在（探针结果 ${probeStatus}），拒绝以空快照覆盖（fail-loud）: ${err.message}`,
-        );
+        const why = probeStatus === 'present'
+          ? `孤立分支 ${BRANCH} 存在但恢复失败`
+          : `无法确认孤立分支 ${BRANCH} 是否存在（探针结果 ${probeStatus}）`;
+        console.error(`[overlay-baseline] ${why}，拒绝以空快照覆盖（fail-loud）: ${err.message}`);
         process.exit(1);
       }
       console.log(`[overlay-baseline] 孤立分支 ${BRANCH} 尚不存在（首夜），基于当前产物构建全新快照`);

--- a/scripts/gate/overlay-baseline.mjs
+++ b/scripts/gate/overlay-baseline.mjs
@@ -25,6 +25,7 @@ import { tmpdir } from 'node:os';
 import {
   BASELINE_FILE_RE,
   GH_API_PER_PAGE,
+  classifyRemoteProbe,
   expectedBaselineFiles,
   mergeArtifactPage,
   mutationArtifacts,
@@ -163,14 +164,21 @@ async function main() {
     // 5. 先恢复孤立分支的现存基线全量快照
     console.log(`[overlay-baseline] 恢复孤立分支 ${BRANCH} 现存基线...`);
     try {
-      // 先确认远端 ref 是否存在：`git fetch` 失败既可能是「分支尚不存在」（首夜，正常降级），
-      // 也可能是网络/权限瞬时故障——后者若被当成空分支，会把沿用中的基线整批丢掉
-      // （实测 2026-09-11 05:18 的 overlay 就出现过一次，日志显示「尚不可达或为空」）。
-      let remoteRefExists = false;
+      // 与 orphan-baseline.mjs 共用**同一个探针与同一套分类**（判据只允许一处实现）：
+      // `ls-remote --exit-code` 的 0 / 2 / 其它 分别是「广告里有这条 ref」/「广告里没有」/「环境故障」。
+      // 这里原本用 `gh api .../git/ref/heads/<branch>`，其失败被裸 catch 吞成「首夜」——
+      // 正是 2026-09-11 05:18 事故的原始形态；#716 只修了「探针成功但 fetch 失败」那一半。
+      let probeStatus = 'unreachable';
       try {
-        remoteRefExists = runGh(['api', `repos/${repo}/git/ref/heads/${BRANCH}`]).length > 0;
-      } catch {
-        remoteRefExists = false;
+        runCmd('git', ['ls-remote', '--exit-code', '--heads', 'origin', `refs/heads/${BRANCH}`], {
+          env: { GIT_TERMINAL_PROMPT: '0' },
+        });
+        probeStatus = 'present';
+      } catch (probeErr) {
+        probeStatus = classifyRemoteProbe({
+          ok: false,
+          code: typeof probeErr.status === 'number' ? probeErr.status : null,
+        });
       }
       runCmd('git', ['fetch', '--depth=1', 'origin', `refs/heads/${BRANCH}`]);
       const treeOutput = runCmd('git', ['ls-tree', '-r', 'FETCH_HEAD']);
@@ -184,8 +192,11 @@ async function main() {
         }
       }
     } catch (err) {
-      if (remoteRefExists) {
-        console.error(`[overlay-baseline] 孤立分支 ${BRANCH} 存在但恢复失败（fail-loud，拒绝以空快照覆盖）: ${err.message}`);
+      // 只有「广告里确实没有这条 ref」才是首夜；探针没能给出否定结论时一律拒绝以空快照覆盖。
+      if (probeStatus !== 'absent') {
+        console.error(
+          `[overlay-baseline] 无法确认孤立分支 ${BRANCH} 是否存在（探针结果 ${probeStatus}），拒绝以空快照覆盖（fail-loud）: ${err.message}`,
+        );
         process.exit(1);
       }
       console.log(`[overlay-baseline] 孤立分支 ${BRANCH} 尚不存在（首夜），基于当前产物构建全新快照`);

--- a/scripts/gate/overlay-baseline.mjs
+++ b/scripts/gate/overlay-baseline.mjs
@@ -64,8 +64,10 @@ async function main() {
     const raw = runGh(['api', `repos/${repo}/commits/${commitSha}/pulls`]);
     pulls = JSON.parse(raw);
   } catch (err) {
-    console.log(`[overlay-baseline] 查询关联 PR 失败或无关联，安全跳过 (No-op): ${err.message}`);
-    process.exit(0);
+    // fail-loud（#690 门禁纪律）：查询失败 ≠「查不到关联 PR」。后者是空数组、属正常 no-op；
+    // 前者意味着无法判定这次合并是否需要覆盖基线，静默跳过会让归档更新无声丢失。
+    console.error(`[overlay-baseline] 查询关联 PR 失败，未执行归档（fail-loud）: ${err.message}`);
+    process.exit(1);
   }
 
   if (!Array.isArray(pulls) || pulls.length === 0) {
@@ -93,8 +95,9 @@ async function main() {
     ]);
     runs = JSON.parse(raw);
   } catch (err) {
-    console.log(`[overlay-baseline] 查询 PR #${pr.number} 的 Workflow Runs 失败，跳过基线覆盖: ${err.message}`);
-    process.exit(0);
+    // 与下方 artifacts 查询同一纪律：查不了就必须红，不能当成「没有成功的 CI Run」。
+    console.error(`[overlay-baseline] 查询 PR #${pr.number} 的 Workflow Runs 失败，未执行归档（fail-loud）: ${err.message}`);
+    process.exit(1);
   }
 
   const successfulCiRun = runs.find((r) => r.name === 'CI' && r.conclusion === 'success');

--- a/scripts/test/baseline-archive.test.ts
+++ b/scripts/test/baseline-archive.test.ts
@@ -21,6 +21,7 @@ import { join } from 'node:path'
 import {
   BASELINE_FILE_RE,
   GH_API_PER_PAGE,
+  decideRestoreOutcome,
   expectedBaselineFiles,
   mergeArtifactPage,
   mutationArtifacts,
@@ -175,4 +176,25 @@ test('脚本静态检查：两处 GitHub API 调用都显式带上分页参数',
   for (const call of apiCalls) {
     assert.match(call, /per_page=/, `gh api 调用缺少分页参数（默认 30 条会截断）：${call}`)
   }
+})
+
+test('#718: restore 三态判定 —— 「取不到」与「不存在」必须走不同分支', () => {
+  // 拿到就把远端树恢复回来。
+  assert.equal(decideRestoreOutcome({ remoteReachable: true, refExists: true, fetchOk: true }).action, 'restore')
+  assert.equal(decideRestoreOutcome({ remoteReachable: true, refExists: false, fetchOk: true }).action, 'restore')
+
+  // 远端不可达 = 无法判定有没有基线 → fail-loud（这正是 2026-09-11 05:18 的形态）。
+  const unreachable = decideRestoreOutcome({ remoteReachable: false, refExists: false, fetchOk: false })
+  assert.equal(unreachable.action, 'fail', '远端不可达不得降级为首夜')
+  assert.ok(!unreachable.reason.includes('安全降级'), 'fail 分支不得复用降级文案')
+
+  // ref 存在但拉取失败 = 基线确实在、只是取不到 → fail-loud，绝不能被当成空分支。
+  const fetchFailed = decideRestoreOutcome({ remoteReachable: true, refExists: true, fetchOk: false })
+  assert.equal(fetchFailed.action, 'fail', 'ref 存在但拉取失败必须 fail-loud')
+  assert.notEqual(fetchFailed.reason, unreachable.reason, '两种 fail 原因应可区分，便于定位')
+
+  // 只有「远端可达且 ref 不存在」才是真正的首夜，允许降级为全量变异。
+  const bootstrap = decideRestoreOutcome({ remoteReachable: true, refExists: false, fetchOk: false })
+  assert.equal(bootstrap.action, 'bootstrap')
+  assert.ok(bootstrap.reason.includes('安全降级为全量变异'), '首夜文案保持既有约定')
 })

--- a/scripts/test/baseline-archive.test.ts
+++ b/scripts/test/baseline-archive.test.ts
@@ -21,6 +21,7 @@ import { join } from 'node:path'
 import {
   BASELINE_FILE_RE,
   GH_API_PER_PAGE,
+  classifyRemoteProbe,
   decideRestoreOutcome,
   expectedBaselineFiles,
   mergeArtifactPage,
@@ -178,23 +179,37 @@ test('脚本静态检查：两处 GitHub API 调用都显式带上分页参数',
   }
 })
 
+test('#718: 远端探针三态 —— 用退出码而不是「stdout 是否为空」', () => {
+  // git ls-remote --exit-code：0=广告里有该 ref；2=广告里没有；其它(128 等)=环境故障。
+  assert.equal(classifyRemoteProbe({ ok: true, code: 0 }), 'present')
+  assert.equal(classifyRemoteProbe({ ok: false, code: 2 }), 'absent')
+  assert.equal(classifyRemoteProbe({ ok: false, code: 128 }), 'unreachable')
+  // 拿不到退出码（信号终止等）一律按环境故障，不得当成「不存在」。
+  assert.equal(classifyRemoteProbe({ ok: false, code: null }), 'unreachable')
+})
+
 test('#718: restore 三态判定 —— 「取不到」与「不存在」必须走不同分支', () => {
-  // 拿到就把远端树恢复回来。
-  assert.equal(decideRestoreOutcome({ remoteReachable: true, refExists: true, fetchOk: true }).action, 'restore')
-  assert.equal(decideRestoreOutcome({ remoteReachable: true, refExists: false, fetchOk: true }).action, 'restore')
+  // 拿到就把远端树恢复回来（探针状态不再重要）。
+  assert.equal(decideRestoreOutcome({ probeStatus: 'present', fetchOk: true }).action, 'restore')
+  assert.equal(decideRestoreOutcome({ probeStatus: 'absent', fetchOk: true }).action, 'restore')
 
-  // 远端不可达 = 无法判定有没有基线 → fail-loud（这正是 2026-09-11 05:18 的形态）。
-  const unreachable = decideRestoreOutcome({ remoteReachable: false, refExists: false, fetchOk: false })
-  assert.equal(unreachable.action, 'fail', '远端不可达不得降级为首夜')
-  assert.ok(!unreachable.reason.includes('安全降级'), 'fail 分支不得复用降级文案')
-
-  // ref 存在但拉取失败 = 基线确实在、只是取不到 → fail-loud，绝不能被当成空分支。
-  const fetchFailed = decideRestoreOutcome({ remoteReachable: true, refExists: true, fetchOk: false })
-  assert.equal(fetchFailed.action, 'fail', 'ref 存在但拉取失败必须 fail-loud')
-  assert.notEqual(fetchFailed.reason, unreachable.reason, '两种 fail 原因应可区分，便于定位')
-
-  // 只有「远端可达且 ref 不存在」才是真正的首夜，允许降级为全量变异。
-  const bootstrap = decideRestoreOutcome({ remoteReachable: true, refExists: false, fetchOk: false })
+  // 探针说「广告里没有」才是首夜，允许降级为全量变异。
+  const bootstrap = decideRestoreOutcome({ probeStatus: 'absent', fetchOk: false })
   assert.equal(bootstrap.action, 'bootstrap')
   assert.ok(bootstrap.reason.includes('安全降级为全量变异'), '首夜文案保持既有约定')
+
+  // ref 确实在、只是取不到 → 数据故障，任何调用方都不得放宽（写路径上意味着删段）。
+  const fetchFailed = decideRestoreOutcome({ probeStatus: 'present', fetchOk: false })
+  assert.equal(fetchFailed.action, 'fail', 'ref 存在但拉取失败必须 fail-loud')
+
+  // 环境故障 → 无法判定，必须 fail-loud；这正是 2026-09-11 05:18 的形态。
+  const unreachable = decideRestoreOutcome({ probeStatus: 'unreachable', fetchOk: false })
+  assert.equal(unreachable.action, 'fail', '远端不可达不得降级为首夜')
+  assert.notEqual(fetchFailed.reason, unreachable.reason, '两种 fail 原因应可区分，便于定位')
+  for (const r of [fetchFailed, unreachable]) {
+    assert.ok(!r.reason.includes('安全降级'), 'fail 分支不得复用降级文案')
+  }
+
+  // 未知状态属于编程错误：宁可判红，也不能默默降级。
+  assert.equal(decideRestoreOutcome({ probeStatus: 'bogus', fetchOk: false }).action, 'fail')
 })

--- a/scripts/test/orphan-baseline.test.ts
+++ b/scripts/test/orphan-baseline.test.ts
@@ -47,11 +47,13 @@ test('#572: orphan-baseline push 在空目录下防御', () => {
   }
 });
 
-test('#572: orphan-baseline restore 在无远端孤立分支时优雅降级（exit 0 + notice）', () => {
+test('#572: orphan-baseline restore 在远端可达但无基线分支时优雅降级（exit 0 + notice）', () => {
   const tmp = mkdtempSync(join(tmpdir(), 'orphan-test-restore-'));
   try {
-    // 在临时 git 仓库中运行 restore（无 baseline/mutation 分支）
+    // 首夜的真实形态是「远端可达、ref 不存在」——不是「没有远端」。
+    // 无远端属「取不到」，必须与「不存在」区分开（见下一条测试）。
     execFileSync('git', ['init'], { cwd: tmp, stdio: 'ignore' });
+    execFileSync('git', ['remote', 'add', 'origin', tmp], { cwd: tmp, stdio: 'ignore' });
     const output = execFileSync('node', [scriptPath, 'restore'], {
       cwd: tmp,
       encoding: 'utf8',
@@ -59,6 +61,58 @@ test('#572: orphan-baseline restore 在无远端孤立分支时优雅降级（ex
     });
     assert.ok(output.includes('::notice::'), '输出包含 notice 标注全量降级');
     assert.ok(output.includes('安全降级为全量变异'), '日志提示安全降级');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('#718: orphan-baseline restore 在远端不可达时 fail-loud（exit != 0）', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'orphan-test-unreachable-'));
+  try {
+    // 无 origin 远端 = 无法判定「是否存在基线」。此时若按空分支继续，会把沿用中的基线整批丢掉。
+    execFileSync('git', ['init'], { cwd: tmp, stdio: 'ignore' });
+    let failed = false;
+    try {
+      execFileSync('node', [scriptPath, 'restore'], { cwd: tmp, encoding: 'utf8', stdio: 'pipe' });
+    } catch (err) {
+      failed = true;
+      const out = `${err.stdout ?? ''}${err.stderr ?? ''}`;
+      assert.notEqual(err.status, 0, '必须非零退出');
+      assert.ok(out.includes('fail-loud'), `输出须点名 fail-loud，实际: ${out}`);
+      assert.ok(out.includes('远端不可达'), `输出须说明远端不可达，实际: ${out}`);
+    }
+    assert.ok(failed, '远端不可达时不得静默降级为全量变异');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('#718: overlay-baseline 查询失败必须 fail-loud（不得静默 No-op）', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'overlay-test-queryfail-'));
+  try {
+    // 用受限 PATH 让 gh 不可用 —— 「查不了」与「查不到（空数组）」必须走不同分支：
+    // 前者 fail-loud，后者才是 no-op。node 用绝对路径调用，故不受 PATH 影响。
+    let failed = false;
+    try {
+      execFileSync(process.execPath, [overlayScriptPath], {
+        cwd: tmp,
+        encoding: 'utf8',
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          PATH: tmp,
+          GITHUB_REPOSITORY: 'owner/repo',
+          COMMIT_SHA: 'a'.repeat(40),
+          GH_TOKEN: 'dummy',
+        },
+      });
+    } catch (err) {
+      failed = true;
+      const out = `${err.stdout ?? ''}${err.stderr ?? ''}`;
+      assert.notEqual(err.status, 0, '必须非零退出');
+      assert.ok(out.includes('fail-loud'), `输出须点名 fail-loud，实际: ${out}`);
+    }
+    assert.ok(failed, '查询失败不得静默 No-op');
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/scripts/test/orphan-baseline.test.ts
+++ b/scripts/test/orphan-baseline.test.ts
@@ -57,13 +57,24 @@ function runScript(script, args, options = {}) {
   return { status: r.status, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
 }
 
-/** 造一个假 gh：只对 pulls 查询返回已合并 PR，其余子命令按 fail 退出（用于分流到指定 catch 站点）。 */
-function writeFakeGh(dir, { pullsOk = true, runsOk = false } = {}) {
+/**
+ * 造一个假 gh。模式必须按**具体度降序**排列：artifacts 的 URL
+ * （`.../actions/runs/<id>/artifacts?...`）也含 `actions/runs`，若把 `*actions/runs*` 放在前面，
+ * 两条分支会被同一条 glob 吞掉，「锁定 Runs 站点」就名不副实了。
+ */
+function writeFakeGh(dir, {
+  pullsOk = true,
+  runsOk = false,
+  runs = '[{"name":"CI","conclusion":"success","id":12345}]',
+  artifactsOk = false,
+  artifacts = '[]',
+} = {}) {
   const head = `[{"number":7,"merged_at":"2026-01-01T00:00:00Z","head":{"sha":"${'b'.repeat(40)}"}}]`;
   const script = `#!/bin/sh
 case "$2" in
   *commits/*/pulls) ${pullsOk ? `printf '%s' '${head}'; exit 0` : `echo 'pulls boom' >&2; exit 1`} ;;
-  *actions/runs*) ${runsOk ? `printf '%s' '[]'; exit 0` : `echo 'runs boom' >&2; exit 1`} ;;
+  *artifacts*) ${artifactsOk ? `printf '%s' '${artifacts}'; exit 0` : `echo 'artifacts boom' >&2; exit 1`} ;;
+  *actions/runs*) ${runsOk ? `printf '%s' '${runs}'; exit 0` : `echo 'runs boom' >&2; exit 1`} ;;
 esac
 echo "unexpected gh args: $*" >&2; exit 1
 `;
@@ -71,6 +82,24 @@ echo "unexpected gh args: $*" >&2; exit 1
   writeFileSync(p, script, { mode: 0o755 });
   return p;
 }
+
+/** 造一个假 git：只拦 `ls-remote`（放行=present）与 `fetch`（强制失败），其余交给真 git。 */
+function writeGitShim(dir, { fetchFails = true } = {}) {
+  const real = execFileSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).trim();
+  const script = `#!/bin/sh
+case "$1" in
+  ls-remote) exit 0 ;;
+  fetch) ${fetchFails ? `echo 'fetch boom' >&2; exit 1` : `exec "${real}" "$@"`} ;;
+esac
+exec "${real}" "$@"
+`;
+  const p = join(dir, 'git');
+  writeFileSync(p, script, { mode: 0o755 });
+  return p;
+}
+
+/** 假 gh 的 artifacts 分支返回 1 个变异产物，使 overlay 走到恢复段（第 5 步）。 */
+const ONE_MUTATION_ARTIFACT = '{"total_count":1,"artifacts":[{"name":"mutation-incremental-dsh-x"}]}';
 
 test('#572: orphan-baseline restore 在远端可达但无基线分支时优雅降级（exit 0 + notice）', () => {
   const tmp = mkdtempSync(join(tmpdir(), 'orphan-test-restore-'));
@@ -103,8 +132,8 @@ test('#718: orphan-baseline restore 在远端不可达时 fail-loud（exit 1）'
   }
 });
 
-// 「探针说 present、但 fetch 失败」这一幕无法用本地仓库构造（破坏远端对象会让 ls-remote 一并失败，
-// 落进 unreachable）。该组合的判定由 baseline-archive.test.ts 的纯函数用例覆盖，此处不写假测试。
+// 「探针说 present、但 fetch 失败」用 git shim 构造（见下方恢复段用例）——评审指出原先那句
+// 「无法用本地仓库构造」不成立：拦 ls-remote 与 fetch 两个子命令即可，不必真造坏远端。
 
 test('#718: overlay-baseline 查询关联 PR 失败必须 fail-loud（exit 1）', () => {
   const tmp = mkdtempSync(join(tmpdir(), 'overlay-test-prfail-'));
@@ -139,8 +168,70 @@ test('#718: overlay-baseline 查询 Workflow Runs 失败必须 fail-loud（exit 
     assert.equal(r.status, 1, `Runs 查询失败必须 exit 1，实际 ${r.status}: ${r.out}`);
     assert.match(r.out, /Workflow Runs/, '必须命中「Workflow Runs」站点，而非只匹配 fail-loud');
     assert.match(r.out, /fail-loud/, '输出须点名 fail-loud');
+    // 站点锁定：Runs 查询在 artifacts 之前，失败时绝不该出现 artifacts 分页日志。
+    assert.doesNotMatch(r.out, /分页取全/, '不得串到 artifacts 站点');
   } finally {
     rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('#718: overlay-baseline 恢复段——探针说 present 但拉取失败时 fail-loud（exit 1）', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'overlay-test-restore-'));
+  const bin = mkdtempSync(join(tmpdir(), 'overlay-test-bin-'));
+  try {
+    // 这条覆盖第 5 步（恢复段）：pulls/runs/artifacts 都放行并给出 1 个变异产物，
+    // 再用 git shim 让 ls-remote 放行、fetch 失败 → probe=present 且 fetch 失败。
+    // 该分支曾是死代码（probeStatus 声明在 try 内、catch 引用 → ReferenceError），必须端到端锁住。
+    writeFakeGh(tmp, { pullsOk: true, runsOk: true, artifactsOk: true, artifacts: ONE_MUTATION_ARTIFACT });
+    writeGitShim(bin, { fetchFails: true });
+    const r = runScript(overlayScriptPath, [], {
+      cwd: tmp,
+      env: {
+        PATH: `${bin}:${tmp}:${process.env.PATH}`,
+        GITHUB_REPOSITORY: 'owner/repo',
+        COMMIT_SHA: 'a'.repeat(40),
+        GH_TOKEN: 'dummy',
+      },
+    });
+    assert.doesNotMatch(r.out, /ReferenceError/, '不得因变量作用域抛 ReferenceError');
+    assert.equal(r.status, 1, `present 但拉取失败必须 exit 1，实际 ${r.status}: ${r.out}`);
+    assert.match(r.out, /存在但恢复失败/, '须点名「存在但恢复失败」，而不是笼统的「无法确认」');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+    rmSync(bin, { recursive: true, force: true });
+  }
+});
+
+test('#718: overlay-baseline 恢复段——探针明确 absent 时走首夜且不得崩（exit 0）', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'overlay-test-firstnight-'));
+  const bin = mkdtempSync(join(tmpdir(), 'overlay-test-bin2-'));
+  try {
+    // git shim：ls-remote 返回 exit 2（absent）、fetch 失败 → 应走「首夜」继续构建新快照。
+    writeFakeGh(tmp, { pullsOk: true, runsOk: true, artifactsOk: true, artifacts: ONE_MUTATION_ARTIFACT });
+    const real = execFileSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).trim();
+    writeFileSync(join(bin, 'git'), `#!/bin/sh
+case "$1" in
+  ls-remote) exit 2 ;;
+  fetch) echo 'fetch boom' >&2; exit 1 ;;
+esac
+exec "${real}" "$@"
+`, { mode: 0o755 });
+    const r = runScript(overlayScriptPath, [], {
+      cwd: tmp,
+      env: {
+        PATH: `${bin}:${tmp}:${process.env.PATH}`,
+        GITHUB_REPOSITORY: 'owner/repo',
+        COMMIT_SHA: 'a'.repeat(40),
+        GH_TOKEN: 'dummy',
+      },
+    });
+    assert.doesNotMatch(r.out, /ReferenceError/, '不得因变量作用域抛 ReferenceError');
+    assert.match(r.out, /尚不存在（首夜）/, 'absent 应走首夜分支');
+    // 之后产物下载失败 → overlayCount 0 → 无有效覆盖，跳过推送并正常退出。
+    assert.equal(r.status, 0, `首夜应继续并最终 no-op exit 0，实际 ${r.status}: ${r.out}`);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+    rmSync(bin, { recursive: true, force: true });
   }
 });
 
@@ -148,7 +239,7 @@ test('#718: overlay-baseline 「查到了但没有」仍是合法 no-op（exit 0
   const tmp = mkdtempSync(join(tmpdir(), 'overlay-test-noop-'));
   try {
     // pulls 成功、runs 成功但为空数组 = 真的没有成功 CI Run → 必须保持 no-op，不得被 fail-loud 误伤。
-    writeFakeGh(tmp, { pullsOk: true, runsOk: true });
+    writeFakeGh(tmp, { pullsOk: true, runsOk: true, runs: '[]' });
     const r = runScript(overlayScriptPath, [], {
       cwd: tmp,
       env: {

--- a/scripts/test/orphan-baseline.test.ts
+++ b/scripts/test/orphan-baseline.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -47,72 +47,119 @@ test('#572: orphan-baseline push 在空目录下防御', () => {
   }
 });
 
+/** 跑脚本并连退出码一起拿到——断言必须放在 try/catch 之外，否则会退化成「进了 catch 就算过」。 */
+function runScript(script, args, options = {}) {
+  const r = spawnSync(process.execPath, [script, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, ORPHAN_BASELINE_RETRY_DELAY_MS: '0', ...(options.env ?? {}) },
+    cwd: options.cwd,
+  });
+  return { status: r.status, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+}
+
+/** 造一个假 gh：只对 pulls 查询返回已合并 PR，其余子命令按 fail 退出（用于分流到指定 catch 站点）。 */
+function writeFakeGh(dir, { pullsOk = true, runsOk = false } = {}) {
+  const head = `[{"number":7,"merged_at":"2026-01-01T00:00:00Z","head":{"sha":"${'b'.repeat(40)}"}}]`;
+  const script = `#!/bin/sh
+case "$2" in
+  *commits/*/pulls) ${pullsOk ? `printf '%s' '${head}'; exit 0` : `echo 'pulls boom' >&2; exit 1`} ;;
+  *actions/runs*) ${runsOk ? `printf '%s' '[]'; exit 0` : `echo 'runs boom' >&2; exit 1`} ;;
+esac
+echo "unexpected gh args: $*" >&2; exit 1
+`;
+  const p = join(dir, 'gh');
+  writeFileSync(p, script, { mode: 0o755 });
+  return p;
+}
+
 test('#572: orphan-baseline restore 在远端可达但无基线分支时优雅降级（exit 0 + notice）', () => {
   const tmp = mkdtempSync(join(tmpdir(), 'orphan-test-restore-'));
   try {
-    // 首夜的真实形态是「远端可达、ref 不存在」——不是「没有远端」。
+    // 首夜的真实形态是「远端可达、广告里没有这条 ref」——不是「没有远端」。
     // 无远端属「取不到」，必须与「不存在」区分开（见下一条测试）。
     execFileSync('git', ['init'], { cwd: tmp, stdio: 'ignore' });
     execFileSync('git', ['remote', 'add', 'origin', tmp], { cwd: tmp, stdio: 'ignore' });
-    const output = execFileSync('node', [scriptPath, 'restore'], {
-      cwd: tmp,
-      encoding: 'utf8',
-      stdio: 'pipe',
-    });
-    assert.ok(output.includes('::notice::'), '输出包含 notice 标注全量降级');
-    assert.ok(output.includes('安全降级为全量变异'), '日志提示安全降级');
+    const r = runScript(scriptPath, ['restore'], { cwd: tmp });
+    assert.equal(r.status, 0, `首夜应 exit 0，实际 ${r.status}: ${r.out}`);
+    assert.match(r.out, /::notice::/, '输出包含 notice 标注全量降级');
+    assert.match(r.out, /安全降级为全量变异/, '日志提示安全降级');
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
 });
 
-test('#718: orphan-baseline restore 在远端不可达时 fail-loud（exit != 0）', () => {
+test('#718: orphan-baseline restore 在远端不可达时 fail-loud（exit 1）', () => {
   const tmp = mkdtempSync(join(tmpdir(), 'orphan-test-unreachable-'));
   try {
     // 无 origin 远端 = 无法判定「是否存在基线」。此时若按空分支继续，会把沿用中的基线整批丢掉。
     execFileSync('git', ['init'], { cwd: tmp, stdio: 'ignore' });
-    let failed = false;
-    try {
-      execFileSync('node', [scriptPath, 'restore'], { cwd: tmp, encoding: 'utf8', stdio: 'pipe' });
-    } catch (err) {
-      failed = true;
-      const out = `${err.stdout ?? ''}${err.stderr ?? ''}`;
-      assert.notEqual(err.status, 0, '必须非零退出');
-      assert.ok(out.includes('fail-loud'), `输出须点名 fail-loud，实际: ${out}`);
-      assert.ok(out.includes('远端不可达'), `输出须说明远端不可达，实际: ${out}`);
-    }
-    assert.ok(failed, '远端不可达时不得静默降级为全量变异');
+    const r = runScript(scriptPath, ['restore'], { cwd: tmp });
+    assert.equal(r.status, 1, `远端不可达必须 exit 1，实际 ${r.status}: ${r.out}`);
+    assert.match(r.out, /fail-loud/, '输出须点名 fail-loud');
+    assert.match(r.out, /远端不可达/, '输出须说明远端不可达');
+    assert.doesNotMatch(r.out, /安全降级为全量变异/, '不得降级为首夜');
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
 });
 
-test('#718: overlay-baseline 查询失败必须 fail-loud（不得静默 No-op）', () => {
-  const tmp = mkdtempSync(join(tmpdir(), 'overlay-test-queryfail-'));
+// 「探针说 present、但 fetch 失败」这一幕无法用本地仓库构造（破坏远端对象会让 ls-remote 一并失败，
+// 落进 unreachable）。该组合的判定由 baseline-archive.test.ts 的纯函数用例覆盖，此处不写假测试。
+
+test('#718: overlay-baseline 查询关联 PR 失败必须 fail-loud（exit 1）', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'overlay-test-prfail-'));
   try {
-    // 用受限 PATH 让 gh 不可用 —— 「查不了」与「查不到（空数组）」必须走不同分支：
-    // 前者 fail-loud，后者才是 no-op。node 用绝对路径调用，故不受 PATH 影响。
-    let failed = false;
-    try {
-      execFileSync(process.execPath, [overlayScriptPath], {
-        cwd: tmp,
-        encoding: 'utf8',
-        stdio: 'pipe',
-        env: {
-          ...process.env,
-          PATH: tmp,
-          GITHUB_REPOSITORY: 'owner/repo',
-          COMMIT_SHA: 'a'.repeat(40),
-          GH_TOKEN: 'dummy',
-        },
-      });
-    } catch (err) {
-      failed = true;
-      const out = `${err.stdout ?? ''}${err.stderr ?? ''}`;
-      assert.notEqual(err.status, 0, '必须非零退出');
-      assert.ok(out.includes('fail-loud'), `输出须点名 fail-loud，实际: ${out}`);
-    }
-    assert.ok(failed, '查询失败不得静默 No-op');
+    // 受限 PATH 让 gh 不可用 —— 「查不了」与「查不到（空数组）」必须走不同分支。
+    const r = runScript(overlayScriptPath, [], {
+      cwd: tmp,
+      env: { PATH: tmp, GITHUB_REPOSITORY: 'owner/repo', COMMIT_SHA: 'a'.repeat(40), GH_TOKEN: 'dummy' },
+    });
+    assert.equal(r.status, 1, `查询失败必须 exit 1，实际 ${r.status}: ${r.out}`);
+    assert.match(r.out, /fail-loud/, '输出须点名 fail-loud');
+    assert.match(r.out, /关联 PR/, '必须命中「关联 PR」站点');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('#718: overlay-baseline 查询 Workflow Runs 失败必须 fail-loud（exit 1）', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'overlay-test-runsfail-'));
+  try {
+    // 假 gh 分流：pulls 查询成功 → 只让 runs 查询失败，锁定本次被改的那一处站点。
+    writeFakeGh(tmp, { pullsOk: true, runsOk: false });
+    const r = runScript(overlayScriptPath, [], {
+      cwd: tmp,
+      env: {
+        PATH: `${tmp}:${process.env.PATH}`,
+        GITHUB_REPOSITORY: 'owner/repo',
+        COMMIT_SHA: 'a'.repeat(40),
+        GH_TOKEN: 'dummy',
+      },
+    });
+    assert.equal(r.status, 1, `Runs 查询失败必须 exit 1，实际 ${r.status}: ${r.out}`);
+    assert.match(r.out, /Workflow Runs/, '必须命中「Workflow Runs」站点，而非只匹配 fail-loud');
+    assert.match(r.out, /fail-loud/, '输出须点名 fail-loud');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('#718: overlay-baseline 「查到了但没有」仍是合法 no-op（exit 0）', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'overlay-test-noop-'));
+  try {
+    // pulls 成功、runs 成功但为空数组 = 真的没有成功 CI Run → 必须保持 no-op，不得被 fail-loud 误伤。
+    writeFakeGh(tmp, { pullsOk: true, runsOk: true });
+    const r = runScript(overlayScriptPath, [], {
+      cwd: tmp,
+      env: {
+        PATH: `${tmp}:${process.env.PATH}`,
+        GITHUB_REPOSITORY: 'owner/repo',
+        COMMIT_SHA: 'a'.repeat(40),
+        GH_TOKEN: 'dummy',
+      },
+    });
+    assert.equal(r.status, 0, `合法 no-op 必须 exit 0，实际 ${r.status}: ${r.out}`);
+    assert.match(r.out, /未找到成功状态的 CI Run/, '应走「查到了但没有」分支');
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 背景

`#718` 取证时定位到：归档链路里 `overlay-baseline.mjs` 的一处静默降级已由 `#716` 修好（fail-loud + 诊断拆细），但**同一缺陷的剩余部分没修**——这是「同一操作两份实现」「同一类查询两套纪律」的直接后果。本 PR 收口这两处。

**红线**：只改 `scripts/`，**未触碰 `.github/`**，故不需要 `approved`。关联 #718。

## 改动

### 1. `orphan-baseline.mjs`：restore 的「取不到」不再被当成「不存在」

**改前**：`fetch` 失败（无论什么原因）→ `::notice::…不可达或暂无基线，本次安全降级为全量变异` + `exit 0`。

问题在于 `fetch` 失败有两种相反含义：

- 远端可达但 ref 不存在 = 首夜，没有基线可恢复，降级为全量是**正常**的；
- **远端不可达 / 权限故障 = 基线可能存在但取不到**。此时按空分支继续，本班产物会被当成「全部内容」推回去，**把沿用中的基线整批删掉**。

`2026-09-11 05:18` 的 overlay 就出现过后者（日志「尚不可达或为空」，而分支明明存在）。

**改后**：先 `git ls-remote --heads origin refs/heads/baseline/mutation` 判「ref 在不在」与「远端可不可达」，再用纯函数三态判定：

| remoteReachable | refExists | fetchOk | 动作 |
|---|---|---|---|
| — | — | true | `restore` |
| false | — | false | **`fail`**（无法判定，拒绝以空基线继续） |
| true | true | false | **`fail`**（基线在、只是取不到） |
| true | false | false | `bootstrap`（首夜，保持既有 `::notice::` 文案） |

判定下沉到 `baseline-archive.mjs` 的 `decideRestoreOutcome()`——该模块的头注释原本就写着「判定逻辑必须能被单测覆盖，否则静默丢失只能靠人事后比对才发现」，本次顺着这个设计走。

### 2. `overlay-baseline.mjs`：查询失败统一 fail-loud

| 站点 | 改前 | 改后 |
|---|---|---|
| 查询关联 PR 失败 | `console.log` + `exit 0`（"失败或无关联，安全跳过"） | `console.error` + **`exit 1`** |
| 查询 Workflow Runs 失败 | `console.log` + `exit 0`（"跳过基线覆盖"） | `console.error` + **`exit 1`** |
| 查询 Artifacts 失败（既有，未改） | `console.error` + `exit 1`（注释引 #690） | 不变 |

判据：**「查不了」与「查不到」是两件事**。后者是空数组，仍是正常 no-op（下面几处 `length === 0` / `!pr` / `!successfulCiRun` 分支保持原样）；前者意味着无法判定这次合并是否需要覆盖基线，静默跳过会让归档更新无声丢失，正是 `#690` 纪律禁止的形态。

## 测试

新增/调整 3 条断言：

- `restore 三态判定`（纯函数，覆盖上表 4 种组合，并断言两种 fail 的原因文案互不相同、fail 分支不得复用「安全降级」文案）；
- `restore 远端不可达必须 fail-loud`（真实 `git` 仓库、无 origin）；
- `overlay 查询失败必须 fail-loud`（**用受限 `PATH` 让 `gh` 不可用**，零 stub，node 以绝对路径调用）。

**同时修正了一条既有测试的前提**：原「无远端孤立分支时优雅降级」用的是一个**根本没有 origin 的仓库**，把「没有远端」当成了「没有基线」——这正是被修的语义混淆。已改为首夜的真实形态（**有远端、ref 不存在**）。

**断言承重验证**（只回退两个源文件、保留测试）：

```
$ git stash push -- scripts/gate/orphan-baseline.mjs scripts/gate/overlay-baseline.mjs
$ node --test scripts/test/orphan-baseline.test.ts
✔ #572: orphan-baseline restore 在远端可达但无基线分支时优雅降级（exit 0 + notice）
✖ #718: orphan-baseline restore 在远端不可达时 fail-loud（exit != 0）
✖ #718: overlay-baseline 查询失败必须 fail-loud（不得静默 No-op）
ℹ pass 5   ℹ fail 2
```

即这两条断言在**改前会红**，不是恒真断言。

## 门禁

（逐条 exit code 见下方评论追加）

- 最小集：`pnpm build` / `pnpm test` / `pnpm contract` / `pnpm pack:check` / `pnpm typecheck`
- 追加（改 `scripts/`）：`pnpm test:scripts`

## 明确不在本 PR 范围

以下同属归档链路但与本次「静默降级纪律」不同类，已在 #718 方案评论中单列，留待 `approved` 后处理：

- `mutation-incremental-*` 的 `retention-days: 1` 与 overlay 的 No-op 分支不可区分（「确实无产物」vs「产物已过期」，属潜在风险，抽样的 12/13 次 No-op 均为真 No-op）；
- 无 `workflow_dispatch` 重投通道；
- 缺口判红只 `exit 1`、不开单；
- overlay 被共享互斥组阻塞（实测最长 10 分 25 秒）。

## 门禁实测（worktree 内，对应最终内容）

```
pnpm install --frozen-lockfile   exit=0
pnpm build                       exit=0
pnpm test                        exit=0
pnpm contract                    exit=0
pnpm pack:check                  exit=0
pnpm typecheck                   exit=0
pnpm test:scripts                exit=0   （303 tests / 0 fail）
```

`node --test scripts/test/{baseline-archive,orphan-baseline}.test.ts` → **20 tests / 0 fail**。

---

## 评审后修订（第二轮，回应独立对抗评审）

独立对抗评审（针对 `d62d3da`）判定「方向正确、不动红线、纯函数下沉的形态是好的」，但给出 6 条必修。逐条处置：

| 评审项 | 处置 |
|---|---|
| **M1** `ls-remote` 探针无重试无超时（比它保护的 `fetch` 更脆） | 探针改为与 `fetch` 同规格的 3 次退避重试，并注入 `GIT_TERMINAL_PROMPT=0` 防无 TTY 挂起；退避间隔可用 `ORPHAN_BASELINE_RETRY_DELAY_MS` 覆盖（测试置 0，套件 8.7s → ~0.7s） |
| **M2** 用「stdout 为空」反推「ref 不存在」证据不足（服务端 `hideRefs` 可复现同形） | 改用 `git ls-remote --exit-code` 的**退出码**做三态分类（新增纯函数 `classifyRemoteProbe`：0=present / 2=absent / 其它=unreachable）；并在 `decideRestoreOutcome` 与 README 中**明写该边界**——`absent` 只证明「本次广告里没有」，不能证明服务端不存在；写路径的真正保障在**推送侧不得删段**（见 #718 方案评论） |
| **M3** overlay 仍有第二份静默探针（`gh api` 失败被裸 catch 吞成「首夜」，即 05:18 事故原始形态） | **已核实并修**：删除 `gh api` 探针，overlay 与 orphan 共用同一 `ls-remote --exit-code` 探针与同一分类函数（判据只允许一处实现）；探针未给出否定结论时一律 fail-loud |
| **M4** 测试：`assert.notEqual(err.status, 0)` 在 catch 内是恒真断言；三处 catch 文案都含 `fail-loud` 无法区分站点；被改的 Runs 查询零覆盖 | 断言全部移出 catch（`spawnSync` + `assert.equal(status, 1)`）；新增**假 `gh` 分流**用例锁定 Runs 站点（断言输出含「Workflow Runs」而非只匹配 `fail-loud`）；另加一条「查到了但没有仍是 exit 0」守卫防过度收紧 |
| **M5** `.github/` 内陈旧注释本 PR 不能改 | 见下节登记；同时在 `scripts/gate/baseline/README.md` 明写「workflow 注释尚未同步，以本节与脚本头部为准」 |
| **M6** 「树里有 blob 却无任何基线文件」仍静默降级（写路径上是删段） | 改为 fail-loud；「树为空」（真·空归档）仍按首夜降级 |

**关于评审 Q1（我未按其「次选」全盘照做，理由如下）**：评审指出让 `ci.yml` 那个**不写归档**的调用方一并 fail-loud 属过度收紧，并建议加 `--on-unreachable=strict|degrade` 开关。我采纳了它对**可靠性倒退**的指摘（M1：探针补重试），但**未加入该开关**：按调用方分流必须改 `ci.yml`（红线，需 `approved`），而先加一个无人使用的开关属投机性设计。当前形态下，`ci.yml` 在「远端瞬时不可达」时确实会判红——这是**有意接受**的行为（`#690`：环境失败不得静默降级；且红 run 可重跑），已在下方登记为待裁决项。

**第二轮断言承重验证（干净 A/B）**——在完全未修的 `184ba08` 上跑本 PR 的新测试：

```
✖ #718: orphan-baseline restore 在远端不可达时 fail-loud（exit 1）
✖ #718: overlay-baseline 查询关联 PR 失败必须 fail-loud（exit 1）
✖ #718: overlay-baseline 查询 Workflow Runs 失败必须 fail-loud（exit 1）
✔ #718: overlay-baseline 「查到了但没有」仍是合法 no-op（exit 0）
ℹ pass 6  fail 3
```

恰好 3 条新 fail-loud 断言在改前变红，防过度收紧的守卫保持绿色。

## 需 `approved` 的配套改动（登记备查）

以下注释仍描述「基线缺失即降级、门禁语义不变」，与收紧后的行为分叉；`.github/` 属红线，须单独取 `approved`：

- `.github/workflows/ci.yml:256`、`:271`、`:320`、`:329`
- `.github/workflows/observe-incremental.yml:62`

同步之前以 `scripts/gate/baseline/README.md` 的新小节为准。

## 记录为后续项（评审提出，本次不修）

- overlay：`overlayCount === 0` 时跳过对账并 exit 0（「全部下载失败」与「本来没产物」同形），建议用 `mutArtifacts.length > 0` 判红。
- overlay：单 artifact 下载失败 / 产物内无预期文件名 / 读取失败 / JSON 非法均为 `warn + continue`，靠对账兜底（受上一条影响）。
- `docs/mutation-testing-optimization-guide.md:161-167` 的伪码与现状脱节（无 try/catch、无对账、无分页），建议整节重写或标注为历史设计稿。
- `decideRestoreOutcome` 对不可能组合无显式拒绝（当前调用方不会传错）。

---

## 第二轮复验后修订（第三轮，`3331cd8` → 本轮）

复验判定 **不可合入**，给出 1 条硬必修 + 1 条测试必修 + 1 条文档必修。逐条处置：

| 复验项 | 处置 |
|---|---|
| **[必修] `overlay-baseline.mjs` 的 `probeStatus` 声明在 `try` 内、`catch` 引用 → `ReferenceError`**（该守卫成为死代码） | 已修：探针提取为 `probeArchiveRef()`，结果**声明在 `try` 之外**；`catch` 文案按探针结果区分（`present` → 「存在但恢复失败」，其它 → 「无法确认…（探针结果 X）」）。另加两条端到端用例锁住该分支 |
| **[必修] 假 `gh` 的 `*actions/runs*` 同时命中 artifacts URL，「锁定 Runs 站点」名实不符；且 overlay 恢复段端到端零覆盖（ReferenceError 正藏于此）** | 已修：模式按具体度降序（`*artifacts*` 先于 `*actions/runs*`）；Runs 用例加 `assert.doesNotMatch(out, /分页取全/)` 做站点锁定；新增 **`git` shim** 用例（`ls-remote` 放行 / `fetch` 失败 → present+fetchFail）与 **absent 首夜** 用例，两条都端到端覆盖恢复段 |
| **[必修] `baseline-archive.mjs` 与 README 把兜底声明为「推送侧不得删段」，而代码里没有该保护** | 已修：改为如实表述——该支上唯一生效的是 workflow 层 `mutation-suites` outcome 门控；**代码里没有推送侧保护**，并集入档已登记在 #718 方案、尚未实施。README 另补「orphan 拒绝推送 vs overlay 照常推送+`archiveGap` 判红」是**有意差异** |
| 复验附带：overlay 探针无重试（与 orphan 三连退避形成新分裂） | 已修：overlay 探针同样 3 次退避 + `GIT_TERMINAL_PROMPT=0`，两入口共用同一退避口径与同一分类函数 |
| 复验附带：orphan 的 `fetch` 未带 `GIT_TERMINAL_PROMPT=0` | 已修：与探针一致 |
| 复验建议（**采纳**）：把 fetch 移出 `if (probeStatus === 'present')`，让「探针三连失败但 fetch 成功」被救回 | 已按此实现：`if (probeStatus !== 'absent')` 才跳过 fetch；`decideRestoreOutcome` 已把 `fetchOk` 放第一位，故 fetch 成功即 `restore` |
| 复验建议（**已撤回**）：加 `--on-unreachable=strict\|degrade` 开关 | 未加。复验已同意撤回该建议（分流必须改 `ci.yml`，无人使用的开关属投机设计） |

**新发现的既有缺陷（本 PR 顺带修复）**：`probeStatus` 的作用域写法**继承自 `#716`** ——
`184ba08` 的 `overlay-baseline.mjs:166` 把 `let remoteRefExists` 声明在外层 `try` 内、`:184` 在
`catch` 引用。实测该分支命中即 `ReferenceError: remoteRefExists is not defined`，也就是说：

- `#716` 声称的「孤立分支存在但恢复失败 → fail-loud」与「首夜 → 降级建新快照」**两条分支都是死代码**；
- 更严重的是**首夜路径功能上坏掉**（ref 真不存在时会崩栈而非优雅降级）。

本 PR 把声明移到 `try` 之外，并新增的「absent 首夜不得崩」用例在 `184ba08` 上**确实变红**（见下）。

**第三轮断言承重验证（干净 A/B，未修的 `184ba08`）**：

```
✖ #718: orphan-baseline restore 在远端不可达时 fail-loud（exit 1）
✖ #718: overlay-baseline 查询关联 PR 失败必须 fail-loud（exit 1）
✖ #718: overlay-baseline 查询 Workflow Runs 失败必须 fail-loud（exit 1）
✖ #718: overlay-baseline 恢复段——探针说 present 但拉取失败时 fail-loud（exit 1）
✖ #718: overlay-baseline 恢复段——探针明确 absent 时走首夜且不得崩（exit 0）
✔ #718: overlay-baseline 「查到了但没有」仍是合法 no-op（exit 0）
ℹ pass 6  fail 5
```

5 条 fail-loud 断言在改前变红，防过度收紧的守卫保持绿。
