### PR TITLE
chore(ci): 门禁分层——PR/本地走增量，gate:full 标签走全量，全量口径留夜间（#722）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       # 无取长度与管道能力，在 if 里对清单做取长判空或裸数组文本比较均脆弱；
       # 下游 if 一律用 needs.changes.outputs.hasMutations == 'true' 精确比较
       hasMutations: ${{ steps.pkgs.outputs.hasMutations }}
+      buildPackages: ${{ steps.pkgs.outputs.buildPackages }}
       # 全量门禁开关（#722 门禁分层）：PR 默认走增量——只跑命中包的构建/测试/产物闸；
       # 打 gate:full 标签才跑覆盖率 + 变异 + 全仓产物闸。策略只在这里计算一处，
       # 下游三个 job 的 if 与判定脚本共用它，避免「标签语义」散落在多处表达式里。
@@ -135,11 +136,14 @@ jobs:
           FILTER_OUTPUTS: ${{ toJson(steps.filter.outputs) }}
         run: node scripts/ci/ci-matrix.mjs
 
-  # ── 第 2 段：全包并行 build + lib artifact；smoke/typecheck 只对命中包切片 ──
-  # 设计说明（#85 评审 F1/F3 修订）：repo-gate 的全局门禁（contract/pack:check/
-  # verify:npmlayout/aggregate:check）断言**全部**插件包的 lib 产物，因此 build 与
-  # artifact 上传必须无条件覆盖全集；切片只作用于测试与类型检查，避免单包 PR
-  # 场景下未命中包缺产物而必红。
+  # ── 第 2 段：命中包并行 build + lib artifact + smoke/typecheck（#722 全切片）──
+  # 矩阵来源 = changes.buildPackages（命中包；空切片时为哨兵项）。为什么不是固定全集：
+  # 固定矩阵会让单包 PR 也拉起 7 个 check 实例（6 个全程 skip，纯耗 runner 分钟）；
+  # 为什么不是裸动态矩阵：GHA 对**零实例**动态矩阵实测回报 failure（实证 run
+  # 32802575298），会连坐 repo-gate 判定表的 build-test == success 判据，故空切片
+  # 用哨兵项占位（哨兵不匹配任何包，所有步骤的 contains(hitPackages, ...) 自然为假）。
+  # 全仓产物闸（contract/pack:check/verify:npmlayout）在 gate:full PR 与夜间 observe
+  # 落地，不再依赖本 job 的全集产物。
   build-test:
     name: Build / Test / Typecheck (${{ matrix.package }})
     needs: changes
@@ -147,14 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package:
-          - dsh-notifier
-          - dsh-web-file-preview
-          - dsh-mcp-manager
-          - dsh-provider-usage
-          - dsh-lan-proxy
-          - dsh-verify-isolated
-          - dsh-plugins-all
+        package: ${{ fromJSON(needs.changes.outputs.buildPackages) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -172,8 +169,9 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
+        # 哨兵实例（空切片）不装依赖：条件与下方各步骤同源，避免在 YAML 里重复哨兵字面量
+        if: contains(fromJSON(needs.changes.outputs.hitPackages), matrix.package)
         run: pnpm install --frozen-lockfile
-
       # Build package：名称选择器 + ... 后缀按 workspace 拓扑先构建依赖（目录选择器
       # + ... 在 pnpm 11 不展开依赖，评审实测须用 @scope/name... 形态）。
       # #722 门禁分层：只构建**命中包**——repo-gate 的产物闸同步改为命中包切片，

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   pull_request:
+    # #722 门禁分层：labeled/unlabeled 必须显式列入——否则给 PR 打 gate:full 标签
+    # 不会触发重跑，全量门禁实际不可达（默认 types 只有 opened/synchronize/reopened）。
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches:
       - main
@@ -33,10 +36,30 @@ jobs:
       # 无取长度与管道能力，在 if 里对清单做取长判空或裸数组文本比较均脆弱；
       # 下游 if 一律用 needs.changes.outputs.hasMutations == 'true' 精确比较
       hasMutations: ${{ steps.pkgs.outputs.hasMutations }}
+      # 全量门禁开关（#722 门禁分层）：PR 默认走增量——只跑命中包的构建/测试/产物闸；
+      # 打 gate:full 标签才跑覆盖率 + 变异 + 全仓产物闸。策略只在这里计算一处，
+      # 下游三个 job 的 if 与判定脚本共用它，避免「标签语义」散落在多处表达式里。
+      fullGate: ${{ steps.fullgate.outputs.fullGate }}
       # 全量包清单（单一事实源，从 plugins-manifest.json active + 聚合包派生）：
       # 供 repo-gate 产物齐备断言等下游消费，空清单 fail-closed
       allPackages: ${{ steps.pkgs.outputs.allPackages }}
     steps:
+      - name: Resolve full-gate switch（gate:full 标签 → 全量门禁）
+        id: fullgate
+        # 非 PR 事件一律 false：主干覆盖与变异归 observe.yml 夜间全量、发版归
+        # release.yml tag 管线（#187 触发面收敛不变量），手动点火用 observe.yml
+        # 自带的 workflow_dispatch，不在 ci.yml 另开入口。
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -e
+          FULL=false
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if printf '%s' "$LABELS" | grep -q '"gate:full"'; then FULL=true; fi
+          fi
+          echo "fullGate=$FULL" >> "$GITHUB_OUTPUT"
+          echo "::notice::fullGate=$FULL（false = 增量门禁：命中包构建/测试/产物闸 + 廉价全仓静态闸；true = 追加覆盖率 + 变异 + 全仓产物闸）"
+
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
@@ -152,9 +175,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # Build package：名称选择器 + ... 后缀按 workspace 拓扑先构建依赖（目录选择器
-      # + ... 在 pnpm 11 不展开依赖，评审实测须用 @scope/name... 形态）。无条件：
-      # repo-gate 全局门禁依赖全量 lib 产物。
-      - name: Build package（无条件：repo-gate 全局门禁依赖全量 lib 产物）
+      # + ... 在 pnpm 11 不展开依赖，评审实测须用 @scope/name... 形态）。
+      # #722 门禁分层：只构建**命中包**——repo-gate 的产物闸同步改为命中包切片，
+      # 全仓产物闸（含全部包 lib/index.js 齐备断言）只在 gate:full 标签 / 夜间跑。
+      - name: Build package（仅命中包；未命中包本 job 只做 checkout+setup）
+        if: contains(fromJSON(needs.changes.outputs.hitPackages), matrix.package)
         run: pnpm --filter "@wingsky-1/${{ matrix.package }}"... build
 
       - name: Smoke tests（仅命中包；聚合包无 test 脚本由 --if-present 跳过）
@@ -165,7 +190,8 @@ jobs:
         if: contains(fromJSON(needs.changes.outputs.hitPackages), matrix.package)
         run: pnpm --filter ./packages/${{ matrix.package }} --if-present typecheck
 
-      - name: Upload package outputs artifact（供 repo-gate 全局门禁复用，F9）
+      - name: Upload package outputs artifact（供 repo-gate 产物闸复用，F9；#722 仅命中包）
+        if: contains(fromJSON(needs.changes.outputs.hitPackages), matrix.package)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pkg-${{ matrix.package }}
@@ -195,7 +221,9 @@ jobs:
   coverage:
     name: Coverage collection (global single-run)
     needs: changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.hasMutations == 'true'
+    # #722 门禁分层：覆盖率是「全仓分母」口径，PR 默认不跑（夜间 observe.yml 每班采集）；
+    # 只有 PR 打 gate:full 标签时才补跑。hasMutations 仍作为对象面判据保留。
+    if: github.event_name == 'pull_request' && needs.changes.outputs.fullGate == 'true' && needs.changes.outputs.hasMutations == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -259,8 +287,10 @@ jobs:
     name: Mutation gate (${{ matrix.combo.package }} · ${{ matrix.combo.seg }})
     needs: changes
     # 与 coverage job 平行（无 needs 依赖）；if 精确锁定事件面与显式布尔切片，
-    # 空 slice 时 if 直接为假、矩阵不实例化（job result = skipped）
-    if: github.event_name == 'pull_request' && needs.changes.outputs.hasMutations == 'true'
+    # 空 slice 时 if 直接为假、矩阵不实例化（job result = skipped）。
+    # #722 门禁分层：变异段耗时最长（单段最坏约 20 分钟，#720），PR 默认不跑；
+    # 打 gate:full 标签时按命中切片补跑，全量变异仍归夜间 observe*.yml。
+    if: github.event_name == 'pull_request' && needs.changes.outputs.fullGate == 'true' && needs.changes.outputs.hasMutations == 'true'
     strategy:
       fail-fast: false
       # #220 B 方案：combo = {package, seg}；改造后 seg=功能段名（数字段名亦兼容），
@@ -365,7 +395,7 @@ jobs:
   mutation-verdict:
     name: Mutation gate verdict (aggregate)
     needs: [changes, coverage, mutation-gate]
-    if: always() && needs.coverage.result == 'success' && needs.mutation-gate.result != 'skipped'
+    if: always() && needs.changes.outputs.fullGate == 'true' && needs.coverage.result == 'success' && needs.mutation-gate.result != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -441,9 +471,16 @@ jobs:
 
   # ── 第 4 段：聚合闸（job 名保持分支保护 required check 名不变，无缝切换）──
   # needs 连坐语义（#217）：coverage / mutation-gate / mutation-verdict 任一失败
-  # 都必须让本闸红——判定表按「事件 × 切片(hasMutations) × coverage × 变异矩阵
-  # × verdict」五维裁决；coverage 失败 → verdict 连坐 skipped → 判定表以
-  # GATE_COVERAGE 维度优先点名「coverage 失败连坐」，而非误报「mutation 绕过」
+  # 都必须让本闸红——判定表按「事件 × fullGate × 切片(hasMutations) × coverage
+  # × 变异矩阵 × verdict」六维裁决；coverage 失败 → verdict 连坐 skipped → 判定表
+  # 以 GATE_COVERAGE 维度优先点名「coverage 失败连坐」，而非误报「mutation 绕过」。
+  #
+  # #722 门禁分层：本 job 分两组步骤——
+  #   组 A（廉价全仓闸，恒跑）：判定脚本、threshold-monotonic、aggregate:check、
+  #     stryker:check、test:scripts、forbid-*、docs:check。不依赖 lib 产物或仅需
+  #     少量声明产物（test:scripts 的前置包清单见 scripts/test/script-test-prereqs.mjs）。
+  #   组 B（产物闸，按 fullGate 切口径）：contract / pack:check / verify:npmlayout
+  #     —— 默认 PR 只验命中包（`--packages <hit>`），gate:full 与夜间验全仓。
   repo-gate:
     name: Build / Contract / Smoke / Pack
     needs: [changes, build-test, coverage, mutation-gate, mutation-verdict]
@@ -472,6 +509,7 @@ jobs:
           GATE_VERDICT: ${{ needs.mutation-verdict.result }}
           GATE_HAS_MUTATIONS: ${{ needs.changes.outputs.hasMutations }}
           GATE_MUTATION_PKGS: ${{ needs.changes.outputs.mutationPackages }}
+          GATE_FULL_REQUESTED: ${{ needs.changes.outputs.fullGate }}
         run: node scripts/gate/repo-gate-assert.mjs
 
       - name: Setup pnpm
@@ -487,52 +525,109 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Download package outputs artifacts（F9：复用 matrix 全集产物，避免重复构建）
+      - name: Download package outputs artifacts（F9：复用 matrix 命中包产物，避免重复构建）
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: pkg-*
           path: artifacts-tmp
 
       - name: Restore package outputs into package trees
+        env:
+          FULL_GATE: ${{ needs.changes.outputs.fullGate }}
+          ALL_PACKAGES: ${{ needs.changes.outputs.allPackages }}
+          HIT_PACKAGES: ${{ needs.changes.outputs.hitPackages }}
         run: |
           set -e
           # 多路径上传的 zip 根 = 包根：artifact 内容即 lib/ shared/ types/ LICENSE 本身
           for dir in artifacts-tmp/pkg-*; do
+            [ -d "$dir" ] || continue
             pkg="${dir#artifacts-tmp/pkg-}"
             mkdir -p "packages/$pkg"
             cp -r "$dir/." "packages/$pkg/"
           done
-          # 断言全部包产物齐备（缺任何一个即红——全局门禁的前提）。
-          # 清单从 needs.changes.outputs.allPackages（plugins-manifest.json 派生）驱动，
-          # 新增 active 包自动纳入；空清单 fail-closed（fail-closed gate assertion 已兜底，
-          # 此处显式防空防「零断言假绿」）。
-          ALL="$(printf '%s' "$ALL_PACKAGES" | jq -c '.')"
-          if [ "$(printf '%s' "$ALL" | jq 'length')" -eq 0 ]; then
-            echo '::error::allPackages 为空（fail-closed，禁止零断言通过）'
-            exit 1
+          # #722 门禁分层：产物齐备的判据随门禁口径走——
+          #   gate:full → 全仓（全仓产物闸的前提，缺任一包即红）；
+          #   默认增量 → 仅命中包（空清单合法：纯文档 PR 无产物闸对象），
+          #   但**非空清单缺产物仍判红**（防 artifact 链路静默丢包）。
+          if [ "$FULL_GATE" = "true" ]; then
+            if [ "$(printf '%s' "$ALL_PACKAGES" | jq 'length')" -eq 0 ]; then
+              echo '::error::allPackages 为空（fail-closed，禁止零断言通过）'
+              exit 1
+            fi
+            WANT="$(printf '%s' "$ALL_PACKAGES" | jq -r '.[]')"
+            SCOPE_DESC="全仓（gate:full）"
+          else
+            WANT="$(printf '%s' "$HIT_PACKAGES" | jq -r '.[]')"
+            SCOPE_DESC="命中包切片（增量）"
           fi
-          for pkg in $(printf '%s' "$ALL" | jq -r '.[]'); do
-            test -f "packages/$pkg/lib/index.js" || { echo "::error::$pkg/lib/index.js 缺失"; exit 1; }
+          for pkg in $WANT; do
+            test -f "packages/$pkg/lib/index.js" || { echo "::error::$pkg/lib/index.js 缺失（产物口径：$SCOPE_DESC）"; exit 1; }
           done
-          echo "全部包构建产物就位（$ALL）"
-        env:
-          ALL_PACKAGES: ${{ needs.changes.outputs.allPackages }}
+          echo "构建产物就位（口径：$SCOPE_DESC）：$(printf '%s' "$WANT" | tr '\n' ' ')"
 
-      - name: Client contract（客户端契约）
-        run: pnpm contract
+      - name: Build all packages（gate:full：全仓产物闸的前提）
+        if: needs.changes.outputs.fullGate == 'true'
+        run: pnpm build
+
+      - name: Build script-test prerequisites（test:scripts 的编译面依赖）
+        # scripts/test 里有用例用 tsc 真实编译契约测试文件，需要对应包的**声明产物**
+        # （lib/index.d.ts）。清单的单一事实源是 scripts/test/script-test-prereqs.mjs，
+        # 该用例自身断言清单覆盖其 SUITES，故「新增编译面用例忘更新清单」会在
+        # test:scripts 内判红，而不是在这里静默少建一个包导致假红。
+        run: |
+          set -e
+          FILTERS=$(node -e "import(require('node:url').pathToFileURL('scripts/test/script-test-prereqs.mjs').href).then(m=>console.log(m.PREREQ_PACKAGES.map(p=>'--filter @wingsky-1/'+p+'...').join(' ')))")
+          echo "prereq filters: $FILTERS"
+          pnpm $FILTERS build
+
+      - name: Client contract（客户端契约；#722 默认只验命中包）
+        env:
+          FULL_GATE: ${{ needs.changes.outputs.fullGate }}
+          HIT_PACKAGES: ${{ needs.changes.outputs.hitPackages }}
+        run: |
+          set -e
+          if [ "$FULL_GATE" = "true" ]; then
+            pnpm contract
+          else
+            node scripts/gate/contract-check.ts --packages "$(printf '%s' "$HIT_PACKAGES" | jq -r 'join(",")')"
+          fi
 
       - name: Threshold monotonicity（F3：阈值只许升不许降，PR 场景生效）
         if: github.event_name == 'pull_request'
         run: node scripts/gate/threshold-monotonic.mjs origin/main
 
-      - name: Pack check（防发布断链）
-        run: pnpm pack:check
+      - name: Pack check（防发布断链；#722 默认只验命中包）
+        env:
+          FULL_GATE: ${{ needs.changes.outputs.fullGate }}
+          HIT_PACKAGES: ${{ needs.changes.outputs.hitPackages }}
+        run: |
+          set -e
+          if [ "$FULL_GATE" = "true" ]; then
+            pnpm pack:check
+          else
+            node scripts/gate/pack-check.ts --packages "$(printf '%s' "$HIT_PACKAGES" | jq -r 'join(",")')"
+          fi
 
-      - name: Npm layout（解包后可加载）
-        run: pnpm verify:npmlayout
+      - name: Npm layout（解包后可加载；#722 默认只验命中包）
+        env:
+          FULL_GATE: ${{ needs.changes.outputs.fullGate }}
+          HIT_PACKAGES: ${{ needs.changes.outputs.hitPackages }}
+        run: |
+          set -e
+          if [ "$FULL_GATE" = "true" ]; then
+            pnpm verify:npmlayout
+          else
+            node scripts/gate/verify-npm-layout.ts --packages "$(printf '%s' "$HIT_PACKAGES" | jq -r 'join(",")')"
+          fi
 
       - name: Aggregate check（聚合 patch 不漂移）
         run: pnpm aggregate:check
+
+      # #722：变异配置 ↔ 拓扑清单一致性必须在**增量路径**也跑——变异段默认只在
+      # gate:full / 夜间执行，若把这条留在变异 job 里，默认 PR 就再也拦不住
+      # 「改了 conf 却没同步拓扑」的漂移。纯文件比对、秒级，无产物依赖。
+      - name: Stryker config check（变异配置与拓扑 SSOT 一致）
+        run: pnpm stryker:check
 
       - name: Scripts self-test（维护脚本自测，含 workflow 结构静态断言）
         run: pnpm test:scripts

--- a/.github/workflows/observe.yml
+++ b/.github/workflows/observe.yml
@@ -60,6 +60,21 @@ jobs:
       - name: Build all
         run: pnpm build
 
+      # #722 门禁分层：PR 侧改为「命中包切片」后，全仓产物闸（contract / pack:check /
+      # verify:npmlayout）必须在这里落地——否则「全仓打包契约」在默认 PR 路径上无人检查，
+      # 只靠 gate:full 标签的 PR 属自觉行为。三个闸都需要全仓 lib 产物，故紧随 Build all。
+      - name: Client contract（全仓）
+        run: pnpm contract
+
+      - name: Pack check（全仓）
+        run: pnpm pack:check
+
+      - name: Npm layout（全仓）
+        run: pnpm verify:npmlayout
+
+      - name: Stryker config check（变异配置与拓扑 SSOT 一致）
+        run: pnpm stryker:check
+
       - name: Coverage（c8 采集）
         run: pnpm cov
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,21 +59,27 @@ git worktree remove /mnt/ssd/worktree/dsh-plugin-hub-task-<n> && git worktree pr
   [agents/_protocol.md](agents/_protocol.md) 的凭据规范（结论 + 改动文件绝对路径 +
   实际命令与 exit code）；遇阻塞停下并在返回值写明原因，由主控决定升级。
 
-## 门禁（提交前）
+## 门禁（分层：快线 / 最小集 / 收尾全量）
 
-最小集：`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck`
+| 层 | 命令 | 用途与口径 |
+|---|---|---|
+| 快线 | `pnpm gate:changed` | 迭代中反复跑：只跑 diff 命中包的 build + test + typecheck。包面归属取自 `ci.yml` 的 paths-filter（**唯一事实源**，本地不重述路径规则）；命中全局面时自动升级为 `gate:pr`，解析失败一律回退全量（fail-closed） |
+| 最小集 | `pnpm gate:pr` | 开 PR 前：快线 + **命中包**的产物闸（`contract` / `pack:check` / `verify:npmlayout` 按 `--packages` 切片）+ 廉价全仓一致性闸（`stryker:check`、`aggregate:check`、`test:src-tests`、`gate:homedir`、`docs:check`、`test:scripts`，均秒级且不依赖 lib 产物） |
+| 收尾 | `pnpm gate:full` | 全仓口径（= 夜间班次口径）：全仓 build/test/typecheck + 全仓产物闸 + 全部静态闸；改过构建链、包结构或发版前跑一遍 |
+| 全量 | CI 夜间班次（`observe.yml` / `observe-incremental.yml`） | 全仓产物闸 + 覆盖率 + CRAP + 全量/增量变异与基线归档。本地不默认跑，需要时 `pnpm gate:full --with-coverage` |
 
-| 改动类型 | 追加 |
+| 改动类型 | 归属层 |
 |---|---|
-| 新增 / 退役包、改 `cordis.patch.yml` | `pnpm aggregate:check && pnpm verify:npmlayout` |
-| 新增 `*.src.test.ts` | `pnpm test:src-tests` |
-| 改 `src/` 里 HOME 来源 API | `pnpm gate:homedir` |
-| 改 `scripts/` / workflow | `pnpm test:scripts` |
-| 改 README、新增文档链接 | `pnpm docs:check` |
-| 提交前最终一遍 | 上面全跑（CI 口径）；单包迭代用 `pnpm --filter @wingsky-1/<pkg> ...` |
+| 新增 / 退役包、改 `cordis.patch.yml` | `gate:full`（含全仓 `aggregate:check` + `verify:npmlayout`） |
+| 新增 `*.src.test.ts` | `gate:pr` 起（含 `test:src-tests`） |
+| 改 `src/` 里 HOME 来源 API | `gate:pr` 起（含 `gate:homedir`） |
+| 改 `scripts/` / workflow | `gate:pr` 起（含 `test:scripts`）；改 `.github/` 属红线，先评审 |
+| 改 README、新增文档链接 | `gate:pr` 起（含 `docs:check`） |
+| 提交前最终一遍 | `pnpm gate:pr`；单包迭代用 `pnpm gate:changed` |
 
-- 最小集**不等于** CI 全量：`test` 不含 `scripts/test`，`contract` 不含 `aggregate:check`，
-  锚点存在性不在任何门禁内。
+- 分层**不减少检查，只改变时机**：PR 与本地都走增量（命中包），只有"必须全仓才能判定"的
+  口径（全仓产物闸、全仓覆盖率分母、全量变异基线）留夜间；高风险改动打 `gate:full` 标签
+  在 PR 上补跑（方案见 #722）。
 - 结论里**逐条粘贴实际 exit code**；任一非 0 不得声称完成。
 - 新增 `homedir()` / `process.env.HOME` / `untildify()` 调用走**双源豁免**：`WHITELIST`
   条目（含 issue 号）+ 调用点紧邻 `// dsh-gate:allow-homedir #<issue> <理由>`，缺一判红

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -394,9 +394,9 @@ export const inject: string[] = [];        // 声明 apply 用到的 ctx 服务�
     自动枚举会退回「目录即事实源」的 fail-open 老路；
   - schema 加载/校验逻辑只有一份：`scripts/lib/plugins-manifest-lib.ts`（纯函数，
     入口脚本只喂数据），测试见 `scripts/test/plugins-manifest.test.ts`。
-- **新增/修改客户端后**：`pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck`
-  全绿再提交（完整门禁清单与「改动类型 → 追加门禁」对照表见根
-  [AGENTS.md 门禁矩阵](../AGENTS.md)，本处是最小集）。
+- **新增/修改客户端后**：`pnpm gate:pr` 全绿再提交（= 命中包 build/test/typecheck + 命中包
+  产物闸 + 廉价全仓一致性闸；迭代中用 `pnpm gate:changed`，全仓口径用 `pnpm gate:full`。
+  分层口径与「改动类型 → 归属层」对照表见根 [AGENTS.md 门禁矩阵](../AGENTS.md)）。
 
 <a id="5-smoke-测试防-flake-纪律"></a><a id="user-content-5-smoke-测试防-flake-纪律"></a>
 ## 5. Smoke 测试防 flake 纪律

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -68,34 +68,38 @@ release.yml tag 管线跑全量门禁——全量只在这三处语义中的后�
   mutant）→ 基线有实质变化即 create-pull-request + auto-merge（无日期闸，每次
   独立判断「有变化即 PR」；create-pull-request 无 diff 时自然 no-op）；增量班
   不跑 cov/self-cov/crap 等报告，职责收敛为「变异 + 基线 PR」。
-- **PR 增量门禁**（ci.yml，#217 变异/覆盖解耦为三段式）：
-  1. `coverage` job（全局单次）：单进程跑 `pnpm cov` + `self-cov.mjs`，产物
-     `coverage/self-coverage.json` 经 artifact 下发——cov 从变异矩阵剥离后，
-     矩阵多实例并行各自全仓 smoke 导致的 lan-proxy 固定端口 EADDRINUSE 与
-     provider-usage K12 时序漂移（flake 根因）随之消除；mutate-scope-guard
-     同步前移进本 job（PR 阶段即暴露 mutate 区间漂移，observe 夜间执行点保留）；
-  2. `mutation-gate` 矩阵（仅基线 + stryker）：按 paths-filter 命中包切片
-     （changes.hasMutations 显式布尔驱动 if），restore-only 读仓库内基线后对该包
-     跑 Stryker——incremental 模式跳过未变 mutant，报告仍为全量口径（复用
-     mutant 继承原状态）；needs coverage 连坐：coverage 失败/skip → 矩阵连带
-     skipped（if 不含 always()，隐式 success() 前提生效）；
-  3. `mutation-verdict`（聚合判分收尾）：下载 self-coverage 与各包 stryker 报告
-     artifact 后逐包跑双指标判分（scripts/gate/mutation-gate.mjs）——测试覆盖率
-     self-written 函数 ≥ threshold 恒硬；变异测试率 covered ≥ per-package
-     threshold 受全局 `mutation.strict` 约束（strict 已开启，按 per-package
-     threshold 判红）。矩阵实例级 failure 时 verdict 仍聚合判分（缺报告的包 exit 2
-     fail-closed）。
+- **PR 门禁分层**（ci.yml，#722）：默认走**增量**，只有给 PR 打 `gate:full` 标签才跑全量链路
+  （`pull_request.types` 含 `labeled`/`unlabeled`，打标签即触发重跑）。策略由 `changes`
+  job 一处计算为 `fullGate` 输出，判定表与三个全量 job 的 `if` 共用同源布尔。
+  1. `build-test` 矩阵（固定 7 实例，防 GHA 零实例矩阵回报 failure）：按 paths-filter
+     命中包切片构建 + test + typecheck，artifact 只上传命中包；
+  2. `repo-gate` 分两组——
+     组 A（廉价全仓闸，恒跑）：判定脚本 `repo-gate-assert.mjs`、`threshold-monotonic`、
+     `aggregate:check`、`stryker:check`、`test:scripts`、`forbid-src-tests`、
+     `forbid-homedir-src`、`docs:check`（`test:scripts` 的编译面前置包清单见
+     `scripts/test/script-test-prereqs.mjs`，CI 与本地门禁同源读取）；
+     组 B（产物闸，按 `fullGate` 切口径）：`contract` / `pack:check` / `verify:npmlayout`
+     —— 默认只验命中包（`--packages <命中清单>`），`gate:full` 时验全仓；
+  3. `coverage` / `mutation-gate` / `mutation-verdict`（全量链路）：只在 `gate:full` 的
+     PR 上实例化。coverage 全局单次采集（`pnpm cov` + `self-cov.mjs`，产物经 artifact
+     下发——cov 从变异矩阵剥离后，矩阵多实例各自全仓 smoke 导致的端口竞争 flake 随之
+     消除）；mutation 按命中包切片跑 Stryker（incremental 跳过未变 mutant）；verdict
+     汇合 artifact 逐包跑双指标判分（self-written 覆盖率 ≥ threshold 恒硬，变异率 covered
+     ≥ per-package threshold 受 `mutation.strict` 约束）。矩阵实例级 failure 时 verdict
+     仍聚合判分（缺报告包 exit 2 fail-closed）。
 
-  成败并入 repo-gate 聚合闸（判定逻辑见 scripts/gate/repo-gate-assert.mjs，
-  五维判定表「事件 × 切片(hasMutations) × coverage × 变异矩阵 × verdict」由
-  单测全组合锁死），不新增分支保护 required check 名。基线缺失时天然降级为
-  全量变异。coverage 失败连坐整体红属预期 fail-closed（coverage job 失败 ≈
-  smoke 失败，同一 c8 包裹，build-test 同级硬信号）。
-- **触发面收敛**（#187 / #217 扩展）：覆盖与变异三段 job 仅限 pull_request
-  触发——push 到 main 时 diff 基准 `before` 不可用会使 paths-filter 走
-  fail-closed 全量 fallback，变异随之退化全量且与当晚夜间全量完全重复；主干
-  覆盖与变异覆盖由 observe.yml 夜间全量承接、发版前由 release.yml tag 管线
-  承接，非 PR 事件下三段 job 整体 skipped（repo-gate 判定表显式放行）。
+  判定表为**六维**「事件 × fullGate × 切片(hasMutations) × coverage × 变异矩阵 ×
+  verdict」，由单测全组合锁死。默认增量路径下三段必须**全部 skipped**——对称 fail-closed：
+  没打标签却跑了全量同样判红。不新增分支保护 required check 名。
+- **为什么分层**（#722）：覆盖率是「全仓分母」口径，变异单段最坏约 20 分钟（#720），而
+  两者夜间 observe.yml（每日全量班 + 四班次增量班）已完整覆盖，PR 上属重复执行且拖长
+  反馈回路。高风险改动（重构、依赖跃迁、发版前）在 PR 上加 `gate:full` 标签按需补跑；
+  全仓产物闸在 `gate:full` PR 与 observe 全量班两处落地，默认 PR 只验命中包。
+- **触发面收敛**（#187 / #217 扩展）：全量三段 job 仅限 pull_request 触发——push 到 main
+  时 diff 基准 `before` 不可用会使 paths-filter 走 fail-closed 全量 fallback，变异随之
+  退化全量且与当晚夜间全量完全重复；主干覆盖与变异覆盖由 observe.yml 夜间全量承接、发版前
+  由 release.yml tag 管线承接，非 PR 事件下三段 job 整体 skipped 且 `fullGate` 恒为 false
+  （repo-gate 判定表显式放行）。
 - 本地手动入口：`npx stryker run stryker.conf.d/dsh-<pkg>.json`（临时强制全量用
   官方 `--force` 参数，勿改配置文件）。
 - **测试单份维护（#423 方案 A）**：变异测试复用 `packages/*/test/*.test.ts`，

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "gate:homedir": "node scripts/gate/forbid-homedir-src.mjs",
     "docs:check": "node scripts/gate/verify-docs.ts --strict-en",
     "typecheck": "pnpm -r --if-present run typecheck",
+    "gate:changed": "node scripts/gate/local-gate.mjs --tier changed",
+    "gate:pr": "node scripts/gate/local-gate.mjs --tier pr",
+    "gate:full": "node scripts/gate/local-gate.mjs --tier full",
     "cov": "c8 --reporter=json --reporter=json-summary --reporter=text pnpm -r --filter !dsh-plugin-hub --if-present test",
     "cov:src": "node scripts/gate/cov.mjs",
     "crap": "node scripts/gate/crap-check.mjs"

--- a/scripts/ci/ci-matrix.mjs
+++ b/scripts/ci/ci-matrix.mjs
@@ -5,6 +5,12 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 /**
+ * 空切片时 build-test 矩阵的哨兵项（#722）：见 computeCiMatrix 内 buildPackages 注释。
+ * 取一个不可能成为包名的值，保证所有 `contains(hitPackages, matrix.package)` 条件为假。
+ */
+export const NO_HIT_PACKAGE = '__no-hit-package__';
+
+/**
  * 计算 CI 切片与变异矩阵
  * 100% 原生 Node.js 内置模块（node:fs, node:path, node:process），无任何外部依赖
  *
@@ -136,9 +142,17 @@ export function computeCiMatrix(options = {}) {
     return a.seg.localeCompare(b.seg);
   });
 
+  // buildPackages（#722）：build-test 矩阵的来源 = 命中包；空切片时用哨兵占位。
+  // 为什么需要哨兵：GHA 的**零实例动态矩阵**实测回报 failure（实证 run 32802575298），
+  // 而 repo-gate 的判定表要求 build-test == success —— 纯文档/meta PR 会因此假红。
+  // 哨兵实例不匹配任何包，所有步骤的 `contains(hitPackages, ...)` 条件自然为假，
+  // 只花一次 checkout+setup 就换来「动态矩阵 + 确定性 success」。
+  const buildPackages = hitPackages.length > 0 ? hitPackages : [NO_HIT_PACKAGE];
+
   return {
     allPackages,
     hitPackages,
+    buildPackages,
     mutationPackages,
     hasMutations,
     mutationCombos,
@@ -157,7 +171,7 @@ export function runCli(argv = process.argv, env = process.env) {
     process.exit(1);
   }
 
-  const { allPackages, hitPackages, mutationPackages, hasMutations, mutationCombos } = result;
+  const { allPackages, hitPackages, buildPackages, mutationPackages, hasMutations, mutationCombos } = result;
   const isJson = argv.includes('--json');
 
   if (isJson) {
@@ -165,6 +179,7 @@ export function runCli(argv = process.argv, env = process.env) {
   } else {
     console.log(`全量包清单（单一事实源）: ${JSON.stringify(allPackages)}`);
     console.log(`命中包（跑 smoke/typecheck 切片）: ${JSON.stringify(hitPackages)}`);
+    console.log(`build-test 矩阵（空切片时含哨兵）: ${JSON.stringify(buildPackages)}`);
     console.log(`变异包: ${JSON.stringify(mutationPackages)}`);
     console.log(`变异组合: ${JSON.stringify(mutationCombos)}`);
     console.log(`hasMutations: ${hasMutations}`);
@@ -175,6 +190,7 @@ export function runCli(argv = process.argv, env = process.env) {
       const lines = [
         `allPackages=${JSON.stringify(allPackages)}`,
         `hitPackages=${JSON.stringify(hitPackages)}`,
+        `buildPackages=${JSON.stringify(buildPackages)}`,
         `mutationPackages=${JSON.stringify(mutationPackages)}`,
         `hasMutations=${hasMutations}`,
         `mutationCombos=${JSON.stringify(mutationCombos)}`,

--- a/scripts/gate/contract-check.ts
+++ b/scripts/gate/contract-check.ts
@@ -19,9 +19,10 @@ import { spawnSync } from 'node:child_process'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { assertClientContract } from '../lib/client-contract-lib.ts'
-import { filterOutRetiredDirs, listPluginDirs, loadManifest } from '../lib/plugins-manifest-lib.ts'
+import { AGGREGATE_NAME, filterOutRetiredDirs, listPluginDirs, loadManifest } from '../lib/plugins-manifest-lib.ts'
 import { runConfigMatrix } from '../lib/config-matrix-gate.ts'
 import { checkCatalogPeers } from '../lib/catalog-peers-lib.ts'
+import { resolvePackageScopeOrExit } from '../lib/package-scope.ts'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const packagesDir = join(ROOT, 'packages')
@@ -41,9 +42,22 @@ if (retiredDirs.length > 0) {
   console.warn(`[contract-check] 跳过已退役包残留目录: ${retiredDirs.join(', ')}（manifest.retired 已登记，请清理）`)
 }
 
+// #722 门禁分层：**产物级**断言（读 lib/client.js）按 --packages 切片——单包 PR 只需
+// 验命中包，全仓口径留夜间（observe.yml）与本地 gate:full。仓库级静态扫描（下方运行时
+// 导入禁线、config matrix、catalog peers）不依赖产物，保持全仓恒跑。
+// known 含聚合包：它不是宿主 bundle 包、不在本闸逐包循环内，出现在切片里不算未知包名
+// （否则全局面命中时假红），但会明示本闸不逐包检查它。
+const scoped = resolvePackageScopeOrExit(process.argv.slice(2), [...pluginDirs, AGGREGATE_NAME])
+const artifactDirs = scoped === null ? pluginDirs : pluginDirs.filter((p) => scoped.includes(p))
+if (scoped !== null) {
+  const notIterated = scoped.filter((p) => !pluginDirs.includes(p))
+  console.log(`[contract-check] 产物断言切片：${artifactDirs.length}/${pluginDirs.length} 包（--packages ${scoped.join(',') || '（空）'}）`
+    + (notIterated.length > 0 ? `；${notIterated.join(', ')} 不在本闸逐包检查范围` : ''))
+}
+
 let failed = 0
 let checked = 0
-for (const p of pluginDirs) {
+for (const p of artifactDirs) {
   const pkgDir = join(packagesDir, p)
   const pkg = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'))
   const clientPath = join(pkgDir, 'lib', 'client.js')
@@ -87,8 +101,8 @@ for (const p of pluginDirs) {
   if (leaks.length > 0) console.log(`     宿主侧标识符泄漏：${leaks.join('；')}`)
 }
 
-// 件数断言：凡 packages/dsh-* 目录都应被检查覆盖（防漏检）
-console.log(`\n检查覆盖：${checked}/${pluginDirs.length} 个客户端插件包（其余为纯宿主包或聚合包）`)
+// 件数断言：本次切片内每个 packages/dsh-* 目录都应被检查覆盖（防漏检）
+console.log(`\n检查覆盖：${checked}/${artifactDirs.length} 个客户端插件包（其余为纯宿主包或聚合包）${scoped === null ? '' : '（--packages 切片口径）'}`)
 if (checked === 0) {
   console.log('（当前无带客户端插件的包）')
 }

--- a/scripts/gate/local-gate.mjs
+++ b/scripts/gate/local-gate.mjs
@@ -26,6 +26,7 @@ import { fileURLToPath } from 'node:url'
 import process from 'node:process'
 
 import { computeCiMatrix } from '../ci/ci-matrix.mjs'
+import { PREREQ_PACKAGES } from '../test/script-test-prereqs.mjs'
 import { planChangedScope } from './local-scope.mjs'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
@@ -72,15 +73,20 @@ function tierSteps(tier, { hitPackages, withCoverage }) {
     return steps
   }
 
-  // 廉价全仓一致性闸：不依赖 lib 产物、秒级，恒跑（不是「全量构建」类成本）
+  // 廉价全仓一致性闸：不依赖 lib 产物、秒级，恒跑（不是「全量构建」类成本）。
+  // test:scripts 不在此列——它有编译面用例依赖声明产物，需先满足前置包（见下方）。
   const cheapGlobal = [
     { label: 'stryker:check（变异配置与拓扑一致）', args: ['stryker:check'] },
     { label: 'aggregate:check（聚合 patch 不漂移）', args: ['aggregate:check'] },
     { label: 'test:src-tests（*.src.test.ts 禁现）', args: ['test:src-tests'] },
     { label: 'gate:homedir（src 禁直连 HOME）', args: ['gate:homedir'] },
     { label: 'docs:check（README/链接）', args: ['docs:check'] },
-    { label: 'test:scripts（门禁脚本自测）', args: ['test:scripts'] },
   ]
+  const prereqStep = {
+    label: `build 编译面前置包（test:scripts 依赖：${PREREQ_PACKAGES.join(', ')}）`,
+    args: [...PREREQ_PACKAGES.map((p) => `--filter @wingsky-1/${p}...`), 'build'],
+  }
+  const scriptsSelfTest = { label: 'test:scripts（门禁脚本自测）', args: ['test:scripts'] }
 
   if (tier === 'pr') {
     // PR 增量口径：命中包构建/测试 + **命中包**产物闸 + 廉价全仓一致性闸。
@@ -100,6 +106,8 @@ function tierSteps(tier, { hitPackages, withCoverage }) {
       { label: `pack:check（切片 ${hitPackages.length} 包）`, cmd: 'node', args: ['scripts/gate/pack-check.ts', '--packages', scopeArg] },
       { label: `verify:npmlayout（切片 ${hitPackages.length} 包）`, cmd: 'node', args: ['scripts/gate/verify-npm-layout.ts', '--packages', scopeArg] },
       ...cheapGlobal,
+      prereqStep,
+      scriptsSelfTest,
     )
     return steps
   }
@@ -112,6 +120,7 @@ function tierSteps(tier, { hitPackages, withCoverage }) {
     { label: 'pack:check（全仓）', args: ['pack:check'] },
     { label: 'verify:npmlayout（全仓）', args: ['verify:npmlayout'] },
     ...cheapGlobal,
+    scriptsSelfTest,
   ]
   if (withCoverage) {
     steps.push({ label: 'cov（c8 全仓覆盖率）', args: ['cov'] }, { label: 'crap（圈复杂度，观察期）', args: ['crap'] })

--- a/scripts/gate/local-gate.mjs
+++ b/scripts/gate/local-gate.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * scripts/gate/local-gate.mjs — 本地门禁分层执行器（#722 门禁分层）。
+ *
+ * 为什么需要它：AGENTS.md 的提交前最小集原本是「全仓 build + 全仓 test + 全仓 typecheck
+ * + contract + pack:check」。全仓口径对单包改动的开发者是纯浪费——CI 早就按 ci.yml 的
+ * paths-filter 做了切片（build-test 只对命中包跑 test/typecheck），本地却一律全量。本
+ * 脚本把同一份包面归属搬到本地，并统一「PR 也走增量」的口径：
+ *
+ *   changed  命中包的 build + test + typecheck（迭代快线；命中全局面时自动升到 pr）
+ *   pr       快线 + **命中包**产物闸（contract / pack:check / verify:npmlayout 切片）
+ *            + 廉价全仓一致性闸（秒级静态检查，不依赖 lib 产物）
+ *   full     全仓口径（= 夜间班次口径；发版前或改过构建链时跑）
+ *
+ * 必须全量的东西（全仓产物闸、覆盖率、变异）不在 PR 口径里：它们归 CI 夜间班次
+ * （observe.yml / observe-incremental.yml），本地只在 --with-coverage 时按需补覆盖率。
+ * 包面归属的唯一事实源是 ci.yml 的 filters 块（见 local-scope.mjs），本脚本不重述路径规则。
+ *
+ * 用法：
+ *   node scripts/gate/local-gate.mjs [--tier changed|pr|full] [--base <ref>] [--dry-run] [--with-coverage]
+ * 退出码：0 = 全部通过；1 = 某步失败（首个失败即停，摘要列出全部已跑步骤的 exit code）。
+ */
+import { spawnSync } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import process from 'node:process'
+
+import { computeCiMatrix } from '../ci/ci-matrix.mjs'
+import { planChangedScope } from './local-scope.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const PNPM = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+
+const TIER_ALIAS = { changed: 'changed', fast: 'changed', pr: 'pr', full: 'full' }
+
+function sh(cmd, args) {
+  return spawnSync(cmd, args, { cwd: ROOT, encoding: 'utf8' })
+}
+
+function gitLines(args) {
+  const res = sh('git', args)
+  if (res.status !== 0) return null
+  return res.stdout.split('\n').map((l) => l.trim()).filter(Boolean)
+}
+
+function resolveChangedFiles(base) {
+  const verified = sh('git', ['rev-parse', '--verify', '--quiet', `${base}^{commit}`])
+  if (verified.status !== 0) return null
+  const tracked = gitLines(['diff', '--name-only', '--diff-filter=ACMR', base])
+  const untracked = gitLines(['ls-files', '--others', '--exclude-standard'])
+  if (tracked === null || untracked === null) return null
+  return [...new Set([...tracked, ...untracked])]
+}
+
+/** 每个步骤 = { label, args }；args 交给 pnpm。 */
+function tierSteps(tier, { hitPackages, withCoverage }) {
+  const pkgFilters = hitPackages.map((p) => `./packages/${p}`)
+  const scopedBuild = hitPackages.map((p) => `@wingsky-1/${p}...`)
+  const scopeArg = hitPackages.join(',')
+
+  if (tier === 'changed') {
+    const steps = []
+    if (hitPackages.length > 0) {
+      steps.push({ label: `build（命中包 + 依赖：${hitPackages.join(', ')}）`, args: [...scopedBuild.flatMap((f) => ['--filter', f]), 'build'] })
+      for (const filter of pkgFilters) {
+        steps.push({ label: `test ${filter}`, args: ['--filter', filter, '--if-present', 'test'] })
+      }
+      for (const filter of pkgFilters) {
+        steps.push({ label: `typecheck ${filter}`, args: ['--filter', filter, '--if-present', 'typecheck'] })
+      }
+    }
+    return steps
+  }
+
+  // 廉价全仓一致性闸：不依赖 lib 产物、秒级，恒跑（不是「全量构建」类成本）
+  const cheapGlobal = [
+    { label: 'stryker:check（变异配置与拓扑一致）', args: ['stryker:check'] },
+    { label: 'aggregate:check（聚合 patch 不漂移）', args: ['aggregate:check'] },
+    { label: 'test:src-tests（*.src.test.ts 禁现）', args: ['test:src-tests'] },
+    { label: 'gate:homedir（src 禁直连 HOME）', args: ['gate:homedir'] },
+    { label: 'docs:check（README/链接）', args: ['docs:check'] },
+    { label: 'test:scripts（门禁脚本自测）', args: ['test:scripts'] },
+  ]
+
+  if (tier === 'pr') {
+    // PR 增量口径：命中包构建/测试 + **命中包**产物闸 + 廉价全仓一致性闸。
+    // 全仓产物闸（无 --packages）与覆盖率/变异归夜间，本地只在 gate:full 跑。
+    const steps = []
+    if (hitPackages.length > 0) {
+      steps.push({ label: `build（命中包 + 依赖：${hitPackages.join(', ')}）`, args: [...scopedBuild.flatMap((f) => ['--filter', f]), 'build'] })
+      for (const filter of pkgFilters) {
+        steps.push({ label: `test ${filter}`, args: ['--filter', filter, '--if-present', 'test'] })
+      }
+      for (const filter of pkgFilters) {
+        steps.push({ label: `typecheck ${filter}`, args: ['--filter', filter, '--if-present', 'typecheck'] })
+      }
+    }
+    steps.push(
+      { label: `contract（切片 ${hitPackages.length} 包）`, cmd: 'node', args: ['scripts/gate/contract-check.ts', '--packages', scopeArg] },
+      { label: `pack:check（切片 ${hitPackages.length} 包）`, cmd: 'node', args: ['scripts/gate/pack-check.ts', '--packages', scopeArg] },
+      { label: `verify:npmlayout（切片 ${hitPackages.length} 包）`, cmd: 'node', args: ['scripts/gate/verify-npm-layout.ts', '--packages', scopeArg] },
+      ...cheapGlobal,
+    )
+    return steps
+  }
+
+  const steps = [
+    { label: 'build（全仓）', args: ['build'] },
+    { label: 'test（全仓）', args: ['test'] },
+    { label: 'typecheck（全仓）', args: ['typecheck'] },
+    { label: 'contract（全仓）', args: ['contract'] },
+    { label: 'pack:check（全仓）', args: ['pack:check'] },
+    { label: 'verify:npmlayout（全仓）', args: ['verify:npmlayout'] },
+    ...cheapGlobal,
+  ]
+  if (withCoverage) {
+    steps.push({ label: 'cov（c8 全仓覆盖率）', args: ['cov'] }, { label: 'crap（圈复杂度，观察期）', args: ['crap'] })
+  }
+  return steps
+}
+
+function main(argv) {
+  const tierArg = valueOf(argv, '--tier') ?? 'changed'
+  const tier = TIER_ALIAS[tierArg]
+  if (tier === undefined) {
+    console.error(`[local-gate] 未知 --tier ${tierArg}（可选 changed / pr / full）`)
+    return 2
+  }
+  const base = valueOf(argv, '--base') ?? 'origin/main'
+  const dryRun = argv.includes('--dry-run')
+  const withCoverage = argv.includes('--with-coverage')
+
+  const { allPackages } = computeCiMatrix({ env: {} })
+
+  let files = null
+  let scopeReason = ''
+  if (tier === 'changed') {
+    files = resolveChangedFiles(base)
+    if (files === null) {
+      scopeReason = `取不到 diff 基准 ${base}（或 git 不可用）—— 按全量处理（fail-closed）`
+      files = null
+    }
+  }
+
+  let plan
+  if (tier !== 'changed') {
+    plan = { hitPackages: [...allPackages], globalHit: false, escalated: false, reason: `--tier ${tier}：全仓口径` }
+  } else if (files === null) {
+    plan = { hitPackages: [...allPackages], globalHit: true, escalated: false, reason: scopeReason }
+  } else {
+    plan = planChangedScope({ root: ROOT, files, allPackages })
+  }
+
+  // 全局面命中（改 shared/scripts/.github/包管理文件）时，changed 快线不足以覆盖静态闸，升到 pr
+  let effectiveTier = tier
+  if (tier === 'changed' && plan.globalHit) effectiveTier = 'pr'
+
+  const steps = tierSteps(effectiveTier, { hitPackages: plan.hitPackages, withCoverage })
+  const escalated = effectiveTier !== tier
+
+  console.log(`[local-gate] tier=${tier}${escalated ? ` → 升级为 ${effectiveTier}` : ''}  base=${base}  变更文件=${files === null ? 'n/a' : files.length}`)
+  console.log(`[local-gate] 包面：${plan.hitPackages.length > 0 ? plan.hitPackages.join(', ') : '（无）'}  —— ${plan.reason}`)
+  if (plan.unknown && plan.unknown.length > 0) {
+    console.log(`[local-gate] 注意：ci.yml filters 里的 ${plan.unknown.join(', ')} 不在包清单内，已忽略（若为新增包请同步 plugins-manifest.json）`)
+  }
+  if (steps.length === 0) {
+    console.log('[local-gate] 无命中包面且已升级未触发 —— 纯文档/meta 改动，本地无需跑包级门禁（CI 静态闸仍会跑）')
+    return 0
+  }
+  console.log('[local-gate] 计划步骤：')
+  for (const s of steps) console.log(`  - ${s.label}`)
+  if (dryRun) {
+    console.log('[local-gate] --dry-run：未执行')
+    return 0
+  }
+
+  const results = []
+  for (const step of steps) {
+    console.log(`\n[local-gate] ▶ ${step.label}\n[local-gate]   ${step.cmd ?? PNPM} ${step.args.join(' ')}`)
+    const res = spawnSync(step.cmd ?? PNPM, step.args, { cwd: ROOT, stdio: 'inherit' })
+    const code = res.status ?? 1
+    results.push({ label: step.label, code })
+    if (code !== 0) {
+      console.error(`\n[local-gate] ✗ ${step.label} 退出码 ${code} —— 后续步骤不再执行（fail-fast）`)
+      break
+    }
+  }
+
+  console.log('\n[local-gate] 执行摘要：')
+  for (const r of results) console.log(`  exit=${r.code}  ${r.label}`)
+  const skipped = steps.length - results.length
+  for (const s of steps.slice(results.length)) console.log(`  exit=skip  ${s.label}`)
+  const failed = results.some((r) => r.code !== 0)
+  if (skipped > 0) console.log(`[local-gate] 因首个失败跳过 ${skipped} 步`)
+  console.log(failed ? '[local-gate] 结果：FAIL' : '[local-gate] 结果：PASS')
+  return failed ? 1 : 0
+}
+
+function valueOf(argv, flag) {
+  const i = argv.indexOf(flag)
+  return i === -1 ? undefined : argv[i + 1]
+}
+
+process.exit(main(process.argv.slice(2)))

--- a/scripts/gate/local-scope.mjs
+++ b/scripts/gate/local-scope.mjs
@@ -1,0 +1,107 @@
+/**
+ * scripts/gate/local-scope.mjs — 「这次改了什么 → 本地该跑哪些包」的纯函数（#722 门禁分层）。
+ *
+ * 为什么从 ci.yml 解析包面，而不是本地另写一份路径规则：包面归属的单一事实源就是
+ * ci.yml 的 paths-filter `filters` 块。本地抄一份必然漂移——docs/** 是否算全局面
+ * 历史上就改过一次（#429 回归 / #220 收敛），漂移的后果是「本地绿而 CI 红」。
+ * 故本模块只解析、不重述；解析失败一律 fail-closed 回退全量。
+ *
+ * 纯函数、无副作用：CLI 与测试都要 import 它（见 local-gate.mjs）。
+ */
+import { readFileSync } from 'node:fs'
+import { join, matchesGlob } from 'node:path'
+
+export const CI_WORKFLOW = '.github/workflows/ci.yml'
+
+/**
+ * 解析 ci.yml 里 dorny/paths-filter 的 `filters: |` 块。
+ * 返回 { global: [...globs], '<pkg>': [...globs] }；块缺失返回 null（调用方 fail-closed）。
+ */
+export function parseFilterBlock(ciYmlText) {
+  const lines = ciYmlText.split('\n')
+  const start = lines.findIndex((l) => /^\s*filters: \|\s*$/.test(l))
+  if (start === -1) return null
+  const rootIndent = lines[start].match(/^\s*/)[0].length
+
+  // 块体：比 `filters:` 缩进更深，直到缩进回落到同一层或更浅。
+  // 块内允许注释行（ci.yml 的 global 面就地写了为何某些路径刻意不在其中）。
+  const body = []
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i]
+    if (line.trim() === '' || line.trim().startsWith('#')) continue
+    if (line.match(/^\s*/)[0].length <= rootIndent) break
+    body.push(line)
+  }
+  if (body.length === 0) return null
+
+  const keyIndent = Math.min(...body.map((l) => l.match(/^\s*/)[0].length))
+  const filters = {}
+  let current = null
+  for (const line of body) {
+    const indent = line.match(/^\s*/)[0].length
+    if (indent === keyIndent) {
+      const m = /^\s*([^:\s#]+):\s*(?:#.*)?$/.exec(line)
+      if (m === null) return null
+      current = m[1]
+      filters[current] = []
+      continue
+    }
+    const item = /^\s*-\s*'([^']+)'\s*(?:#.*)?$/.exec(line) ?? /^\s*-\s*"([^"]+)"\s*(?:#.*)?$/.exec(line)
+    if (item === null || current === null) return null
+    filters[current].push(item[1])
+  }
+  return Object.keys(filters).length > 0 ? filters : null
+}
+
+/** 按 filters 匹配变更文件清单；返回 { globalHit, packages }（packages 为 filters 里的键）。 */
+export function matchFilterBlock(filters, files) {
+  const hit = new Set()
+  let globalHit = false
+  for (const file of files) {
+    for (const [key, globs] of Object.entries(filters)) {
+      if (globs.some((glob) => safeMatchesGlob(file, glob))) {
+        if (key === 'global') globalHit = true
+        else hit.add(key)
+      }
+    }
+  }
+  return { globalHit, packages: [...hit].sort() }
+}
+
+function safeMatchesGlob(file, glob) {
+  try {
+    return matchesGlob(file, glob)
+  } catch {
+    // 非法 glob：宁可当作命中（放大跑的面），不可静默漏跑
+    return true
+  }
+}
+
+/**
+ * 汇总：变更文件 + 包清单 → 本次该跑哪些包的 build/test/typecheck。
+ * fail-closed 语义与 ci.yml 一致：全局面命中 → 全量；filters 不可解析 → 全量。
+ */
+export function planChangedScope({ root, files, allPackages }) {
+  let filters = null
+  try {
+    filters = parseFilterBlock(readFileSync(join(root, CI_WORKFLOW), 'utf8'))
+  } catch {
+    filters = null
+  }
+  if (filters === null) {
+    return { hitPackages: [...allPackages], globalHit: true, escalated: true, reason: `${CI_WORKFLOW} 的 filters 块不可解析 —— 回退全量（fail-closed）` }
+  }
+  const { globalHit, packages } = matchFilterBlock(filters, files)
+  if (globalHit) {
+    return { hitPackages: [...allPackages], globalHit, escalated: false, reason: '命中全局面（shared/scripts/.github/包管理文件）—— 回退全量' }
+  }
+  const known = packages.filter((p) => allPackages.includes(p))
+  const unknown = packages.filter((p) => !allPackages.includes(p))
+  return {
+    hitPackages: known,
+    globalHit,
+    escalated: false,
+    unknown,
+    reason: known.length > 0 ? `命中 ${known.length} 个包面` : '未命中任何包面（纯文档/纯 meta 改动）',
+  }
+}

--- a/scripts/gate/pack-check.ts
+++ b/scripts/gate/pack-check.ts
@@ -17,6 +17,7 @@ import { fileURLToPath } from 'node:url'
 import { executeClient } from '../lib/client-contract-lib.ts'
 import { extractInlinedPackages, readMermaidChunkRefs } from '../build/collect-licenses.ts'
 import { AGGREGATE_NAME, checkAggregateConsistency, filterOutRetiredDirs, listPluginDirs, loadManifest, warnUnknownEntries } from '../lib/plugins-manifest-lib.ts'
+import { resolvePackageScopeOrExit } from '../lib/package-scope.ts'
 import { assertSharedDtsNoExtras, assertSharedDtsPresent, listSharedDts } from '../lib/shared-dts-lib.ts'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
@@ -56,12 +57,23 @@ const { kept: plugins, skipped: retiredDirs } = filterOutRetiredDirs(listPluginD
 if (retiredDirs.length > 0) {
   console.warn(`[pack-check] 跳过已退役包残留目录: ${retiredDirs.join(', ')}（manifest.retired 已登记，请清理）`)
 }
+// #722 门禁分层：**产物级**断言的切片（单包 PR 只需 pack 命中包；全仓口径留夜间）。
+// 目录集 == manifest 的一致性校验（上方）不依赖产物，保持全仓恒跑。
+// known 里含聚合包：它由 checkAggregateConsistency 覆盖、不在逐包 pack 循环内，
+// 出现在切片里不算未知包名（否则全局面命中时会假红），但会明示本闸不逐包检查它。
+const scoped = resolvePackageScopeOrExit(process.argv.slice(2), [...plugins, AGGREGATE_NAME])
+const targets = scoped === null ? plugins : plugins.filter((p) => scoped.includes(p))
+if (scoped !== null) {
+  const notIterated = scoped.filter((p) => !plugins.includes(p))
+  console.log(`[pack-check] 打包切片：${targets.length}/${plugins.length} 包（--packages ${scoped.join(',') || '（空）'}）`
+    + (notIterated.length > 0 ? `；${notIterated.join(', ')} 不在本闸逐包检查范围（聚合包一致性由 plugins-manifest 检查覆盖）` : ''))
+}
 // shared 声明副本期望清单（issue #461 L2）：仓库 shared/ 全部 .d.ts（递归含子目录）
 // 随包逐一断言——新增 shared 子目录/文件（如 client/i18n.d.ts）自动纳入，防漏打包静默
 const SHARED_DTS_EXPECTED = listSharedDts(ROOT)
 
 let failed = 0
-for (const p of plugins) {
+for (const p of targets) {
   const tmp = mkdtempSync(join(tmpdir(), 'dsh-pack-'))
   const name = JSON.parse(readFileSync(join(ROOT, 'packages', p, 'package.json'), 'utf8')).name
   try {

--- a/scripts/gate/repo-gate-assert.mjs
+++ b/scripts/gate/repo-gate-assert.mjs
@@ -14,35 +14,32 @@
  *   GATE_VERDICT        needs.mutation-verdict.result（#217：聚合判分收尾 job）
  *   GATE_HAS_MUTATIONS  needs.changes.outputs.hasMutations（'true'/'false' 显式布尔）
  *   GATE_MUTATION_PKGS  needs.changes.outputs.mutationPackages（JSON 数组文本，恒为合法数组）
+ *   GATE_FULL_REQUESTED needs.changes.outputs.fullGate（'true'/'false'；#722 门禁分层开关）
  *
  * 判定表（fail-closed：任何未显式放行的组合一律红；维度：
- *   事件 × 切片(hasMutations) × coverage × 变异矩阵 × verdict）：
+ *   事件 × 全量开关(fullGate) × 切片(hasMutations) × coverage × 变异矩阵 × verdict）：
  *   1) changes != success → 红（一切切片判定的前提，#85 F2）；
- *   2) build-test != success → 红（全集构建是全局门禁的产物前提，评审 F1）；
+ *   2) build-test != success → 红（构建/测试切片是全局门禁的产物前提，评审 F1）；
  *   3) mutationPackages 解析失败 / 非数组、hasMutations 非 'true'/'false'、
- *      hasMutations 与切片非空性交叉矛盾 → 环境数据违约（exit 2，fail-closed）；
- *   4) pull_request 且 hasMutations='true'（该跑必须真跑）：
- *      - coverage 必须 success。failure/cancelled =「coverage 失败连坐」——
- *        c8 全仓 smoke 同级硬信号；矩阵与 coverage 平行不受连坐、会独立跑完，
- *        但聚合判分 verdict 因 if 要求 coverage success 而连带缺席，整体照红；
- *        skipped = 结构性违约（hasMutations=true 却缺席，if 契约被改坏）；
- *      - 变异矩阵不得 skipped（该维度与 coverage 平行，skipped = 门禁静默绕过，
- *        #187 堵语义漏洞；failure 容忍——实例级 stryker 非零退出由 verdict
- *        统一裁决，报告已 if: always() 下发）；
- *      - verdict 必须 success。skipped/failure/cancelled 一律红：skipped 点名
- *        「mutation 门禁绕过」，cancelled 点名「被取消（未完成判分）」，
- *        failure 点名「判分未通过」；
- *   5) pull_request 且 hasMutations='false'（空切片合法缺席）：coverage 只收
- *      skipped（普通 job if=false 语义确定）；变异矩阵与 verdict 收
- *      skipped/failure（GitHub 对零实例动态矩阵实测回报 failure 而非官方口径
- *      skipped，实证 run 32802575298；#217 后 if 含 hasMutations 使零实例形态
- *      理论上不再触发，宽容仅防御平台行为漂移）。success/cancelled 说明契约
- *      被破坏，照旧判红；
- *   6) 非 pull_request 事件（push / workflow_dispatch / 未来新增触发器）→
- *      coverage / 变异矩阵 / verdict 三者全部必须 skipped。这是 #187 触发面
- *      收敛不变量的 #217 扩展：主干覆盖与变异覆盖归 observe.yml 夜间全量、
- *      发版归 release.yml tag 管线；任一非 skipped 说明 ci.yml 中 if 的事件
- *      限制已被破坏，宁可显性红也不静默退化。
+ *      fullGate 非 'true'/'false'、hasMutations 与切片非空性交叉矛盾 → 环境数据违约
+ *      （exit 2，fail-closed）；
+ *   4) pull_request 且 fullGate='false'（#722 默认增量门禁）：coverage / 变异矩阵 /
+ *      verdict 三者必须**全部 skipped**。这是对称 fail-closed——默认 PR 是「该被跳过」
+ *      而不是「可以随便跑」：没打 gate:full 标签却跑了全量链路，说明 ci.yml 的 if 或
+ *      标签语义被改坏，同样判红（既防 CI 静默回到全量，也防矩阵在增量路径下空转）；
+ *   5) pull_request 且 fullGate='true'（gate:full 标签，语义与 #217 版完全一致）：
+ *      - hasMutations='true'：coverage 必须 success（failure/cancelled = 覆盖失败
+ *        连坐，skipped = if 契约被改坏）；变异矩阵不得 skipped（failure 容忍，由
+ *        verdict 统一裁决）；verdict 必须 success（skipped = 门禁绕过，cancelled =
+ *        未完成判分，failure = 判分未通过）；
+ *      - hasMutations='false'（空切片合法缺席）：coverage 只收 skipped；矩阵与
+ *        verdict 收 skipped/failure（GitHub 对零实例动态矩阵实测回报 failure 而非
+ *        官方口径 skipped，实证 run 32802575298，宽容仅防御平台行为漂移）；
+ *   6) 非 pull_request 事件（push / workflow_dispatch / 未来新增触发器）→ fullGate
+ *      必须为 'false'，且 coverage / 变异矩阵 / verdict 三者全部必须 skipped。这是
+ *      #187 触发面收敛不变量的 #217 扩展：主干覆盖与变异覆盖归 observe.yml 夜间全量、
+ *      发版归 release.yml tag 管线；任一非 skipped 说明 ci.yml 中 if 的事件限制已被
+ *      破坏，宁可显性红也不静默退化。
  *
  * 用法：node scripts/gate/repo-gate-assert.mjs   （无命令行参数，全部走 env）
  * 退出码：0 = 通过；1 = 门禁违约；2 = 环境/数据缺失错误（fail-closed）
@@ -60,6 +57,7 @@ import { pathToFileURL } from 'node:url';
  *   verdict: string,
  *   hasMutations: string,
  *   mutationPkgsJson: string,
+ *   fullRequested: string,
  * }} input
  * @returns {{ ok: boolean, code: 0 | 1 | 2, reason: string }}
  */
@@ -70,7 +68,8 @@ export function evaluateGate(input) {
   if (changes !== 'success') {
     return { ok: false, code: 1, reason: `changes 作业未成功（${changes}）—— fail-closed` };
   }
-  // build-test 恒全集构建（不受触发面收敛影响），任何实例失败/skipped 即红
+  // build-test 恒全集矩阵（#722 后矩阵仍固定 7 实例、未命中实例只跑 checkout+setup），
+  // 任何实例失败/skipped 即红
   if (buildTest !== 'success') {
     return { ok: false, code: 1, reason: `build-test 存在失败/skipped 实例（${buildTest}）—— fail-closed` };
   }
@@ -88,9 +87,28 @@ export function evaluateGate(input) {
   if (hasMutations !== 'true' && hasMutations !== 'false') {
     return { ok: false, code: 2, reason: `hasMutations 必须为 'true'/'false'（实际 "${hasMutations}"）—— 数据契约破坏` };
   }
+  if (input.fullRequested !== 'true' && input.fullRequested !== 'false') {
+    return { ok: false, code: 2, reason: `fullGate 必须为 'true'/'false'（实际 "${input.fullRequested}"）—— 数据契约破坏` };
+  }
   // 交叉校验：hasMutations 与切片清单非空性由 changes 同一函数推导，不一致即违约
   if ((hasMutations === 'true') !== (pkgs.length > 0)) {
     return { ok: false, code: 2, reason: `hasMutations=${hasMutations} 与切片长度 ${pkgs.length} 矛盾 —— 数据契约破坏` };
+  }
+
+  if (event === 'pull_request' && input.fullRequested === 'false') {
+    // ── #722 增量门禁路径：全量链路「该被跳过」而不是「可以随便跑」──
+    // 对称 fail-closed：出现任何非 skipped 结果，说明 ci.yml 的 if 或 gate:full
+    // 标签语义被改坏（默认 PR 不该实例化 coverage/变异矩阵）。
+    for (const [name, result] of [['coverage', coverage], ['mutation-gate', mutation], ['mutation-verdict', verdict]]) {
+      if (result !== 'skipped') {
+        return {
+          ok: false,
+          code: 1,
+          reason: `PR 未打 gate:full 标签，${name} 结果为 ${result}（期望 skipped）—— 增量门禁契约被破坏（ci.yml if 的 fullGate 条件疑似失效）`,
+        };
+      }
+    }
+    return { ok: true, code: 0, reason: `PR 增量门禁：命中包构建/测试/产物闸 + 廉价全仓静态闸通过（全量链路按 gate:full 标签缺席，符合预期）` };
   }
 
   if (event === 'pull_request') {
@@ -139,9 +157,17 @@ export function evaluateGate(input) {
     return { ok: true, code: 0, reason: 'PR 空切片：无变异对象包，覆盖/变异链合法缺席' };
   }
 
-  // 非 PR 事件：触发面收敛不变量（#187 + #217 扩展）——覆盖/变异三段全部只允许
-  // skipped（main 归夜间、发版归 release）；出现其他结果说明 ci.yml if 的事件
-  // 限制已失效，显性红防静默退化
+  // 非 PR 事件：触发面收敛不变量（#187 + #217 扩展）——fullGate 必须为 false
+  // （changes job 里非 PR 一律 false），且覆盖/变异三段全部只允许 skipped（main 归
+  // 夜间、发版归 release）；出现其他结果说明 ci.yml if 的事件限制已失效，显性红防
+  // 静默退化
+  if (input.fullRequested === 'true') {
+    return {
+      ok: false,
+      code: 1,
+      reason: `${event} 事件下 fullGate=true（期望 false）—— #187 触发面收敛不变量被破坏（全量门禁只允许在 PR 上按标签触发）`,
+    };
+  }
   for (const [name, result] of [['coverage', coverage], ['mutation-gate', mutation], ['mutation-verdict', verdict]]) {
     if (result !== 'skipped') {
       return {
@@ -166,11 +192,12 @@ if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) 
     verdict: env.GATE_VERDICT ?? '',
     hasMutations: env.GATE_HAS_MUTATIONS ?? '',
     mutationPkgsJson: env.GATE_MUTATION_PKGS ?? '',
+    fullRequested: env.GATE_FULL_REQUESTED ?? '',
   });
   console.log(`event=${env.GATE_EVENT}  changes=${env.GATE_CHANGES}  `
     + `build-test=${env.GATE_BUILD_TEST}  coverage=${env.GATE_COVERAGE}  `
     + `mutation-gate=${env.GATE_MUTATION}  verdict=${env.GATE_VERDICT}  `
-    + `hasMutations=${env.GATE_HAS_MUTATIONS}`);
+    + `hasMutations=${env.GATE_HAS_MUTATIONS}  fullGate=${env.GATE_FULL_REQUESTED}`);
   // 违约/环境错误走 ::error:: 注解（GitHub PR 页面可见，与旧内联断言同款）
   if (verdict.code === 0) {
     console.log(`判定：${verdict.reason}`);

--- a/scripts/gate/verify-npm-layout.ts
+++ b/scripts/gate/verify-npm-layout.ts
@@ -20,6 +20,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { executeClient } from '../lib/client-contract-lib.ts'
 import { AGGREGATE_NAME, filterOutRetiredDirs, listPluginDirs, loadManifest } from '../lib/plugins-manifest-lib.ts'
+import { resolvePackageScopeOrExit } from '../lib/package-scope.ts'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
@@ -58,7 +59,17 @@ for (const p of allPackages) {
 }
 
 
-for (const p of plugins) {
+// #722 门禁分层：**解包级**断言（npm pack + 解包）按 --packages 切片——单包 PR 只需验
+// 命中包；全仓口径留夜间与本地 gate:full。上方的安装期脚本扫描是纯 package.json 读取，
+// 不依赖产物，保持全仓恒跑。
+const scoped = resolvePackageScopeOrExit(process.argv.slice(2), allPackages)
+const layoutTargets = scoped === null ? plugins : plugins.filter((p) => scoped.includes(p))
+if (scoped !== null) {
+  console.log(`[verify-npm-layout] 解包切片：${layoutTargets.length}/${plugins.length} 包（--packages ${scoped.join(',') || '（空）'}）`)
+}
+
+
+for (const p of layoutTargets) {
   const tmp = mkdtempSync(join(tmpdir(), 'dsh-npmlayout-'))
   const name = JSON.parse(readFileSync(join(ROOT, 'packages', p, 'package.json'), 'utf8')).name
   try {

--- a/scripts/lib/package-scope.ts
+++ b/scripts/lib/package-scope.ts
@@ -1,0 +1,53 @@
+/**
+ * scripts/lib/package-scope.ts — 产物闸的包级切片参数（#722 门禁分层）。
+ *
+ * 为什么存在：`contract-check` / `pack-check` / `verify-npm-layout` 是「必须读 lib 产物」
+ * 的闸，全仓口径在单包 PR 上是纯浪费。分层后 PR 只对 diff 命中包跑这三个闸，全仓口径
+ * 移交夜间（observe.yml），本地 `gate:full` 仍走全仓。
+ *
+ * 切片必须 fail-closed：**未知包名一律判红**。否则「包面写错」（例如把 dsh-notifier
+ * 写成 notifier）会退化成静默跳过——比不切片更危险。空列表是合法输入，语义是
+ * 「本次无产物闸对象」（纯文档/纯 meta 改动），不视为错误。
+ */
+import process from 'node:process'
+
+export const PACKAGE_SCOPE_FLAG = '--packages'
+
+/**
+ * 解析 `--packages a,b` / `--packages a b`。
+ * @param argv 进程参数（不含 node 与脚本路径）
+ * @param known 允许的包名全集（调用方枚举口径）
+ * @returns { packages: null } 表示不切片（全仓）；{ packages: string[] } 为切片清单（可为空数组）
+ * @throws 未知包名或缺失取值（调用方负责打印并 exit 1）
+ */
+export function resolvePackageScope(argv: string[], known: string[]): { packages: string[] | null } {
+  const eq = argv.find((a) => a.startsWith(`${PACKAGE_SCOPE_FLAG}=`))
+  let raw: string | undefined
+  if (eq !== undefined) {
+    raw = eq.slice(PACKAGE_SCOPE_FLAG.length + 1)
+  } else {
+    const i = argv.indexOf(PACKAGE_SCOPE_FLAG)
+    if (i !== -1) raw = argv[i + 1] ?? ''
+  }
+  if (raw === undefined) return { packages: null }
+
+  const names = raw.split(/[\s,]+/).filter(Boolean)
+  const unknown = names.filter((n) => !known.includes(n))
+  if (unknown.length > 0) {
+    throw new Error(
+      `未知包名 ${unknown.join(', ')}（--packages 切片）—— 可用包：${known.join(', ')}`
+      + '；包面写错会静默漏检，故 fail-closed',
+    )
+  }
+  return { packages: [...new Set(names)] }
+}
+
+/** CLI 便捷包装：解析失败即打印 FAIL 并退出（与各闸脚本的 fail 风格一致）。 */
+export function resolvePackageScopeOrExit(argv: string[], known: string[]): string[] | null {
+  try {
+    return resolvePackageScope(argv, known).packages
+  } catch (e) {
+    console.log(`FAIL package-scope | ${(e as Error).message}`)
+    process.exit(1)
+  }
+}

--- a/scripts/test/ci-matrix.test.ts
+++ b/scripts/test/ci-matrix.test.ts
@@ -23,6 +23,7 @@ test('ci-matrix: 场景 a - 正常命中单一 active 包 (via FILTER_OUTPUTS)',
 
   assert.deepEqual(res.allPackages, EXPECTED_ALL);
   assert.deepEqual(res.hitPackages, ['dsh-notifier']);
+  assert.deepEqual(res.buildPackages, ['dsh-notifier'], '#722：矩阵 = 命中包（有命中时）')
   assert.deepEqual(res.mutationPackages, ['dsh-notifier']);
   assert.equal(res.hasMutations, 'true');
   // T2-7：dsh-notifier 变异 4 段 → 按域重划 8 段（S3-30/N-24；combos 字母序展开）
@@ -31,6 +32,24 @@ test('ci-matrix: 场景 a - 正常命中单一 active 包 (via FILTER_OUTPUTS)',
     res.mutationCombos.map((c) => c.seg),
     ['channels', 'config', 'events', 'pipeline', 'sdk', 'server', 'stores', 'text']
   );
+});
+
+test('ci-matrix: 空切片 → buildPackages 用哨兵占位（防零实例动态矩阵回报 failure，#722）', () => {
+  const res = computeCiMatrix({
+    env: {
+      GLOBAL_HIT: 'false',
+      FILTER_OUTCOME: 'success',
+      BASE_SET: 'origin/main',
+      // 纯文档 PR：docs/**、AGENTS.md 刻意不在 global 面（#220），故全 false
+      FILTER_OUTPUTS: '{}',
+    },
+    rootDir: ROOT,
+  });
+
+  assert.deepEqual(res.hitPackages, [], '空切片');
+  assert.deepEqual(res.buildPackages, ['__no-hit-package__'],
+    'GHA 对零实例动态矩阵回报 failure（实证 run 32802575298），必须用哨兵项占位');
+  assert.equal(res.hasMutations, 'false');
 });
 
 test('ci-matrix: 场景 a - 正常命中单一 active 包 (via BASE_SET 空格分隔)', () => {

--- a/scripts/test/local-scope.test.ts
+++ b/scripts/test/local-scope.test.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * 本地门禁分层（#722）的包面推导回归。
+ *
+ * 为什么存在：`pnpm gate:changed` 的价值全押在「本地切片 == CI 切片」上。它靠解析
+ * ci.yml 的 paths-filter `filters` 块拿到包面归属，所以三类回归必须钉死：
+ *   1. 解析器被块内注释行/引号形态打挂 → 静默回退全量（本地又变慢，无人察觉）；
+ *   2. 解析器「宽容」到把注释里的路径当规则 → 本地少跑（本地绿 CI 红）；
+ *   3. 全局面（shared/scripts/.github/包管理文件）不再升级 → 静态闸在本地被绕过。
+ * 断言全部锚在真实 ci.yml 上（不另写 fixture 副本，避免与事实源漂移）。
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { readFileSync } from 'node:fs'
+
+import { CI_WORKFLOW, matchFilterBlock, parseFilterBlock, planChangedScope } from '../gate/local-scope.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const CI_YML = readFileSync(join(ROOT, CI_WORKFLOW), 'utf8')
+
+test('parseFilterBlock：真实 ci.yml 的 filters 块可解析，且含全局面与 7 个包面', () => {
+  const filters = parseFilterBlock(CI_YML)
+  assert.ok(filters !== null, 'filters 块必须可解析（不可解析 → 本地静默回退全量）')
+  assert.ok(Array.isArray(filters.global) && filters.global.length > 0, 'global 面必须存在且非空')
+  for (const pkg of ['dsh-notifier', 'dsh-web-file-preview', 'dsh-mcp-manager', 'dsh-provider-usage', 'dsh-lan-proxy', 'dsh-verify-isolated', 'dsh-plugins-all']) {
+    assert.ok(Array.isArray(filters[pkg]), `包面 ${pkg} 必须在 filters 块内`)
+  }
+  // #220 决策：docs/** 与 AGENTS.md 刻意不在全局面，纯文档 PR 不跑变异/切片
+  assert.ok(filters.global.includes('shared/**'), 'shared/** 属于全局面')
+  assert.ok(filters.global.includes('pnpm-lock.yaml'), '锁文件属于全局面')
+  assert.ok(filters.global.some((g) => g === '.github/**'), '.github/** 属于全局面')
+  assert.ok(!filters.global.some((g) => g.startsWith('docs/') || g === 'AGENTS.md'), 'docs 面不得混入全局面（#220）')
+  // 块内注释行不得被当成规则
+  assert.ok(!Object.keys(filters).some((k) => k.startsWith('#')), '注释行不得被解析为 filter 键')
+  assert.ok(!Object.values(filters).flat().some((g) => g.startsWith('#')), '注释行不得被解析为 glob')
+})
+
+test('parseFilterBlock：块缺失/畸形一律返回 null（调用方 fail-closed）', () => {
+  assert.equal(parseFilterBlock('name: CI\non:\n  pull_request:\n'), null, '无 filters 块 → null')
+  assert.equal(parseFilterBlock('        filters: |\n          global:\n            - no-quotes-here\n'), null, '未加引号的条目 → null')
+})
+
+test('matchFilterBlock：包内改动命中该包；全局面命中 global；纯文档两者都不命中', () => {
+  const filters = parseFilterBlock(CI_YML)
+  assert.deepEqual(matchFilterBlock(filters, ['packages/dsh-notifier/src/text/sanitize.ts']), { globalHit: false, packages: ['dsh-notifier'] })
+  assert.deepEqual(matchFilterBlock(filters, ['pnpm-lock.yaml']), { globalHit: true, packages: [] })
+  assert.deepEqual(matchFilterBlock(filters, ['docs/DEVELOPMENT.md', 'AGENTS.md']), { globalHit: false, packages: [] })
+  // 段配置是变异单一事实源（#322）：改段配置必须命中该包
+  assert.deepEqual(matchFilterBlock(filters, ['stryker.conf.d/dsh-lan-proxy-2.json']), { globalHit: false, packages: ['dsh-lan-proxy'] })
+})
+
+test('planChangedScope：全局面命中回退全量；单包改动只命中该包；解析失败回退全量', () => {
+  const allPackages = ['dsh-lan-proxy', 'dsh-notifier', 'dsh-plugins-all']
+
+  const scoped = planChangedScope({ root: ROOT, files: ['packages/dsh-lan-proxy/src/proxy.ts'], allPackages })
+  assert.deepEqual(scoped.hitPackages, ['dsh-lan-proxy'])
+  assert.equal(scoped.globalHit, false)
+
+  const global = planChangedScope({ root: ROOT, files: ['scripts/gate/local-gate.mjs'], allPackages })
+  assert.deepEqual(global.hitPackages, allPackages, '改 scripts/** 必须回退全量（本地快线覆盖不到静态闸）')
+  assert.equal(global.globalHit, true)
+
+  // 解析失败：临时根里放一份没有 filters 块的 workflow
+  const tmpRoot = mkdtempSync(join(tmpdir(), 'local-scope-'))
+  try {
+    mkdirSync(join(tmpRoot, '.github', 'workflows'), { recursive: true })
+    writeFileSync(join(tmpRoot, CI_WORKFLOW), 'name: CI\non:\n  pull_request:\n', 'utf8')
+    const broken = planChangedScope({ root: tmpRoot, files: ['packages/dsh-lan-proxy/src/proxy.ts'], allPackages })
+    assert.deepEqual(broken.hitPackages, allPackages, 'filters 不可解析 → 全量（fail-closed）')
+    assert.equal(broken.escalated, true)
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true })
+  }
+})

--- a/scripts/test/package-scope.test.ts
+++ b/scripts/test/package-scope.test.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * 产物闸包级切片（#722 门禁分层）的回归。
+ *
+ * 为什么存在：切片让 PR 只验命中包，代价是「包面写错」会静默漏检——这是比不切片更
+ * 危险的失败形态。故未知包名必须判红、空列表必须合法（纯文档 PR 无产物闸对象），
+ * 两条语义在纯函数层锁死，避免各闸脚本各自解释。
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { resolvePackageScope } from '../lib/package-scope.ts'
+
+const KNOWN = ['dsh-notifier', 'dsh-lan-proxy', 'dsh-plugins-all']
+
+test('resolvePackageScope：不带 --packages 即不切片（全仓口径）', () => {
+  assert.deepEqual(resolvePackageScope([], KNOWN), { packages: null })
+  assert.deepEqual(resolvePackageScope(['--check'], KNOWN), { packages: null })
+})
+
+test('resolvePackageScope：逗号/空白/等号三种写法等价，重复项去重', () => {
+  assert.deepEqual(resolvePackageScope(['--packages', 'dsh-notifier,dsh-lan-proxy'], KNOWN).packages, ['dsh-notifier', 'dsh-lan-proxy'])
+  assert.deepEqual(resolvePackageScope(['--packages=dsh-notifier,dsh-lan-proxy'], KNOWN).packages, ['dsh-notifier', 'dsh-lan-proxy'])
+  assert.deepEqual(resolvePackageScope(['--packages', 'dsh-notifier dsh-lan-proxy'], KNOWN).packages, ['dsh-notifier', 'dsh-lan-proxy'])
+  assert.deepEqual(resolvePackageScope(['--packages', 'dsh-notifier,dsh-notifier'], KNOWN).packages, ['dsh-notifier'])
+})
+
+test('resolvePackageScope：空列表合法（纯文档/meta 改动的产物闸对象为空）', () => {
+  assert.deepEqual(resolvePackageScope(['--packages', ''], KNOWN).packages, [])
+  assert.deepEqual(resolvePackageScope(['--packages='], KNOWN).packages, [])
+})
+
+test('resolvePackageScope：未知包名抛错（fail-closed，防包面写错静默漏检）', () => {
+  assert.throws(() => resolvePackageScope(['--packages', 'notifier'], KNOWN), /未知包名 notifier/)
+  assert.throws(() => resolvePackageScope(['--packages', 'dsh-notifier,nope'], KNOWN), /未知包名 nope/)
+})

--- a/scripts/test/script-test-prereqs.mjs
+++ b/scripts/test/script-test-prereqs.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+/**
+ * scripts/test/script-test-prereqs.mjs — `test:scripts` 里依赖**编译产物**的用例前置包清单
+ * （#722 门禁分层）。
+ *
+ * 为什么单列：PR 侧改为按改动切片构建后，repo-gate 不再保证全仓 lib 产物齐备；而
+ * `service-contract-wiring.test.ts` 用仓库 tsc 真实编译契约测试文件，需要这些包的
+ * **声明产物**（`lib/index.d.ts` 等）。CI（repo-gate 构建步骤）与本地门禁
+ * （`scripts/gate/local-gate.mjs`）都从本清单读取，避免「少建一个包 → 门禁假红」这类
+ * 只能靠人记住的耦合。
+ *
+ * 不变式：`service-contract-wiring.test.ts` 的 SUITES 必须被本清单覆盖——该用例自带
+ * 断言，新增编译面套件却忘记登记时会在 test:scripts 内判红（fail-closed）。
+ */
+export const PREREQ_PACKAGES = ['dsh-notifier', 'dsh-mcp-manager']

--- a/scripts/test/service-contract-wiring.test.ts
+++ b/scripts/test/service-contract-wiring.test.ts
@@ -27,6 +27,8 @@ import { spawnSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { PREREQ_PACKAGES } from './script-test-prereqs.mjs'
+
 const ROOT = join(import.meta.dirname, '..', '..')
 // tsc 真实 JS 入口（node_modules/.bin/tsc 是 shell shim，不能经 node 执行；
 // 用 typescript 包内的 bin 入口，node 直接加载）。
@@ -35,15 +37,29 @@ const TSC = join(ROOT, 'node_modules', 'typescript', 'bin', 'tsc')
 const SUITES = [
   {
     name: 'dsh-mcp-manager（提供方契约 + apply provide 方法面）',
+    pkg: 'dsh-mcp-manager',
     tsconfig: join(ROOT, 'packages', 'dsh-mcp-manager', 'test', 'tsconfig.json'),
     expectFiles: [join('integration', 'service-contract.test.ts')],
   },
   {
     name: 'dsh-notifier（SDK 契约 + L1/L2 直测 + 消费方类型编译用例）',
+    pkg: 'dsh-notifier',
     tsconfig: join(ROOT, 'packages', 'dsh-notifier', 'test', 'tsconfig.json'),
     expectFiles: [join('integration', 'service-contract.test.ts'), join('integration', 'consumer-types.test.ts')],
   },
 ]
+
+test('#722: 编译面套件的前置包清单覆盖完整（防切片构建后假红）', () => {
+  // 本用例需要各包**声明产物**（lib/index.d.ts）；#722 门禁分层后 PR 默认只构建命中包，
+  // 故 CI/本地门禁按 script-test-prereqs.mjs 的清单补建。新增套件却忘记登记时会在此判红，
+  // 而不是在 CI 里表现为「tsc 找不到 ../../lib/index.js」的假红。
+  for (const suite of SUITES) {
+    assert.ok(
+      PREREQ_PACKAGES.includes(suite.pkg),
+      `套件「${suite.name}」的包 ${suite.pkg} 未登记进 scripts/test/script-test-prereqs.mjs 的 PREREQ_PACKAGES`,
+    )
+  }
+})
 
 test('service-contract 编译面接线：契约测试文件被 tsc 真实编译（#476）', () => {
   assert.ok(existsSync(TSC), `仓库 tsc 应存在（${TSC}）——pnpm install 后才有`)

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -118,16 +118,24 @@ test('ci.yml: filter 失败 fallback 全量切片（fail-closed 双闸）', () =
   assert.ok(/按全量处理/.test(CI), 'diff base 不可用时按全量处理（F4）')
 })
 
-test('ci.yml: build-test 矩阵恒全集且 build 无条件（评审 F1：全局门禁依赖全量产物）', () => {
+test('ci.yml: build-test 矩阵恒全集（防零实例矩阵）且 build/artifact 仅命中包（#722 增量门禁）', () => {
   const bt = CI.slice(CI.indexOf('\n  build-test:'), CI.indexOf('\n  repo-gate:'))
   for (const pkg of MATRIX_PACKAGES) {
     assert.ok(bt.includes(`- ${pkg}\n`), `矩阵含 ${pkg}`)
   }
-  // build 步骤不得带切片条件；smoke/typecheck 必须带切片条件且 --if-present（评审 F3）
-  const buildStep = /#([^#\n]*)Build package[^\n]*\n(?:.*\n)*?- name: Smoke tests/
-  assert.ok(/Build package（无条件[^\n]*\n        run: pnpm --filter/.exec(bt.replace(buildStep, (s) => s)), null)
+  // 矩阵保持固定 7 实例：GHA 动态零实例矩阵实测回报 failure（实证 run 32802575298），
+  // 切片改由步骤级 if 表达，矩阵本身不得动态化
+  assert.ok(!bt.includes('matrix:\n        package: ${{ fromJSON'),
+    '矩阵不得动态化（零实例矩阵在 GHA 上回报 failure，会连坐 repo-gate 判定表）')
+  // #722：build 必须按命中清单切片——全仓产物由 gate:full 时的 repo-gate `pnpm build`
+  // 与命中包 artifact 共同保证，未命中包不再构建
   const buildBlock = bt.slice(bt.indexOf('- name: Build package'), bt.indexOf('- name: Smoke tests'))
-  assert.ok(!buildBlock.includes('if:'), 'build 步骤不允许任何 if 条件（产物全集保障）')
+  assert.ok(buildBlock.includes('contains(fromJSON(needs.changes.outputs.hitPackages), matrix.package)'),
+    'build 步骤必须按命中清单切片（#722 增量门禁）')
+  // 上传必须与 build 同步切片：未命中包无产物，if-no-files-found: error 会直接红
+  const uploadBlock = bt.slice(bt.indexOf('- name: Upload package outputs artifact'))
+  assert.ok(uploadBlock.slice(0, 300).includes('contains(fromJSON(needs.changes.outputs.hitPackages), matrix.package)'),
+    'artifact 上传必须与 build 同步切片（否则未命中包因无产物判红）')
   for (const stepName of ['Smoke tests', 'Typecheck']) {
     const idx = bt.indexOf(`- name: ${stepName}`)
     const block = bt.slice(idx, bt.indexOf('- name:', idx + 10))
@@ -526,25 +534,32 @@ test('#572: baseline-overlay.yml 主干合入秒级差量覆盖基线工作流�
 
 // ── #187 触发面收敛：mutation-gate 仅限 pull_request，主干变异归夜间全量 ──
 
-test('#187: ci.yml mutation-gate if 收敛至 pull_request（删除或改坏必红）', () => {
-  // build-test 不受收敛影响：push 时仍须全集构建（repo-gate 全局门禁依赖产物）
+test('#187+#722: ci.yml mutation-gate if 收敛至「PR + gate:full 标签」（删除或改坏必红）', () => {
+  // build-test 不受收敛影响：push 时仍须全事件运行（repo-gate 静态闸依赖其切片产物）
   const bt = CI.slice(CI.indexOf('\n  build-test:'), CI.indexOf('\n  mutation-gate:'))
   assert.ok(bt.includes('if: always() && needs.changes.result == \'success\''),
-    'build-test 的 if 必须保持 always() 全事件构建语义')
+    'build-test 的 if 必须保持 always() 全事件语义')
 
   const mg = CI.slice(CI.indexOf('\n  mutation-gate:'), CI.indexOf('\n  mutation-verdict:'))
   const m = /^    if: (.+)$/m.exec(mg)
   assert.ok(m, 'mutation-gate 声明 job 级 if')
   assert.equal(
     m[1].trim(),
-    "github.event_name == 'pull_request' && needs.changes.outputs.hasMutations == 'true'",
-    'mutation-gate 的 if 必须精确为「仅 PR 且 hasMutations 显式布尔」——'
-    + '事件限制被删除（退化 push 全量变异）或被改坏（PR 门禁静默缺席）均判红；'
-    + '#217 起空切片判定走 changes.hasMutations，禁止 fromJSON|length 或裸 \'[]\' 比较',
+    "github.event_name == 'pull_request' && needs.changes.outputs.fullGate == 'true' && needs.changes.outputs.hasMutations == 'true'",
+    'mutation-gate 的 if 必须精确为「仅 PR 且 gate:full 且 hasMutations 显式布尔」——'
+    + '#722 起变异段默认不在 PR 上跑（单段最坏约 20 分钟，#720），全量变异归夜间 observe*.yml；'
+    + '事件限制或 fullGate 条件被删除/改坏（退化 push 全量变异、或默认 PR 静默跑全量）均判红',
   )
+  // 覆盖率与 verdict 必须共用同一开关，避免「变异跑了但覆盖率没跑」的半通状态
+  const cov = CI.slice(CI.indexOf('\n  coverage:'), CI.indexOf('\n  mutation-gate:'))
+  assert.ok(/^    if: .*needs\.changes\.outputs\.fullGate == 'true'.*$/m.test(cov),
+    'coverage job 的 if 必须含 fullGate 开关（与 mutation-gate 同源）')
+  const vd = CI.slice(CI.indexOf('\n  mutation-verdict:'), CI.indexOf('\n  repo-gate:'))
+  assert.ok(/^    if: .*needs\.changes\.outputs\.fullGate == 'true'.*$/m.test(vd),
+    'mutation-verdict 的 if 必须含 fullGate 开关（否则增量路径下会空跑判分）')
 })
 
-test('#217+#187: repo-gate-assert 判定表全组合锁定（事件 × 切片 × coverage × 矩阵 × verdict）', async () => {
+test('#217+#187+#722: repo-gate-assert 判定表全组合锁定（事件 × fullGate × 切片 × coverage × 矩阵 × verdict）', async () => {
   const { evaluateGate } = await import('../gate/repo-gate-assert.mjs')
   const base = {
     event: 'pull_request',
@@ -555,18 +570,24 @@ test('#217+#187: repo-gate-assert 判定表全组合锁定（事件 × 切片 ×
     verdict: 'success',
     hasMutations: 'true',
     mutationPkgsJson: '["dsh-notifier"]',
+    fullRequested: 'true',
   }
   const run = (over) => evaluateGate({ ...base, ...over })
   const RESULTS = ['success', 'failure', 'cancelled', 'skipped']
+  const allSkipped = (cov, mut, verd) => cov === 'skipped' && mut === 'skipped' && verd === 'skipped'
 
   // 手写期望表（独立于实现成文，防同义反复；0=绿 1=红）：
-  //   - 非 PR：覆盖/变异三段全部 skipped 才绿（触发面收敛不变量）
-  //   - PR + hasMutations=true：coverage==success && 矩阵∈{success,failure}
-  //     && verdict==success 才绿
-  //   - PR + 空切片：coverage==skipped && 矩阵/verdict∈{skipped,failure} 才绿
-  const expectOf = (event, hm, cov, mut, verd) => {
+  //   - 非 PR：fullGate 必须 false，且覆盖/变异三段全部 skipped 才绿（触发面收敛不变量）
+  //   - PR + fullGate=false（#722 默认增量）：三段必须全部 skipped 才绿（对称 fail-closed）
+  //   - PR + fullGate=true + hasMutations=true：coverage==success &&
+  //     矩阵∈{success,failure} && verdict==success 才绿
+  //   - PR + fullGate=true + 空切片：coverage==skipped && 矩阵/verdict∈{skipped,failure} 才绿
+  const expectOf = (event, full, hm, cov, mut, verd) => {
     if (event !== 'pull_request') {
-      return (cov === 'skipped' && mut === 'skipped' && verd === 'skipped') ? 0 : 1
+      return (full === 'false' && allSkipped(cov, mut, verd)) ? 0 : 1
+    }
+    if (full === 'false') {
+      return allSkipped(cov, mut, verd) ? 0 : 1
     }
     if (hm === 'true') {
       return (cov === 'success' && (mut === 'success' || mut === 'failure') && verd === 'success') ? 0 : 1
@@ -576,30 +597,46 @@ test('#217+#187: repo-gate-assert 判定表全组合锁定（事件 × 切片 ×
       && (verd === 'skipped' || verd === 'failure')) ? 0 : 1
   }
 
-  // PR 分支：hasMutations × coverage × 矩阵 × verdict 全组合（2×4×4×4 = 128 case）
+  // PR 全量路径（gate:full）：hasMutations × coverage × 矩阵 × verdict 全组合（2×4×4×4 = 128 case）
   for (const hm of ['true', 'false']) {
     const pkgsJson = hm === 'true' ? '["dsh-notifier"]' : '[]'
     for (const cov of RESULTS) {
       for (const mut of RESULTS) {
         for (const verd of RESULTS) {
-          const expected = expectOf('pull_request', hm, cov, mut, verd)
+          const expected = expectOf('pull_request', 'true', hm, cov, mut, verd)
           const v = run({ hasMutations: hm, mutationPkgsJson: pkgsJson, coverage: cov, mutation: mut, verdict: verd })
           assert.equal(v.code, expected,
-            `PR hasMutations=${hm} coverage=${cov} mutation=${mut} verdict=${verd} 应为 code=${expected}`)
+            `PR gate:full hasMutations=${hm} coverage=${cov} mutation=${mut} verdict=${verd} 应为 code=${expected}`)
         }
       }
     }
   }
 
-  // 非 PR 分支：三段结果全组合（2 事件 × 4×4×4 = 128 case）；push fail-closed
-  // 真实形态（GATE_MUTATION_PKGS 的 push 取值）为非空全集清单，数据校验须放行
+  // PR 增量路径（默认，无标签）：三段必须全部 skipped；任何非 skipped 都是契约破坏
+  for (const hm of ['true', 'false']) {
+    const pkgsJson = hm === 'true' ? '["dsh-notifier"]' : '[]'
+    for (const cov of RESULTS) {
+      for (const mut of RESULTS) {
+        for (const verd of RESULTS) {
+          const expected = expectOf('pull_request', 'false', hm, cov, mut, verd)
+          const v = run({ fullRequested: 'false', hasMutations: hm, mutationPkgsJson: pkgsJson, coverage: cov, mutation: mut, verdict: verd })
+          assert.equal(v.code, expected,
+            `PR 增量 hasMutations=${hm} coverage=${cov} mutation=${mut} verdict=${verd} 应为 code=${expected}`)
+        }
+      }
+    }
+  }
+
+  // 非 PR 分支：三段结果全组合（2 事件 × 4×4×4 = 128 case）；push 真实形态
+  // （GATE_MUTATION_PKGS 的 push 取值）为非空全集清单，数据校验须放行
   for (const ev of ['push', 'workflow_dispatch']) {
     for (const cov of RESULTS) {
       for (const mut of RESULTS) {
         for (const verd of RESULTS) {
-          const expected = expectOf(ev, 'true', cov, mut, verd)
+          const expected = expectOf(ev, 'false', 'true', cov, mut, verd)
           const v = run({
             event: ev,
+            fullRequested: 'false',
             hasMutations: 'true',
             mutationPkgsJson: JSON.stringify(MUTATION_PACKAGES),
             coverage: cov,
@@ -612,6 +649,11 @@ test('#217+#187: repo-gate-assert 判定表全组合锁定（事件 × 切片 ×
       }
     }
   }
+  // 非 PR 下 fullGate=true：全量门禁只允许在 PR 上按标签触发（#187 收敛不变量）
+  assert.equal(run({ event: 'push', mutationPkgsJson: JSON.stringify(MUTATION_PACKAGES) }).code, 1,
+    '非 PR 事件 fullGate=true 必须红（触发面收敛不变量）')
+  assert.match(run({ event: 'push', mutationPkgsJson: JSON.stringify(MUTATION_PACKAGES) }).reason, /收敛不变量/,
+    '非 PR + fullGate=true 的判词须点名收敛不变量')
 
   // ── reason 文案锚：区分「coverage 失败连坐」与「mutation 门禁绕过」（#217）──
   assert.match(run({ coverage: 'failure' }).reason, /coverage 失败连坐/,
@@ -654,6 +696,11 @@ test('#217+#187: repo-gate-assert 判定表全组合锁定（事件 × 切片 ×
   for (const badHm of ['', 'TRUE', '1', 'null']) {
     assert.equal(run({ hasMutations: badHm }).code, 2, `hasMutations="${badHm}" 必须 exit 2`)
   }
+  for (const badFull of ['', 'TRUE', '1', 'null']) {
+    assert.equal(run({ fullRequested: badFull }).code, 2, `fullGate="${badFull}" 必须 exit 2（#722 数据契约）`)
+  }
+  assert.match(run({ fullRequested: 'false', coverage: 'success' }).reason, /增量门禁契约被破坏/,
+    '默认 PR 却跑了覆盖率：判词须点名「增量门禁契约被破坏」，不得混用连坐/绕过判词')
   assert.equal(run({ hasMutations: 'true', mutationPkgsJson: '[]' }).code, 2,
     'hasMutations=true 而切片为空 = 数据矛盾 exit 2')
   assert.equal(run({ hasMutations: 'false', mutationPkgsJson: '["dsh-notifier"]' }).code, 2,
@@ -671,17 +718,30 @@ test('#217+#187: repo-gate-assert CLI 退出码转发（GitHub Actions 判红依
     GATE_VERDICT: over.verdict ?? '',
     GATE_HAS_MUTATIONS: over.hasMutations ?? '',
     GATE_MUTATION_PKGS: over.mutationPkgsJson ?? '',
+    GATE_FULL_REQUESTED: over.fullRequested ?? '',
   })
-  // 通过场景 exit 0：push 触发面收敛形态（三段全 skipped + 非空全集清单）
+  // 通过场景 exit 0：push 触发面收敛形态（非 PR → fullGate=false，三段全 skipped）
   const okRun = spawnSync(process.execPath, [script], {
     encoding: 'utf8',
     env: { ...process.env, ...envOf({
       event: 'push', changes: 'success', buildTest: 'success',
       coverage: 'skipped', mutation: 'skipped', verdict: 'skipped',
       hasMutations: 'true', mutationPkgsJson: JSON.stringify(MUTATION_PACKAGES),
+      fullRequested: 'false',
     }) },
   })
   assert.equal(okRun.status, 0, 'push + 三段全 skipped 场景 CLI 必须 exit 0')
+  // #722 增量路径 exit 0：默认 PR（无标签）三段全 skipped
+  const incRun = spawnSync(process.execPath, [script], {
+    encoding: 'utf8',
+    env: { ...process.env, ...envOf({
+      event: 'pull_request', changes: 'success', buildTest: 'success',
+      coverage: 'skipped', mutation: 'skipped', verdict: 'skipped',
+      hasMutations: 'true', mutationPkgsJson: '["dsh-lan-proxy"]',
+      fullRequested: 'false',
+    }) },
+  })
+  assert.equal(incRun.status, 0, '默认 PR 增量路径（三段 skipped）CLI 必须 exit 0')
   // 违约场景 exit 1 且输出 ::error:: 可检索的判词：PR 该跑没跑（verdict skipped）
   const failRun = spawnSync(process.execPath, [script], {
     encoding: 'utf8',
@@ -689,6 +749,7 @@ test('#217+#187: repo-gate-assert CLI 退出码转发（GitHub Actions 判红依
       event: 'pull_request', changes: 'success', buildTest: 'success',
       coverage: 'success', mutation: 'skipped', verdict: 'skipped',
       hasMutations: 'true', mutationPkgsJson: '["dsh-lan-proxy"]',
+      fullRequested: 'true',
     }) },
   })
   assert.equal(failRun.status, 1, 'PR 该跑没跑场景 CLI 必须 exit 1')
@@ -703,6 +764,7 @@ test('#217+#187: repo-gate-assert CLI 退出码转发（GitHub Actions 判红依
       event: 'pull_request', changes: 'success', buildTest: 'success',
       coverage: 'failure', mutation: 'success', verdict: 'skipped',
       hasMutations: 'true', mutationPkgsJson: '["dsh-lan-proxy"]',
+      fullRequested: 'true',
     }) },
   })
   assert.equal(covFailRun.status, 1, 'coverage 失败连坐场景 CLI 必须 exit 1')
@@ -722,19 +784,25 @@ test('#306+#586: ci.yml 静态包名出现处 == MATRIX_PACKAGES（防清单漂�
     'Compute hit packages 步骤已下沉至 ci-matrix.mjs')
 })
 
-test('#306: repo-gate 产物断言必须动态驱动且空清单 fail-closed（防静默漏检）', () => {
+test('#306+#722: repo-gate 产物断言随门禁口径切换且空清单 fail-closed（防静默漏检）', () => {
   const restoreBlock = CI.slice(CI.indexOf('- name: Restore package outputs'))
-  // 产物断言从 needs.changes.outputs.allPackages 驱动（manifest 单一事实源）
+  // 两个口径的清单都必须从 changes 输出动态注入（manifest 单一事实源，禁止静态包名）
   assert.ok(/ALL_PACKAGES: \${{ needs\.changes\.outputs\.allPackages }}/.test(restoreBlock),
-    '产物断言必须注入 needs.changes.outputs.allPackages')
-  assert.ok(/for pkg in \$\(printf '%s' "\$ALL" \| jq -r '\.\[\]'\)/.test(restoreBlock),
-    '产物断言必须从 allPackages 动态循环（禁止静态包名清单）')
+    '产物断言必须注入 needs.changes.outputs.allPackages（gate:full 口径）')
+  assert.ok(/HIT_PACKAGES: \${{ needs\.changes\.outputs\.hitPackages }}/.test(restoreBlock),
+    '产物断言必须注入 needs.changes.outputs.hitPackages（#722 增量口径）')
+  assert.ok(/FULL_GATE: \${{ needs\.changes\.outputs\.fullGate }}/.test(restoreBlock),
+    '产物断言必须按 fullGate 选择口径（单一开关，禁止两套并行判据）')
+  assert.ok(/for pkg in \$WANT/.test(restoreBlock),
+    '产物断言必须从动态清单循环（禁止静态包名清单）')
   // 禁止回归为静态包名清单（评审发现：曾漏 verify-isolated 与 standalone）
   assert.ok(!/for pkg in dsh-[a-z0-9-]+ dsh-[a-z0-9-]+/.test(restoreBlock),
     '产物断言不得出现静态包名列表（曾漏 verify-isolated）')
-  // 空清单 fail-closed：禁止零断言假绿
+  // 空清单 fail-closed：全量口径下必须显式防空（禁止零断言假绿）；增量口径下空清单合法
   assert.ok(/allPackages 为空（fail-closed/.test(restoreBlock),
-    '产物断言必须显式防空清单（fail-closed，防零断言通过）')
+    '全量口径必须显式防空清单（fail-closed，防零断言通过）')
+  assert.ok(/SCOPE_DESC="命中包切片（增量）"/.test(restoreBlock),
+    '增量口径须在日志里标明产物判据范围（可审计）')
 })
 
 test('#306+#586: 全量列表动态化——fallback/GLOBAL_HIT 从 manifest 派生且空清单 fail-closed', () => {
@@ -807,8 +875,8 @@ test('#217: coverage job 全局单次采集——if 精确、步骤链与 artifa
   assert.ok(!cov.includes('matrix:'), 'coverage job 不得使用 matrix（全局单次语义）')
   assert.equal(
     /^    if: (.+)$/m.exec(cov)?.[1]?.trim(),
-    "github.event_name == 'pull_request' && needs.changes.outputs.hasMutations == 'true'",
-    'coverage if 必须精确为「仅 PR 且 hasMutations」',
+    "github.event_name == 'pull_request' && needs.changes.outputs.fullGate == 'true' && needs.changes.outputs.hasMutations == 'true'",
+    'coverage if 必须精确为「仅 PR 且 gate:full 且 hasMutations」（#722：覆盖率是全仓分母口径，归夜间/标签触发）',
   )
   // 步骤链顺序：build → cov → self-cov → upload
   const buildIdx = cov.indexOf('- name: Build all packages')
@@ -842,8 +910,8 @@ test('#217: mutation-gate 剥离 cov——与 coverage 平行（needs 仅 change
   assert.ok(m, 'mutation-gate 声明 job 级 if')
   assert.equal(
     m[1].trim(),
-    "github.event_name == 'pull_request' && needs.changes.outputs.hasMutations == 'true'",
-    '矩阵 if 必须精确锁定事件面与显式布尔切片',
+    "github.event_name == 'pull_request' && needs.changes.outputs.fullGate == 'true' && needs.changes.outputs.hasMutations == 'true'",
+    '矩阵 if 必须精确锁定事件面、gate:full 开关与显式布尔切片',
   )
   // cov 已剥离出矩阵（每实例重复全仓 smoke 是 flake 根因）
   assert.ok(!mg.includes('run: pnpm cov'), '矩阵不得再跑 pnpm cov（已收敛至 coverage job 单次）')
@@ -865,9 +933,10 @@ test('#217: mutation-verdict 聚合收尾——artifact 汇合 + 逐包双指标
     'verdict needs 三元：切片清单 + 覆盖产物 + 变异报告缺一不可')
   assert.equal(
     /^    if: (.+)$/m.exec(mv)?.[1]?.trim(),
-    "always() && needs.coverage.result == 'success' && needs.mutation-gate.result != 'skipped'",
-    'verdict if 必须精确为「always() 且 coverage success 且矩阵非 skipped」——'
-    + '矩阵 failure 时仍聚合判分（缺报告包 exit 2 fail-closed）；coverage 非 success 或矩阵 skipped 时连带缺席',
+    "always() && needs.changes.outputs.fullGate == 'true' && needs.coverage.result == 'success' && needs.mutation-gate.result != 'skipped'",
+    'verdict if 必须精确为「always() 且 gate:full 且 coverage success 且矩阵非 skipped」——'
+    + '矩阵 failure 时仍聚合判分（缺报告包 exit 2 fail-closed）；增量路径（无标签）下本 job 不实例化，'
+    + '由 repo-gate 判定表按 fullGate=false 要求三段全 skipped',
   )
   // artifact 下载：精确名 + pattern 双通道；download self-coverage 步骤块逐项精确断言
   const dlIdx = mv.indexOf('- name: Download self-coverage artifact')
@@ -883,13 +952,34 @@ test('#217: mutation-verdict 聚合收尾——artifact 汇合 + 逐包双指标
     'verdict 以 changes 切片清单驱动逐包判分')
 })
 
-test('#217: repo-gate 五维聚合 needs + 判定脚本 env 全维注入', () => {
+test('#217+#722: repo-gate 六维聚合 needs + 判定脚本 env 全维注入', () => {
   const rg = CI.slice(CI.indexOf('\n  repo-gate:'))
   for (const env of ['GATE_EVENT', 'GATE_CHANGES', 'GATE_BUILD_TEST',
-    'GATE_COVERAGE', 'GATE_MUTATION', 'GATE_VERDICT', 'GATE_HAS_MUTATIONS', 'GATE_MUTATION_PKGS']) {
+    'GATE_COVERAGE', 'GATE_MUTATION', 'GATE_VERDICT', 'GATE_HAS_MUTATIONS', 'GATE_MUTATION_PKGS',
+    'GATE_FULL_REQUESTED']) {
     assert.ok(new RegExp(`${env}: \\$\\{\\{`).test(rg), `判定脚本 env ${env} 注入缺失`)
   }
+  // fullGate 是 #722 的新维度：由 changes job 一处计算，判定表与三个 job 的 if 共用同源输出
+  assert.ok(CI.includes('fullGate: ${{ steps.fullgate.outputs.fullGate }}'),
+    'changes outputs 必须声明并透传 fullGate（单一策略来源）')
+  // #722：变异段默认不在 PR 上跑，conf ↔ 拓扑漂移必须仍能在增量路径被拦住
+  assert.ok(rg.includes('run: pnpm stryker:check'),
+    'repo-gate 组 A 必须含 stryker:check（增量路径下 conf↔拓扑漂移的唯一拦截点）')
   // 判定表实现侧同维锁定（env ↔ evaluateGate 输入一一对应）
+})
+
+test('#722: 全仓产物闸在夜间班次落地（PR 改增量后全仓口径的唯一出处）', () => {
+  const sIdx = OBSERVE.indexOf('- name: Build all')
+  assert.ok(sIdx > 0, 'observe.yml 全量班 Build all 步骤在位')
+  const tail = OBSERVE.slice(sIdx)
+  for (const [cmd, why] of [
+    ['run: pnpm contract', '客户端契约'],
+    ['run: pnpm pack:check', '打包契约'],
+    ['run: pnpm verify:npmlayout', '解包布局'],
+    ['run: pnpm stryker:check', '变异配置与拓扑一致性'],
+  ]) {
+    assert.ok(tail.includes(cmd), `observe.yml 必须跑全仓${why}（${cmd}）—— #722 后 PR 默认只验命中包，缺了就没有全仓口径`)
+  }
 })
 
 test('#217+#572: observe 两班 Mutation suites id + push 区分整套 skip 与部分失败', () => {

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -118,20 +118,26 @@ test('ci.yml: filter 失败 fallback 全量切片（fail-closed 双闸）', () =
   assert.ok(/按全量处理/.test(CI), 'diff base 不可用时按全量处理（F4）')
 })
 
-test('ci.yml: build-test 矩阵恒全集（防零实例矩阵）且 build/artifact 仅命中包（#722 增量门禁）', () => {
+test('ci.yml: build-test 矩阵动态来自 buildPackages（哨兵防空实例）且各步骤仅命中包（#722）', () => {
   const bt = CI.slice(CI.indexOf('\n  build-test:'), CI.indexOf('\n  repo-gate:'))
-  for (const pkg of MATRIX_PACKAGES) {
-    assert.ok(bt.includes(`- ${pkg}\n`), `矩阵含 ${pkg}`)
+  // #722：矩阵改为动态（来源 changes.buildPackages）。空切片时由 ci-matrix.mjs 填哨兵项，
+  // 因为 GHA 对零实例动态矩阵实测回报 failure（实证 run 32802575298），会连坐判定表。
+  assert.ok(bt.includes('package: ${{ fromJSON(needs.changes.outputs.buildPackages) }}'),
+    'build-test 矩阵必须动态来自 changes.buildPackages')
+  assert.ok(!/^\s+- dsh-[a-z0-9-]+$/m.test(bt),
+    'build-test 不得再出现静态包名清单（清单 SSOT 已下沉 ci-matrix.mjs）')
+  // 全量包清单仍必须注入（gate:full 的产物齐备断言与快照消费都用它）
+  const computeBlock = CI.slice(CI.indexOf('Compute hit packages'), CI.indexOf('build-test:'))
+  assert.ok(computeBlock.includes('run: node scripts/ci/ci-matrix.mjs'),
+    'Compute hit packages 步骤已下沉至 ci-matrix.mjs')
+  // 切片条件必须覆盖 install（哨兵实例零消耗）与 build（未命中包不构建）
+  for (const stepName of ['Install dependencies', 'Build package', 'Smoke tests', 'Typecheck']) {
+    const idx = bt.indexOf(`- name: ${stepName}`)
+    assert.ok(idx > 0, `${stepName} 步骤在位`)
+    const block = bt.slice(idx, bt.indexOf('- name:', idx + 10))
+    assert.ok(block.includes('contains(fromJSON(needs.changes.outputs.hitPackages), matrix.package)'),
+      `${stepName} 必须按命中清单切片`)
   }
-  // 矩阵保持固定 7 实例：GHA 动态零实例矩阵实测回报 failure（实证 run 32802575298），
-  // 切片改由步骤级 if 表达，矩阵本身不得动态化
-  assert.ok(!bt.includes('matrix:\n        package: ${{ fromJSON'),
-    '矩阵不得动态化（零实例矩阵在 GHA 上回报 failure，会连坐 repo-gate 判定表）')
-  // #722：build 必须按命中清单切片——全仓产物由 gate:full 时的 repo-gate `pnpm build`
-  // 与命中包 artifact 共同保证，未命中包不再构建
-  const buildBlock = bt.slice(bt.indexOf('- name: Build package'), bt.indexOf('- name: Smoke tests'))
-  assert.ok(buildBlock.includes('contains(fromJSON(needs.changes.outputs.hitPackages), matrix.package)'),
-    'build 步骤必须按命中清单切片（#722 增量门禁）')
   // 上传必须与 build 同步切片：未命中包无产物，if-no-files-found: error 会直接红
   const uploadBlock = bt.slice(bt.indexOf('- name: Upload package outputs artifact'))
   assert.ok(uploadBlock.slice(0, 300).includes('contains(fromJSON(needs.changes.outputs.hitPackages), matrix.package)'),
@@ -139,8 +145,6 @@ test('ci.yml: build-test 矩阵恒全集（防零实例矩阵）且 build/artifa
   for (const stepName of ['Smoke tests', 'Typecheck']) {
     const idx = bt.indexOf(`- name: ${stepName}`)
     const block = bt.slice(idx, bt.indexOf('- name:', idx + 10))
-    assert.ok(block.includes('contains(fromJSON(needs.changes.outputs.hitPackages), matrix.package)'),
-      `${stepName} 步骤须按命中清单切片`)
     assert.ok(block.includes('--if-present'), `${stepName} 须 --if-present（聚合包无该脚本）`)
   }
 })
@@ -772,13 +776,16 @@ test('#217+#187: repo-gate-assert CLI 退出码转发（GitHub Actions 判红依
   assert.match(covFailRun.stderr, /coverage 失败连坐/, '连坐场景判词必须点名「coverage 失败连坐」，不得误报为门禁绕过')
 })
 
-test('#306+#586: ci.yml 静态包名出现处 == MATRIX_PACKAGES（防清单漂移，替代旧 #178 全包名断言）', () => {
-  // 动态化后 ci.yml 的静态包名只应出现在显式清单：build-test matrix。
-  // 切片分支已下沉至 ci-matrix.mjs 动态计算（#586），不再存在脆弱内联 for/case。
+test('#306+#586+#722: ci.yml 包名清单 SSOT 下沉——workflow 内不得再有静态包名矩阵', () => {
+  // 静态清单已彻底退役：build-test 矩阵来自 changes.buildPackages（ci-matrix.mjs 派生
+  // 自 plugins-manifest.json），故 ci.yml 里不应再出现包名逐行列举（防清单漂移）。
   const bt = CI.slice(CI.indexOf('\n  build-test:'), CI.indexOf('\n  repo-gate:'))
-  const matrixNames = [...bt.matchAll(/^\s*- (dsh-[a-z0-9-]+)\s*$/gm)].map((m) => m[1]).sort()
-  assert.deepEqual(matrixNames, [...MATRIX_PACKAGES].sort(),
-    `build-test matrix 包名与 MATRIX_PACKAGES 不一致：matrix=${matrixNames.join(',')} expected=${MATRIX_PACKAGES.join(',')}`)
+  const matrixNames = [...bt.matchAll(/^\s*- (dsh-[a-z0-9-]+)\s*$/gm)].map((m) => m[1])
+  assert.deepEqual(matrixNames, [],
+    `build-test 段不得再列举动包名（发现：${matrixNames.join(',')}）——清单 SSOT 在 ci-matrix.mjs`)
+  // buildPackages 必须是 changes 的声明输出并被矩阵消费
+  assert.ok(CI.includes('buildPackages: ${{ steps.pkgs.outputs.buildPackages }}'),
+    'changes outputs 必须声明 buildPackages')
   const computeBlock = CI.slice(CI.indexOf('Compute hit packages'), CI.indexOf('build-test:'))
   assert.ok(computeBlock.includes('run: node scripts/ci/ci-matrix.mjs'),
     'Compute hit packages 步骤已下沉至 ci-matrix.mjs')


### PR DESCRIPTION
Part of #722

## 说明

#722 的目标形态要求「PR 与本地都按改动切片，只有**必须全仓**的口径留夜间」。此前 PR 上 `coverage` / `mutation-gate` / `mutation-verdict` 三段全量链路与夜间 `observe*.yml` 完全重复（变异单段最坏约 20 分钟，#720），本地又一律全仓（build + test + typecheck），反馈回路被两头拖长。

本 PR 按 #722 的方案评论（[issuecomment-5634415704](https://github.com/wingsky-1/dsh-plugin-hub/issues/722#issuecomment-5634415704)，含 `.github/` 改动的红线方案，维护者已 `approved`）落地门禁分层。

## 改动

**策略单点**：`changes` job 计算 `fullGate` 输出（PR 且带 `gate:full` 标签；非 PR 恒 false），下游三个全量 job 的 `if` 与判定脚本共用同源布尔；`pull_request` 增加 `labeled`/`unlabeled` types（否则打标签不重跑）。

**CI 增量路径（默认）**
- `build-test`：build 与 artifact 上传改为**仅命中包**（未命中实例只做 checkout+setup）；矩阵保持固定 7 实例（GHA 零实例动态矩阵回报 failure）。
- `repo-gate` 组 A（廉价全仓闸，恒跑）：判定脚本、`threshold-monotonic`、`aggregate:check`、**新增 `stryker:check`**（变异段默认不在 PR 跑后，conf↔拓扑漂移在增量路径的唯一拦截点）、`test:scripts`、`forbid-*`、`docs:check`。
- `repo-gate` 组 B（产物闸，按 `fullGate` 切口径）：`contract` / `pack:check` / `verify:npmlayout` 默认用 `--packages <命中清单>` 只验命中包。

**CI 全量路径（`gate:full` 标签）**：三段链路实例化，行为与 #217 版完全一致。

**判定表**：`repo-gate-assert.mjs` 新增 `fullGate` 维度（六维），默认增量路径要求三段**全部 skipped** —— 对称 fail-closed：没打标签却跑了全量同样判红。

**夜间补齐**：`observe.yml` 全量班补上 `contract` / `pack:check` / `verify:npmlayout` / `stryker:check` —— PR 改增量后，全仓打包契约必须在这里落地，否则无人检查。

**本地分层**：`pnpm gate:changed`（命中包 build/test/typecheck）/ `gate:pr`（+ 命中包产物闸 + 廉价全仓闸）/ `gate:full`（全仓口径）。包面归属**解析 `ci.yml` 的 paths-filter**（唯一事实源，不重述路径规则），解析失败或命中全局面一律回退全量。

**切片参数的 fail-closed**：三个产物闸的 `--packages` 对未知包名判红（防包面写错静默漏检）、空列表合法（纯文档改动）。

**编译面耦合显式化**：新增 `scripts/test/script-test-prereqs.mjs`（`test:scripts` 中依赖声明产物的用例前置包清单），CI 与本地门禁同源读取；`service-contract-wiring` 用例自带断言锁死清单覆盖，避免切片构建后出现「tsc 找不到 `../../lib/index.js`」假红。

## 验证

| 命令 | 结果 |
|---|---|
| `pnpm build` | exit 0 |
| `pnpm typecheck` | exit 0 |
| `pnpm contract`（全仓） | exit 0 |
| `pnpm verify:npmlayout`（全仓） | exit 0 |
| `pnpm pack:check`（全仓） | exit 0 |
| `pnpm test:scripts` | 328 pass / 0 fail（含新增结构断言） |
| `pnpm docs:check` | exit 0 |
| `pnpm stryker:check` | exit 0（31 份配置与拓扑一致） |
| `contract-check.ts --packages dsh-web-file-preview` | exit 0（切片 1/6） |
| `pack-check.ts --packages dsh-web-file-preview` | exit 0（切片 1/6） |
| `verify-npm-layout.ts --packages dsh-web-file-preview` | exit 0（切片 1/6） |
| `--packages nope`（未知包名） | exit 1（fail-closed） |
| `--packages ''`（空列表） | exit 0（合法跳过） |
| `pnpm $FILTERS build`（`dsh-notifier... dsh-mcp-manager...`，repo-gate 新步骤） | exit 0 |
| `ci.yml` / `observe.yml` YAML 解析 | 通过 |

改动面为 `scripts/` + `.github/workflows/` + 文档，未触及 `packages/**/src`，故包级 smoke 无行为变化（CI 会跑切片路径）。

### 客户端改动截图证据（勾选式）

- [x] **不涉及客户端改动**（未改动 `src/client/**`、`src/client/style.css`、客户端产物 `lib/client.js`）
