### PR TITLE
perf(gate): #720 静态拆段——dsh-notifier config 按 mutant 密度拆三段（31 → 33 段）

### DIFF
--- a/scripts/data/mutation-topology.json
+++ b/scripts/data/mutation-topology.json
@@ -206,15 +206,33 @@
             "concurrency": 16,
             "timeoutMS": 60000,
             "segments": {
-                "config": {
+                "config-normalize": {
+                    "mutate": [
+                        "packages/dsh-notifier/src/config/normalize.ts"
+                    ],
+                    "excludes": [
+                        "!packages/dsh-notifier/src/**/interface.ts",
+                        "!packages/dsh-notifier/src/client/**"
+                    ],
+                    "comment": "#720 静态拆段（1/3）：原 #669 PR2 T2-7 的 config 段按文件 mutant 密度拆三。本段 = normalize.ts 单文件 877 mutant（占原段 2366 的 37.1%），是段内 mutant 的最大来源。拆段动因是密度失衡而非文件数：normalize.ts 284 行 877 mutant 对 config.ts 307 行 95 mutant（密度差约 8 倍），按行数或按文件数均分都会拆错。按文件拆而非按行区间（--mutate file:1-142）：行号是脆弱依赖，且会把分段 SSOT 从本文件迁进 CI matrix，扩大自研面。interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                },
+                "config-validate": {
+                    "mutate": [
+                        "packages/dsh-notifier/src/config/validators.ts"
+                    ],
+                    "excludes": [
+                        "!packages/dsh-notifier/src/**/interface.ts",
+                        "!packages/dsh-notifier/src/client/**"
+                    ],
+                    "comment": "#720 静态拆段（2/3）：本段 = validators.ts 单文件 862 mutant（占原段 2366 的 36.4%），与 normalize.ts 合计 73.5%。二者单独成段而不与其余文件混装，是因为 mutant 密度与行数严重不成比例（validators.ts 324 行 / 862 mutant 对 config.ts 307 行 / 95 mutant，密度差约 8 倍）——按行数或按文件数均分都会拆错。interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                },
+                "config-rest": {
                     "mutate": [
                         "packages/dsh-notifier/src/config/config.ts",
                         "packages/dsh-notifier/src/config/migrate.ts",
-                        "packages/dsh-notifier/src/config/normalize.ts",
                         "packages/dsh-notifier/src/config/paths.ts",
                         "packages/dsh-notifier/src/config/redact.ts",
                         "packages/dsh-notifier/src/config/settings.ts",
-                        "packages/dsh-notifier/src/config/validators.ts",
                         "packages/dsh-notifier/src/config/quiet-hours.ts",
                         "packages/dsh-notifier/src/config/settings-bridge.ts"
                     ],
@@ -222,7 +240,7 @@
                         "!packages/dsh-notifier/src/**/interface.ts",
                         "!packages/dsh-notifier/src/client/**"
                     ],
-                    "comment": "#669 PR2 T2-7 按域重划：config——配置域全 9 实现（config/migrate/normalize/paths/redact/settings/validators/quiet-hours/settings-bridge；settings-bridge/quiet-hours 自 PR1 盲区并入，S3-30 修复）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#720 静态拆段（3/3）：原 config 段余下 7 实现（config/migrate/paths/redact/settings/quiet-hours/settings-bridge）合计 627 mutant（占原段 26.5%），远低于两个密度异常文件，故合并为一段。配置域划分沿用 #669 PR2 T2-7（settings-bridge/quiet-hours 自 PR1 盲区并入，S3-30 修复）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
                 },
                 "text": {
                     "mutate": [

--- a/scripts/test/baseline-archive.test.ts
+++ b/scripts/test/baseline-archive.test.ts
@@ -106,11 +106,13 @@ test('期望集合派生：dsh- 前缀剥离 + seg=0 单配置形态', () => {
   assert.deepEqual(expectedBaselineFiles(['README.md', null]), [], '非 .json 条目不得进期望集合')
 })
 
-test('期望集合与真实仓库一致：stryker.conf.d/*.json 一条不落（31 段）', () => {
+test('期望集合与真实仓库一致：stryker.conf.d/*.json 一条不落（33 段）', () => {
   const confNames = readdirSync(join(ROOT, 'stryker.conf.d')).filter((f) => f.endsWith('.json'))
   const expected = expectedBaselineFiles(confNames)
   assert.equal(expected.length, confNames.length, '每个段配置都应对应一个基线文件')
-  assert.equal(expected.length, 31, `段数应为 31，实际 ${expected.length}`)
+  // 段数为显式哨兵：拆段/合段必须同时改这里（#720 把 dsh-notifier config 段拆三段，31 → 33），
+  // 否则新增段静默漏进归档期望集合也无人察觉。
+  assert.equal(expected.length, 33, `段数应为 33，实际 ${expected.length}`)
   for (const f of expected) assert.match(f, BASELINE_FILE_RE, `文件名应匹配归档形态：${f}`)
 })
 

--- a/scripts/test/ci-matrix.test.ts
+++ b/scripts/test/ci-matrix.test.ts
@@ -26,11 +26,13 @@ test('ci-matrix: 场景 a - 正常命中单一 active 包 (via FILTER_OUTPUTS)',
   assert.deepEqual(res.buildPackages, ['dsh-notifier'], '#722：矩阵 = 命中包（有命中时）')
   assert.deepEqual(res.mutationPackages, ['dsh-notifier']);
   assert.equal(res.hasMutations, 'true');
-  // T2-7：dsh-notifier 变异 4 段 → 按域重划 8 段（S3-30/N-24；combos 字母序展开）
-  assert.equal(res.mutationCombos.length, 8);
+  // T2-7：dsh-notifier 变异 4 段 → 按域重划 8 段（S3-30/N-24）；#720 再把 config 段按
+  // mutant 密度拆为 config-normalize / config-validate / config-rest → 10 段
+  //（combos 字母序展开）
+  assert.equal(res.mutationCombos.length, 10);
   assert.deepEqual(
     res.mutationCombos.map((c) => c.seg),
-    ['channels', 'config', 'events', 'pipeline', 'sdk', 'server', 'stores', 'text']
+    ['channels', 'config-normalize', 'config-rest', 'config-validate', 'events', 'pipeline', 'sdk', 'server', 'stores', 'text']
   );
 });
 
@@ -195,7 +197,9 @@ test('ci-matrix: 场景 d - 变异段展开正确性 (单配置与多段配置)'
   assert.deepEqual(resMulti.mutationPackages, ['dsh-notifier', 'dsh-web-file-preview']);
   assert.deepEqual(resMulti.mutationCombos, [
     { package: 'dsh-notifier', seg: 'channels' },
-    { package: 'dsh-notifier', seg: 'config' },
+    { package: 'dsh-notifier', seg: 'config-normalize' },
+    { package: 'dsh-notifier', seg: 'config-rest' },
+    { package: 'dsh-notifier', seg: 'config-validate' },
     { package: 'dsh-notifier', seg: 'events' },
     { package: 'dsh-notifier', seg: 'pipeline' },
     { package: 'dsh-notifier', seg: 'sdk' },
@@ -314,7 +318,7 @@ test('ci-matrix: 场景 f - GITHUB_OUTPUT 写入契约', () => {
     assert.equal(record.hasMutations, 'true');
     assert.deepEqual(JSON.parse(record.allPackages), EXPECTED_ALL);
     const combos = JSON.parse(record.mutationCombos);
-    assert.equal(combos.length, 8);
+    assert.equal(combos.length, 10);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/stryker.conf.d/dsh-notifier-config-normalize.json
+++ b/stryker.conf.d/dsh-notifier-config-normalize.json
@@ -1,15 +1,7 @@
 {
   "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "mutate": [
-    "packages/dsh-notifier/src/config/config.ts",
-    "packages/dsh-notifier/src/config/migrate.ts",
     "packages/dsh-notifier/src/config/normalize.ts",
-    "packages/dsh-notifier/src/config/paths.ts",
-    "packages/dsh-notifier/src/config/redact.ts",
-    "packages/dsh-notifier/src/config/settings.ts",
-    "packages/dsh-notifier/src/config/validators.ts",
-    "packages/dsh-notifier/src/config/quiet-hours.ts",
-    "packages/dsh-notifier/src/config/settings-bridge.ts",
     "!packages/dsh-notifier/src/**/interface.ts",
     "!packages/dsh-notifier/src/client/**",
     "!packages/dsh-notifier/src/**/interface.ts",
@@ -44,9 +36,9 @@
     "configFile": "vitest.stryker.d/dsh-notifier.config.ts"
   },
   "jsonReporter": {
-    "fileName": "coverage/mutation/dsh-notifier-config.json"
+    "fileName": "coverage/mutation/dsh-notifier-config-normalize.json"
   },
   "incremental": true,
-  "incrementalFile": "coverage/mutation/incremental-notifier-config.json",
-  "_comment": "#669 PR2 T2-7 按域重划：config——配置域全 9 实现（config/migrate/normalize/paths/redact/settings/validators/quiet-hours/settings-bridge；settings-bridge/quiet-hours 自 PR1 盲区并入，S3-30 修复）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "incrementalFile": "coverage/mutation/incremental-notifier-config-normalize.json",
+  "_comment": "#720 静态拆段（1/3）：原 #669 PR2 T2-7 的 config 段按文件 mutant 密度拆三。本段 = normalize.ts 单文件 877 mutant（占原段 2366 的 37.1%），是 20~21 分钟关键路径的两大来源之一（#720 实测：run 34410912088 最长段 19.5 min / run 34536263640 最长段 21.2 min）。按文件拆而非按行区间（--mutate file:1-142）：行号是脆弱依赖，且会把分段 SSOT 从本文件迁进 CI matrix，扩大自研面。interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
 }

--- a/stryker.conf.d/dsh-notifier-config-normalize.json
+++ b/stryker.conf.d/dsh-notifier-config-normalize.json
@@ -40,5 +40,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-notifier-config-normalize.json",
-  "_comment": "#720 静态拆段（1/3）：原 #669 PR2 T2-7 的 config 段按文件 mutant 密度拆三。本段 = normalize.ts 单文件 877 mutant（占原段 2366 的 37.1%），是 20~21 分钟关键路径的两大来源之一（#720 实测：run 34410912088 最长段 19.5 min / run 34536263640 最长段 21.2 min）。按文件拆而非按行区间（--mutate file:1-142）：行号是脆弱依赖，且会把分段 SSOT 从本文件迁进 CI matrix，扩大自研面。interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#720 静态拆段（1/3）：原 #669 PR2 T2-7 的 config 段按文件 mutant 密度拆三。本段 = normalize.ts 单文件 877 mutant（占原段 2366 的 37.1%），是段内 mutant 的最大来源。拆段动因是密度失衡而非文件数：normalize.ts 284 行 877 mutant 对 config.ts 307 行 95 mutant（密度差约 8 倍），按行数或按文件数均分都会拆错。按文件拆而非按行区间（--mutate file:1-142）：行号是脆弱依赖，且会把分段 SSOT 从本文件迁进 CI matrix，扩大自研面。interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
 }

--- a/stryker.conf.d/dsh-notifier-config-rest.json
+++ b/stryker.conf.d/dsh-notifier-config-rest.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "mutate": [
+    "packages/dsh-notifier/src/config/config.ts",
+    "packages/dsh-notifier/src/config/migrate.ts",
+    "packages/dsh-notifier/src/config/paths.ts",
+    "packages/dsh-notifier/src/config/redact.ts",
+    "packages/dsh-notifier/src/config/settings.ts",
+    "packages/dsh-notifier/src/config/quiet-hours.ts",
+    "packages/dsh-notifier/src/config/settings-bridge.ts",
+    "!packages/dsh-notifier/src/**/interface.ts",
+    "!packages/dsh-notifier/src/client/**",
+    "!packages/dsh-notifier/src/**/interface.ts",
+    "!packages/dsh-notifier/src/**/*.d.ts",
+    "!packages/dsh-notifier/src/**/*.ps1"
+  ],
+  "testRunner": "vitest",
+  "mutator": {
+    "excludedMutations": [
+      "StringLiteral",
+      "ArrayLiteral",
+      "ObjectLiteral",
+      "TemplateLiteral"
+    ]
+  },
+  "plugins": [
+    "@stryker-mutator/vitest-runner"
+  ],
+  "concurrency": 16,
+  "timeoutMS": 60000,
+  "dryRunTimeoutMinutes": 5,
+  "reporters": [
+    "progress",
+    "clear-text",
+    "json"
+  ],
+  "coverageAnalysis": "perTest",
+  "tempDirName": ".stryker-tmp",
+  "cleanTempDir": true,
+  "vitest": {
+    "related": false,
+    "configFile": "vitest.stryker.d/dsh-notifier.config.ts"
+  },
+  "jsonReporter": {
+    "fileName": "coverage/mutation/dsh-notifier-config-rest.json"
+  },
+  "incremental": true,
+  "incrementalFile": "coverage/mutation/incremental-notifier-config-rest.json",
+  "_comment": "#720 静态拆段（3/3）：原 config 段余下 7 实现（config/migrate/paths/redact/settings/quiet-hours/settings-bridge）合计 627 mutant（占原段 26.5%），远低于两个密度异常文件，故合并为一段。配置域划分沿用 #669 PR2 T2-7（settings-bridge/quiet-hours 自 PR1 盲区并入，S3-30 修复）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+}

--- a/stryker.conf.d/dsh-notifier-config-validate.json
+++ b/stryker.conf.d/dsh-notifier-config-validate.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "mutate": [
+    "packages/dsh-notifier/src/config/validators.ts",
+    "!packages/dsh-notifier/src/**/interface.ts",
+    "!packages/dsh-notifier/src/client/**",
+    "!packages/dsh-notifier/src/**/interface.ts",
+    "!packages/dsh-notifier/src/**/*.d.ts",
+    "!packages/dsh-notifier/src/**/*.ps1"
+  ],
+  "testRunner": "vitest",
+  "mutator": {
+    "excludedMutations": [
+      "StringLiteral",
+      "ArrayLiteral",
+      "ObjectLiteral",
+      "TemplateLiteral"
+    ]
+  },
+  "plugins": [
+    "@stryker-mutator/vitest-runner"
+  ],
+  "concurrency": 16,
+  "timeoutMS": 60000,
+  "dryRunTimeoutMinutes": 5,
+  "reporters": [
+    "progress",
+    "clear-text",
+    "json"
+  ],
+  "coverageAnalysis": "perTest",
+  "tempDirName": ".stryker-tmp",
+  "cleanTempDir": true,
+  "vitest": {
+    "related": false,
+    "configFile": "vitest.stryker.d/dsh-notifier.config.ts"
+  },
+  "jsonReporter": {
+    "fileName": "coverage/mutation/dsh-notifier-config-validate.json"
+  },
+  "incremental": true,
+  "incrementalFile": "coverage/mutation/incremental-notifier-config-validate.json",
+  "_comment": "#720 静态拆段（2/3）：本段 = validators.ts 单文件 862 mutant（占原段 2366 的 36.4%），与 normalize.ts 合计 73.5%。二者单独成段而不与其余文件混装，是因为 mutant 密度与行数严重不成比例（validators.ts 324 行 / 862 mutant 对 config.ts 307 行 / 95 mutant，密度差约 8 倍）——按行数或按文件数均分都会拆错。interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+}


### PR DESCRIPTION
Fixes #720

## 动机

夜班全量班（`observe.yml`）刻意不读增量缓存（无 restore = 天然全量冷跑），墙钟由最长段封顶。
从 run 日志的 `##[group]stryker <name>` / `##[endgroup]` 边界解析逐段墙钟（口径：整段 group 墙钟，含
Stryker 启动 + 项目读取 + instrument + dry run + 变异执行，不含 install/build）：

| run | 日期 | 段数 | 最长段 | `dsh-notifier-config` |
|---|---|---|---|---|
| `34536263640` | 2026-09-10（90 分钟超时被杀） | 31 | `dsh-mcp-manager-runtime` 21.20 min | **10.26 min** |
| `34410912088` | 2026-09-09（success，旧 4 段口径） | 27 | `dsh-mcp-manager-middleware` 19.5 min | 不可比（旧段划分） |

本 PR 按 #720 评论「补充输入：`dsh-notifier · config` 段的静态拆段量化」的量化输入实施**静态拆段**，
落点依据 #718 维护者裁决 4（「#720 拆段与 S0 并行，且在 S0.1 / S0.2 之前完成」）。

## 改动清单

| 文件 | 说明 |
|---|---|
| `scripts/data/mutation-topology.json` | SSOT：`dsh-notifier` 的 `config` 段拆为 `config-normalize`(877) / `config-validate`(862) / `config-rest`(627)；三段 `excludes` 与原段逐字一致 |
| `stryker.conf.d/dsh-notifier-config.json` | 删除：拆段后无对应段，留着会被 `--check` 判为游离配置 |
| `stryker.conf.d/dsh-notifier-config-normalize.json` | 生成物（`pnpm stryker:gen`） |
| `stryker.conf.d/dsh-notifier-config-validate.json` | 生成物 |
| `stryker.conf.d/dsh-notifier-config-rest.json` | 生成物 |
| `scripts/test/baseline-archive.test.ts` | 归档段数哨兵 31 → 33 |
| `scripts/test/ci-matrix.test.ts` | notifier combos 期望 8 段 → 10 段（场景 a / 场景 d / 场景 f 三处） |

只动 SSOT 与生成物；段集合的消费方（`ci-matrix.mjs`、`mutation-gate.mjs`、`observe-check.mjs`、
`baseline-archive.mjs`、`overlay-baseline.mjs`、两个 observe workflow）全部从 `stryker.conf.d/`
动态推导，本次核对确认无需改动。

## 前置补验：#720 要求的「拆段漏文件」唯一防线

#720 评论指出该层**尚未验证**，要求先补验。补验结论：**防线已存在且真实有效，无需新增断言**。

- 断言位置：`scripts/gate/verify-dir-imports.mjs:34-36, 500-511`（`src ⊆ ∪mutate ∪ ∪excludes`），
  派生规则与生成器同源（`scripts/gate/mutation-topology.mjs` 的 `collectMutationSpecs`），
  存量登记在 `scripts/data/dir-imports-baseline.json` 的 `uncoveredSrcFiles`（6 个包全为 `[]`）。
- 执法点：`pnpm contract` → `verify-dir-imports.mjs --package dsh-mcp-manager --package dsh-notifier`
  （hard 模式，`contract-check.ts:202`），**不是** `pnpm stryker:check`。
  即 `stryker:check` 确实不覆盖该层（与 #720 评论的判断一致），但 `pnpm contract` 覆盖。

**注入实验（对抗性验证）**：临时从 `config.mutate` 删掉 `migrate.ts` 模拟拆段漏文件，跑 `pnpm contract`：

```
verify-dir-imports | FAIL 1 条硬违规：
  [dsh-notifier] 单调基线上升：[质量型] uncoveredSrcFiles: 新增未覆盖源文件 packages/dsh-notifier/src/config/migrate.ts
verify-dir-imports | FAIL exit=1
[ELIFECYCLE] Command failed with exit code 1.
```

`exit=1`，精确点名漏掉的文件。实验后已 `git checkout` 恢复（`git status --porcelain` 为空）。

## 与 #720 评论的一处偏差（实测发现）

评论称「**零脚本改动**：只改 `scripts/data/mutation-topology.json` + 跑 `pnpm stryker:gen`；
`ci-matrix.mjs`、`mutation-gate.mjs`、`workflow-assert.test.ts`、`baseline-archive.test.ts`、
两个 observe workflow 全部从 `stryker.conf.d/` 目录动态推导，已逐项实测确认无需改动」。

**脚本实现确实全部动态推导，但测试里的期望值是硬编码的**，拆段后 4 个用例判红（实测）：

```
✖ 期望集合与真实仓库一致：stryker.conf.d/*.json 一条不落（31 段）
  AssertionError [ERR_ASSERTION]: 段数应为 31，实际 33
✖ ci-matrix: 场景 a - 正常命中单一 active 包 (via FILTER_OUTPUTS)
✖ ci-matrix: 场景 d - 变异段展开正确性 (单配置与多段配置)
✖ ci-matrix: 场景 f - GITHUB_OUTPUT 写入契约
```

另有必须手工做的一步：旧 `stryker.conf.d/dsh-notifier-config.json` 不会被 `pnpm stryker:gen`
删除，留着会被 `--check` 判为「游离配置文件」。本 PR 已 `git rm`。

这三处期望值**按原强度同步**（仍精确断言段数与段名列表，未放宽为动态推导）——它们是
「段集合变化必须显式确认」的哨兵。

## 门禁（提交前逐条实跑，exit code 为真实值）

| 命令 | exit code | 备注 |
|---|---|---|
| `pnpm build` | 0 | |
| `pnpm test` | 0 | |
| `pnpm contract` | 0 | 含 `verify-dir-imports` 全覆盖断言 |
| `pnpm pack:check` | 0 | |
| `pnpm typecheck` | 0 | |
| `pnpm test:scripts` | 0 | 340 tests / 340 pass（改 `scripts/` 追加） |
| `pnpm stryker:check` | 0 | 「33 份配置与拓扑严格一致」 |
| `pnpm docs:check` | 0 | |

## 验收判据对照

| # | 判据 | 结果 | 证据 |
|---|---|---|---|
| 1 | `ls stryker.conf.d/dsh-notifier-*.json \| wc -l` = 10（原 8 + 2） | 满足 | 10 |
| 2 | `pnpm stryker:check` exit 0 | 满足 | exit 0，「33 份配置与拓扑严格一致」 |
| 3 | `pnpm test:scripts` exit 0 | 满足 | exit 0，340/340 |
| 4 | 新 3 段耗时 vs 拆段前 config 段（注明口径） | 见下节 | 分子分母同口径 |
| 5 | 产物零污染 | 满足 | `git status --porcelain \| grep -E 'undefined/\|\.jsonl$'` 为空 |

## 耗时对比（口径分别标注）

拆段只改变「一段内的 mutant 如何分组」，不改变任何 mutant 的杀灭判定：三段 `excludes` 与原段逐字一致，
mutate 并集与原段逐字相同（由前节的全覆盖断言兜住）。三段 mutant 数由 instrument 阶段实测：

| 段 | mutants（instrumenter 实测） | 占原段 |
|---|---|---|
| `dsh-notifier-config-normalize` | 877 | 37.1% |
| `dsh-notifier-config-validate` | 862 | 36.4% |
| `dsh-notifier-config-rest` | 627 | 26.5% |
| 合计 | 2366 | 100% |

三个数与 #720 评论的预测量化逐个吻合（CI 侧增量报告为 2365，差 1 属主干漂移）。

拆段前的 CI 真实基线（从 run 日志的 `##[group]stryker <name>` 与配对 `##[endgroup]` 边界解析；
口径 = **整段 group 墙钟**，含 Stryker 启动、项目读取、instrument、dry run、变异执行、报告落盘，不含 install / build）：

| 口径 | run | 环境 | `dsh-notifier-config` |
|---|---|---|---|
| A：全量冷跑（夜班 `observe.yml`） | `34536263640` | CI 4 vCPU / concurrency 16 / 无 baseline | **10.26 min** |
| B：增量（`observe-incremental.yml`） | `34579060425` | CI 4 vCPU / concurrency 16 / 有 baseline | **0.25 min**（复用 1986/2365 = 84.0%） |

**拆段后的 CI 耗时待产出，本 PR 不填本地数字充数**：PR 侧 `mutation-gate` 当前仍受 `fullGate` 门控
（`.github/workflows/ci.yml`），PR 默认不跑变异，故本 PR 的 CI run 中该 job 为 skipped。该门控正是
#742 阶段 1.1 要删除的项（改为「PR 且 `hasMutations=true` → mutation 不得 skipped」，按
`baseline/mutation` 孤立分支增量跑）；#718 S1 落地（变异矩阵化 + `max-parallel: 5`）后，新 3 段的
CI 耗时将由每次 PR 与每班全量自然产出，无需本地测量。

本机数据仅用于确认 mutant 分布（上表）：本机为 8 线程低压移动 CPU，与 CI runner 不同级，实测约 4 倍差距，
绝对值与 CI 不可比，故不作为验收证据。
