### PR TITLE
chore(lint): #722 阶段五——引入 ESLint 复杂度门禁并重建 CRAP 的 src 口径

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -628,6 +628,9 @@ jobs:
       - name: Scripts self-test（维护脚本自测，含 workflow 结构静态断言）
         run: pnpm test:scripts
 
+      - name: Lint（ESLint 复杂度门禁；阈值唯一事实源 gauntlet.config.json 的 complexity 段）
+        run: pnpm lint
+
       - name: Forbid legacy src tests（#423：变异测试单份维护，*.src.test.ts 全仓禁现）
         run: node scripts/gate/forbid-src-tests.mjs
 

--- a/.github/workflows/health-report.yml
+++ b/.github/workflows/health-report.yml
@@ -41,9 +41,11 @@ jobs:
       - name: Coverage（vitest coverage，分母仅 src，阈值见 vitest.config.ts）
         run: pnpm cov
 
-      # CRAP 自 #722 阶段三起处于 fail-closed 停用态（圈复杂度取自 lib 产物、覆盖率已切
-      # src 口径，行号不可比 → crap-check 入口自检 exit 2），故移除本步骤；src 口径重建
-      # 归阶段 5。crap-report.json 缺席时报告正文自动省略该段（见 health-report-body.mjs）。
+      # CRAP 于 #722 阶段五完成 src 口径重建（复杂度取自 ESLint 的 complexity 规则，
+      # 覆盖率取自同一份 src 口径产物），恢复接入；crap-report.json 供报告正文消费
+      # （见 health-report-body.mjs）。
+      - name: CRAP（热点报告；strict 见 gauntlet.config.json 的 crap.strict）
+        run: pnpm crap
 
       - name: Generate report body
         run: node scripts/release/health-report-body.mjs > health-body.md

--- a/.github/workflows/observe.yml
+++ b/.github/workflows/observe.yml
@@ -81,10 +81,10 @@ jobs:
       - name: Coverage（vitest coverage，阈值 coverage.thresholds 内 fail-closed）
         run: pnpm cov
 
-      # CRAP 自 #722 阶段三起处于 fail-closed 停用态（其圈复杂度取自 lib 产物，
-      # 而覆盖率已切 src 口径，行号不可比 → crap-check 入口自检 exit 2），故移除本
-      # 步骤而非保留一个恒红/恒空的执行点。src 口径重建归阶段 5（与 ESLint 复杂度
-      # 规则同批），届时重新接入本班次。crap-report.json 缺席时报告正文自动省略该段。
+      # CRAP 于 #722 阶段五完成 src 口径重建（复杂度取自 ESLint 的 complexity 规则，
+      # 覆盖率取自同一份 src 口径产物，两者行号可比），恢复接入本班次。
+      - name: CRAP（热点报告；strict 见 gauntlet.config.json 的 crap.strict）
+        run: pnpm crap
 
       - name: Resolve mutation suites（#276 方案 A + #433 全量班：每日一次全量）
         id: suite-plan

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ git worktree remove /mnt/ssd/worktree/dsh-plugin-hub-task-<n> && git worktree pr
 | 层 | 命令 | 用途与口径 |
 |---|---|---|
 | 快线 | `pnpm gate:changed` | 迭代中反复跑：只跑 diff 命中包的 build + test + typecheck。包面归属取自 `ci.yml` 的 paths-filter（**唯一事实源**，本地不重述路径规则）；命中全局面时自动升级为 `gate:pr`，解析失败一律回退全量（fail-closed） |
-| 最小集 | `pnpm gate:pr` | 开 PR 前：快线 + **命中包**的产物闸（`contract` / `pack:check` / `verify:npmlayout` 按 `--packages` 切片）+ 廉价全仓一致性闸（`stryker:check`、`aggregate:check`、`test:src-tests`、`gate:homedir`、`docs:check`、`test:scripts`，均秒级且不依赖 lib 产物） |
+| 最小集 | `pnpm gate:pr` | 开 PR 前：快线 + **命中包**的产物闸（`contract` / `pack:check` / `verify:npmlayout` 按 `--packages` 切片）+ 廉价全仓一致性闸（`stryker:check`、`aggregate:check`、`test:src-tests`、`gate:homedir`、`docs:check`、`test:scripts`、`lint`，均秒级且不依赖 lib 产物） |
 | 收尾 | `pnpm gate:full` | 全仓口径（= 夜间班次口径）：全仓 build/test/typecheck + 全仓产物闸 + 全部静态闸；改过构建链、包结构或发版前跑一遍 |
 | 全量 | CI 夜间班次（`observe.yml` / `observe-incremental.yml`） | 全仓产物闸 + 覆盖率 + 全量/增量变异与基线归档。本地不默认跑，需要时 `pnpm gate:full --with-coverage` |
 
@@ -75,6 +75,7 @@ git worktree remove /mnt/ssd/worktree/dsh-plugin-hub-task-<n> && git worktree pr
 | 改 `src/` 里 HOME 来源 API | `gate:pr` 起（含 `gate:homedir`） |
 | 改 `scripts/` / workflow | `gate:pr` 起（含 `test:scripts`）；改 `.github/` 属红线，先评审 |
 | 改 README、新增文档链接 | `gate:pr` 起（含 `docs:check`） |
+| 改任意手写源码（`packages/*/src`、`packages/*/test`、`shared/`、`scripts/`） | `gate:pr` 起（含 `lint`：ESLint 复杂度门禁，阈值见 `gauntlet.config.json` 的 `complexity` 段） |
 | 提交前最终一遍 | `pnpm gate:pr`；单包迭代用 `pnpm gate:changed` |
 
 - 分层**不减少检查，只改变时机**：PR 与本地都走增量（命中包），只有"必须全仓才能判定"的

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -407,6 +407,17 @@ export const inject: string[] = [];        // 声明 apply 用到的 ctx 服务�
     自动枚举会退回「目录即事实源」的 fail-open 老路；
   - schema 加载/校验逻辑只有一份：`scripts/lib/plugins-manifest-lib.ts`（纯函数，
     入口脚本只喂数据），测试见 `scripts/test/plugins-manifest.test.ts`。
+- **复杂度门禁（#722 阶段五）**：`pnpm lint` = ESLint `complexity` + `sonarjs/cognitive-complexity`，
+  跑在 `packages/*/src`、`packages/*/test`、`shared`、`scripts` 的手写源码上（秒级）。
+  - **工具链隔离**：lint 工具链装在 `tools/lint`（刻意不在 `packages/` 下）——typescript-eslint
+    需要 TypeScript 的 compiler API，而仓根 `typescript` 是 tsgo 7.x（无 API，且根 `tsc` 由它
+    提供、各包 build/typecheck 依赖它）。pnpm 的子包隔离让 lint 专用的 TS 6 与根 tsgo 共存；
+    `scripts/test/lint-toolchain.test.ts` 逐条钉死该前提——隔离一旦被破坏，失败形态是
+    「lint 全绿但没在跑规则」或「build 悄悄换了编译器」，两者都不会自己报出来。
+  - **阈值唯一事实源**：`scripts/data/gauntlet.config.json` 的 `complexity` 段。起步值 =
+    全域实测最大值（cyclomatic 78 / cognitive 84），只拦新增劣化；收紧路线与目标见 issue #732。
+  - **与 CRAP 的关系**：`pnpm crap` 的圈复杂度**取自同一条 ESLint 规则**（`Linter` API + 阈值 0
+    枚举全部函数），不实现第二份算法——两者是同一事实源的消费方，不存在口径漂移面。
 - **新增/修改客户端后**：`pnpm gate:pr` 全绿再提交（= 命中包 build/test/typecheck + 命中包
   产物闸 + 廉价全仓一致性闸；迭代中用 `pnpm gate:changed`，全仓口径用 `pnpm gate:full`。
   分层口径与「改动类型 → 归属层」对照表见根 [AGENTS.md 门禁矩阵](../AGENTS.md)）。

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "gate:pr": "node scripts/gate/local-gate.mjs --tier pr",
     "gate:full": "node scripts/gate/local-gate.mjs --tier full",
     "cov": "vitest run --coverage --project unit --project integration",
-    "crap": "node scripts/gate/crap-check.mjs"
+    "crap": "node scripts/gate/crap-check.mjs",
+    "lint": "node tools/lint/bin/lint.mjs"
   },
   "keywords": [
     "dsh",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,24 @@ importers:
 
   packages/dsh-web-file-preview: {}
 
+  tools/lint:
+    devDependencies:
+      '@eslint/js':
+        specifier: 10.0.1
+        version: 10.0.1(eslint@10.10.0(supports-color@7.2.0))
+      eslint:
+        specifier: 10.10.0
+        version: 10.10.0(supports-color@7.2.0)
+      eslint-plugin-sonarjs:
+        specifier: 4.2.0
+        version: 4.2.0(eslint@10.10.0(supports-color@7.2.0))
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      typescript-eslint:
+        specifier: 8.70.0
+        version: 8.70.0(eslint@10.10.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+
 packages:
 
   '@babel/code-frame@7.29.7':
@@ -474,6 +492,12 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@cacheable/memory@2.2.0':
+    resolution: {integrity: sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==}
+
+  '@cacheable/utils@2.5.0':
+    resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
 
   '@deepseek-ai/cordis@4.0.2':
     resolution: {integrity: sha512-asOnXP1TzFSFQlHb1iegDZp0z/8WD1c7YNrwJR/Tx2bzNuMXfcekE/I67Iv6SQXeLB4csxqCngzQKANP7gdw0g==}
@@ -752,11 +776,70 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.10.1':
+    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.3':
+    resolution: {integrity: sha512-IkO+/KEUvwbVpiURZg+P7zF74z5Jxe0UgJxVni+RtoHQ6IZieXaO02kmadomap/q+l6bc/jdPGGqTjhuZnuz1Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@hono/node-server@2.1.1':
     resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@inquirer/ansi@2.0.7':
     resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
@@ -911,6 +994,15 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@keyv/bigmap@1.3.1':
+    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      keyv: ^5.6.0
+
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
   '@modelcontextprotocol/sdk@1.30.0':
     resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
@@ -1077,6 +1169,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -1101,6 +1196,9 @@ packages:
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/node-forge@1.3.14':
     resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
 
@@ -1124,6 +1222,65 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@typescript-eslint/eslint-plugin@8.70.0':
+    resolution: {integrity: sha512-/v8HZt6RlyIZxB3ntehELOcUcfxKPVGWXnQdJuHRmzrqgF8nQypcC/oxGW+Ot4VGKDq81XugPKxx0n5PBtf9PA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.70.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.70.0':
+    resolution: {integrity: sha512-zYvrmj9Yxd63UGaXw+kdt6A0F0s0qveJyuatIM77bYC2DE4pgmg7a50u8LR7PRtXd0x+h+Tl3eXabGm06SWd3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.70.0':
+    resolution: {integrity: sha512-hFHbTNqhU9G+2eKFXCBVb1tjFT/LceiJ4+HfLO4pTpDI0KHi6iajpcFFkaSQ9gXmCh7n82A0PthaayEdN6mspQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.70.0':
+    resolution: {integrity: sha512-8nP3Kwh5hlgZ4FicGvmznAmJe8UL4sdU8tLukrPaMuQmDuk4Y8xYfzu/aYZW4xT2JCgc7H/TpDI5cGlxcWJSqQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.70.0':
+    resolution: {integrity: sha512-adnkeeNq9Sq1sUf4+FRVc0KdgYghzsgFpZSQVZVvY0LCuUuN0FnQgyGzCJeC4fW1cdXseBAjU2EOqUIjbNcZUw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.70.0':
+    resolution: {integrity: sha512-NUMKIhYVaVIVLnRL9CRt+VVcuLgSHUCpXn4/+K8wql+vdInUzvx8BjUO1oJ7cG9shjFJKtF8F8Hh2kCh3/KBVw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.70.0':
+    resolution: {integrity: sha512-asTOIYhDg4zdzOScCyaytrsV3cR6B4ecPQlXw/dJIm7J/MZTtCtfVII9JD8Geh4jTCrK/Xe6cg5UevoleMcoJQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.70.0':
+    resolution: {integrity: sha512-d9NmHMPEKQ7QCLLm1jI3zmoQBwT5KwFYjXBJ9ymZfKCUU+5rmTRykKAFvH5Qn/ZCds3CEAFS9OC9M/jkl0X2bA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.70.0':
+    resolution: {integrity: sha512-oZmtKJz/4fufZ2p3+Cn3ijEojcdfR+1zYDH2xKYrEly0dR/Q/1xUPRCOlKGxod78nWlU2UnDe09GZ3TaknBFGA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.70.0':
+    resolution: {integrity: sha512-BoC8PiO4Hkdo0TVJh9Ntxr5MxPDI7/oFsrygN5ADelFSeXG/qgNuucIGA+L5Z6JpPTE/uRfcTWtscjbUaufepQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -1283,6 +1440,11 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   acorn@8.18.0:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
@@ -1290,6 +1452,9 @@ packages:
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
@@ -1339,6 +1504,10 @@ packages:
     resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
     engines: {node: '>=4.0'}
 
+  builtin-modules@3.3.0:
+    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
+    engines: {node: '>=6'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -1352,6 +1521,9 @@ packages:
     peerDependenciesMeta:
       monocart-coverage-reports:
         optional: true
+
+  cacheable@2.5.0:
+    resolution: {integrity: sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1446,6 +1618,9 @@ packages:
       supports-color:
         optional: true
 
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -1512,8 +1687,59 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-plugin-sonarjs@4.2.0:
+    resolution: {integrity: sha512-bqADfuNtTL7VK6RU29eoiFTtaaBKIpVPuX3bOl+rBpWSBa0zIBVZlqZNZQjfP6s4iXkAJokv5IsD8OsACkwApg==}
+    peerDependencies:
+      eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.10.0:
+    resolution: {integrity: sha512-NPXn6r5zl4uET1DAVPaOwzX3rut4c0wcmw3dWJAfOsTM5+TogXo0DDjz8pwm/hL8cyVNpHqeK4JpN0NjnyFFNw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -1555,6 +1781,12 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -1580,6 +1812,9 @@ packages:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
 
+  file-entry-cache@11.1.5:
+    resolution: {integrity: sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==}
+
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
@@ -1587,6 +1822,12 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  flat-cache@6.1.23:
+    resolution: {integrity: sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==}
+
+  flatted@3.4.4:
+    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -1617,6 +1858,9 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  functional-red-black-tree@1.0.1:
+    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -1641,9 +1885,17 @@ packages:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
 
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
+
+  globals@17.12.0:
+    resolution: {integrity: sha512-cezEd/DTyyht9cvSSURyygXPfy04GtWO/5e6ZPvH7fCtjKz9PYOmuawphw1Ctd1f6C+5JypXfGD7ahNMXvevBA==}
+    engines: {node: '>=18'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1661,6 +1913,10 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
+  hashery@1.5.1:
+    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
+    engines: {node: '>=20'}
+
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
@@ -1668,6 +1924,12 @@ packages:
   hono@4.13.5:
     resolution: {integrity: sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==}
     engines: {node: '>=16.9.0'}
+
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
+
+  hookified@2.2.0:
+    resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -1688,8 +1950,20 @@ packages:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.9:
+    resolution: {integrity: sha512-brTTsvFRt5C1gGHtPst/281UjPD5t9fBqbgoMPlVWy11ZLTPfu7HxK4ZYqO9H7o/yC9rSTCI85EaQ4OoY12qYw==}
+    engines: {node: '>= 4'}
+
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1701,6 +1975,14 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
@@ -1752,16 +2034,33 @@ packages:
   json-rpc-2.0@1.8.0:
     resolution: {integrity: sha512-4nw+XlJbk5XokA7BtqHGu+0PEiUPfAkRzXXd1Cgjy1c3F2UI/3Gy7yr76wyJEv3X1F1SRGGF8xPAPPhelBiGmA==}
 
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsx-ast-utils-x@0.1.0:
+    resolution: {integrity: sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
@@ -1844,6 +2143,9 @@ packages:
   lodash.groupby@4.6.0:
     resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
 
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
@@ -1920,6 +2222,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
@@ -1962,6 +2267,10 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -2016,6 +2325,10 @@ packages:
     resolution: {integrity: sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
   pretty-ms@9.3.1:
     resolution: {integrity: sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA==}
     engines: {node: '>=18'}
@@ -2027,6 +2340,14 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  qified@0.10.1:
+    resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
+    engines: {node: '>=20'}
 
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
@@ -2043,6 +2364,14 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
+
+  refa@0.12.1:
+    resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  regexp-ast-analysis@0.7.1:
+    resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -2071,6 +2400,10 @@ packages:
 
   schemastery@3.18.0:
     resolution: {integrity: sha512-Jw2uxjoyyqc/yeurmChUEc/jbi8GsrdXV/KmqRUDZXJAXAmrJiPsz8vKa17l/VckyzljHZ9oGaul443CQiXxtA==}
+
+  scslre@0.3.0:
+    resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
+    engines: {node: ^14.0.0 || >=16.0.0}
 
   selfsigned@2.4.1:
     resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
@@ -2201,12 +2534,22 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -2219,6 +2562,18 @@ packages:
   typed-rest-client@2.3.1:
     resolution: {integrity: sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==}
     engines: {node: '>= 16.0.0'}
+
+  typescript-eslint@8.70.0:
+    resolution: {integrity: sha512-P/W5cz70/cQAuKfY3xwQMWWTV7BvJ0mAQmi+9mBcsVPaBUpd6Ohpa+fECv9rBFrQcig86jAiNBFNWUqnTjr4pw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
@@ -2248,6 +2603,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
@@ -2357,6 +2715,10 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
 
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
@@ -2751,6 +3113,18 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@cacheable/memory@2.2.0':
+    dependencies:
+      '@cacheable/utils': 2.5.0
+      '@keyv/bigmap': 1.3.1(keyv@5.6.0)
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/utils@2.5.0':
+    dependencies:
+      hashery: 1.5.1
+      keyv: 5.6.0
+
   '@deepseek-ai/cordis@4.0.2':
     dependencies:
       '@deepseek-ai/cosmokit': 1.8.3
@@ -2940,9 +3314,59 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.10.0(supports-color@7.2.0))':
+    dependencies:
+      eslint: 10.10.0(supports-color@7.2.0)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5(supports-color@7.2.0)':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3(supports-color@7.2.0)
+      minimatch: 10.2.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.7.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/js@10.0.1(eslint@10.10.0(supports-color@7.2.0))':
+    optionalDependencies:
+      eslint: 10.10.0(supports-color@7.2.0)
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.3':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
   '@hono/node-server@2.1.1(hono@4.13.5)':
     dependencies:
       hono: 4.13.5
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@inquirer/ansi@2.0.7': {}
 
@@ -3083,6 +3507,14 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.6.0
+
+  '@keyv/bigmap@1.3.1(keyv@5.6.0)':
+    dependencies:
+      hashery: 1.5.1
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@keyv/serialize@1.1.1': {}
 
   '@modelcontextprotocol/sdk@1.30.0(supports-color@7.2.0)':
     dependencies:
@@ -3257,6 +3689,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/express-serve-static-core@5.1.3':
@@ -3284,6 +3718,8 @@ snapshots:
 
   '@types/jsesc@2.5.1': {}
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/node-forge@1.3.14':
     dependencies:
       '@types/node': 26.4.0
@@ -3310,6 +3746,97 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 26.4.0
+
+  '@typescript-eslint/eslint-plugin@8.70.0(@typescript-eslint/parser@8.70.0(eslint@10.10.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.10.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.70.0(eslint@10.10.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.70.0
+      '@typescript-eslint/type-utils': 8.70.0(eslint@10.10.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.70.0(eslint@10.10.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.70.0
+      eslint: 10.10.0(supports-color@7.2.0)
+      ignore: 7.0.9
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.70.0(eslint@10.10.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.70.0
+      '@typescript-eslint/types': 8.70.0
+      '@typescript-eslint/typescript-estree': 8.70.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.70.0
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 10.10.0(supports-color@7.2.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.70.0(supports-color@7.2.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.70.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.70.0
+      debug: 4.4.3(supports-color@7.2.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.70.0':
+    dependencies:
+      '@typescript-eslint/types': 8.70.0
+      '@typescript-eslint/visitor-keys': 8.70.0
+
+  '@typescript-eslint/tsconfig-utils@8.70.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/type-utils@8.70.0(eslint@10.10.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.70.0
+      '@typescript-eslint/typescript-estree': 8.70.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.70.0(eslint@10.10.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      debug: 4.4.3(supports-color@7.2.0)
+      eslint: 10.10.0(supports-color@7.2.0)
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.70.0': {}
+
+  '@typescript-eslint/typescript-estree@8.70.0(supports-color@7.2.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.70.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.70.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.70.0
+      '@typescript-eslint/visitor-keys': 8.70.0
+      debug: 4.4.3(supports-color@7.2.0)
+      minimatch: 10.2.6
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.70.0(eslint@10.10.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.10.0(supports-color@7.2.0))
+      '@typescript-eslint/scope-manager': 8.70.0
+      '@typescript-eslint/types': 8.70.0
+      '@typescript-eslint/typescript-estree': 8.70.0(supports-color@7.2.0)(typescript@6.0.3)
+      eslint: 10.10.0(supports-color@7.2.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.70.0':
+    dependencies:
+      '@typescript-eslint/types': 8.70.0
+      eslint-visitor-keys: 5.0.1
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -3433,11 +3960,22 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.1.0
 
+  acorn-jsx@5.3.2(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
+
   acorn@8.18.0: {}
 
   ajv-formats@3.0.1:
     dependencies:
       ajv: 8.20.0
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ajv@8.20.0:
     dependencies:
@@ -3492,6 +4030,8 @@ snapshots:
     dependencies:
       '@types/node': 26.4.0
 
+  builtin-modules@3.3.0: {}
+
   bytes@3.1.2: {}
 
   c8@12.0.0:
@@ -3507,6 +4047,14 @@ snapshots:
       v8-to-istanbul: 9.3.0
       yargs: 18.1.0
       yargs-parser: 21.1.1
+
+  cacheable@2.5.0:
+    dependencies:
+      '@cacheable/memory': 2.2.0
+      '@cacheable/utils': 2.5.0
+      hookified: 1.15.1
+      keyv: 5.6.0
+      qified: 0.10.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -3589,6 +4137,8 @@ snapshots:
     optionalDependencies:
       supports-color: 7.2.0
 
+  deep-is@0.1.4: {}
+
   depd@2.0.0: {}
 
   des.js@1.1.0:
@@ -3661,9 +4211,92 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-sonarjs@4.2.0(eslint@10.10.0(supports-color@7.2.0)):
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      builtin-modules: 3.3.0
+      bytes: 3.1.2
+      eslint: 10.10.0(supports-color@7.2.0)
+      functional-red-black-tree: 1.0.1
+      globals: 17.12.0
+      jsx-ast-utils-x: 0.1.0
+      lodash.merge: 4.6.2
+      minimatch: 10.2.6
+      scslre: 0.3.0
+      semver: 7.8.5
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+      yaml: 2.9.0
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.10.0(supports-color@7.2.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.10.0(supports-color@7.2.0))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5(supports-color@7.2.0)
+      '@eslint/config-helpers': 0.7.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.3
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@7.2.0)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 11.1.5
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.6
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
+      eslint-visitor-keys: 5.0.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
+
+  esutils@2.0.3: {}
 
   etag@1.8.1: {}
 
@@ -3737,6 +4370,10 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -3757,6 +4394,10 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
 
+  file-entry-cache@11.1.5:
+    dependencies:
+      flat-cache: 6.1.23
+
   finalhandler@2.1.1(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
@@ -3772,6 +4413,14 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  flat-cache@6.1.23:
+    dependencies:
+      cacheable: 2.5.0
+      flatted: 3.4.4
+      hookified: 1.15.1
+
+  flatted@3.4.4: {}
 
   follow-redirects@1.16.0(debug@4.4.3(supports-color@7.2.0)):
     optionalDependencies:
@@ -3790,6 +4439,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  functional-red-black-tree@1.0.1: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -3820,11 +4471,17 @@ snapshots:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
 
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.6
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  globals@17.12.0: {}
 
   gopd@1.2.0: {}
 
@@ -3845,11 +4502,19 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
+  hashery@1.5.1:
+    dependencies:
+      hookified: 1.15.1
+
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
   hono@4.13.5: {}
+
+  hookified@1.15.1: {}
+
+  hookified@2.2.0: {}
 
   html-escaper@2.0.2: {}
 
@@ -3875,13 +4540,25 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ignore@5.3.2: {}
+
+  ignore@7.0.9: {}
+
   import-meta-resolve@4.2.0: {}
+
+  imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
 
   ip-address@10.7.0: {}
 
   ipaddr.js@1.9.1: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
 
   is-plain-obj@4.1.0: {}
 
@@ -3918,11 +4595,26 @@ snapshots:
 
   json-rpc-2.0@1.8.0: {}
 
+  json-schema-traverse@0.4.1: {}
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
 
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
   json5@2.2.3: {}
+
+  jsx-ast-utils-x@0.1.0: {}
+
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lightningcss-android-arm64@1.33.0:
     optional: true
@@ -3978,6 +4670,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.groupby@4.6.0: {}
+
+  lodash.merge@4.6.2: {}
 
   lru-cache@11.5.2: {}
 
@@ -4039,6 +4733,8 @@ snapshots:
 
   nanoid@3.3.18: {}
 
+  natural-compare@1.4.0: {}
+
   negotiator@0.6.4: {}
 
   negotiator@1.1.0:
@@ -4069,6 +4765,15 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
 
   p-limit@3.1.0:
     dependencies:
@@ -4109,6 +4814,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prelude-ls@1.2.1: {}
+
   pretty-ms@9.3.1:
     dependencies:
       parse-ms: 4.0.0
@@ -4119,6 +4826,12 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  punycode@2.3.1: {}
+
+  qified@0.10.1:
+    dependencies:
+      hookified: 2.2.0
 
   qs@6.15.1:
     dependencies:
@@ -4137,6 +4850,15 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       unpipe: 1.0.0
+
+  refa@0.12.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+
+  regexp-ast-analysis@0.7.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      refa: 0.12.1
 
   require-from-string@2.0.2: {}
 
@@ -4185,6 +4907,12 @@ snapshots:
     dependencies:
       '@standard-schema/spec': 1.1.0
       cosmokit: 1.8.1
+
+  scslre@0.3.0:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      refa: 0.12.1
+      regexp-ast-analysis: 0.7.1
 
   selfsigned@2.4.1:
     dependencies:
@@ -4322,9 +5050,17 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  ts-api-utils@2.5.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
   tslib@2.8.1: {}
 
   tunnel@0.0.6: {}
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
 
   type-is@2.1.0:
     dependencies:
@@ -4341,6 +5077,19 @@ snapshots:
       qs: 6.15.1
       tunnel: 0.0.6
       underscore: 1.13.8
+
+  typescript-eslint@8.70.0(eslint@10.10.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.70.0(@typescript-eslint/parser@8.70.0(eslint@10.10.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.10.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.70.0(eslint@10.10.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.70.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.70.0(eslint@10.10.0(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      eslint: 10.10.0(supports-color@7.2.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript@6.0.3: {}
 
   typescript@7.0.2:
     optionalDependencies:
@@ -4380,6 +5129,10 @@ snapshots:
       browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -4443,6 +5196,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  word-wrap@1.2.5: {}
 
   wrap-ansi@9.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - 'packages/*'
   - 'shared'
+  - 'tools/*'
 
 # SDK peers 不自动安装，运行时由 DSH profile 树解析（与 dsh-web-ui 同策略）。
 autoInstallPeers: false

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,13 +45,24 @@
 - `test/run-vitest.mjs` — 包级 test 脚本的 vitest 包装：在 vitest 之上恢复 `--min <文件数>` fail-closed 判据（防 include 漂移的假绿）。
 - `test/build-client.test.ts` — build-client 脚本自测。
 - `test/collect-licenses.test.ts` — collect-licenses 脚本自测。
-- `test/crap-check.test.ts` — crap-check 脚本自测（config.strict 单一开关；#722 起含「src 口径数据必须 fail-closed」用例）。
+- `test/crap-check.test.ts` — crap-check 脚本自测（config.strict 单一开关；#722 阶段五起含「非 src 口径数据必须 fail-closed」用例）。
 - `test/threshold-monotonic.test.ts` — 阈值单调性自测（#722：vitest.config.ts 的 coverage.thresholds 提取、降线判红、缺块 fail-closed）。
 
 ## data/（配置数据）
 
 - `data/plugins-manifest.json` — 插件清单（某插件是否参与聚合/发布校验的唯一声明处）。
-- `data/gauntlet.config.json` — 变异与 CRAP 阈值唯一事实源（覆盖率阈值自 #722 阶段三起改由 `vitest.config.ts` 的 `coverage.thresholds` 承载）。
+- `data/gauntlet.config.json` — 变异 / CRAP / ESLint 复杂度阈值唯一事实源（覆盖率阈值自 #722 阶段三起改由 `vitest.config.ts` 的 `coverage.thresholds` 承载；`complexity` 段自 #722 阶段五起供 `tools/lint` 消费）。
+
+## tools/lint/（lint 工具链隔离包，非发布包）
+
+- 为什么不放 `packages/`：`typescript-eslint` 需要 TypeScript 的 compiler API，而仓根 `typescript` 是
+  tsgo 7.x（无 API，且根 `tsc` 由它提供、各包 build/typecheck 依赖它）。子包隔离让 lint 专用 TS 6 与
+  根 tsgo 共存；放在 `packages/` 之外还避免被插件清单 / 产物闸 / CI 矩阵误当插件包。
+- `lint/bin/lint.mjs` — `pnpm lint` 入口：固定以仓库根为 cwd（ESLint 的 basePath 与 lint-staged 传入
+  的路径据此同口径），默认 lint 面见脚本内 `DEFAULT_PATTERNS`。
+- `lint/eslint.config.js` — 扁平配置：`complexity` + `sonarjs/cognitive-complexity`；阈值读
+  `data/gauntlet.config.json` 的 `complexity` 段，不在配置里硬编码。
+- 上述前提由 `test/lint-toolchain.test.ts` 逐条钉死（根仍是 tsgo、子包有 compiler API、两版本共存）。
 
 ## 仓库根的派生生成物
 

--- a/scripts/data/gauntlet.config.json
+++ b/scripts/data/gauntlet.config.json
@@ -5,6 +5,15 @@
     "strict": false,
     "note": "#722 阶段三起 crap-check 处于 fail-closed 停用态：其圈复杂度取自 lib 编译产物，而覆盖率采集已切到 src 口径（vitest/istanbul），两者行号不可比，入口自检不匹配即 exit 2（不再以「0 个函数」静默归零）。src 口径重建归阶段 5，与 ESLint 复杂度规则同批。"
   },
+  "complexity": {
+    "note": "#722 阶段五：ESLint 复杂度门禁阈值（唯一事实源，由 tools/lint/eslint.config.js 消费）。起步值 = 全域实测最大值——锚定当前最坏函数，保证零存量命中、只拦新增劣化（量化表见 #732）；收紧路线与最终目标见 #732，target 仅记录目标值，门禁不读取。",
+    "cyclomatic": 78,
+    "cognitive": 84,
+    "target": {
+      "cyclomatic": 10,
+      "cognitive": 15
+    }
+  },
   "mutation": {
     "note": "观察期仅记录不卡点；阶段三按 #42 二期校准后接入 ci.yml 硬卡点。score 为 Stryker 报告口径（分母含 noCoverage），covered 为官方 mutationScore 口径（(killed+timeout)/(total-noCoverage)）。#151 起 tap-runner 的 RuntimeError 分类缺陷曾由 scripts/test/mutation-tap-bridge.cjs 修正（未捕获异常转写 TAP not ok），error=0，自动口径与此前人工换算口径一致；#722 起 runner 换为 @stryker-mutator/vitest-runner，该桥接随 tap-runner 一并退役，未捕获异常改由 vitest runner 归入 errorsSet 并判该次运行 Error。",
     "strict": true,

--- a/scripts/gate/crap-check.mjs
+++ b/scripts/gate/crap-check.mjs
@@ -1,212 +1,140 @@
 #!/usr/bin/env node
 /**
- * 单函数 CRAP 检查（指导文档 5.0；移植自 gauntlet-demo/scripts/crap-check.mjs，
- * monorepo 适配：按 packages/<pkg>/lib 编译产物扫描——smoke 消费的就是它）。
+ * 单函数 CRAP 检查（#722 阶段五重建版，src 口径）。
  *
  *   CRAP = comp^2 * (1 - cov) + comp
  *
- * comp：acorn（ESTree）对 lib 编译产物的逐函数圈复杂度；
- * cov：istanbul 格式 coverage/coverage-final.json 中该函数的命中状态。
- * 先跑 `pnpm cov` 生成覆盖率，再运行本脚本。
+ * comp：ESLint 内置 `complexity` 规则对 `packages/<pkg>/src` 的逐函数圈复杂度。
+ *   **本脚本不实现第二份复杂度算法**——与 tools/lint 的复杂度门禁共用同一规则实现，
+ *   口径不存在长期漂移面（这是 #722 阶段五的单一事实源约定）。
+ * cov：`coverage/coverage-final.json`（vitest/istanbul 的 src 口径）中该函数的命中状态。
+ *   先跑 `pnpm cov` 生成覆盖率，再运行本脚本。
  *
- * 现状（#722 阶段三起）——本脚本处于 fail-closed 停用态：
- *   阶段三把覆盖率采集切到 vitest/istanbul 的 src 口径，而 comp 仍取自 lib 编译产物，
- *   两者行号不可比。此时按 lib 过滤会命中 0 个文件、以「0 个函数」的名义 exit 0
- *   （静默降级，#718 定性），故入口处加了数据源口径自检：不匹配即 exit 2 并说明原因。
- *   src 口径重建归 #722 阶段 5（与 ESLint 复杂度规则同批，届时可直接消费其 TS parser）。
- *   四个消费点（observe.yml / health-report.yml / local-gate.mjs / 本脚本自测）已同步摘除。
+ * 与旧实现的差别：旧版从 `packages/<pkg>/lib` 编译产物取复杂度，需要 esbuild 边界注释分段
+ * （foreignSegments）与垫片识别（shimRanges）来剔除内联 vendor；覆盖率切到 src 口径后两者行号
+ * 不可比。阶段五改为直接从源码取复杂度，src 无内联 vendor，分段逻辑整体退役。
  *
- * 圈复杂度决策点口径——已计入：if / for / for-of / for-in / while / do-while /
- *   case / catch / 三元（ConditionalExpression）/ && / || / ?? / optional chaining（?.）
- * 未计入：label 语句、正则字面量内部逻辑。同行多函数的覆盖判定取「任一命中即算命中」，
- *   该宽松处理使 CRAP 系统性偏低（方向性偏差，校准阈值时须知）。
- *
- * 噪音过滤：esbuild 内联的 node_modules 依赖段与 `__` 前缀垫片函数不计入统计
- *   （发布物自包含导致依赖代码进 bundle，但它们不是本仓自写代码）。
+ * 两处必须的 join 处理（阶段五实测）：
+ *   1. ESLint 把「类字段初始化器」也报为一个可计复杂度节点，而 istanbul 不计入 fnMap；
+ *      不过滤会让这类节点稳定匹配失败。
+ *   2. vitest/istanbul 在 TS 转译 + sourcemap 回映后存在 ±1 行偏移（ESLint 直接在原始
+ *      TS 上工作），故按行号 join 时允许 ±1 容差：实测精确匹配 98.75%、带容差 99.86%，
+ *      残余项判为「未覆盖」，方向偏保守。
  *
  * 模式说明：
- * 1. 全量模式（默认）：
- *    读取 scripts/data/gauntlet.config.json 的 crap.threshold / crap.strict。
- *    crap.strict=false：超阈热点 exit 0，仅落盘 coverage/crap-report.json（观察期）；
- *    crap.strict=true：超阈热点 exit 1。
- *
+ * 1. 全量模式（默认）：读 scripts/data/gauntlet.config.json 的 crap.threshold / crap.strict。
+ *    strict=false：超阈热点 exit 0，仅落盘 coverage/crap-report.json（观察期）；
+ *    strict=true：超阈热点 exit 1。
  * 2. 增量防劣化模式（--diff [base]）：
- *    对比 base（默认 origin/main，自适应 fallback）与当前工作区的改动：
- *    - 过滤只对本次改动触及的函数进行 CRAP 评估；
- *    - 新增函数：必须满足 CRAP <= threshold（默认 16）；
- *    - 修改的存量函数：若存量函数原本超标，修改后不得恶化（CRAP_new <= CRAP_base）；
- *    - 未触及的存量函数：全部豁免报警；
- *    - 存在新增超标或存量恶化时打印阻断日志并 exit 1；全部合规时 exit 0。
+ *    对比 base（默认 origin/main，自适应 fallback）与当前工作区在包 src 下的改动：
+ *    - 新增函数：CRAP <= threshold；
+ *    - 修改的存量函数：CRAP_new <= CRAP_base；
+ *    - 未触及的存量函数：全部豁免；
+ *    - 存在新增超标或存量恶化时 exit 1，否则 exit 0。
  */
 import { readFileSync, existsSync, mkdirSync, writeFileSync, realpathSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join, resolve, dirname } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-import * as acorn from 'acorn';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
 
-/** 圈复杂度 = 1 + 决策点数（口径见文件头注释）。 */
-export function complexityOf(fnNode) {
-  let count = 1;
-  function visit(node) {
-    if (!node || typeof node.type !== 'string') return;
-    if (node.type === 'IfStatement' || node.type === 'ForStatement'
-      || node.type === 'ForOfStatement' || node.type === 'WhileStatement'
-      || node.type === 'DoWhileStatement' || node.type === 'SwitchCase'
-      || node.type === 'CatchClause' || node.type === 'ConditionalExpression'
-      || node.type === 'ChainExpression') count++;
-    else if (node.type === 'LogicalExpression') count++;
-    for (const key of Object.keys(node)) {
-      const child = node[key];
-      if (Array.isArray(child)) child.forEach(visit);
-      else if (child && typeof child === 'object' && typeof child.type === 'string') visit(child);
-    }
-  }
-  if (fnNode.body) visit(fnNode.body);
-  return count;
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const SCRIPT_DIR = dirname(SCRIPT_PATH);
+
+// 工具链来源：本脚本所属仓库的 tools/lint 隔离包（与「被评估的仓库」可能是两个位置——
+// 测试 fixture 用 cwd 指向临时目录，而 ESLint 工具链始终来自本脚本所在仓库）。
+const TOOLCHAIN_PKG = join(SCRIPT_DIR, '..', '..', 'tools', 'lint', 'package.json');
+
+/** 被评估文件的路径口径（仓库根相对 posix）。 */
+const SRC_RE = /(?:^|\/)packages\/[^/]+\/src\//;
+
+let toolchainCache = null;
+
+/**
+ * 从 tools/lint 隔离包解析 ESLint 工具链。
+ * 为什么不能从本文件所在目录解析：lint 工具链装在 tools/lint 下（typescript-eslint 需要带
+ * compiler API 的 TS 6，而仓根 typescript 是 tsgo），pnpm 严格布局下父目录解析不到子包依赖。
+ */
+async function loadToolchain() {
+  if (toolchainCache !== null) return toolchainCache;
+  const requireFromLint = createRequire(TOOLCHAIN_PKG);
+  const { Linter } = await import(pathToFileURL(requireFromLint.resolve('eslint')).href);
+  const tseslint = await import(pathToFileURL(requireFromLint.resolve('typescript-eslint')).href);
+  toolchainCache = { Linter, parser: tseslint.default.parser };
+  return toolchainCache;
+}
+
+/** 从 ESLint 诊断文本里取函数名（无名形态回退为空串）。 */
+function nameFromMessage(message) {
+  const m = /^(?:Function|Method|Getter|Setter|Constructor|Static block) '([^']+)'/.exec(message);
+  return m === null ? '' : m[1];
 }
 
 /**
- * 标记 esbuild 注入的模块边界注释，划分「本仓段 / 依赖段」：
- * 形如 `// ../../node_modules/.pnpm/...` 的注释开启依赖段，直到下一个路径注释。
+ * 单个文件的逐函数圈复杂度（ESLint `complexity` 规则，阈值 0 = 枚举全部函数）。
+ * 返回 { fns: [{ name, line, column, complexity }], parseError: string|null }。
  */
-export function foreignSegments(code) {
-  const segments = [];
-  let current = null;
-  let offset = 0;
-  for (const line of code.split('\n')) {
-    const m = /^\/\/ (\S+)\s*$/.exec(line);
-    // 只把包含 `/` 的注释作为模块边界（路径注释），过滤 `@__NO_SIDE_EFFECTS__` 等
-    // esbuild 内联注解——后者不关闭外层依赖段，避免依赖函数漏过滤。
-    if (m && m[1].includes('/')) {
-      if (current) segments.push({ start: current.start, end: offset, foreign: current.foreign });
-      current = { start: offset, foreign: m[1].includes('node_modules') };
-    }
-    offset += Buffer.byteLength(line, 'utf8') + 1;
-  }
-  if (current) segments.push({ start: current.start, end: offset, foreign: current.foreign });
-  return segments.filter((s) => s.foreign);
-}
-
-export function inForeign(offset, ranges) {
-  return ranges.some((r) => offset >= r.start && offset < r.end);
-}
-
-/**
- * 统计覆盖率数据的路径口径：lib（本脚本的圈复杂度来源）/ src（#722 阶段三起的采集口径）。
- *
- * 为什么需要它：复杂度与覆盖率必须同源才能按行号对齐。阶段三把覆盖率采集切到
- * vitest/istanbul 后分母只剩 src，而本脚本仍从 lib 产物算复杂度——此时按 lib 过滤
- * 会命中 0 个文件，脚本以「0 个函数」的名义 exit 0，属静默降级（#718 定性）。
- */
-export function coverageDataSource(coverage) {
-  let libCount = 0;
-  let srcCount = 0;
-  for (const file of Object.keys(coverage ?? {})) {
-    const norm = file.replace(/\\/g, '/');
-    if (/\/packages\/[^/]+\/lib\//.test(norm)) libCount += 1;
-    else if (/\/packages\/[^/]+\/src\//.test(norm)) srcCount += 1;
-  }
-  return { libCount, srcCount };
-}
-
-/** 数据源口径不匹配时的统一报错（fail-closed，防「0 个函数仍 exit 0」的静默降级）。 */
-function reportDataSourceMismatch(counts, mode = '') {
-  const tag = mode ? ` [${mode}]` : '';
-  console.error(`crap-check${tag}: 覆盖率数据里没有任何 packages/*/lib/ 条目（lib ${counts.libCount} / src ${counts.srcCount}）—— 数据源口径不匹配，fail-closed`);
-  console.error('  本脚本的圈复杂度取自 lib 编译产物，而 #722 阶段三起覆盖率只采集 src（vitest/istanbul），');
-  console.error('  两者行号不可比；继续运行会命中 0 个文件并以 exit 0 放行，属静默降级。');
-  console.error('  src 口径的 CRAP 重建归 #722 阶段 5（与 ESLint 复杂度规则同批，届时可用 TS parser）。');
-}
-
-/**
- * 收集垫片范围：esbuild 以 `var __xxx = (...) => ...` 形式定义的运行时辅助
- * （__async/__await/__generator 等），连同其函数体整体划为依赖段。
- */
-export function shimRanges(ast) {
-  const ranges = [];
-  function visit(node) {
-    if (!node || typeof node.type !== 'string') return;
-    if (node.type === 'VariableDeclarator'
-      && node.id?.type === 'Identifier' && /^__/.test(node.id.name)
-      && node.init && node.end != null && node.start != null) {
-      ranges.push({ start: node.start, end: node.end });
-    }
-    for (const key of Object.keys(node)) {
-      const child = node[key];
-      if (Array.isArray(child)) child.forEach(visit);
-      else if (child && typeof child === 'object' && typeof child.type === 'string') visit(child);
-    }
-  }
-  visit(ast);
-  return ranges;
-}
-
-/** 提取 AST 函数节点名或所在变量/属性名 */
-function getFunctionName(node, parent) {
-  if (node.id?.name) return node.id.name;
-  if (parent) {
-    if (parent.type === 'VariableDeclarator' && parent.id?.name) return parent.id.name;
-    if (parent.type === 'Property' || parent.type === 'MethodDefinition') {
-      if (parent.key?.type === 'Identifier') return parent.key.name;
-      if (parent.key?.type === 'Literal') return String(parent.key.value);
-    }
-    if (parent.type === 'AssignmentExpression') {
-      if (parent.left?.type === 'Identifier') return parent.left.name;
-      if (parent.left?.type === 'MemberExpression' && parent.left.property?.name) {
-        return parent.left.property.name;
-      }
-    }
-  }
-  return '';
-}
-
-/** 收集一个文件的全部本仓函数，返回 {comp, line, startLine, endLine, name} 列表（line 为 1-based 起始行）。 */
-export function functionsOf(code) {
-  // lib 宿主产物为 ESM，client 外壳为 IIFE：先按 module 解析，失败降级 script
-  let ast;
+export async function functionsOf(code, filename) {
+  const { Linter, parser } = await loadToolchain();
+  const isJs = /\.(js|mjs|cjs)$/.test(filename);
+  const linter = new Linter();
+  const config = [{
+    files: isJs ? ['**/*.{js,mjs,cjs}'] : ['**/*.{ts,tsx,mts,cts}'],
+    languageOptions: isJs
+      ? { ecmaVersion: 'latest', sourceType: 'module' }
+      : { parser, ecmaVersion: 'latest', sourceType: 'module' },
+    rules: { complexity: ['error', 0] },
+  }];
+  const verifyName = isJs ? 'x.mjs' : filename.endsWith('.tsx') ? 'x.tsx' : 'x.ts';
+  let messages;
   try {
-    ast = acorn.parse(code, { ecmaVersion: 'latest', sourceType: 'module', allowHashBang: true, locations: true });
-  } catch {
-    ast = acorn.parse(code, { ecmaVersion: 'latest', sourceType: 'script', allowHashBang: true, locations: true });
+    messages = linter.verify(code, config, { filename: verifyName });
+  } catch (error) {
+    return { fns: [], parseError: String(error.message).split('\n')[0] };
   }
-  const foreign = foreignSegments(code);
-  const shims = shimRanges(ast);
-  const out = [];
-  let skippedForeign = 0;
-  function visit(node, parent) {
-    if (!node || typeof node.type !== 'string') return;
-    const isFn = node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression'
-      || node.type === 'ArrowFunctionExpression';
-    if (isFn && node.body) {
-      // 过滤 esbuild 垫片（__commonJS/__toESM/__async 等）与依赖段内函数
-      const isShim = (node.id?.name ?? '').startsWith('__');
-      if (isShim || inForeign(node.start, foreign) || inForeign(node.start, shims)) {
-        skippedForeign++;
-      } else {
-        const startLine = node.loc.start.line;
-        const endLine = node.loc.end.line;
-        const name = getFunctionName(node, parent);
-        out.push({
-          name,
-          comp: complexityOf(node),
-          line: startLine,
-          startLine,
-          endLine,
-        });
-      }
-    }
-    for (const key of Object.keys(node)) {
-      if (key === 'loc' || key === 'range') continue;
-      const child = node[key];
-      if (Array.isArray(child)) {
-        for (const c of child) visit(c, node);
-      } else if (child && typeof child === 'object' && typeof child.type === 'string') {
-        visit(child, node);
-      }
-    }
+  const fatal = messages.find((m) => m.fatal === true);
+  if (fatal !== undefined) {
+    return { fns: [], parseError: String(fatal.message).split('\n')[0] };
   }
-  visit(ast, null);
-  return { fns: out, skippedForeign };
+  const fns = [];
+  for (const m of messages) {
+    // 类字段初始化器不是函数（istanbul 的 fnMap 不含它），排除以保持两侧同口径。
+    if (/Class field initializer/.test(m.message)) continue;
+    const c = /complexity of (\d+)/.exec(m.message);
+    if (c === null) continue;
+    fns.push({ name: nameFromMessage(m.message), line: m.line, column: m.column, complexity: Number(c[1]) });
+  }
+  return { fns, parseError: null };
+}
+
+/** 单函数 CRAP 值。 */
+export function crapOf(comp, covered) {
+  return comp * comp * (covered ? 0 : 1) + comp;
+}
+
+/**
+ * 构建「起始行 → 是否被覆盖」索引（istanbul fnMap/f）。
+ * 同行多函数取「任一命中即算命中」——该放宽使 CRAP 系统性偏低（方向性偏差，校准阈值时须知）。
+ */
+export function coverageHitLines(fileCov) {
+  const hit = new Map();
+  for (const [id, fn] of Object.entries(fileCov?.fnMap ?? {})) {
+    const line = fn.decl?.start?.line ?? fn.loc?.start?.line ?? fn.line;
+    if (typeof line !== 'number') continue;
+    const covered = (fileCov.f?.[id] ?? 0) > 0;
+    hit.set(line, (hit.get(line) ?? false) || covered);
+  }
+  return hit;
+}
+
+/**
+ * 按起始行查覆盖状态，允许 ±1 行容差（istanbul 转译回映的固有偏移）。
+ */
+export function coveredAt(hitByLine, line) {
+  if (hitByLine.has(line)) return hitByLine.get(line);
+  if (hitByLine.has(line - 1)) return hitByLine.get(line - 1);
+  if (hitByLine.has(line + 1)) return hitByLine.get(line + 1);
+  return false;
 }
 
 /**
@@ -422,21 +350,21 @@ export function resolveBaseRef(base, cwd) {
 }
 
 /**
- * 规范化文件路径为相对于 repoRoot 的正斜杠路径。
+ * 补出函数结束行：ESLint 只报起始位置。用「下一个函数起始行 - 1」近似；
+ * 末个函数取大值，使纯删除 hunk 的插入点判定不因范围过窄而漏判。
  */
-function normalizeRelativePath(file, repoRoot) {
-  const normFile = file.replace(/\\/g, '/');
-  const normRoot = repoRoot.replace(/\\/g, '/');
-  if (normFile.startsWith(normRoot + '/')) {
-    return normFile.slice(normRoot.length + 1);
-  }
-  return normFile;
+function withRange(fns) {
+  return fns.map((fn, i) => ({
+    ...fn,
+    startLine: fn.line,
+    endLine: i + 1 < fns.length ? fns[i + 1].line - 1 : Number.MAX_SAFE_INTEGER,
+  }));
 }
 
 /**
- * 执行 --diff 增量防劣化评估
+ * 执行 --diff 增量防劣化评估。
  */
-export function runDiffCheck({ repoRoot, threshold, baseArg, coveragePath }) {
+export async function runDiffCheck({ repoRoot, threshold, baseArg, coveragePath }) {
   const baseRef = resolveBaseRef(baseArg, repoRoot);
   const diffRes = spawnSync('git', ['diff', '-U0', baseRef, '--'], {
     cwd: repoRoot,
@@ -450,13 +378,11 @@ export function runDiffCheck({ repoRoot, threshold, baseArg, coveragePath }) {
   }
 
   const diffFiles = parseGitDiff(diffRes.stdout);
-  // 仅评估 packages/*/lib/ 目录下的改动文件
-  const relevantDiffFiles = Array.from(diffFiles.entries()).filter(([path]) =>
-    /\/packages\/[^/]+\/lib\//.test('/' + path.replace(/\\/g, '/'))
-  );
+  // 只评估包 src 下的改动（复杂度与覆盖率同口径）
+  const relevantDiffFiles = Array.from(diffFiles.entries()).filter(([path]) => SRC_RE.test(path.replace(/\\/g, '/')));
 
   if (relevantDiffFiles.length === 0) {
-    console.log(`crap-check [diff]: base=${baseRef}，未检测到插件包编译产物（packages/*/lib/）的代码变更，OK`);
+    console.log(`crap-check [diff]: base=${baseRef}，未检测到包 src 下的代码变更，OK`);
     return { exitCode: 0, passed: true, violations: [] };
   }
 
@@ -471,17 +397,9 @@ export function runDiffCheck({ repoRoot, threshold, baseArg, coveragePath }) {
     console.warn('crap-check [diff]: 未检测到 coverage/coverage-final.json，默认按未覆盖（cov=0）评估');
   }
 
-  const counts = coverageDataSource(coverage);
-  if (counts.libCount === 0 && counts.srcCount > 0) {
-    reportDataSourceMismatch(counts, 'diff');
-    return { exitCode: 2, passed: false, violations: [] };
-  }
-
-  // 构建 coverage 索引：按 relativePath -> fileData
-  const coverageByRel = new Map();
+  const coverageByAbs = new Map();
   for (const [covFile, covData] of Object.entries(coverage)) {
-    const rel = normalizeRelativePath(covFile, repoRoot);
-    coverageByRel.set(rel, covData);
+    coverageByAbs.set(resolve(covFile), covData);
   }
 
   const violations = [];
@@ -493,7 +411,12 @@ export function runDiffCheck({ repoRoot, threshold, baseArg, coveragePath }) {
     if (!existsSync(absPath)) continue;
 
     const currentCode = readFileSync(absPath, 'utf8');
-    const { fns: currentFns } = functionsOf(currentCode);
+    const current = await functionsOf(currentCode, absPath);
+    if (current.parseError !== null) {
+      console.error(`crap-check [diff]: ${relPath} 解析失败（${current.parseError}）—— fail-closed`);
+      return { exitCode: 2, passed: false, violations: [] };
+    }
+    const currentFns = withRange(current.fns);
 
     // 读取 base 提交中的老文件内容
     let baseFns = [];
@@ -504,21 +427,11 @@ export function runDiffCheck({ repoRoot, threshold, baseArg, coveragePath }) {
         stdio: ['pipe', 'pipe', 'pipe'],
       });
       if (showRes.status === 0) {
-        baseFns = functionsOf(showRes.stdout).fns;
+        baseFns = withRange((await functionsOf(showRes.stdout, absPath)).fns);
       }
     }
 
-    // 提取当前文件在 coverage 中的逐行命中状态
-    const fileCov = coverageByRel.get(relPath);
-    const hitByLine = new Map();
-    if (fileCov?.fnMap) {
-      for (const [id, fn] of Object.entries(fileCov.fnMap)) {
-        const line = fn.loc?.start?.line ?? fn.decl?.start?.line;
-        if (line == null) continue;
-        const hit = (fileCov.f?.[id] ?? 0) > 0;
-        hitByLine.set(line, (hitByLine.get(line) ?? false) || hit);
-      }
-    }
+    const hitByLine = coverageHitLines(coverageByAbs.get(absPath));
 
     for (const fn of currentFns) {
       if (!isFunctionTouched(fn, fileDiff)) {
@@ -527,56 +440,49 @@ export function runDiffCheck({ repoRoot, threshold, baseArg, coveragePath }) {
       }
       touchedCount++;
 
-      const covered = hitByLine.get(fn.line) ?? false;
-      const crapNew = fn.comp * fn.comp * (covered ? 0 : 1) + fn.comp;
+      const covered = coveredAt(hitByLine, fn.line);
+      const crapNew = crapOf(fn.complexity, covered);
 
       if (crapNew <= threshold) {
-        // 合规放行
         compliantCount++;
         continue;
       }
 
-      // CRAP 超标，判定存量恶化或新增超标
       const baseFn = findBaseFunction(fn, baseFns, fileDiff.hunks);
 
       if (!baseFn) {
-        // 新增函数超标
         violations.push({
           type: 'NEW_EXCEEDED',
           file: relPath,
-          line: fn.startLine,
+          line: fn.line,
           name: fn.name || '<anonymous>',
-          comp: fn.comp,
+          comp: fn.complexity,
           covered,
           crap: crapNew,
           threshold,
         });
       } else {
-        // 修改的存量函数：计算 base CRAP
-        const crapBase = baseFn.comp * baseFn.comp * (covered ? 0 : 1) + baseFn.comp;
+        const crapBase = crapOf(baseFn.complexity, covered);
         if (crapNew > crapBase) {
-          // 恶化拦截
           violations.push({
             type: 'REGRESSION',
             file: relPath,
-            line: fn.startLine,
+            line: fn.line,
             name: fn.name || '<anonymous>',
-            compNew: fn.comp,
-            compBase: baseFn.comp,
+            compNew: fn.complexity,
+            compBase: baseFn.complexity,
             covered,
             crapNew,
             crapBase,
             threshold,
           });
         } else {
-          // 未恶化（重构降复杂度或持平），放行
           compliantCount++;
         }
       }
     }
   }
 
-  // 输出结果与报告
   if (violations.length > 0) {
     console.error(`crap-check [diff]: FAIL - 发现 ${violations.length} 处 CRAP 增量违规（base: ${baseRef}，阈值: ${threshold}）：`);
     for (const v of violations) {
@@ -594,55 +500,52 @@ export function runDiffCheck({ repoRoot, threshold, baseArg, coveragePath }) {
 }
 
 /**
- * 执行默认的全量评估逻辑
+ * 执行默认的全量评估逻辑。
  */
-export function runFullCheck({ repoRoot, threshold, strict, coveragePath }) {
+export async function runFullCheck({ repoRoot, threshold, strict, coveragePath }) {
   if (!existsSync(coveragePath)) {
     console.error('crap-check: coverage/coverage-final.json 不存在，请先运行 pnpm cov');
     return { exitCode: 2, passed: false, hotspots: [] };
   }
 
   const coverage = JSON.parse(readFileSync(coveragePath, 'utf8'));
-
-  const counts = coverageDataSource(coverage);
-  if (counts.libCount === 0) {
-    reportDataSourceMismatch(counts);
-    return { exitCode: 2, passed: false, hotspots: [] };
-  }
+  const normRoot = repoRoot.replace(/\\/g, '/').replace(/\/$/, '');
 
   const hotspots = [];
   let totalFns = 0;
   let coveredFns = 0;
-  let skippedForeignTotal = 0;
+  let scannedFiles = 0;
+  let parseFailed = 0;
 
   for (const [file, data] of Object.entries(coverage)) {
-    // 包产物过滤对分隔符归一后匹配：coverage 键是 V8 原生路径（Windows 反斜杠），
-    // 按字面正斜杠匹配会在 Windows 上整批跳过报 0（Linux 不受影响）。
+    // 路径口径：只评估包 src（与 vitest coverage 的 include 同口径）。先对分隔符归一，
+    // 避免 Windows 反斜杠路径整批跳过而报 0。
     const normFile = file.replace(/\\/g, '/');
-    if (!/\/packages\/[^/]+\/lib\//.test(normFile)) continue;
-    const rel = existsSync(file) ? file : join(repoRoot, file);
-    if (!existsSync(rel)) continue;
-    const { fns, skippedForeign } = functionsOf(readFileSync(rel, 'utf8'));
-    skippedForeignTotal += skippedForeign;
+    if (!SRC_RE.test(normFile)) continue;
+    const absPath = resolve(file);
+    if (!existsSync(absPath)) continue;
+    scannedFiles++;
 
-    const hitByLine = new Map();
-    for (const [id, fn] of Object.entries(data.fnMap ?? {})) {
-      const line = fn.loc?.start?.line ?? fn.decl?.start?.line;
-      if (line == null) continue;
-      const hit = (data.f?.[id] ?? 0) > 0;
-      hitByLine.set(line, (hitByLine.get(line) ?? false) || hit);
+    const { fns, parseError } = await functionsOf(readFileSync(absPath, 'utf8'), absPath);
+    if (parseError !== null) {
+      parseFailed++;
+      console.warn(`crap-check: ${normFile} 解析失败，跳过（${parseError}）`);
+      continue;
     }
+
+    const hitByLine = coverageHitLines(data);
 
     for (const fn of fns) {
       totalFns++;
-      const covered = hitByLine.get(fn.line) ?? false;
+      const covered = coveredAt(hitByLine, fn.line);
       if (covered) coveredFns++;
-      const crap = fn.comp * fn.comp * (covered ? 0 : 1) + fn.comp;
+      const crap = crapOf(fn.complexity, covered);
       if (crap > threshold) {
         hotspots.push({
-          file: file.slice(repoRoot.length + 1),
+          file: normFile.startsWith(normRoot + '/') ? normFile.slice(normRoot.length + 1) : normFile,
           line: fn.line,
-          comp: fn.comp,
+          name: fn.name,
+          comp: fn.complexity,
           covered,
           crap,
         });
@@ -650,9 +553,16 @@ export function runFullCheck({ repoRoot, threshold, strict, coveragePath }) {
     }
   }
 
+  // 零函数 = 数据源口径不匹配，属静默降级（#718 定性），必须 fail-closed。
+  if (totalFns === 0) {
+    console.error(`crap-check: 在 coverage 数据里没有任何包 src 条目（扫描文件 ${scannedFiles}）——`);
+    console.error('  覆盖率数据源口径不匹配（期望 vitest/istanbul 的 src 口径）。请先运行 pnpm cov，再重试。');
+    return { exitCode: 2, passed: false, hotspots: [] };
+  }
+
   hotspots.sort((a, b) => b.crap - a.crap);
-  console.log(`crap-check: 本仓函数 ${totalFns} 个（已排除依赖/垫片 ${skippedForeignTotal} 个），`
-    + `已覆盖 ${coveredFns}（${totalFns ? Math.round((coveredFns / totalFns) * 100) : 0}%），阈值 ${threshold}`);
+  console.log(`crap-check: 本仓函数 ${totalFns} 个（${scannedFiles} 个 src 文件，解析失败 ${parseFailed} 个），`
+    + `已覆盖 ${coveredFns}（${Math.round((coveredFns / totalFns) * 100)}%），阈值 ${threshold}`);
 
   mkdirSync(join(repoRoot, 'coverage'), { recursive: true });
   writeFileSync(
@@ -663,7 +573,8 @@ export function runFullCheck({ repoRoot, threshold, strict, coveragePath }) {
       strict,
       totalFns,
       coveredFns,
-      skippedForeignTotal,
+      scannedFiles,
+      parseFailed,
       hotspots,
     }, null, 2),
   );
@@ -689,9 +600,9 @@ export function runFullCheck({ repoRoot, threshold, strict, coveragePath }) {
 }
 
 /**
- * 主入口解析与分发
+ * 主入口解析与分发。
  */
-export function runCrapCheck(argv = process.argv.slice(2), { shouldExit = true } = {}) {
+export async function runCrapCheck(argv = process.argv.slice(2), { shouldExit = true } = {}) {
   const repoRoot = process.cwd();
   const configPath = join(repoRoot, 'scripts', 'data', 'gauntlet.config.json');
   const config = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf8')) : {};
@@ -722,12 +633,9 @@ export function runCrapCheck(argv = process.argv.slice(2), { shouldExit = true }
     }
   }
 
-  let result;
-  if (isDiff) {
-    result = runDiffCheck({ repoRoot, threshold, baseArg, coveragePath });
-  } else {
-    result = runFullCheck({ repoRoot, threshold, strict, coveragePath });
-  }
+  const result = isDiff
+    ? await runDiffCheck({ repoRoot, threshold, baseArg, coveragePath })
+    : await runFullCheck({ repoRoot, threshold, strict, coveragePath });
 
   if (shouldExit && typeof result.exitCode === 'number') {
     process.exit(result.exitCode);
@@ -739,7 +647,7 @@ export function runCrapCheck(argv = process.argv.slice(2), { shouldExit = true }
 function isDirectExecution() {
   if (!process.argv[1]) return false;
   try {
-    const scriptPath = realpathSync(fileURLToPath(import.meta.url));
+    const scriptPath = realpathSync(SCRIPT_PATH);
     const execPath = realpathSync(process.argv[1]);
     return scriptPath === execPath;
   } catch {
@@ -748,5 +656,5 @@ function isDirectExecution() {
 }
 
 if (isDirectExecution()) {
-  runCrapCheck(process.argv.slice(2), { shouldExit: true });
+  await runCrapCheck(process.argv.slice(2), { shouldExit: true });
 }

--- a/scripts/gate/local-gate.mjs
+++ b/scripts/gate/local-gate.mjs
@@ -81,6 +81,7 @@ function tierSteps(tier, { hitPackages, withCoverage }) {
     { label: 'test:src-tests（*.src.test.ts 禁现）', args: ['test:src-tests'] },
     { label: 'gate:homedir（src 禁直连 HOME）', args: ['gate:homedir'] },
     { label: 'docs:check（README/链接）', args: ['docs:check'] },
+    { label: 'lint（ESLint 复杂度门禁，阈值见 gauntlet.config.json）', args: ['lint'] },
   ]
   const prereqStep = {
     label: `build 编译面前置包（test:scripts 依赖：${PREREQ_PACKAGES.join(', ')}）`,
@@ -123,9 +124,10 @@ function tierSteps(tier, { hitPackages, withCoverage }) {
     scriptsSelfTest,
   ]
   if (withCoverage) {
-    // crap 不在此列（#722 阶段三）：其圈复杂度取自 lib 产物、覆盖率已切 src 口径，
-    // 入口自检 exit 2；src 口径重建归阶段 5，届时与 ESLint 复杂度规则同批接入。
     steps.push({ label: 'cov（vitest 覆盖率，unit + integration 直连 src）', args: ['cov'] })
+    // crap 于 #722 阶段五完成 src 口径重建（复杂度取自 ESLint 的 complexity 规则，覆盖率取自
+    // 同一份 src 口径产物），与 cov 同批恢复接入。
+    steps.push({ label: 'crap（CRAP 热点，strict 见 gauntlet.config.json）', args: ['crap'] })
   }
   return steps
 }

--- a/scripts/test/crap-check-diff.test.ts
+++ b/scripts/test/crap-check-diff.test.ts
@@ -12,8 +12,6 @@ import {
   mapOldToNewLine,
   isFunctionTouched,
   findBaseFunction,
-  functionsOf,
-  complexityOf,
 } from '../gate/crap-check.mjs'
 
 const ROOT = join(import.meta.dirname, '../..')
@@ -23,16 +21,16 @@ const SCRIPT = join(ROOT, 'scripts/gate/crap-check.mjs')
 
 test('parseGitDiff: 正确解析 unified diff hunk 并提取变更行号集合', () => {
   const diffSample = `
-diff --git a/packages/fake/lib/index.js b/packages/fake/lib/index.js
+diff --git a/packages/fake/src/index.ts b/packages/fake/src/index.ts
 index 1111111..2222222 100644
---- a/packages/fake/lib/index.js
-+++ b/packages/fake/lib/index.js
+--- a/packages/fake/src/index.ts
++++ b/packages/fake/src/index.ts
 @@ -10,3 +10,5 @@
  funcA()
 `
   const diffMap = parseGitDiff(diffSample.trim())
-  assert.ok(diffMap.has('packages/fake/lib/index.js'))
-  const entry = diffMap.get('packages/fake/lib/index.js')
+  assert.ok(diffMap.has('packages/fake/src/index.ts'))
+  const entry = diffMap.get('packages/fake/src/index.ts')
   assert.equal(entry.hunks.length, 1)
   assert.deepEqual(entry.hunks[0], { oldStart: 10, oldCount: 3, newStart: 10, newCount: 5 })
   // newChangedLines: 10, 11, 12, 13, 14
@@ -121,7 +119,7 @@ function setupGitFixture() {
 
   mkdirSync(join(dir, 'scripts/data'), { recursive: true })
   mkdirSync(join(dir, 'coverage'), { recursive: true })
-  mkdirSync(join(dir, 'packages/fake/lib'), { recursive: true })
+  mkdirSync(join(dir, 'packages/fake/src'), { recursive: true })
 
   // 写入默认配置：threshold=16, strict=false
   writeFileSync(join(dir, 'scripts/data/gauntlet.config.json'), JSON.stringify({ crap: { threshold: 16, strict: false } }))
@@ -134,8 +132,8 @@ function setupGitFixture() {
 test('#592 crap-check --diff: 新增函数 CRAP 超标拦截（exit 1）', () => {
   const dir = setupGitFixture()
   try {
-    const pkgLib = join(dir, 'packages/fake/lib/index.js')
-    writeFileSync(pkgLib, 'function baseFunc() { return 1; }\nbaseFunc();\n')
+    const pkgSrc = join(dir, 'packages/fake/src/index.ts')
+    writeFileSync(pkgSrc, 'function baseFunc() { return 1; }\nbaseFunc();\n')
     execFileSync('git', ['add', '.'], { cwd: dir, stdio: 'pipe' })
     execFileSync('git', ['commit', '-m', 'initial commit'], { cwd: dir, stdio: 'pipe' })
 
@@ -151,9 +149,9 @@ function complexNew(a, b, c, d) {
   return 0;
 }
 `
-    writeFileSync(pkgLib, newCode)
+    writeFileSync(pkgSrc, newCode)
     writeFileSync(join(dir, 'coverage/coverage-final.json'), JSON.stringify({
-      [pkgLib]: {
+      [pkgSrc]: {
         fnMap: {
           '0': { loc: { start: { line: 1, column: 0 } } },
           '1': { loc: { start: { line: 4, column: 0 } } },
@@ -174,8 +172,8 @@ function complexNew(a, b, c, d) {
 test('#592 crap-check --diff: 新增函数 CRAP 合规放行（exit 0）', () => {
   const dir = setupGitFixture()
   try {
-    const pkgLib = join(dir, 'packages/fake/lib/index.js')
-    writeFileSync(pkgLib, 'function baseFunc() { return 1; }\nbaseFunc();\n')
+    const pkgSrc = join(dir, 'packages/fake/src/index.ts')
+    writeFileSync(pkgSrc, 'function baseFunc() { return 1; }\nbaseFunc();\n')
     execFileSync('git', ['add', '.'], { cwd: dir, stdio: 'pipe' })
     execFileSync('git', ['commit', '-m', 'initial commit'], { cwd: dir, stdio: 'pipe' })
 
@@ -188,9 +186,9 @@ function simpleNew(a) {
   return 0;
 }
 `
-    writeFileSync(pkgLib, newCode)
+    writeFileSync(pkgSrc, newCode)
     writeFileSync(join(dir, 'coverage/coverage-final.json'), JSON.stringify({
-      [pkgLib]: {
+      [pkgSrc]: {
         fnMap: {
           '0': { loc: { start: { line: 1, column: 0 } } },
           '1': { loc: { start: { line: 4, column: 0 } } },
@@ -210,7 +208,7 @@ function simpleNew(a) {
 test('#592 crap-check --diff: 修改存量超标函数导致复杂度恶化拦截（exit 1）', () => {
   const dir = setupGitFixture()
   try {
-    const pkgLib = join(dir, 'packages/fake/lib/index.js')
+    const pkgSrc = join(dir, 'packages/fake/src/index.ts')
     // base: 存量超标函数，复杂度 4，未覆盖，CRAP = 4^2 + 4 = 20 > 16
     const baseCode = `function legacyHeavy(a, b, c) {
   if (a) return 1;
@@ -220,7 +218,7 @@ test('#592 crap-check --diff: 修改存量超标函数导致复杂度恶化拦�
 }
 legacyHeavy();
 `
-    writeFileSync(pkgLib, baseCode)
+    writeFileSync(pkgSrc, baseCode)
     execFileSync('git', ['add', '.'], { cwd: dir, stdio: 'pipe' })
     execFileSync('git', ['commit', '-m', 'initial commit'], { cwd: dir, stdio: 'pipe' })
 
@@ -234,9 +232,9 @@ legacyHeavy();
 }
 legacyHeavy();
 `
-    writeFileSync(pkgLib, regressedCode)
+    writeFileSync(pkgSrc, regressedCode)
     writeFileSync(join(dir, 'coverage/coverage-final.json'), JSON.stringify({
-      [pkgLib]: {
+      [pkgSrc]: {
         fnMap: { '0': { loc: { start: { line: 1, column: 0 } } } },
         f: { '0': 0 }, // 未覆盖
       },
@@ -255,7 +253,7 @@ legacyHeavy();
 test('#592 crap-check --diff: 修改存量超标函数但复杂度降低/持平放行（exit 0）', () => {
   const dir = setupGitFixture()
   try {
-    const pkgLib = join(dir, 'packages/fake/lib/index.js')
+    const pkgSrc = join(dir, 'packages/fake/src/index.ts')
     // base: 存量超标函数，复杂度 5，未覆盖，CRAP = 5^2 + 5 = 30 > 16
     const baseCode = `function legacyHeavy(a, b, c, d) {
   if (a) return 1;
@@ -266,7 +264,7 @@ test('#592 crap-check --diff: 修改存量超标函数但复杂度降低/持平�
 }
 legacyHeavy();
 `
-    writeFileSync(pkgLib, baseCode)
+    writeFileSync(pkgSrc, baseCode)
     execFileSync('git', ['add', '.'], { cwd: dir, stdio: 'pipe' })
     execFileSync('git', ['commit', '-m', 'initial commit'], { cwd: dir, stdio: 'pipe' })
 
@@ -279,9 +277,9 @@ legacyHeavy();
 }
 legacyHeavy();
 `
-    writeFileSync(pkgLib, improvedCode)
+    writeFileSync(pkgSrc, improvedCode)
     writeFileSync(join(dir, 'coverage/coverage-final.json'), JSON.stringify({
-      [pkgLib]: {
+      [pkgSrc]: {
         fnMap: { '0': { loc: { start: { line: 1, column: 0 } } } },
         f: { '0': 0 },
       },
@@ -298,7 +296,7 @@ legacyHeavy();
 test('#592 crap-check --diff: 未触及的存量超标函数全部豁免报警（exit 0）', () => {
   const dir = setupGitFixture()
   try {
-    const pkgLib = join(dir, 'packages/fake/lib/index.js')
+    const pkgSrc = join(dir, 'packages/fake/src/index.ts')
     // base 包含一个严重超标的存量函数和一个普通函数
     const baseCode = `function untouchedHeavy(a, b, c, d, e) {
   if (a) return 1;
@@ -315,7 +313,7 @@ function touchedSmall(x) {
 untouchedHeavy();
 touchedSmall(1);
 `
-    writeFileSync(pkgLib, baseCode)
+    writeFileSync(pkgSrc, baseCode)
     execFileSync('git', ['add', '.'], { cwd: dir, stdio: 'pipe' })
     execFileSync('git', ['commit', '-m', 'initial commit'], { cwd: dir, stdio: 'pipe' })
 
@@ -336,9 +334,9 @@ function touchedSmall(x) {
 untouchedHeavy();
 touchedSmall(1);
 `
-    writeFileSync(pkgLib, newCode)
+    writeFileSync(pkgSrc, newCode)
     writeFileSync(join(dir, 'coverage/coverage-final.json'), JSON.stringify({
-      [pkgLib]: {
+      [pkgSrc]: {
         fnMap: {
           '0': { loc: { start: { line: 1, column: 0 } } },
           '1': { loc: { start: { line: 10, column: 0 } } },
@@ -367,7 +365,7 @@ test('#592 crap-check --diff: 无相关代码变更时放行（exit 0）', () =>
 
     const res = spawnSync(process.execPath, [SCRIPT, '--diff', 'HEAD'], { cwd: dir, encoding: 'utf8' })
     assert.equal(res.status, 0, `无相关变更必须 exit 0，实际输出：${res.stdout} ${res.stderr}`)
-    assert.match(res.stdout, /未检测到插件包编译产物/)
+    assert.match(res.stdout, /未检测到包 src 下的代码变更/)
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }

--- a/scripts/test/crap-check.test.ts
+++ b/scripts/test/crap-check.test.ts
@@ -14,11 +14,12 @@ function fixture(strict) {
   const dir = mkdtempSync(join(tmpdir(), 'crap-check-test-'))
   mkdirSync(join(dir, 'scripts/data'), { recursive: true })
   mkdirSync(join(dir, 'coverage'), { recursive: true })
-  mkdirSync(join(dir, 'packages/fake/lib'), { recursive: true })
+  mkdirSync(join(dir, 'packages/fake/src'), { recursive: true })
   writeFileSync(join(dir, 'scripts/data/gauntlet.config.json'), JSON.stringify({ crap: { threshold: 1, strict } }))
-  writeFileSync(join(dir, 'packages/fake/lib/index.js'), 'function uncovered() { if (false) return 1; return 0 }\nuncovered()\n')
+  // 复杂度 2（一个 if）、未覆盖 → CRAP = 2^2 + 2 = 6 > threshold 1，稳定产生超阈热点。
+  writeFileSync(join(dir, 'packages/fake/src/index.ts'), 'export function uncovered(): number { if (false) return 1; return 0 }\n')
   writeFileSync(join(dir, 'coverage/coverage-final.json'), JSON.stringify({
-    [join(dir, 'packages/fake/lib/index.js')]: {
+    [join(dir, 'packages/fake/src/index.ts')]: {
       fnMap: { '0': { loc: { start: { line: 1, column: 0 } } } },
       f: { '0': 0 },
     },
@@ -45,27 +46,26 @@ test('crap.strict 是唯一判红开关，忽略 --strict argv', () => {
   assert.match(hard.stderr, /判定为红/)
 })
 
-test('#722: 覆盖率数据为 src 口径时 fail-closed（不再以「0 个函数」静默放行）', () => {
-  // 阶段三把覆盖率采集切到 vitest/istanbul 的 src 口径，而本脚本的圈复杂度取自
-  // lib 产物——不设自检时按 lib 过滤命中 0 个文件、以 exit 0 放行（#718 定性的
-  // 静默降级）。本用例锁死该路径必须报错。
-  const dir = mkdtempSync(join(tmpdir(), 'crap-check-src-'))
+test('#722 阶段五: 覆盖率数据里没有包 src 条目时 fail-closed（不再以「0 个函数」静默放行）', () => {
+  // 阶段五把 CRAP 的复杂度与覆盖率统一到包 src 口径。若数据源不是该口径（例如误用旧 lib
+  // 产物），旧行为是命中 0 个文件、以 exit 0 放行（#718 定性的静默降级）。本用例锁死它。
+  const dir = mkdtempSync(join(tmpdir(), 'crap-check-lib-'))
   try {
     mkdirSync(join(dir, 'scripts/data'), { recursive: true })
     mkdirSync(join(dir, 'coverage'), { recursive: true })
-    mkdirSync(join(dir, 'packages/fake/src'), { recursive: true })
+    mkdirSync(join(dir, 'packages/fake/lib'), { recursive: true })
     writeFileSync(
       join(dir, 'scripts/data/gauntlet.config.json'),
       JSON.stringify({ crap: { threshold: 16, strict: false } }),
     )
-    writeFileSync(join(dir, 'packages/fake/src/index.ts'), 'export function f() { return 1 }\n')
+    writeFileSync(join(dir, 'packages/fake/lib/index.js'), 'function f() { return 1 }\nf()\n')
     writeFileSync(join(dir, 'coverage/coverage-final.json'), JSON.stringify({
-      [join(dir, 'packages/fake/src/index.ts')]: { fnMap: { '0': { loc: { start: { line: 1 } } } }, f: { '0': 1 } },
+      [join(dir, 'packages/fake/lib/index.js')]: { fnMap: { '0': { loc: { start: { line: 1 } } } }, f: { '0': 1 } },
     }))
     const res = spawnSync(process.execPath, [SCRIPT], { cwd: dir, encoding: 'utf8' })
-    assert.equal(res.status, 2, `src 口径数据必须 fail-closed：${res.stdout}${res.stderr}`)
-    assert.match(res.stderr, /数据源口径不匹配/, '错误信息必须点名根因，而非静默放行')
-    assert.match(res.stderr, /阶段 5/, '错误信息必须指明重建去向')
+    assert.equal(res.status, 2, `非 src 口径数据必须 fail-closed：${res.stdout}${res.stderr}`)
+    assert.match(res.stderr, /没有任何包 src 条目/, '错误信息必须点名根因，而非静默放行')
+    assert.match(res.stderr, /pnpm cov/, '错误信息必须指明重建数据源的命令')
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }

--- a/scripts/test/lint-toolchain.test.ts
+++ b/scripts/test/lint-toolchain.test.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * lint 工具链隔离的结构断言（#722 阶段五）。
+ *
+ * 为什么需要：tools/lint 位于 packages/ 之外，所有既有门禁（listPluginDirs / catalog-peers /
+ * ci-matrix / aggregate / pack-check）都只扫 packages/，因此这一层没有任何现成看守。而它承载
+ * 一个会「静默失效」的关键前提——typescript-eslint 必须解析到带 compiler API 的 TS 6.x，
+ * 同时仓根 typescript 必须仍是 tsgo（根 tsc 由它提供，各包 build/typecheck 依赖它）。
+ * 隔离一旦被破坏（依赖被提升、overrides 被加、根本被降级），失败形态是「lint 全绿但没在跑规则」
+ * 或「build/typecheck 换了编译器」，两者都不会自己报出来，故在此逐条钉死。
+ *
+ * 运行：pnpm test:scripts
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = join(import.meta.dirname, '..', '..')
+const requireRoot = createRequire(join(ROOT, 'package.json'))
+const requireLint = createRequire(join(ROOT, 'tools', 'lint', 'package.json'))
+
+test('#722 阶段五：lint 工具链隔离——根 tsgo 与 lint 专用 TS 6 各自归位', () => {
+  // ⓪ 结构存在性
+  for (const rel of [
+    'tools/lint/package.json',
+    'tools/lint/eslint.config.js',
+    'tools/lint/bin/lint.mjs',
+  ]) {
+    assert.ok(existsSync(join(ROOT, rel)), `${rel} 必须存在（lint 工具链隔离包）`)
+  }
+
+  // ① 根 typescript 必须仍是 tsgo：有版本号、无 compiler API
+  const rootTs = requireRoot('typescript')
+  assert.match(String(rootTs.version), /^7\./, `根 typescript 应为 7.x（实测 ${rootTs.version}）`)
+  assert.equal(typeof rootTs.createSourceFile, 'undefined',
+    '根 typescript 必须是 tsgo 原生版（无 compiler API）——根 tsc 由它提供，各包 build/typecheck 依赖它；被换成 6.x 会静默改变全部产物的生成器')
+
+  // ② tools/lint 的 typescript 必须有 compiler API（typescript-eslint 的硬前提）
+  const lintTs = requireLint('typescript')
+  assert.equal(typeof lintTs.createSourceFile, 'function',
+    'tools/lint 的 typescript 必须带 compiler API——否则 typescript-eslint 会在加载时抛 "does not support TS 7.0"')
+  assert.match(String(lintTs.version), /^6\./,
+    `tools/lint 的 typescript 应为 6.x（实测 ${lintTs.version}）；7.x 无 API，typescript-eslint 不支持`)
+
+  // ③ 两个版本必须真的共存（防止某一侧被提升/覆盖后「看起来还能跑」）
+  assert.notEqual(rootTs.version, lintTs.version,
+    '根与 lint 子包必须解析到不同大版本的 typescript——同版意味着隔离已失效')
+
+  // ④ 根 tsc 可执行文件必须仍来自 tsgo
+  const tscBin = join(ROOT, 'node_modules', '.bin', 'tsc')
+  assert.ok(existsSync(tscBin), 'node_modules/.bin/tsc 必须存在（各包 build/typecheck 调用它）')
+})
+
+test('#722 阶段五：复杂度阈值唯一事实源在 gauntlet.config.json，配置不得硬编码', () => {
+  const gauntlet = JSON.parse(readFileSync(join(ROOT, 'scripts', 'data', 'gauntlet.config.json'), 'utf8'))
+  const c = gauntlet.complexity
+  assert.ok(c !== undefined, 'gauntlet.config.json 必须有 complexity 段（阈值唯一事实源）')
+  assert.equal(typeof c.cyclomatic, 'number', 'complexity.cyclomatic 必须是数字')
+  assert.equal(typeof c.cognitive, 'number', 'complexity.cognitive 必须是数字')
+  // 起步值 = 全域实测最大值；收紧路线见 issue #732。此处只锁「不得高于起步基线」，
+  // 允许后续按 #732 下调（下调是收紧，方向正确），但不得反弹回更高。
+  assert.ok(c.cyclomatic <= 78, `complexity.cyclomatic 不得高于起步基线 78（实测 ${c.cyclomatic}）`)
+  assert.ok(c.cognitive <= 84, `complexity.cognitive 不得高于起步基线 84（实测 ${c.cognitive}）`)
+
+  // 配置必须消费事实源，不得写死数字阈值（否则改 gauntlet 不生效 = 事实源被绕过）
+  const configText = readFileSync(join(ROOT, 'tools', 'lint', 'eslint.config.js'), 'utf8')
+  assert.ok(!/complexity:\s*\[\s*'error'\s*,\s*\d/.test(configText),
+    'eslint.config.js 不得硬编码 complexity 的数字阈值（必须读 gauntlet.config.json）')
+  assert.ok(!/'sonarjs\/cognitive-complexity':\s*\[\s*'error'\s*,\s*\d/.test(configText),
+    'eslint.config.js 不得硬编码 cognitive-complexity 的数字阈值（必须读 gauntlet.config.json）')
+  assert.match(configText, /gauntlet\.config\.json/,
+    'eslint.config.js 必须显式读取 gauntlet.config.json 作为阈值来源')
+})

--- a/tools/lint/bin/lint.mjs
+++ b/tools/lint/bin/lint.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * 仓库 lint 入口（#722 阶段五）。
+ *
+ * 为什么包一层而不直接跑 eslint：ESLint 的 basePath 由 cwd 决定，而 `eslint` 可执行文件位于
+ * tools/lint/node_modules —— 直接在子包目录里跑会让配置文件中的 `files` 模式、以及 lint-staged
+ * 传入的仓库根相对路径双双错位。这里把 cwd 恒定在仓库根，使两条路径口径统一。
+ */
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { ESLint } from 'eslint'
+
+const LINT_PKG = dirname(dirname(fileURLToPath(import.meta.url)))
+const REPO_ROOT = join(LINT_PKG, '..', '..')
+
+/**
+ * 默认 lint 面：手写源码与其配置，不含构建产物（忽略规则见 eslint.config.js）。
+ *
+ * 为什么写成文件级 glob 而非目录：ESLint 的 lintFiles 对裸目录模式（形如「包目录 + src」）
+ * 报 file-not-found，必须展开到文件；且扩展名要逐个列出，花括号写法匹配不到 .d.mts 一类多段后缀。
+ */
+const SOURCE_EXT = '{ts,tsx,mts,cts,js,mjs,cjs}'
+const DEFAULT_PATTERNS = [
+  `packages/*/src/**/*.${SOURCE_EXT}`,
+  `packages/*/test/**/*.${SOURCE_EXT}`,
+  `shared/**/*.${SOURCE_EXT}`,
+  `scripts/**/*.${SOURCE_EXT}`,
+  'tools/lint/eslint.config.js',
+  `tools/lint/bin/*.${SOURCE_EXT}`,
+  `vitest.config.${SOURCE_EXT}`,
+]
+
+const argv = process.argv.slice(2)
+const fix = argv.includes('--fix')
+const patterns = argv.filter((a) => !a.startsWith('-'))
+
+const eslint = new ESLint({
+  cwd: REPO_ROOT,
+  overrideConfigFile: join(LINT_PKG, 'eslint.config.js'),
+  fix,
+})
+
+const results = await eslint.lintFiles(patterns.length > 0 ? patterns : DEFAULT_PATTERNS)
+if (fix) await ESLint.outputFixes(results)
+
+const formatter = await eslint.loadFormatter('stylish')
+const output = formatter.format(results)
+if (output.trim() !== '') console.log(output)
+
+const errorCount = results.reduce((n, r) => n + r.errorCount, 0)
+const fileCount = results.length
+console.log(`lint: 检查 ${fileCount} 个文件，error ${errorCount}（阈值来源 scripts/data/gauntlet.config.json 的 complexity 段）`)
+process.exit(errorCount > 0 ? 1 : 0)

--- a/tools/lint/eslint.config.js
+++ b/tools/lint/eslint.config.js
@@ -1,0 +1,59 @@
+/**
+ * 仓库 ESLint 扁平配置（#722 阶段五）。
+ *
+ * 本文件与整个 lint 工具链一起放在 tools/lint 隔离包内：typescript-eslint 需要 TypeScript 的
+ * compiler API，而仓根 typescript 是 tsgo 7.x（无 API，且根 tsc 由它提供、不可替换）。
+ * 隔离带来两个约束，配置与入口都必须遵守：
+ *   1. 本文件只能 import 本包声明的依赖（pnpm 严格布局下父目录解析不到子包依赖）；
+ *   2. files 模式相对 basePath 解析，而 basePath 由入口的 cwd 决定——入口固定以仓库根为 cwd，
+ *      故此处模式一律写成仓库根相对形式。
+ *
+ * 阈值不在本文件硬编码：唯一事实源是 scripts/data/gauntlet.config.json 的 complexity 段
+ * （起步值为全域实测最大值，收紧路线见 issue #732）。
+ */
+import { readFileSync } from 'node:fs'
+import tseslint from 'typescript-eslint'
+import sonarjs from 'eslint-plugin-sonarjs'
+
+const gauntlet = JSON.parse(
+  readFileSync(new URL('../../scripts/data/gauntlet.config.json', import.meta.url), 'utf8'),
+)
+const { cyclomatic, cognitive } = gauntlet.complexity
+if (typeof cyclomatic !== 'number' || typeof cognitive !== 'number') {
+  throw new Error('gauntlet.config.json 缺少 complexity.cyclomatic / complexity.cognitive —— 阈值事实源不可读，fail-closed')
+}
+
+// 手写源码面：逐扩展名显式列出，花括号写法匹配不到 .d.mts 一类的多段后缀。
+const TS_SOURCES = ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts']
+const JS_SOURCES = ['**/*.js', '**/*.mjs', '**/*.cjs']
+
+// 构建产物、依赖与本地草稿不参与 lint；声明文件没有实现体，复杂度门禁对其无意义。
+const IGNORES = [
+  '**/node_modules/**',
+  '**/lib/**',
+  'coverage/**',
+  '.maintenance-drafts/**',
+  '**/*.d.ts',
+  '**/*.d.mts',
+  '**/*.d.cts',
+]
+
+const complexityRules = {
+  complexity: ['error', cyclomatic],
+  'sonarjs/cognitive-complexity': ['error', cognitive],
+}
+
+export default [
+  { ignores: IGNORES },
+  {
+    files: TS_SOURCES,
+    languageOptions: { parser: tseslint.parser, ecmaVersion: 'latest', sourceType: 'module' },
+    plugins: { sonarjs },
+    rules: complexityRules,
+  },
+  {
+    files: JS_SOURCES,
+    plugins: { sonarjs },
+    rules: complexityRules,
+  },
+]

--- a/tools/lint/package.json
+++ b/tools/lint/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@dsh-tools/lint",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "lint 工具链隔离包（#722 阶段五）。typescript-eslint 需要 TypeScript 的 compiler API，而根 typescript 是 tsgo 7.x（无 API，根 tsc 由它提供，不可替换）；pnpm 的子包隔离让 TS 6 与 TS 7 共存，根链路不受影响。非发布包。",
+  "devDependencies": {
+    "@eslint/js": "10.0.1",
+    "eslint": "10.10.0",
+    "eslint-plugin-sonarjs": "4.2.0",
+    "typescript": "6.0.3",
+    "typescript-eslint": "8.70.0"
+  }
+}


### PR DESCRIPTION
Refs #722（阶段五 · B 项）、Refs #732（阈值收紧跟踪）

## 范围

引入 ESLint 复杂度门禁并完成 CRAP 的 src 口径重建（含阶段五 A4：lib 产物分段逻辑退役）。依赖变更与 `.github/` 接入均已经维护者在 #722 裁决批准（[方案修订评论](https://github.com/wingsky-1/dsh-plugin-hub/issues/722#issuecomment-5641808081)）。

**本 PR 不删任何依赖**：`c8` / `@stryker-mutator/tap-runner` 的清理属 D 项，走后续 PR（两者现已无消费者）。

## 一、核心约束与解法

`typescript-eslint@8.70.0` 需要 TypeScript 的 compiler API，而仓根 `typescript@7.0.2` 是 **tsgo 原生版**（`createSourceFile` 为 `undefined`），且根 `tsc` 由它提供、各包 build/typecheck 依赖它——**不能降级**。上游对 TS 7 是硬守卫（`typescript-eslint does not support TS 7.0`，issue [#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940) 未落地）。

解法：`tools/lint` workspace 子包持有 lint 专用 `typescript@6.0.3`。pnpm 的子包隔离让两个大版本共存：

```
根 typescript       : 7.0.2   createSourceFile: undefined   ← tsgo，未被污染
tools/lint          : 6.0.3   createSourceFile: function
根 tsc bin          : Version 7.0.2
```

刻意放 `tools/` 而非 `packages/`：所有既有门禁（`listPluginDirs` / `catalog-peers-lib` / `ci-matrix` / `aggregate` / `pack-check`）都只扫 `packages/` 且要求 `dsh-` 前缀，`tools/` 完全在扫描面外，无需改插件清单。实测 `pnpm -r build/test` 仍 exit 0（无脚本的子包被自动跳过）。

## 二、复杂度门禁

- 规则：core `complexity` + `sonarjs/cognitive-complexity`
- 覆盖面：`packages/*/src`、`packages/*/test`、`shared`、`scripts` 的手写源码（368 文件，8.6s）
- **阈值唯一事实源**：`scripts/data/gauntlet.config.json` 的 `complexity` 段（配置读取它，不硬编码）
- **起步值 = 全域实测最大值**（cyclomatic 78 / cognitive 84）→ 存量命中 0，只拦新增劣化；收紧路线见 [#732](https://github.com/wingsky-1/dsh-plugin-hub/issues/732)（目标 10/15）
- 入口 `tools/lint/bin/lint.mjs` 固定以仓库根为 cwd：ESLint 的 basePath 与 lint-staged 传入路径据此同口径

## 三、CRAP 重建（src 口径）

- **复杂度不再自算**：改用 ESLint 的 `Linter` API + `complexity: ['error', 0]` 枚举全部函数——与门禁**共用同一条规则实现**，消除口径漂移面（这是阶段五的单一事实源约定）
- **覆盖率**取 `coverage/coverage-final.json`（vitest/istanbul）的 `fnMap` / `f`
- **两处 join 处理**（实测发现）：① ESLint 会把「类字段初始化器」也报为函数，istanbul 不计入 → 过滤；② vitest/istanbul 在 TS 转译 + sourcemap 回映后有 ±1 行偏移 → 容差。两者处理后对齐率 **98.75% 精确 / 99.86% 带容差**，残余判未覆盖（方向保守）
- **退役**：`foreignSegments` / `inForeign` / `shimRanges` / `coverageDataSource` 与 `acorn` 依赖整段删除（src 无内联 vendor，分段逻辑失去对象）
- **`--diff` 修正**：改为评估 `packages/*/src/` 的 git diff——旧版评估 `packages/*/lib/`，而该目录从未入库，真实仓库恒走「无产物变更」分支 exit 0（其单测 fixture 自行 git init 并提交 lib 文件，所以测试通过但脱离现实）
- 阈值来源不变：`crap.threshold` / `crap.strict` **未改动**（`strict` 是否翻期由维护者裁决）

重建前后：

| | 重建前（阶段三起） | 重建后 |
|---|---|---|
| 行为 | 入口自检不匹配 → exit 2 停用态 | 正常评估 |
| 函数数 | 0（静默归零已被自检拦下） | **1441 个 / 125 个 src 文件 / 0 解析失败** |
| 覆盖率 | — | 已覆盖 1171（81%） |
| 超阈热点 | — | 115 个（Top1 `supervisor.ts:129` CRAP=2756 comp=52 未覆盖） |

## 四、防「静默失效」的结构断言

`tools/lint` 在 `packages/` 之外，没有任何现成门禁看守它，而它承载一个**会静默失效**的前提。故新增 `scripts/test/lint-toolchain.test.ts` 逐条钉死：

1. 根 `typescript` 仍是 7.x **且 `createSourceFile` 为 undefined**（被换成 6.x 会静默改变全部产物的生成器）
2. `tools/lint` 的 `typescript` 必须有 `createSourceFile`（否则 typescript-eslint 加载即抛错）
3. 两者版本必须不同（同版 = 隔离已失效）
4. 根 `node_modules/.bin/tsc` 存在
5. 阈值必须来自 `gauntlet.config.json`，且配置里**不得硬编码数字阈值**（否则改事实源不生效）
6. 阈值不得高于起步基线（允许按 #732 下调 = 收紧，禁止反弹）

## 五、接入

| 位置 | 改动 |
|---|---|
| `ci.yml` `repo-gate` | 新增 `pnpm lint`（廉价静态闸组，秒级、无产物依赖） |
| `local-gate.mjs` | `gate:pr` / `gate:full` 的廉价全仓闸新增 `lint`；`withCoverage` 恢复 `crap` 步骤 |
| `observe.yml` | 恢复 `pnpm crap` 步骤（阶段三因停用态移除） |
| `health-report.yml` | 恢复 `pnpm crap` 步骤（`crap-report.json` 供报告正文消费） |

## 六、验收（本地实跑 exit code）

| 命令 | exit | 备注 |
|---|---|---|
| `pnpm install` | 0 | 打 peer WARN（预期：根 tsgo 与子包 TS 6 并存；本仓无 `peers check` 门禁） |
| `pnpm lint` | **0** | 367 文件 / 0 error / 1 warn（既有 `eslint-disable` 注释未被使用，真实信号）/ 8.6s |
| `pnpm crap` | **0** | 1441 函数 / 115 热点 / strict=false 观察期 / 2.7s |
| `pnpm test:scripts` | **0** | 313 通过（原 311 + 新增 2 条工具链断言） |
| `pnpm docs:check` | **0** | — |
| `pnpm build && pnpm test && pnpm contract && pnpm pack:check && pnpm typecheck` | **0** | 串行复合；`&&` 语义下五步均 0 |

## 七、遗留与后续

- **D 项**（删 `c8` / `@stryker-mutator/tap-runner`）与 **C 项**（lefthook + lint-staged + commitlint）走后续 PR
- **E 项**（client 覆盖率纳入）按裁决推后：触发条件 = happy-dom project 落地且 `test/client/**` 全部直连 `src/client/**` 的同一 PR 内移除 exclude 并重新基线化
- 复杂度阈值收紧进度跟踪于 #732；`crap.strict` 翻期由维护者裁决
