### PR TITLE
fix(gate): #733 M0 地基——死声明判据修正 + 基线拆结构型/质量型 + 28 类型锚

### DIFF
--- a/packages/dsh-notifier/test/integration/consumer-types.test.ts
+++ b/packages/dsh-notifier/test/integration/consumer-types.test.ts
@@ -10,8 +10,21 @@
  * 由 scripts/test/service-contract-wiring.test.ts 以真实 tsc 编译，随
  * pnpm test:scripts 无条件执行。文件内的运行时断言只是「用例没被绕开」的护栏，
  * 本文件的判据在编译期。
+ *
+ * 覆盖纪律（#733 M0c）：导出面快照门禁（scripts/data/dsh-notifier-export-surface.json）
+ * 的 declBlocks 96 条**全部是 `export declare const/function/class`**，对 interface /
+ * type 体零覆盖——加一个联合成员、给接口加字段时快照不会红。故类型面由本文件的
+ * 「类型体快照锚」兜住：包导出面 28 个类型导出**逐个**一条 `Equal<T, 完整字面量>`，
+ * 成员增删 / 字段改型 / 可选性变化都会编译报错。
+ *
+ * 写死期望值的纪律：期望值必须是**独立字面量**。用 `T["m"]` 自引用、或 import 包内
+ * 未导出类型当期望值，会让两侧同步漂移、锚退化为恒真。未进包导出面的依赖域类型
+ * （HistoryStore / SseHub / SystemNotifier / DoneBatcher / ConfigPort 等）一律按结构
+ * 写死为本文件的 Shape 别名。
  */
 import { describe, expect, it } from "vitest";
+import type { Agent } from "@deepseek-ai/dsh-agent";
+import type { ServerResponse } from "node:http";
 import {
   BUILTIN_CHANNELS,
   DEFAULT_CONFIG,
@@ -21,9 +34,17 @@ import {
   applyConfigPatch,
 } from "../../src/index.ts";
 import type {
+  BarkChannelConfig,
+  BarkLevel,
   ChannelCapabilities,
+  ChannelStatusEntry,
+  EventHandlers,
+  EventHandlersDeps,
   KindRegistration,
+  MigrationOutcome,
+  NotifierApplyConfig,
   NotifierService,
+  NotifierServiceDeps,
   NotifierServiceInternal,
   NotifyChannel,
   NotifyConfig,
@@ -32,7 +53,15 @@ import type {
   NotifyResult,
   NotifySeverity,
   PatchResult,
+  QuietHoursConfig,
   RouteDeps,
+  SettingInvalid,
+  SettingsBridge,
+  SoundChannel,
+  SoundId,
+  SoundSetting,
+  StatusStore,
+  SystemTone,
 } from "../../src/index.ts";
 
 /** 双向类型相等（编译期判据：任一侧漂移即 false）。 */
@@ -40,7 +69,115 @@ type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ?
 /** 编译期闸门：泛型实参不是 true 就报错。 */
 type Expect<T extends true> = T;
 
-// ---- SDK ABI：消费方按这些签名调用，逐条锁死 ----
+// ---------------------------------------------------------------- 未导出依赖域形状
+// 消费者无法命名这些类型（不在包导出面），故按结构写死期望值；引用实现侧类型会让
+// 锚与被测类型同步漂移、退化为恒真，故宁可重复写一遍结构。
+
+/** stores 域 HistoryEntry / HistoryStore（src/stores/history.ts）。 */
+type HistoryEntryShape = {
+  ts: number;
+  kind: string;
+  title: string;
+  message: string;
+  suppressed?: string;
+};
+type HistoryStoreShape = {
+  append(entry: HistoryEntryShape): void;
+  read(): Promise<Array<Record<string, unknown>>>;
+  clear(): Promise<number>;
+};
+
+/** sdk 域 NotifySentEvent（src/sdk/interface.ts；有意不进包导出面）。 */
+type NotifySentEventShape = {
+  kind: string;
+  title: string;
+  message: string;
+  channelId: string;
+  status: "ok" | "failed";
+  error?: string;
+  ts: number;
+};
+
+/** config 域 WebhookChannelConfig / ChannelConfig 联合（src/config/config.ts）。 */
+type WebhookChannelConfigShape = {
+  id: string;
+  name?: string;
+  type: "webhook";
+  url: string;
+  enabled: boolean;
+  auth: "none" | "bearer" | "basic" | "header";
+  token?: string;
+  username?: string;
+  password?: string;
+  headerName?: string;
+  headerValue?: string;
+  preset?: "ntfy" | "gotify" | "custom";
+  template?: string;
+  timeoutSec?: number;
+};
+type ChannelConfigShape = BarkChannelConfig | WebhookChannelConfigShape;
+
+/** pipeline 域投递决议与载荷（src/pipeline/interface.ts）。 */
+type BrowserDispatchSpecShape = {
+  pop: boolean;
+  sound: { mode: "silent" | "system" | "selfplay"; tone?: SoundId };
+};
+type SystemDispatchSpecShape = { pop: boolean; sound: SoundSetting };
+type ResolvedTargetShape = {
+  id: string;
+  channel: NotifyChannel;
+  dispatch?: BrowserDispatchSpecShape | SystemDispatchSpecShape;
+};
+type DeliverPayloadShape = {
+  title: string;
+  body: string;
+  kind: string;
+  ts: number;
+  severity?: NotifySeverity;
+};
+
+/** server 域 SseHub / SystemNotifier（src/server/sse-bus.ts、src/server/system-notifier.ts）。 */
+type SseEvictStatsShape = { close: number; error: number; limit: number; stalled: number; maxage: number; destroyed: number };
+type SseConnHealthShape = { ageMs: number; lastWriteAgoMs: number; stalledMs: number };
+type SseHubShape = {
+  register(res: ServerResponse): void;
+  broadcast(payload: Record<string, unknown>): void;
+  framesSince(since: number): Array<Record<string, unknown> & { seq: number }>;
+  size(): number;
+  evictStats(): SseEvictStatsShape;
+  connHealth(now?: number): SseConnHealthShape[];
+  dispose(): void;
+};
+type SystemNotifierShape = {
+  notify(pop: boolean, tone: SoundSetting, title: string, message: string): Promise<boolean>;
+};
+
+/** config 域 settings 最小服务面（src/config/settings.ts）。 */
+type OwnerScopeLikeShape = {
+  get(): NotifyConfig;
+  watch(cb: (next: NotifyConfig, prev: NotifyConfig) => void): () => void;
+  update(patch: object): Promise<void>;
+};
+type SettingsServiceLikeShape = {
+  register(ns: string, schema: unknown, options?: { base?: unknown }): OwnerScopeLikeShape;
+  describe(options?: { redactSecrets?: boolean }): Array<{ ns: string; user?: unknown; revision: number }>;
+  update(ns: string, patch: object, expectedRevision?: number): Promise<void>;
+};
+
+/** events 域 DoneBatcher / SubagentOwnership（src/events/aggregate.ts、src/events/agent-session.ts）。 */
+type DoneBatcherShape = {
+  enqueue(kind: string, title: string | undefined, durationMs: number): void;
+  flush(): void;
+  dispose(): void;
+};
+type SubagentOwnershipShape = {
+  get(id: string): Agent | undefined;
+  isOwnedBy(id: string, owner: Agent): boolean;
+};
+
+// ---------------------------------------------------------------- SDK ABI 逐方法锚
+// 消费方按这些签名调用，逐条锁死（与下方类型体快照锚互补：这里给局部签名的可读判据）。
+
 type _ApiVersion = Expect<Equal<NotifierService["apiVersion"], 1>>;
 type _RegisterKind = Expect<Equal<NotifierService["registerKind"], (reg: KindRegistration) => void>>;
 type _ConfirmKind = Expect<Equal<NotifierService["confirmKind"], (kind: string, confirmed: boolean) => void>>;
@@ -54,7 +191,8 @@ type _SendKind = Expect<
   >
 >;
 
-// ---- 请求面与能力契约 ----
+// ---------------------------------------------------------------- 请求面与能力契约
+
 type _Severity = Expect<Equal<NotifySeverity, "info" | "success" | "warning" | "failure">>;
 type _Data = Expect<Equal<NotifyRequest["data"], Record<string, string> | undefined>>;
 type _TitleMaxLen = Expect<Equal<ChannelCapabilities["titleMaxLen"], number>>;
@@ -63,7 +201,8 @@ type _MergeTitleIntoBody = Expect<Equal<ChannelCapabilities["mergeTitleIntoBody"
 type _Retry = Expect<Equal<ChannelCapabilities["retry"], { maxRetries: number; backoffMs?: number } | undefined>>;
 type _MaxInflight = Expect<Equal<ChannelCapabilities["maxInflight"], number | undefined>>;
 
-// ---- 路由面契约（结构化字面量：server 不 import sdk 的前提） ----
+// ---------------------------------------------------------------- 路由面契约（结构化字面量：server 不 import sdk 的前提）
+
 type _SendTest = Expect<
   Equal<RouteDeps["sendTest"], (channelId?: string) => Array<{ channelId: string; status: string; error?: string }>>
 >;
@@ -71,10 +210,339 @@ type _StatusReader = Expect<Equal<RouteDeps["statusReader"], () => Promise<Recor
 type _RouteListKinds = Expect<Equal<RouteDeps["listKinds"], () => Array<{ id: string; label: string; confirmed: boolean }>>>;
 type _PatchResult = Expect<Equal<ReturnType<typeof applyConfigPatch>, Promise<PatchResult>>>;
 
-// ---- 常量与配置面 ----
+// ---------------------------------------------------------------- 常量与配置面
+
 type _BuiltinChannels = Expect<Equal<typeof BUILTIN_CHANNELS, { readonly browser: "browser"; readonly system: "system" }>>;
 type _SanitizeDefault = Expect<Equal<NotifyConfig["sanitizeContent"], boolean>>;
 type _QuietAllowKinds = Expect<Equal<NotifyConfig["quietHours"]["allowKinds"], string[] | undefined>>;
+
+// ---------------------------------------------------------------- 类型体快照锚（#733 M0c）
+// 28 个包导出类型逐个一条：期望值 = 该类型体的完整独立字面量。
+// 对照：scripts/data/dsh-notifier-export-surface.json 的 isType:true 条目。
+
+/** 类型 1/28：NotifierService（src/sdk/interface.ts）。 */
+type _NotifierServiceShape = Expect<
+  Equal<
+    NotifierService,
+    {
+      readonly apiVersion: 1;
+      registerKind(reg: KindRegistration): void;
+      confirmKind(kind: string, confirmed: boolean): void;
+      listKinds(): Array<{ id: string; label: string; confirmed: boolean }>;
+      registerChannel(ch: NotifyChannel): void;
+      send(req: NotifyRequest): Promise<NotifyResult[]>;
+    }
+  >
+>;
+
+/** 类型 2/28：NotifierServiceInternal（src/sdk/interface.ts；extends NotifierService + sendKind）。 */
+type _NotifierServiceInternalShape = Expect<
+  Equal<
+    NotifierServiceInternal,
+    {
+      readonly apiVersion: 1;
+      registerKind(reg: KindRegistration): void;
+      confirmKind(kind: string, confirmed: boolean): void;
+      listKinds(): Array<{ id: string; label: string; confirmed: boolean }>;
+      registerChannel(ch: NotifyChannel): void;
+      send(req: NotifyRequest): Promise<NotifyResult[]>;
+      sendKind(kind: string, detail?: NotifyDetail, opts?: { bypassQuiet?: boolean; onlyChannel?: string }): NotifyResult[];
+    }
+  >
+>;
+
+/** 类型 3/28：NotifierServiceDeps（src/sdk/interface.ts）。 */
+type _NotifierServiceDepsShape = Expect<
+  Equal<
+    NotifierServiceDeps,
+    {
+      current(): NotifyConfig;
+      enabled(): boolean;
+      history: HistoryStoreShape;
+      logger: { warn: (m: string) => void; info: (m: string) => void };
+      outboundChannels(): Array<{ id: string; channel: NotifyChannel }>;
+      builtinChannels: Array<{ id: string; channel: NotifyChannel }>;
+      recordStatus(channelId: string, status: "ok" | "failed", error?: string): void;
+      emitSent(payload: NotifySentEventShape): void;
+      setConfirm(kind: string, confirmed: boolean): void;
+      play(target: ResolvedTargetShape, payload: DeliverPayloadShape): void | Promise<void>;
+    }
+  >
+>;
+
+/** 类型 4/28：NotifySeverity（src/sdk/interface.ts）。 */
+type _NotifySeverityShape = Expect<Equal<NotifySeverity, "info" | "success" | "warning" | "failure">>;
+
+/** 类型 5/28：NotifyRequest（src/sdk/interface.ts）。 */
+type _NotifyRequestShape = Expect<
+  Equal<
+    NotifyRequest,
+    {
+      source: string;
+      kind: string;
+      severity: NotifySeverity;
+      body: string;
+      title?: string;
+      data?: Record<string, string>;
+    }
+  >
+>;
+
+/** 类型 6/28：NotifyResult（src/sdk/interface.ts）。 */
+type _NotifyResultShape = Expect<
+  Equal<NotifyResult, { channelId: string; status: "ok" | "skipped" | "failed"; error?: string }>
+>;
+
+/** 类型 7/28：KindRegistration（src/sdk/interface.ts）。 */
+type _KindRegistrationShape = Expect<Equal<KindRegistration, { id: string; label: string; channels?: string[] }>>;
+
+/** 类型 8/28：ChannelCapabilities（src/sdk/interface.ts）。 */
+type _ChannelCapabilitiesShape = Expect<
+  Equal<
+    ChannelCapabilities,
+    {
+      titleMaxLen: number;
+      maxBodyLen: number;
+      mergeTitleIntoBody?: boolean;
+      retry?: { maxRetries: number; backoffMs?: number };
+      maxInflight?: number;
+    }
+  >
+>;
+
+/** 类型 9/28：NotifyChannel（src/sdk/interface.ts）。 */
+type _NotifyChannelShape = Expect<
+  Equal<
+    NotifyChannel,
+    {
+      name: string;
+      capabilities: ChannelCapabilities;
+      send(payload: { title: string; body: string; kind: string; ts: number; severity?: NotifySeverity }): void | Promise<void>;
+    }
+  >
+>;
+
+/** 类型 10/28：BarkLevel（src/config/config.ts）。 */
+type _BarkLevelShape = Expect<Equal<BarkLevel, "active" | "timeSensitive" | "passive" | "critical">>;
+
+/** 类型 11/28：BarkChannelConfig（src/config/config.ts）。 */
+type _BarkChannelConfigShape = Expect<
+  Equal<
+    BarkChannelConfig,
+    {
+      id: string;
+      name?: string;
+      type: "bark";
+      baseUrl: string;
+      deviceKey: string;
+      enabled: boolean;
+      sound?: string;
+      level?: BarkLevel;
+      levels?: Record<string, BarkLevel>;
+      group?: string;
+      icon?: string;
+      url?: string;
+      badge?: number;
+    }
+  >
+>;
+
+/** 类型 12/28：NotifyConfig（src/config/config.ts）。 */
+type _NotifyConfigShape = Expect<
+  Equal<
+    NotifyConfig,
+    {
+      notifyAsk: boolean;
+      notifyQuestion: boolean;
+      notifyTaskDone: boolean;
+      notifySubagentDone: boolean;
+      notifyTaskError: boolean;
+      notifyTurnEnd: boolean;
+      systemNotify: boolean;
+      browserNotify: boolean;
+      notifyWhenVisible: boolean;
+      notifySound: boolean;
+      browserSound: SoundSetting;
+      systemSound: SoundSetting;
+      quietHours: QuietHoursConfig;
+      errorMergeWindowMs: number;
+      askRemindMin: number;
+      doneMergeWindowMs: number;
+      historyMaxAgeDays: number;
+      maxConnections: number;
+      channels: ChannelConfigShape[];
+      kindRoutes: Record<string, string[]>;
+      allowKinds: string[];
+      sanitizeContent: boolean;
+    }
+  >
+>;
+
+/** 类型 13/28：QuietHoursConfig（src/config/quiet-hours.ts）。 */
+type _QuietHoursConfigShape = Expect<
+  Equal<QuietHoursConfig, { enabled: boolean; start: string; end: string; allowKinds?: string[] }>
+>;
+
+/** 类型 14/28：SoundId（src/config/config.ts；由 SOUND_IDS 派生）。 */
+type _SoundIdShape = Expect<Equal<SoundId, "ding" | "bell" | "chime" | "pop">>;
+
+/** 类型 15/28：SoundSetting（src/config/config.ts）。 */
+type _SoundSettingShape = Expect<Equal<SoundSetting, boolean | SoundId>>;
+
+/** 类型 16/28：SoundChannel（src/config/config.ts）。 */
+type _SoundChannelShape = Expect<Equal<SoundChannel, "browser" | "system">>;
+
+/** 类型 17/28：NotifierApplyConfig（src/config/config.ts）。 */
+type _NotifierApplyConfigShape = Expect<
+  Equal<
+    NotifierApplyConfig,
+    { enabled?: boolean; configFile?: string; toastScript?: string; historyFile?: string; statusFile?: string }
+  >
+>;
+
+/** 类型 18/28：SettingInvalid（src/config/validators.ts）。 */
+type _SettingInvalidShape = Expect<Equal<SettingInvalid, { key: string; hint: string }>>;
+
+/** 类型 19/28：MigrationOutcome（src/config/migrate.ts）。 */
+type _MigrationOutcomeShape = Expect<
+  Equal<
+    MigrationOutcome,
+    {
+      performed: boolean;
+      migrated: boolean;
+      rolledBack: boolean;
+      skippedCorrupt: boolean;
+      skippedIdempotent: boolean;
+      resumed: boolean;
+    }
+  >
+>;
+
+/** 类型 20/28：SettingsBridge（src/config/settings-bridge.ts；extends ConfigPort）。 */
+type _SettingsBridgeShape = Expect<
+  Equal<
+    SettingsBridge,
+    {
+      resolve(): NotifyConfig;
+      readUser(): { user: Record<string, unknown>; revision?: number };
+      writable(): boolean;
+      update(patch: object, expectedRevision?: number): Promise<void>;
+      confirmKind(kind: string, confirmed: boolean): Promise<void>;
+      entry: Record<string, unknown>;
+      getCurrent: () => NotifyConfig;
+      getSource: () => NotifyConfig;
+      isWritable: () => boolean;
+      updateConfig: (patch: object, expectedRevision?: number) => Promise<void>;
+      confirmKindToConfig: (kind: string, confirmed: boolean) => Promise<void>;
+      getScope: () => OwnerScopeLikeShape | undefined;
+      getService: () => SettingsServiceLikeShape | undefined;
+    }
+  >
+>;
+
+/** 类型 21/28：RouteDeps（src/server/routes.ts；extends ConfigPort）。 */
+type _RouteDepsShape = Expect<
+  Equal<
+    RouteDeps,
+    {
+      resolve(): NotifyConfig;
+      readUser(): { user: Record<string, unknown>; revision?: number };
+      writable(): boolean;
+      update(patch: object, expectedRevision?: number): Promise<void>;
+      confirmKind(kind: string, confirmed: boolean): Promise<void>;
+      logger: { warn: (message: string) => void; info: (message: string) => void };
+      sse: SseHubShape;
+      system: SystemNotifierShape;
+      history: HistoryStoreShape;
+      sendTest(channelId?: string): Array<{ channelId: string; status: string; error?: string }>;
+      statusReader(): Promise<Record<string, unknown>>;
+      listKinds(): Array<{ id: string; label: string; confirmed: boolean }>;
+    }
+  >
+>;
+
+/** 类型 22/28：PatchResult（src/server/routes.ts）。 */
+type _PatchResultShape = Expect<
+  Equal<
+    PatchResult,
+    | { ok: true; value: { user: Record<string, unknown>; revision?: number } }
+    | { ok: false; status: number; code: string; response: Record<string, unknown> }
+  >
+>;
+
+/** 类型 23/28：StatusStore（src/stores/status.ts）。 */
+type _StatusStoreShape = Expect<
+  Equal<
+    StatusStore,
+    {
+      record(channelId: string, status: "ok" | "failed", error?: string): void;
+      read(): Promise<Record<string, ChannelStatusEntry>>;
+    }
+  >
+>;
+
+/** 类型 24/28：ChannelStatusEntry（src/stores/status.ts）。 */
+type _ChannelStatusEntryShape = Expect<
+  Equal<ChannelStatusEntry, { lastTs: number; lastStatus: "ok" | "failed"; lastError?: string; failStreak: number }>
+>;
+
+/** 类型 25/28：EventHandlers（src/events/event-handlers.ts）。 */
+type _EventHandlersShape = Expect<
+  Equal<
+    EventHandlers,
+    {
+      handleApprovalRequest: (req: any, next: () => Promise<any>) => Promise<any>;
+      handleInternalService: (name: string) => void;
+      handleSessionEvent: (session: any, event: any) => void;
+      handleAgentStatus: (payload: { agent: any; status: string }) => void;
+      handleAgentDisposed: (payload: { agent: any }) => void;
+      handleAgentError: (payload: any) => void;
+      handleAgentTurnStopping: (payload: any) => Promise<void>;
+      hookUserQuestions: () => void;
+      dispose: () => void;
+    }
+  >
+>;
+
+/** 类型 26/28：EventHandlersDeps（src/events/event-handlers.ts）。 */
+type _EventHandlersDepsShape = Expect<
+  Equal<
+    EventHandlersDeps,
+    {
+      getConfig: () => NotifyConfig;
+      notify: (kind: string, detail?: NotifyDetail) => boolean;
+      appendHistory: (entry: HistoryEntryShape) => void;
+      doneBatcher: DoneBatcherShape;
+      logger: { warn: (msg: string) => void };
+      getAgents: () => SubagentOwnershipShape | undefined;
+      getUserQuestionsService: () => { ask?: unknown } | undefined;
+    }
+  >
+>;
+
+/** 类型 27/28：NotifyDetail（src/text/message.ts）。 */
+type _NotifyDetailShape = Expect<
+  Equal<
+    NotifyDetail,
+    {
+      tool?: string;
+      taskTitle?: string;
+      reason?: string;
+      question?: string;
+      durationMs?: number;
+      turn?: number;
+      step?: number;
+      message?: string;
+      mergedCount?: number;
+      remindMinutes?: number;
+      mergedErrors?: string[];
+      ts?: number;
+    }
+  >
+>;
+
+/** 类型 28/28：SystemTone（src/text/system-commands.ts）。 */
+type _SystemToneShape = Expect<Equal<SystemTone, SoundId | "default">>;
 
 // ---- 负向断言：非法用法必须不可编译（指令本身也受检：错误消失即 unused 报错） ----
 // @ts-expect-error severity 只接受四值联合

--- a/scripts/data/dir-imports-baseline.json
+++ b/scripts/data/dir-imports-baseline.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "S0 门禁基线（#690）：每包每类计数只许降不许升；uncoveredSrcFiles 只许减不许增。由 verify-dir-imports.mjs --write-baseline 生成。",
+  "$comment": "S0 门禁基线（#690）：结构型计数由 verify-dir-imports.mjs --write-baseline 登记（随新增文件/目录合法上升）；质量型计数（leafModuleCycles/fileCycles/raLegacy*/implToOtherImpl/missingInterface/directImpl）与 uncoveredSrcFiles 只许降不许升，--write-baseline 不更新它们，须人工处置。",
   "version": 1,
   "packages": {
     "dsh-lan-proxy": {

--- a/scripts/gate/verify-dir-imports.mjs
+++ b/scripts/gate/verify-dir-imports.mjs
@@ -30,7 +30,7 @@
  *   - `--zones`：叶子口径跨域引用明细 + R-A 两个语义口径计数（D-2 前后）。
  *   - `--graph`：依赖矩阵 + 扇入扇出 + 模块级/文件级值环 + 死声明。
  *   - **单调基线**：每包每类计数只许降不许升（`scripts/data/dir-imports-baseline.json`），
- *     上升即 exit 1。基线由 `--write-baseline` 生成/更新。
+ *     上升即 exit 1。基线由 `--write-baseline` 生成/更新（#733 M0b 起只更新结构型计数）。
  *   - **源码全覆盖断言**：`src` 下每个文件必须落在 `∪mutate ∪ ∪excludes` 之内。
  *     `gen-stryker-conf --check` 只比对「磁盘配置 ↔ 拓扑派生」，不会因新增源文件
  *     而变红，故新增未被度量覆盖的源文件必须由本断言兜住（存量登记在基线里）。
@@ -553,12 +553,45 @@ function analyzePackage(pkgName, topology) {
 }
 
 /**
- * 基线字段（数值型）：只许降不许升。
- * 全部为**叶子模块粒度**——顶层域历史对照口径不进此表也不进基线：它复刻的是
- * 有缺陷的旧算法（嵌套目标丢边），对它设阈值等于让「结构搬迁」误红（三域移入
- * src/server/ 就会改变顶层域集合），且与叶子口径构成同一约束的双轨判定
- * （ARCHITECTURE-METHOD §9 禁止双轨）。它只用于打印跨期对照。
+ * 基线计数分两组（#733 M0b）。
+ *
+ * **结构型**（规模计数）：随新增源文件 / 模块目录 / 合法跨模块引用上升是结构演进的
+ * 正常结果——它们的价值是跨期对照与「结构变更显式登记」，故 `--write-baseline` 更新。
+ *
+ * **质量型**（缺陷 / 债务计数）：只许降不许升，任何上升都是回归。`--write-baseline`
+ * **不得**自动放宽它们（保持旧基线值），否则「每次结构 PR 顺手放宽质量计数」会让
+ * 单调基线退化为「每次放宽」（#690 B1 的原始病灶）。
+ *   - leafModuleCycles / fileCycles：值环（M1 目标 0）
+ *   - raLegacy*：`<域>/<impl>.ts` 直接引用他域文件的存量（ARCHITECTURE-METHOD §2
+ *     载体依赖表：impl 只允许依赖本目录内 + 本域 deps.ts，跨域须经 deps.ts 声明）
+ *   - implToOtherImpl：impl 直引他域**实现文件**（D-2 新口径，目标 0）
+ *   - missingInterface / directImpl：规则违例存量
+ *
+ * 两组之外另有质量型**清单** `uncoveredSrcFiles`（只许减不许增），同样不由
+ * `--write-baseline` 更新。
+ *
+ * 字段顺序沿用既有入库顺序（跨组混排），避免 `--write-baseline` 产生纯重排 diff；
+ * 分组是语义划分，顺序是文件格式，两者分离。
  */
+const STRUCTURAL_METRICS = [
+  'modules',
+  'scannedSrcFiles',
+  'allSrcTsFiles',
+  'interfaceFacades',
+  'leafValueEdges',
+  'fileValueEdges',
+  'crossModuleRefs',
+]
+const QUALITY_METRICS = [
+  'leafModuleCycles',
+  'fileCycles',
+  'raLegacy',
+  'raLegacyValue',
+  'raLegacyType',
+  'implToOtherImpl',
+  'missingInterface',
+  'directImpl',
+]
 const COUNTED_METRICS = [
   'modules',
   'scannedSrcFiles',
@@ -576,6 +609,18 @@ const COUNTED_METRICS = [
   'missingInterface',
   'directImpl',
 ]
+// 分组与计数字段必须严格同集：漏登记会让某个计数既不被判红也不被写基线（静默脱管）。
+{
+  const grouped = new Set([...STRUCTURAL_METRICS, ...QUALITY_METRICS])
+  const missing = COUNTED_METRICS.filter((k) => !grouped.has(k))
+  const extra = [...grouped].filter((k) => !COUNTED_METRICS.includes(k))
+  const dup = STRUCTURAL_METRICS.filter((k) => QUALITY_METRICS.includes(k))
+  if (missing.length > 0 || extra.length > 0 || dup.length > 0 || grouped.size !== COUNTED_METRICS.length) {
+    throw new Error(
+      `计数分组与 COUNTED_METRICS 不一致：未分组 [${missing}]、多余 [${extra}]、跨组重复 [${dup}]、组内重复 [${[...grouped].length !== STRUCTURAL_METRICS.length + QUALITY_METRICS.length}]`,
+    )
+  }
+}
 
 /** 读取基线 JSON；缺失返回 null（调用方按 fail-closed 处理）。 */
 function loadBaseline() {
@@ -588,7 +633,7 @@ function loadBaseline() {
   }
 }
 
-/** 单调基线比对：数值上升或未覆盖清单新增条目即判红。 */
+/** 单调基线比对：数值上升或未覆盖清单新增条目即判红（结构型与质量型一视同仁）。 */
 function compareWithBaseline(analysis, baseline) {
   const pkgBase = baseline?.packages?.[analysis.package]
   if (pkgBase === undefined) return { mode: 'absent', rises: [] }
@@ -596,12 +641,15 @@ function compareWithBaseline(analysis, baseline) {
   for (const key of COUNTED_METRICS) {
     const cur = analysis.metrics[key]
     const base = pkgBase[key]
-    if (typeof base !== 'number') rises.push(`${key}: 基线未登记（当前 ${cur}）`)
-    else if (cur > base) rises.push(`${key}: ${cur} > 基线 ${base}`)
+    // 标签区分两类红因：结构型上升 = 结构变更未登记（跑 --write-baseline）；
+    // 质量型上升 = 缺陷/债务回归（只能改代码，不能靠写基线放行）。
+    const tag = QUALITY_METRICS.includes(key) ? '质量型' : '结构型'
+    if (typeof base !== 'number') rises.push(`[${tag}] ${key}: 基线未登记（当前 ${cur}）`)
+    else if (cur > base) rises.push(`[${tag}] ${key}: ${cur} > 基线 ${base}`)
   }
   const baseUncovered = new Set(pkgBase.uncoveredSrcFiles ?? [])
   for (const f of analysis.metrics.uncoveredSrcFiles) {
-    if (!baseUncovered.has(f)) rises.push(`uncoveredSrcFiles: 新增未覆盖源文件 ${f}`)
+    if (!baseUncovered.has(f)) rises.push(`[质量型] uncoveredSrcFiles: 新增未覆盖源文件 ${f}`)
   }
   return { mode: 'compared', rises }
 }
@@ -698,41 +746,68 @@ function renderGraph(analysis) {
   return lines
 }
 
-/** 生成基线 JSON 结构（稳定排序，便于 diff）。 */
-function buildBaseline(analyses) {
+/**
+ * 生成基线 JSON 结构（稳定排序，便于 diff）。
+ *
+ * `--write-baseline` 的更新面（#733 M0b）：**只更新结构型计数**。质量型计数与
+ * `uncoveredSrcFiles` 清单保持旧基线值——首次登记（旧基线无该包或该键）才按当前值
+ * 写入并单独提示。这样「结构 PR 顺手放宽质量计数」的路径被机器堵死；收紧（当前值
+ * 更低）同样不自动写入，基线变更须显式且说明理由（ARCHITECTURE-METHOD §11）。
+ *
+ * @returns `{ baseline, qualityKept, qualityFirst }`——后两项供写基线时显式报告。
+ */
+function buildBaseline(analyses, previous) {
   const packages = {}
+  const qualityKept = [] // 保留旧基线值的质量型项（当前值 ≠ 基线值）
+  const qualityFirst = [] // 首次登记的质量型项（旧基线无条目 → 按当前值写入）
   for (const a of [...analyses].sort((x, y) => x.package.localeCompare(y.package))) {
     const m = a.metrics
-    packages[a.package] = {
-      modules: m.modules,
-      scannedSrcFiles: m.scannedSrcFiles,
-      allSrcTsFiles: m.allSrcTsFiles,
-      interfaceFacades: m.interfaceFacades,
-      leafValueEdges: m.leafValueEdges,
-      leafModuleCycles: m.leafModuleCycles,
-      fileValueEdges: m.fileValueEdges,
-      fileCycles: m.fileCycles,
-      crossModuleRefs: m.crossModuleRefs,
-      raLegacy: m.raLegacy,
-      raLegacyValue: m.raLegacyValue,
-      raLegacyType: m.raLegacyType,
-      implToOtherImpl: m.implToOtherImpl,
-      missingInterface: m.missingInterface,
-      directImpl: m.directImpl,
-      uncoveredSrcFiles: m.uncoveredSrcFiles,
+    const prev = previous?.packages?.[a.package]
+    const entry = {}
+    for (const key of COUNTED_METRICS) {
+      if (!QUALITY_METRICS.includes(key)) {
+        entry[key] = m[key]
+        continue
+      }
+      if (typeof prev?.[key] === 'number') {
+        entry[key] = prev[key]
+        if (prev[key] !== m[key]) qualityKept.push(`${a.package}.${key}：当前 ${m[key]} / 保持基线 ${prev[key]}`)
+      } else {
+        entry[key] = m[key]
+        qualityFirst.push(`${a.package}.${key}：${m[key]}`)
+      }
     }
+    const prevUncovered = prev?.uncoveredSrcFiles
+    if (Array.isArray(prevUncovered)) {
+      entry.uncoveredSrcFiles = prevUncovered
+      const cur = m.uncoveredSrcFiles
+      if (cur.length !== prevUncovered.length || cur.some((f) => !prevUncovered.includes(f))) {
+        qualityKept.push(
+          `${a.package}.uncoveredSrcFiles：当前 ${cur.length} 项 / 保持基线 ${prevUncovered.length} 项（人工处置后手工更新）`,
+        )
+      }
+    } else {
+      entry.uncoveredSrcFiles = m.uncoveredSrcFiles
+      if (m.uncoveredSrcFiles.length > 0) qualityFirst.push(`${a.package}.uncoveredSrcFiles：${m.uncoveredSrcFiles.length} 项`)
+    }
+    packages[a.package] = entry
   }
   return {
-    // S0（#690 A 轨）门禁基线：每包每类计数只许降不许升。
-    // 口径：全部为**叶子模块粒度**实测（S0 起模块 = 递归含 interface.ts 的目录）。
-    // 顶层域历史对照口径刻意不入库：它复刻的是有缺陷的旧算法（嵌套目标丢边），
-    // 对它设阈值会让结构搬迁误红，并与叶子口径构成同一约束的双轨（§9 禁止双轨）。
-    // leafModuleCycles/fileCycles 的存量环待 #690 P1 拆解，本阶段只锁「不许变多」；
-    // uncoveredSrcFiles = `src ⊆ ∪mutate ∪ ∪excludes` 断言的历史存量，新增即红。
-    $comment:
-      'S0 门禁基线（#690）：每包每类计数只许降不许升；uncoveredSrcFiles 只许减不许增。由 verify-dir-imports.mjs --write-baseline 生成。',
-    version: 1,
-    packages,
+    baseline: {
+      // S0（#690 A 轨）门禁基线：结构型计数随新增文件/目录容许上升（--write-baseline 登记），
+      // 质量型计数只许降不许升且**不由 --write-baseline 更新**（#733 M0b）。
+      // 口径：全部为**叶子模块粒度**实测（S0 起模块 = 递归含 interface.ts 的目录）。
+      // 顶层域历史对照口径刻意不入库：它复刻的是有缺陷的旧算法（嵌套目标丢边），
+      // 对它设阈值会让结构搬迁误红，并与叶子口径构成同一约束的双轨（§9 禁止双轨）。
+      // leafModuleCycles/fileCycles 的存量环待 #690 P1 拆解，本阶段只锁「不许变多」；
+      // uncoveredSrcFiles = `src ⊆ ∪mutate ∪ ∪excludes` 断言的历史存量，新增即红。
+      $comment:
+        'S0 门禁基线（#690）：结构型计数由 verify-dir-imports.mjs --write-baseline 登记（随新增文件/目录合法上升）；质量型计数（leafModuleCycles/fileCycles/raLegacy*/implToOtherImpl/missingInterface/directImpl）与 uncoveredSrcFiles 只许降不许升，--write-baseline 不更新它们，须人工处置。',
+      version: 1,
+      packages,
+    },
+    qualityKept,
+    qualityFirst,
   }
 }
 
@@ -794,22 +869,37 @@ if (WRITE_BASELINE) {
     for (const f of failures) console.log(`  ${f}`)
     process.exit(1)
   }
-  const baseline = buildBaseline(analyses)
-  // `--write-baseline --package X` 只应更新 X 的条目：直接整体覆盖会抹掉其他包的
-  // 基线（随后它们全部落到 fail-closed），补救只能全量重写——那等于一键放宽。
+  // 旧基线同时承担两个职责：质量型计数/未覆盖清单的**保留来源**（#733 M0b），以及
+  // `--write-baseline --package X` 只写 X 时的其余包条目来源。
+  let previous = null
   if (existsSync(BASELINE_PATH)) {
     try {
-      const existing = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'))
-      for (const [name, entry] of Object.entries(existing?.packages ?? {})) {
-        if (!(name in baseline.packages)) baseline.packages[name] = entry
-      }
+      previous = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'))
     } catch {
-      // 旧基线不可解析时按「全量重写」处理：保留损坏内容只会延续问题。
+      // 旧基线不可解析时按「全量首次登记」处理：保留损坏内容只会延续问题。
+      previous = null
     }
+  }
+  const { baseline, qualityKept, qualityFirst } = buildBaseline(analyses, previous)
+  // `--write-baseline --package X` 只应更新 X 的条目：直接整体覆盖会抹掉其他包的
+  // 基线（随后它们全部落到 fail-closed），补救只能全量重写——那等于一键放宽。
+  for (const [name, entry] of Object.entries(previous?.packages ?? {})) {
+    if (!(name in baseline.packages)) baseline.packages[name] = entry
   }
   mkdirSync(dirname(BASELINE_PATH), { recursive: true })
   writeFileSync(BASELINE_PATH, `${JSON.stringify(baseline, null, 2)}\n`, 'utf8')
   console.log(`verify-dir-imports | 已写入基线 ${BASELINE_PATH}（${analyses.length} 个包）`)
+  console.log(
+    `verify-dir-imports |   结构型计数已更新（${STRUCTURAL_METRICS.length} 类，随新增文件/目录登记）：${STRUCTURAL_METRICS.join(' / ')}`,
+  )
+  console.log(
+    `verify-dir-imports |   质量型未更新，须人工处置（${QUALITY_METRICS.length} 类 + uncoveredSrcFiles）：保持基线值，不被本次写入放宽`,
+  )
+  for (const note of qualityKept) console.log(`verify-dir-imports |     ${note}`)
+  if (qualityFirst.length > 0) {
+    console.log('verify-dir-imports |   质量型首次登记（旧基线无条目 → 按当前值写入，须在 PR 内确认）：')
+    for (const note of qualityFirst) console.log(`verify-dir-imports |     ${note}`)
+  }
   for (const a of analyses) {
     const coverNote = a.topologyRegistered
       ? `未覆盖 ${a.metrics.uncoveredSrcFiles.length} 个`
@@ -864,7 +954,9 @@ for (const analysis of analyses) {
 
   if (state.mode === 'compared') {
     if (state.rises.length === 0) {
-      summary.push(`${pkgName}: 单调基线通过（${COUNTED_METRICS.length} 类计数与未覆盖清单均未上升）`)
+      summary.push(
+        `${pkgName}: 单调基线通过（结构型 ${STRUCTURAL_METRICS.length} 类 + 质量型 ${QUALITY_METRICS.length} 类 + 未覆盖清单均未上升）`,
+      )
     } else {
       for (const rise of state.rises) failures.push(`[${pkgName}] 单调基线上升：${rise}`)
     }

--- a/scripts/gate/verify-dir-imports.mjs
+++ b/scripts/gate/verify-dir-imports.mjs
@@ -35,6 +35,13 @@
  *     `gen-stryker-conf --check` 只比对「磁盘配置 ↔ 拓扑派生」，不会因新增源文件
  *     而变红，故新增未被度量覆盖的源文件必须由本断言兜住（存量登记在基线里）。
  *
+ * #733 M0 修正：
+ *   - **死声明口径改「值面判死、类型面豁免」**（M0a）：`deps.ts` 的类型边不进死声明
+ *     计算（类型声明本身即完整性），值边必须由本模块非 deps.ts 文件佐证；`deps.ts`
+ *     自身出现值 import 单独硬判红。
+ *   - **计数拆「结构型 / 质量型」**（M0b）：结构型随新增文件/目录合法上升，
+ *     `--write-baseline` 只更新结构型；质量型不得被自动放宽（保持旧基线值），上升仍判红。
+ *
  * 豁免：
  *   - `src/client/`（index.ts 为 build-client 契约锚点）：from 侧完全豁免；
  *     target 侧同样不入模块表与依赖图。
@@ -456,15 +463,27 @@ function analyzePackage(pkgName, topology) {
 
   // 死声明（意图 - 事实）：deps.ts 声明依赖某模块，而本模块 deps.ts **之外**的
   // 实现/门面文件并无对应事实边。deps.ts 自身的边属意图声明，不能自证为事实。
-  // S0 时 deps.ts 尚未落地，故一般为空；机制先建好，S5 落地后即自动生效。
+  //
+  // 口径（#733 M0a）：**值面判死、类型面豁免**。
+  //   - 类型边（import type / export type）是「本域对上依赖的形状声明」，声明本身
+  //     即完整性（供意图图对照），不构成可被判死的依赖承诺——跨域类型引用集中进
+  //     deps.ts 后事实边从实现文件消失，按旧口径会报假死声明（sdk → stores 的唯一
+  //     来源是 interface.ts 的 import type，迁入 deps.ts 后 actual 变空即误报）。
+  //   - 值边是「本域真的要取用的运行时能力」，必须由本模块非 deps.ts 文件佐证。
+  //   - 「改覆盖式」（把 deps.ts 自身的边并入 actual）会让 intended ⊆ actual 恒成立、
+  //     指标恒 0——空判，明确不采用。
   const deadDeclarations = []
+  const depsValueImports = []
   for (const [modDir, modId] of modules) {
     const depsFile = join(modDir, 'deps.ts')
     if (!existsSync(depsFile)) continue
     const intended = new Set()
     for (const r of refs) {
       if (r.fromFile !== depsFile) continue
+      // 声明面混入值依赖：不论目标模块（含同模块与 src 根），一律单独判红。
+      if (!r.isType) depsValueImports.push(r)
       if (r.toModule === null || r.toModule === modId) continue
+      if (r.isType) continue // 类型面豁免：声明即完整性，不参与死声明计算
       intended.add(r.toModule)
     }
     const actual = new Set()
@@ -474,7 +493,7 @@ function analyzePackage(pkgName, topology) {
       actual.add(r.toModule)
     }
     for (const target of intended) {
-      if (!actual.has(target)) deadDeclarations.push(`${modId}/deps.ts → ${target}（意图有而事实无）`)
+      if (!actual.has(target)) deadDeclarations.push(`${modId}/deps.ts → ${target}（值声明有而事实无）`)
     }
   }
 
@@ -504,6 +523,7 @@ function analyzePackage(pkgName, topology) {
     graphs: { topValueEdges, leafValueEdges, fileValueEdges },
     cycles: { top: topCycles, leaf: leafCycles, file: fileCycles },
     deadDeclarations,
+    depsValueImports,
     // 覆盖断言可判定性：包未登记拓扑时 uncoveredSrcFiles 恒为空，若不显式区分，
     // 「从拓扑里删掉一个包」就成了让覆盖断言消失的绕过路径（已复现的假绿向量）。
     topologyRegistered: specs !== null,
@@ -634,7 +654,7 @@ function renderZones(analysis) {
 
 /** 渲染 --graph 段：依赖矩阵 + 扇入扇出 + 模块级/文件级值环 + 死声明。 */
 function renderGraph(analysis) {
-  const { package: pkgName, moduleIds, graphs, cycles, deadDeclarations, refs } = analysis
+  const { package: pkgName, moduleIds, graphs, cycles, deadDeclarations, depsValueImports, refs } = analysis
   const lines = [`graph ${pkgName}（叶子粒度依赖图）`]
   const cellType = (from, to) => {
     const hasV = (graphs.leafValueEdges.get(from) ?? new Set()).has(to)
@@ -670,9 +690,11 @@ function renderGraph(analysis) {
   for (const c of cycles.leaf.values()) lines.push(`  ${c.join(' → ')}`)
   lines.push(`文件级值环（门禁口径，按节点集合去重的环集合数）：${cycles.file.size} 个`)
   for (const c of cycles.file.values()) lines.push(`  ${c.join(' → ')}`)
-  lines.push(`死声明（意图 - 事实）：${deadDeclarations.length} 条`)
+  lines.push(`死声明（意图 - 事实，只计 deps.ts 的值声明）：${deadDeclarations.length} 条`)
   for (const d of deadDeclarations) lines.push(`  ${d}`)
-  lines.push('（意图图 = 各模块 deps.ts；S0 阶段尚未落地，故死声明为空属预期）')
+  lines.push(`deps.ts 值依赖声明（声明面混入值 import，硬判红）：${depsValueImports.length} 条`)
+  for (const r of depsValueImports) lines.push(`  ${rel(analysis.srcDir, r.fromFile)} → import "${r.spec}"`)
+  lines.push('（意图图 = 各模块 deps.ts；类型边 import type/export type 是声明即完整性，豁免死声明判定）')
   return lines
 }
 
@@ -810,6 +832,15 @@ for (const analysis of analyses) {
   const { package: pkgName, metrics } = analysis
   const state = baseline === null ? { mode: 'absent', rises: [] } : compareWithBaseline(analysis, baseline)
   registerRuleViolations(analysis, state)
+  // deps.ts 是**依赖声明面**（本域对上依赖的形状），只能 import type / export type：
+  // 出现值 import 即声明面混入了运行时依赖，跨域运行时能力必须经组合根注入
+  // （ARCHITECTURE-METHOD §2「跨域运行时能力一律经 deps.ts 注入」），故硬判红且
+  // 不受单调基线与 soft 模式影响（有基线也红——它不是存量计数而是结构缺陷）。
+  for (const r of analysis.depsValueImports) {
+    failures.push(
+      `[${pkgName}] ${rel(analysis.srcDir, r.fromFile)} 出现值 import "${r.spec}"（deps.ts 只能声明类型依赖：改 import type / export type，运行时能力由组合根注入）`,
+    )
+  }
   if (!analysis.topologyRegistered && topology !== null) {
     failures.push(
       `[${pkgName}] 未在 scripts/data/mutation-topology.json 登记 —— 源码全覆盖断言无法判定（fail-closed：新增源文件会静默逃逸度量）`,

--- a/scripts/gate/verify-dir-imports.mjs
+++ b/scripts/gate/verify-dir-imports.mjs
@@ -617,7 +617,7 @@ const COUNTED_METRICS = [
   const dup = STRUCTURAL_METRICS.filter((k) => QUALITY_METRICS.includes(k))
   if (missing.length > 0 || extra.length > 0 || dup.length > 0 || grouped.size !== COUNTED_METRICS.length) {
     throw new Error(
-      `计数分组与 COUNTED_METRICS 不一致：未分组 [${missing}]、多余 [${extra}]、跨组重复 [${dup}]、组内重复 [${[...grouped].length !== STRUCTURAL_METRICS.length + QUALITY_METRICS.length}]`,
+      `计数分组与 COUNTED_METRICS 不一致：未分组 [${missing}]、多余 [${extra}]、跨组重复 [${dup}]、两组去重后 ${grouped.size} 项 != 计数字段 ${COUNTED_METRICS.length} 项`,
     )
   }
 }

--- a/scripts/test/verify-dir-imports-s0.test.ts
+++ b/scripts/test/verify-dir-imports-s0.test.ts
@@ -150,12 +150,99 @@ test('单调基线：写入基线后 PASS，人为把跨域引用计数调高即
     assert.match(before.out, /单调基线通过/, `应报基线通过：\n${before.out}`)
 
     // 人为把计数调高：c 域新增一条跨模块引用（模块级值边与跨模块引用计数同时 +1）。
+    // #733 M0b 起该变更同时抬高两个质量型计数（值环 leafModuleCycles/fileCycles 与
+    // raLegacy）——本用例只锁结构型红因，质量型红因由下方 M0b 用例专项覆盖。
     const impl = join(root, `${SRC}/c/impl.ts`)
     writeFileSync(impl, 'import { A } from "../a/interface.ts";\nexport const C = A;\n')
     const after = runOn(root)
     assert.equal(after.status, 1, `计数上升应 exit 1，实际 ${after.status}：\n${after.out}`)
     assert.match(after.out, /单调基线上升/, `应点名单调基线上升：\n${after.out}`)
-    assert.match(after.out, /leafValueEdges: 3 > 基线 2/, `应给出具体计数对照：\n${after.out}`)
+    assert.match(after.out, /\[结构型\] leafValueEdges: 3 > 基线 2/, `应给出具体计数对照：\n${after.out}`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+/** 读 fixture 根下的基线 JSON（M0b 用例断言 --write-baseline 的实际落库内容）。 */
+function readFixtureBaseline(root) {
+  return JSON.parse(readFileSync(join(root, 'scripts/data/dir-imports-baseline.json'), 'utf8'))
+}
+
+/** 制造「结构型 + 质量型同时上升」：c → a 新增跨模块引用（值边 +1，同时成环）。 */
+function addCyclicCrossReference(root) {
+  writeFileSync(join(root, `${SRC}/c/impl.ts`), 'import { A } from "../a/interface.ts";\nexport const C = A;\n')
+}
+
+test('--write-baseline 只更新结构型，质量型计数不得被放宽（#733 M0b）', () => {
+  const root = makeFixtureRoot(chainFixture(''))
+  try {
+    const first = runOn(root, ['--write-baseline'])
+    assert.equal(first.status, 0, `写基线应成功：\n${first.out}`)
+    const before = readFixtureBaseline(root)
+    assert.equal(before.packages[PKG].leafModuleCycles, 0, `fixture 初始无环：${JSON.stringify(before.packages[PKG])}`)
+
+    addCyclicCrossReference(root)
+    const second = runOn(root, ['--write-baseline'])
+    assert.equal(second.status, 0, `写基线应成功：\n${second.out}`)
+    assert.match(second.out, /结构型计数已更新/, `应报结构型已更新：\n${second.out}`)
+    assert.match(second.out, /质量型未更新，须人工处置/, `应显式提示质量型未更新：\n${second.out}`)
+
+    const after = readFixtureBaseline(root)
+    // 结构型：随本次结构变更登记（c → a 值边 +1）。
+    assert.equal(after.packages[PKG].leafValueEdges, 3, `结构型应被更新为当前值：${JSON.stringify(after.packages[PKG])}`)
+    // 质量型：保持旧基线值，不被本次写入放宽（含环、raLegacy、未覆盖清单）。
+    assert.equal(after.packages[PKG].leafModuleCycles, 0, `质量型不得被 --write-baseline 放宽：${JSON.stringify(after.packages[PKG])}`)
+    assert.equal(after.packages[PKG].fileCycles, 0, `质量型 fileCycles 不得被放宽：${JSON.stringify(after.packages[PKG])}`)
+    assert.equal(after.packages[PKG].raLegacy, 0, `质量型 raLegacy 不得被放宽：${JSON.stringify(after.packages[PKG])}`)
+    assert.match(second.out, /leafModuleCycles：当前 1 \/ 保持基线 0/, `应列出被保留的质量型差异：\n${second.out}`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('质量型计数上升仍判红，且 --write-baseline 不能放行（#733 M0b）', () => {
+  const root = makeFixtureRoot(chainFixture(''))
+  try {
+    assert.equal(runOn(root, ['--write-baseline']).status, 0)
+    assert.equal(runOn(root).status, 0, '基线写入后应 PASS')
+
+    addCyclicCrossReference(root)
+    const after = runOn(root)
+    assert.equal(after.status, 1, `质量型上升应 exit 1，实际 ${after.status}：\n${after.out}`)
+    assert.match(after.out, /\[质量型\] leafModuleCycles: 1 > 基线 0/, `应点名模块级值环：\n${after.out}`)
+    assert.match(after.out, /\[质量型\] fileCycles: 1 > 基线 0/, `应点名文件级值环：\n${after.out}`)
+    assert.match(after.out, /\[质量型\] raLegacy: 1 > 基线 0/, `应点名 raLegacy：\n${after.out}`)
+
+    // 写基线（只更新结构型）之后必须仍然红：质量型不得经由 --write-baseline 洗白。
+    assert.equal(runOn(root, ['--write-baseline']).status, 0, '写基线本身应成功（结构型登记）')
+    const again = runOn(root)
+    assert.equal(again.status, 1, `--write-baseline 后质量型上升仍应判红，实际 ${again.status}：\n${again.out}`)
+    assert.match(again.out, /\[质量型\] leafModuleCycles: 1 > 基线 0/, `质量型红因须保持：\n${again.out}`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('结构型计数上升 → --write-baseline 正常放行（#733 M0b）', () => {
+  const root = makeFixtureRoot(chainFixture(''))
+  try {
+    assert.equal(runOn(root, ['--write-baseline']).status, 0)
+    assert.equal(runOn(root).status, 0, '基线写入后应 PASS')
+
+    // 新增一个叶子模块目录（modules / scannedSrcFiles / allSrcTsFiles 上升）。
+    mkdirSync(join(root, `${SRC}/d`), { recursive: true })
+    writeFileSync(join(root, `${SRC}/d/interface.ts`), 'export { D } from "./impl.ts";\n')
+    writeFileSync(join(root, `${SRC}/d/impl.ts`), 'export const D = 4;\n')
+
+    const before = runOn(root)
+    assert.equal(before.status, 1, `结构型上升未登记时应判红，实际 ${before.status}：\n${before.out}`)
+    assert.match(before.out, /\[结构型\] modules: 4 > 基线 3/, `结构型上升应点名：\n${before.out}`)
+
+    const written = runOn(root, ['--write-baseline'])
+    assert.equal(written.status, 0, `--write-baseline 应成功：\n${written.out}`)
+    const after = runOn(root)
+    assert.equal(after.status, 0, `结构型登记后应 PASS，实际 ${after.status}：\n${after.out}`)
+    assert.match(after.out, /单调基线通过/, `应报基线通过：\n${after.out}`)
   } finally {
     rmSync(root, { recursive: true, force: true })
   }
@@ -321,7 +408,7 @@ test('--soft：单调基线上升仍判红（CI 对 provider-usage 走 --soft）
     writeFileSync(join(root, `${SRC}/c/impl.ts`), 'import { A } from "../a/interface.ts";\nexport const C = A;\n')
     const after = runOn(root, ['--soft'])
     assert.equal(after.status, 1, `--soft 下计数上升仍须判红，实际 ${after.status}：\n${after.out}`)
-    assert.match(after.out, /单调基线上升：leafValueEdges: 3 > 基线 2/, `应给出计数对照：\n${after.out}`)
+    assert.match(after.out, /单调基线上升：\[结构型\] leafValueEdges: 3 > 基线 2/, `应给出计数对照：\n${after.out}`)
   } finally {
     rmSync(root, { recursive: true, force: true })
   }

--- a/scripts/test/verify-dir-imports-s0.test.ts
+++ b/scripts/test/verify-dir-imports-s0.test.ts
@@ -11,7 +11,8 @@
  *   - 叶子粒度：同样三域「平铺」与「移入 src/server/」必须报出**相同**的模块数与
  *     值边数（旧实现下后者退化为 1 目录 / 0 值边但仍 PASS）；
  *   - deps.ts 判据：跨模块引用目标 deps.ts 放行、直引实现文件判红；
- *   - 单调基线：写入基线后人为把某计数调高必须 exit 1；
+ *   - 死声明判据（#733 M0a）：值面判死、类型面豁免；deps.ts 自身含值 import 硬判红；
+ *   - 单调基线：写入基线后人为把某计数调高必须 exit 1（#733 M0b 起分结构型 / 质量型）；
  *   - 全覆盖断言：新增未被 mutate/excludes 覆盖的 src 文件必须 exit 1。
  *
  * fixture 经 VERIFY_DIR_IMPORTS_ROOT 指向 mkdtemp 隔离目录（基线路径随根推导），
@@ -160,30 +161,81 @@ test('单调基线：写入基线后 PASS，人为把跨域引用计数调高即
   }
 })
 
-test('--graph 死声明：deps.ts 声明而本模块无事实边 → 报出，有事实边 → 不报', () => {
+test('--graph 死声明（#733 M0a）：deps.ts 只 import type 时不得报死声明（类型面豁免）', () => {
+  // 语义变化（相对 S0 原断言「deps.ts 声明而本模块无事实边 → 报出」）：原实现把
+  // deps.ts 的**类型边**也计入意图图，故该形态报 1 条死声明。M0a 改「值面判死、
+  // 类型面豁免」后恒为 0 条——修正目的即此：deps.ts 一旦落地（M1 的 F1 / #690 P1），
+  // 跨域类型引用会集中进 deps.ts，实现文件上的事实边随之消失，旧口径会把真声明
+  // 报成假死声明（已定位实例：sdk → stores 的唯一来源是 sdk/interface.ts 的
+  // import type { HistoryStore }，迁入 deps.ts 后 actual 变空）。
+  const root = makeFixtureRoot({
+    [`${SRC}/a/interface.ts`]: 'export { A } from "./impl.ts";\n',
+    [`${SRC}/a/impl.ts`]: 'export const A = 1;\n',
+    [`${SRC}/b/interface.ts`]: 'export { B } from "./impl.ts";\n',
+    [`${SRC}/b/impl.ts`]: 'export const B = 2;\n',
+    [`${SRC}/b/deps.ts`]: 'import type { A } from "../a/interface.ts";\nexport type BDep = A;\n',
+  })
+  try {
+    const { status, out } = runOn(root, ['--graph'])
+    assert.equal(status, 0, `类型面声明豁免后应 PASS，实际 ${status}：\n${out}`)
+    assert.match(out, /死声明（意图 - 事实，只计 deps\.ts 的值声明）：0 条/, `类型边不得报死声明：\n${out}`)
+    assert.match(out, /deps\.ts 值依赖声明（声明面混入值 import，硬判红）：0 条/, `类型边不得报值依赖：\n${out}`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('--graph 死声明（#733 M0a）：值面判死——deps.ts 值边无佐证 → 报出，有佐证 → 不报', () => {
   const base = {
     [`${SRC}/a/interface.ts`]: 'export { A } from "./impl.ts";\n',
     [`${SRC}/a/impl.ts`]: 'export const A = 1;\n',
     [`${SRC}/b/interface.ts`]: 'export { B } from "./impl.ts";\n',
     [`${SRC}/b/impl.ts`]: 'export const B = 2;\n',
-    [`${SRC}/b/deps.ts`]: 'export type { A } from "../a/interface.ts";\n',
+    [`${SRC}/b/deps.ts`]: 'import { A } from "../a/interface.ts";\nexport const AFromA = A;\n',
   }
   const dead = makeFixtureRoot(base)
+  // 有事实边：佐证来自**非 deps.ts** 的本模块实现文件（deps.ts 自身不自证）。
   const alive = makeFixtureRoot({
     ...base,
     [`${SRC}/b/impl.ts`]: 'import { A } from "../a/interface.ts";\nexport const B = A;\n',
   })
   try {
     const d = runOn(dead, ['--graph'])
-    assert.equal(d.status, 0, `死声明 S0 只报告不判红，应 PASS：\n${d.out}`)
-    assert.match(d.out, /死声明（意图 - 事实）：1 条/, `声明无事实支撑应报死声明：\n${d.out}`)
-    assert.match(d.out, /b\/deps\.ts → a（意图有而事实无）/, `应点名死声明来源与目标：\n${d.out}`)
+    assert.match(d.out, /死声明（意图 - 事实，只计 deps\.ts 的值声明）：1 条/, `值声明无事实支撑应报死声明：\n${d.out}`)
+    assert.match(d.out, /b\/deps\.ts → a（值声明有而事实无）/, `应点名死声明来源与目标：\n${d.out}`)
     const a = runOn(alive, ['--graph'])
-    assert.equal(a.status, 0, `无误报时应 PASS：\n${a.out}`)
-    assert.match(a.out, /死声明（意图 - 事实）：0 条/, `有事实边时不得误报死声明：\n${a.out}`)
+    assert.match(a.out, /死声明（意图 - 事实，只计 deps\.ts 的值声明）：0 条/, `有事实边时不得误报死声明：\n${a.out}`)
   } finally {
     rmSync(dead, { recursive: true, force: true })
     rmSync(alive, { recursive: true, force: true })
+  }
+})
+
+test('deps.ts 值依赖判红（#733 M0a）：声明面混入值 import → exit 1 且提示清晰', () => {
+  const crossModule = makeFixtureRoot({
+    [`${SRC}/a/interface.ts`]: 'export { A } from "./impl.ts";\n',
+    [`${SRC}/a/impl.ts`]: 'export const A = 1;\n',
+    [`${SRC}/b/interface.ts`]: 'export { B } from "./impl.ts";\n',
+    [`${SRC}/b/impl.ts`]: 'export const B = 2;\n',
+    [`${SRC}/b/deps.ts`]: 'import { A } from "../a/interface.ts";\nexport type BDep = typeof A;\n',
+  })
+  // 同模块值 import 同样是「声明面混入值依赖」：deps.ts 只能声明形状，不得参与运行时。
+  const sameModule = makeFixtureRoot({
+    [`${SRC}/a/interface.ts`]: 'export { A } from "./impl.ts";\n',
+    [`${SRC}/a/impl.ts`]: 'export const A = 1;\n',
+    [`${SRC}/a/deps.ts`]: 'import { A } from "./impl.ts";\nexport type ADep = typeof A;\n',
+  })
+  try {
+    const c = runOn(crossModule)
+    assert.equal(c.status, 1, `跨模块值 import 应硬判红，实际 ${c.status}：\n${c.out}`)
+    assert.match(c.out, /b\/deps\.ts 出现值 import "\.\.\/a\/interface\.ts"/, `应点名文件与 spec：\n${c.out}`)
+    assert.match(c.out, /deps\.ts 只能声明类型依赖/, `应给出修法提示：\n${c.out}`)
+    const s = runOn(sameModule)
+    assert.equal(s.status, 1, `同模块值 import 同样应判红，实际 ${s.status}：\n${s.out}`)
+    assert.match(s.out, /a\/deps\.ts 出现值 import "\.\/impl\.ts"/, `应点名同模块值 import：\n${s.out}`)
+  } finally {
+    rmSync(crossModule, { recursive: true, force: true })
+    rmSync(sameModule, { recursive: true, force: true })
   }
 })
 

--- a/scripts/test/verify-dir-imports-s0.test.ts
+++ b/scripts/test/verify-dir-imports-s0.test.ts
@@ -178,6 +178,9 @@ test('--write-baseline 只更新结构型，质量型计数不得被放宽（#73
   try {
     const first = runOn(root, ['--write-baseline'])
     assert.equal(first.status, 0, `写基线应成功：\n${first.out}`)
+    // 首次登记路径（旧基线无该包）是质量型**唯一**会被写入的路径，须显式提示并锁住——
+    // 否则未来重构可把它变成「静默按当前值写入」＝静默放宽。
+    assert.match(first.out, /质量型首次登记/, `首次写基线应提示质量型首次登记：\n${first.out}`)
     const before = readFixtureBaseline(root)
     assert.equal(before.packages[PKG].leafModuleCycles, 0, `fixture 初始无环：${JSON.stringify(before.packages[PKG])}`)
 


### PR DESCRIPTION
Refs #733（长开跟踪 issue，**不写 Closes**）

#733「dsh-notifier 目标架构定稿（v3）」的 **M0 地基阶段**：修正两道门禁判据、补齐类型锚。
本 PR **不改任何包源码、不改公共 API、不新增依赖**，是 M1（结构定点）的硬前置。

## 改动面

| 子任务 | commit | 文件 |
|---|---|---|
| M0a 死声明判据修正（值面判死 / 类型面豁免） | `92f89e3` | `scripts/gate/verify-dir-imports.mjs`、`scripts/test/verify-dir-imports-s0.test.ts` |
| M0b 基线拆「结构型 / 质量型」 | `d893ee9` | 同上 + `scripts/data/dir-imports-baseline.json`（仅 `$comment` 一行） |
| M0c 类型锚前置（22 → 28 个类型导出全覆盖） | `8a5e118` | `packages/dsh-notifier/test/integration/consumer-types.test.ts` |

---

## M0a 死声明判据：值面判死、类型面豁免

**问题（已实测）**：原判据 `intended − actual` 的 `actual` 只统计本模块**非 deps.ts** 文件的事实边。
`deps.ts` 一旦落地（M1 的 F1 / #690 P1），跨域**类型**引用会集中进 `deps.ts`，该边从 `actual`
消失 → 报**假死声明**。真实实例：`sdk → stores` 的唯一来源是 `sdk/interface.ts:13` 的
`import type { HistoryStore }`，随 `NotifierServiceDeps` 迁入 `sdk/deps.ts` 后 `actual` 变空。

**采用的口径**：

- `deps.ts` 的**类型边**（`import type` / `export type`）→ 不进死声明计算（类型声明本身即完整性，供意图图对照）；
- `deps.ts` 的**值边** → 计入，且必须由本模块非 deps.ts 文件佐证；
- `deps.ts` 自身出现**值 import** → 单独硬判红（声明面混入运行时依赖，跨域能力必须经组合根注入）。

**明确未采用**：把 `deps.ts` 自身的边并入 `actual`（「改覆盖式」）——那会让 `intended ⊆ actual`
恒成立、指标恒 0，成为**空判**。

### 验收输出原文（`mkdtempSync` 隔离根，逐条为脚本原始 stdout）

① 类型边、无非 deps.ts 佐证 → **不报**死声明：

```
exit=0
  死声明（意图 - 事实，只计 deps.ts 的值声明）：0 条
  deps.ts 值依赖声明（声明面混入值 import，硬判红）：0 条
verify-dir-imports | PASS（跨模块引用全部走 interface.ts/deps.ts，符号存在性校验通过，基线未上升）
```

② 值边、无非 deps.ts 佐证 → **报**死声明：

```
exit=1
  死声明（意图 - 事实，只计 deps.ts 的值声明）：1 条
    b/deps.ts → a（值声明有而事实无）
  deps.ts 值依赖声明（声明面混入值 import，硬判红）：1 条
verify-dir-imports | FAIL 1 条硬违规：
  [fixture-pkg] b/deps.ts 出现值 import "../a/interface.ts"（deps.ts 只能声明类型依赖：改 import type / export type，运行时能力由组合根注入）
```

② 反向（值边有非 deps.ts 佐证）→ 死声明 0 条（红线只剩「值 import」本身）：

```
exit=1
  死声明（意图 - 事实，只计 deps.ts 的值声明）：0 条
  deps.ts 值依赖声明（声明面混入值 import，硬判红）：1 条
```

③ `deps.ts` 自身含值 import → 判红且提示清晰（同上 FAIL 行）；同模块值 import（`./impl.ts`）同样判红。

### 既有 fixture 的语义变化（逐条说明理由）

| 用例 | 变化 | 理由 |
|---|---|---|
| `--graph 死声明：deps.ts 声明而本模块无事实边 → 报出` | 拆为三条：类型面豁免（0 条）/ 值面判死（1 条）/ 值 import 判红 | 原「报出」用例声明的正是 `export type { A } from`（**类型边**），新口径下必须豁免；正向断言改用**值边**才保有判别力。这不是放宽：新增了「值 import 硬判红」这一更严判据 |
| `单调基线`、`--soft` 两用例的红因正则 | `leafValueEdges: 3 > 基线 2` → `[结构型] leafValueEdges: 3 > 基线 2` | M0b 给红因加了分组标签；断言锁定的语义（具体计数对照）不变 |

真实包不回归：`verify-dir-imports --package dsh-mcp-manager --package dsh-notifier`（hard）与
`--package dsh-provider-usage --soft` 均 exit 0（当前仓库**无任何 deps.ts**，新判据不触发存量）。

---

## M0b 基线拆「结构型 / 质量型」

**问题**：`COUNTED_METRICS`（15 类）统一「只许降不许升」。任何新增源文件都会让
`modules`/`scannedSrcFiles`/`allSrcTsFiles` 上升 → 必须 `--write-baseline`；而它**整体重写该包
全部计数**，于是「每次结构 PR 都顺手放宽质量型计数」（#690 B1 的原始病灶）。

### 分组表（15 类 + 未覆盖清单，逐项裁决）

| 组 | 计数 | 裁决理由 |
|---|---|---|
| **结构型**（7） | `modules`、`scannedSrcFiles`、`allSrcTsFiles`、`interfaceFacades`、`leafValueEdges`、`fileValueEdges`、`crossModuleRefs` | 规模计数：随新增源文件 / 模块目录 / 合法跨模块引用单调上升是结构演进的正常结果；价值在跨期对照与「结构变更显式登记」。`--write-baseline` 更新 |
| **质量型**（8） | `leafModuleCycles`、`fileCycles`、`raLegacy`、`raLegacyValue`、`raLegacyType`、`implToOtherImpl`、`missingInterface`、`directImpl` | 缺陷 / 债务计数：值环（M1 目标 0）；`raLegacy*` 是「impl 直接引用他域文件」的存量（ARCHITECTURE-METHOD §2：impl 只允许依赖本目录内 + 本域 `deps.ts`，跨域须经 `deps.ts` 声明）；`implToOtherImpl` 是 D-2 新口径（目标 0）；`missingInterface`/`directImpl` 是规则违例存量 |
| **质量型清单** | `uncoveredSrcFiles` | 源码全覆盖断言的历史存量，只许减不许增；同属质量型，不被 `--write-baseline` 更新 |

字段顺序沿用既有入库顺序（跨组混排），分组是语义划分、顺序是文件格式，避免纯重排 diff；
脚本内加了一致性护栏：两组之并必须与 `COUNTED_METRICS` **严格同集**（漏登记即抛错，
防「某计数既不被判红也不被写基线」的静默脱管）。

### 行为

- `--write-baseline` **只更新结构型**；质量型与 `uncoveredSrcFiles` 保持旧基线值，并在输出中显式列出
  「**质量型未更新，须人工处置**」+ 逐项「当前值 / 保持基线值」；旧基线无该包条目时属**首次登记**
  （按当前值写入并单独提示，PR 内确认）。
- 质量型上升**仍判红**，且 `--write-baseline` 不能放行；结构型上升未登记时也判红（单调基线语义不变），
  登记后放行。
- 红因带分组标签：`[结构型]` / `[质量型]`。

### 验收输出原文

① `--write-baseline` 不改变质量型计数（结构变更后再写基线）：

```
verify-dir-imports |   结构型计数已更新（7 类，随新增文件/目录登记）：modules / scannedSrcFiles / allSrcTsFiles / interfaceFacades / leafValueEdges / fileValueEdges / crossModuleRefs
verify-dir-imports |   质量型未更新，须人工处置（8 类 + uncoveredSrcFiles）：保持基线值，不被本次写入放宽
verify-dir-imports |     fixture-pkg.raLegacy：当前 1 / 保持基线 0
verify-dir-imports |     fixture-pkg.raLegacyValue：当前 1 / 保持基线 0
  基线字段 modules: 2 → 3
  基线字段 leafValueEdges: 0 → 1
  基线字段 leafModuleCycles: 0 → 0
  基线字段 fileCycles: 0 → 0
  基线字段 raLegacy: 0 → 0
  基线字段 implToOtherImpl: 0 → 0
```

② 质量型上升仍判红，且写基线后仍红：

```
[质量型上升后] exit=1
verify-dir-imports | FAIL 8 条硬违规：
  [fixture-pkg] 单调基线上升：[质量型] leafModuleCycles: 1 > 基线 0
  [fixture-pkg] 单调基线上升：[质量型] fileCycles: 1 > 基线 0
  [fixture-pkg] 单调基线上升：[质量型] raLegacy: 2 > 基线 0
  [fixture-pkg] 单调基线上升：[质量型] raLegacyValue: 2 > 基线 0
[再跑 --write-baseline] exit=0
[写基线之后再跑] exit=1（4 条质量型红因保持）
```

③ 结构型上升 → `--write-baseline` 正常放行：

```
[新增模块后] exit=1
  [fixture-pkg] 单调基线上升：[结构型] modules: 3 > 基线 2
  [fixture-pkg] 单调基线上升：[结构型] scannedSrcFiles: 6 > 基线 4
  [fixture-pkg] 单调基线上升：[结构型] allSrcTsFiles: 6 > 基线 4
  [fixture-pkg] 单调基线上升：[结构型] fileValueEdges: 3 > 基线 2
[--write-baseline] exit=0
[登记后] exit=0
verify-dir-imports | fixture-pkg: 单调基线通过（结构型 7 类 + 质量型 8 类 + 未覆盖清单均未上升）
```

**真实基线自洽性**：对 6 个包跑全量 `--write-baseline`，与入库基线逐字段比对 → **计数差异 0 处**
（结构型实测值与基线一致；质量型全部被保留），仓库基线文件的实际 diff 只有 `$comment` 一行。

---

## M0c 类型锚前置

**问题**：导出面快照的 `declBlocks`（96 条）**全部是 `export declare const/function/class`**，
对 `interface` / `type` 体零覆盖（实测 0 命中）。给 `NotifySeverity` 加成员、给 `NotifyChannel`
加字段，快照**不会红**——而 M1/M2 的改动面恰恰是类型面。

做法：`consumer-types.test.ts` 在保留既有局部锚的基础上，为包导出面 **28 个 `isType: true`
条目逐个**补一条「类型体快照锚」`Expect<Equal<T, 完整字面量>>`。期望值一律写成**独立字面量**
（不用 `T["m"]` 自引用、不 import 包内未导出类型），未进导出面的依赖域类型（`HistoryStore` /
`SseHub` / `SystemNotifier` / `DoneBatcher` / `SubagentOwnership` / `OwnerScopeLike` /
`SettingsServiceLike` / `WebhookChannelConfig` / 投递决议等）按结构写死为本地 Shape 别名——
引用实现侧类型会让两侧同步漂移、锚退化为恒真。

### 28 个类型锚对照表（类型符号 → 断言位置）

| # | 类型导出 | 定义域 | 断言 | 行号 |
|---|---|---|---|---|
| 1 | `NotifierService` | `sdk/interface.ts` | `_NotifierServiceShape` | 224 |
| 2 | `NotifierServiceInternal` | `sdk/interface.ts` | `_NotifierServiceInternalShape` | 239 |
| 3 | `NotifierServiceDeps` | `sdk/interface.ts` | `_NotifierServiceDepsShape` | 255 |
| 4 | `NotifySeverity` | `sdk/interface.ts` | `_NotifySeverityShape` | 274 |
| 5 | `NotifyRequest` | `sdk/interface.ts` | `_NotifyRequestShape` | 277 |
| 6 | `NotifyResult` | `sdk/interface.ts` | `_NotifyResultShape` | 292 |
| 7 | `KindRegistration` | `sdk/interface.ts` | `_KindRegistrationShape` | 297 |
| 8 | `ChannelCapabilities` | `sdk/interface.ts` | `_ChannelCapabilitiesShape` | 300 |
| 9 | `NotifyChannel` | `sdk/interface.ts` | `_NotifyChannelShape` | 314 |
| 10 | `BarkLevel` | `config/config.ts` | `_BarkLevelShape` | 326 |
| 11 | `BarkChannelConfig` | `config/config.ts` | `_BarkChannelConfigShape` | 329 |
| 12 | `NotifyConfig` | `config/config.ts` | `_NotifyConfigShape` | 351 |
| 13 | `QuietHoursConfig` | `config/quiet-hours.ts` | `_QuietHoursConfigShape` | 382 |
| 14 | `SoundId` | `config/config.ts` | `_SoundIdShape` | 387 |
| 15 | `SoundSetting` | `config/config.ts` | `_SoundSettingShape` | 390 |
| 16 | `SoundChannel` | `config/config.ts` | `_SoundChannelShape` | 393 |
| 17 | `NotifierApplyConfig` | `config/config.ts` | `_NotifierApplyConfigShape` | 396 |
| 18 | `SettingInvalid` | `config/validators.ts` | `_SettingInvalidShape` | 404 |
| 19 | `MigrationOutcome` | `config/migrate.ts` | `_MigrationOutcomeShape` | 407 |
| 20 | `SettingsBridge` | `config/settings-bridge.ts` | `_SettingsBridgeShape` | 422 |
| 21 | `RouteDeps` | `server/routes.ts` | `_RouteDepsShape` | 444 |
| 22 | `PatchResult` | `server/routes.ts` | `_PatchResultShape` | 465 |
| 23 | `StatusStore` | `stores/status.ts` | `_StatusStoreShape` | 474 |
| 24 | `ChannelStatusEntry` | `stores/status.ts` | `_ChannelStatusEntryShape` | 485 |
| 25 | `EventHandlers` | `events/event-handlers.ts` | `_EventHandlersShape` | 490 |
| 26 | `EventHandlersDeps` | `events/event-handlers.ts` | `_EventHandlersDepsShape` | 508 |
| 27 | `NotifyDetail` | `text/message.ts` | `_NotifyDetailShape` | 524 |
| 28 | `SystemTone` | `text/system-commands.ts` | `_SystemToneShape` | 545 |

### 反向有效性实测（临时改类型 → tsc 报错 → 改回，不留痕）

| 反向用例 | tsc 结果 |
|---|---|
| `NotifySeverity` 加 `"critical"` | exit 1：`consumer-types.test.ts(196,25)`、`(274,36)` Equal 锚红 + `(548,1)` 负向断言的 `@ts-expect-error` 变 unused |
| `NotifyChannel` 加字段 `description?: string` | exit 1：`(315,3)` `_NotifyChannelShape` 红 |
| `NotifierService.apiVersion` `1` → `number` | exit 1：`(181,27)`、`(225,3)`、`(240,3)` 三条锚红 |
| `ChannelCapabilities` 加 `maxQueue?: number` | exit 1：`(301,3)` `_ChannelCapabilitiesShape` 红 |

四次改回后 `git status --porcelain` 只剩本 PR 的目标文件，全量 `tsc -p packages/dsh-notifier/test/tsconfig.json --noEmit` exit 0。

接线验收：`node --test scripts/test/service-contract-wiring.test.ts` exit 0（该用例 spawn 真实 tsc 编译
`packages/dsh-notifier/test/tsconfig.json`，含本文件）。

---

## 门禁（逐条实际 exit code）

| 命令 | exit |
|---|---|
| `pnpm build` | 0 |
| `pnpm test` | 0 |
| `pnpm contract` | 0 |
| `pnpm pack:check` | 0 |
| `pnpm typecheck` | 0 |
| `pnpm test:scripts` | 0 |
| `pnpm --filter @wingsky-1/dsh-notifier test` | 0（35 files / 1708 tests） |
| `node --test scripts/test/verify-dir-imports-s0.test.ts` | 0（31 tests） |
| `node --test scripts/test/service-contract-wiring.test.ts` | 0（2 tests） |
| `git status --porcelain \| grep -E 'undefined/\|\.jsonl$'` | 无匹配（产物零污染） |

基线（改动前，同一 worktree）：`build 0 / typecheck 0 / contract 0 / pack:check 0 / notifier-test 0`。

## 未验证 / 不在本 PR 范围

- 未做浏览器实测：本阶段不改包源码与产物（`lib/` 零 diff），不涉及 UI。
- M0d（本 issue 取 `approved` 标签）由维护者执行，不在本 PR 范围。
- 质量型存量的清零（`leafModuleCycles`/`fileCycles`/`raLegacy*`）属 M1 与 #690 P1；本 PR 只把
  「不许被自动放宽」变成机器约束。
