### PR TITLE
fix(gate): pack-check 聚合段按切片口径门控 + local-gate 前置构建实参拼接

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,6 +47,7 @@
 - `test/collect-licenses.test.ts` — collect-licenses 脚本自测。
 - `test/crap-check.test.ts` — crap-check 脚本自测（config.strict 单一开关；#722 阶段五起含「非 src 口径数据必须 fail-closed」用例）。
 - `test/threshold-monotonic.test.ts` — 阈值单调性自测（#722：vitest.config.ts 的 coverage.thresholds 提取、降线判红、缺块 fail-closed）。
+- `test/pack-check-scope.test.ts` — pack-check 聚合段切片口径自测（#722：增量切片下不得对未构建的聚合包假红；全仓口径必须仍执行该段，缺产物 fail-loud）。
 
 ## data/（配置数据）
 

--- a/scripts/gate/local-gate.mjs
+++ b/scripts/gate/local-gate.mjs
@@ -85,7 +85,9 @@ function tierSteps(tier, { hitPackages, withCoverage }) {
   ]
   const prereqStep = {
     label: `build 编译面前置包（test:scripts 依赖：${PREREQ_PACKAGES.join(', ')}）`,
-    args: [...PREREQ_PACKAGES.map((p) => `--filter @wingsky-1/${p}...`), 'build'],
+    // --filter 与取值必须是两个独立 argv 元素（与本文件其余步骤同写法）；拼成单个
+    // 字符串会被 pnpm 当成一个未知选项：Unknown options: 'filter @wingsky-1/<pkg>...'
+    args: [...PREREQ_PACKAGES.flatMap((p) => ['--filter', `@wingsky-1/${p}...`]), 'build'],
   }
   const scriptsSelfTest = { label: 'test:scripts（门禁脚本自测）', args: ['test:scripts'] }
 

--- a/scripts/gate/pack-check.ts
+++ b/scripts/gate/pack-check.ts
@@ -212,42 +212,60 @@ for (const p of targets) {
   }
 }
 // 聚合包专项：dsh-plugins-all tarball 完整性 + 聚合 patch 与子包一致（防 P6 复发）
+//
+// 本段是**产物级**断言：`pnpm --filter dsh-plugins-all pack` 要求聚合包已构建（lib/index.js），
+// 而聚合包由 `pnpm build` 产出、不由本脚本产出。故必须与上方逐包循环共用**同一个切片口径**
+// （#722 门禁分层）：
+//   - 全仓口径（未传 --packages，或聚合包在切片内）：本段执行，覆盖不变；
+//   - 增量切片（--packages 命中的是真子集）：本段跳过——此时聚合包未构建，执行必然假红。
+//     全仓覆盖不因此丢失：夜间 observe.yml 的「Pack check（全仓）」与 release.yml 均无切片，
+//     两者都会执行本段（observe.yml 注释即声明「全仓产物闸必须在这里落地」）。
+// 历史：本段此前不受切片控制，凡 HIT_PACKAGES 不含聚合包的 PR 都会假红（PR #747 首次触发）。
 {
   const AGG = 'dsh-plugins-all'
-  const tmp = mkdtempSync(join(tmpdir(), 'dsh-pack-agg-'))
-  const aggName = JSON.parse(readFileSync(join(ROOT, 'packages', AGG, 'package.json'), 'utf8')).name
-  try {
-    execFileSync('pnpm', ['--filter', aggName, 'pack', '--pack-destination', tmp], { cwd: ROOT, stdio: 'pipe' })
-    const tgz = readdirSync(tmp).find(f => f.endsWith('.tgz'))
-    execFileSync('tar', tarArgs(['-xzf', join(tmp, tgz), '-C', tmp]))
-    const pkgRoot = join(tmp, 'package')
-    const problems = []
-    if (!existsSync(join(pkgRoot, 'lib', 'index.js'))) problems.push('缺 lib/index.js')
-    const patch = existsSync(join(pkgRoot, 'cordis.patch.yml')) ? readFileSync(join(pkgRoot, 'cordis.patch.yml'), 'utf8') : ''
-    if (!patch) problems.push('缺 cordis.patch.yml')
-    // 聚合行/依赖与 manifest.active 双向相等（issue #36：deps「多」也会 fail-loud）
-    if (patch) {
-      const aggRows = [...patch.matchAll(/^\s*- id:\s*(\S+)/gm)].map(m => m[1])
-      const deps = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8')).dependencies ?? {}
-      // 期望聚合 id 集 = 各 active 子包 cordis.patch.yml 的实际 insert id
-      // （客户端插件 ui-<dir>，纯宿主插件如 dsh-verify-isolated 用 skill- 前缀；
-      //   与 aggregate.ts「子包行原样拼接」语义一致，不硬编码 ui-）
-      const expectedPatchIds = []
-      for (const dir of manifest.active) {
-        const childPatch = join(ROOT, 'packages', dir, 'cordis.patch.yml')
-        const childText = existsSync(childPatch) ? readFileSync(childPatch, 'utf8') : ''
-        expectedPatchIds.push(...[...childText.matchAll(/^\s*-\s+id:\s*(\S+)/gm)].map(m => m[1]))
-      }
-      problems.push(...checkAggregateConsistency({ dirNames: plugins, manifest, aggDeps: deps, aggPatchIds: aggRows, expectedPatchIds }))
-      if (/^\s*config:/m.test(patch)) problems.push('聚合行带 config（应走 schema 默认值）')
-    }
-    if (problems.length > 0) failed++
-    console.log(`${problems.length === 0 ? 'PASS' : 'FAIL'} ${aggName} | ${problems.join('; ') || '聚合 tarball 完整且与子包一致'}`)
-  } catch (e) {
+  const inScope = scoped === null || scoped.includes(AGG)
+  if (!inScope) {
+    console.log(`[pack-check] 聚合包专项跳过：不在 --packages 切片内（本闸逐包范围：${targets.join(', ') || '（空）'}）；全仓口径由 observe.yml / release.yml 覆盖`)
+  } else if (!existsSync(join(ROOT, 'packages', AGG, 'lib', 'index.js'))) {
+    // 产物前提缺失时给出可诊断原因，而不是让 pnpm pack 抛裸错误（artifact 链路静默丢包时同此）
     failed++
-    console.log(`FAIL ${aggName} | ${String(e.message).split('\n')[0]}`)
-  } finally {
-    rmSync(tmp, { recursive: true, force: true })
+    console.log(`FAIL ${AGG} | 缺 packages/${AGG}/lib/index.js —— 本段是产物级断言，需先构建聚合包（全仓口径用 pnpm build；增量口径须把 ${AGG} 纳入 HIT_PACKAGES）`)
+  } else {
+    const tmp = mkdtempSync(join(tmpdir(), 'dsh-pack-agg-'))
+    const aggName = JSON.parse(readFileSync(join(ROOT, 'packages', AGG, 'package.json'), 'utf8')).name
+    try {
+      execFileSync('pnpm', ['--filter', aggName, 'pack', '--pack-destination', tmp], { cwd: ROOT, stdio: 'pipe' })
+      const tgz = readdirSync(tmp).find(f => f.endsWith('.tgz'))
+      execFileSync('tar', tarArgs(['-xzf', join(tmp, tgz), '-C', tmp]))
+      const pkgRoot = join(tmp, 'package')
+      const problems = []
+      if (!existsSync(join(pkgRoot, 'lib', 'index.js'))) problems.push('缺 lib/index.js')
+      const patch = existsSync(join(pkgRoot, 'cordis.patch.yml')) ? readFileSync(join(pkgRoot, 'cordis.patch.yml'), 'utf8') : ''
+      if (!patch) problems.push('缺 cordis.patch.yml')
+      // 聚合行/依赖与 manifest.active 双向相等（issue #36：deps「多」也会 fail-loud）
+      if (patch) {
+        const aggRows = [...patch.matchAll(/^\s*- id:\s*(\S+)/gm)].map(m => m[1])
+        const deps = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8')).dependencies ?? {}
+        // 期望聚合 id 集 = 各 active 子包 cordis.patch.yml 的实际 insert id
+        // （客户端插件 ui-<dir>，纯宿主插件如 dsh-verify-isolated 用 skill- 前缀；
+        //   与 aggregate.ts「子包行原样拼接」语义一致，不硬编码 ui-）
+        const expectedPatchIds = []
+        for (const dir of manifest.active) {
+          const childPatch = join(ROOT, 'packages', dir, 'cordis.patch.yml')
+          const childText = existsSync(childPatch) ? readFileSync(childPatch, 'utf8') : ''
+          expectedPatchIds.push(...[...childText.matchAll(/^\s*-\s+id:\s*(\S+)/gm)].map(m => m[1]))
+        }
+        problems.push(...checkAggregateConsistency({ dirNames: plugins, manifest, aggDeps: deps, aggPatchIds: aggRows, expectedPatchIds }))
+        if (/^\s*config:/m.test(patch)) problems.push('聚合行带 config（应走 schema 默认值）')
+      }
+      if (problems.length > 0) failed++
+      console.log(`${problems.length === 0 ? 'PASS' : 'FAIL'} ${aggName} | ${problems.join('; ') || '聚合 tarball 完整且与子包一致'}`)
+    } catch (e) {
+      failed++
+      console.log(`FAIL ${aggName} | ${String(e.message).split('\n')[0]}`)
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
   }
 }
 console.log(failed === 0 ? '\npack-check：全部通过' : `\npack-check：${failed} 个失败`)

--- a/scripts/test/pack-check-scope.test.ts
+++ b/scripts/test/pack-check-scope.test.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * pack-check 聚合段切片口径的回归（#722 门禁分层 / PR #747 实证）。
+ *
+ * 为什么存在：`pack-check.ts` 的聚合包专项是**产物级**断言（要 `dsh-plugins-all/lib/index.js`），
+ * 而聚合包由 `pnpm build` 产出、不由本脚本产出。它此前不受 `--packages` 切片控制，于是
+ * 「HIT_PACKAGES 不含聚合包」的 PR（改单个插件包、纯文档 PR 等）会在 CI 上假红——
+ * 而这正是本仓大多数 PR 的形态，属比「漏检」更难发现的**假红**失败模式。
+ *
+ * 本测试锁死两条语义，缺一不可：
+ *   1. 增量切片（--packages 命中的是真子集）⇒ 聚合段**不执行**，且不得报 FAIL；
+ *   2. 全仓口径（未传 --packages）⇒ 聚合段**必须执行**（缺产物时 fail-loud，不得静默跳过）。
+ * 第 2 条防的是「修第 1 条时把全仓覆盖一并删掉」——那会把切片代价从假红变成真漏检。
+ *
+ * 产物前提：`test:scripts` 只保证 `script-test-prereqs.mjs` 登记的包被构建，**不含聚合包**。
+ * 故全仓口径的用例对「产物在 / 不在」两种情形分别断言，不假定聚合包已被构建
+ * （与 pack-check 自身的 fail-loud 语义一致）。
+ *
+ * 成本：全仓口径会真实 `pnpm pack` 各包（约 12-15s），故该口径只在模块内跑一次、共享结果。
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const PACK_CHECK = join(ROOT, 'scripts', 'gate', 'pack-check.ts')
+
+/** 跑 pack-check 并返回 { status, stdout }（非 0 也要拿到输出，不抛）。 */
+function runPackCheck(args) {
+  try {
+    const stdout = execFileSync(process.execPath, [PACK_CHECK, ...args], { cwd: ROOT, encoding: 'utf8', stdio: 'pipe' })
+    return { status: 0, stdout }
+  } catch (e) {
+    return { status: e.status ?? 1, stdout: `${e.stdout ?? ''}` }
+  }
+}
+
+test('增量切片：聚合段不执行，且不报 FAIL（修的是假红，不是放宽判据）', () => {
+  // 切片取真子集（不含 dsh-plugins-all）：这正是 CI 上改单个插件包时的形态。
+  const { status, stdout } = runPackCheck(['--packages', 'dsh-verify-isolated'])
+  assert.equal(status, 0, `增量切片应 exit 0，实际 ${status}\n${stdout}`)
+  assert.match(stdout, /聚合包专项跳过/, '应明示聚合段被切片跳过——口径可见，避免被误读为「已检查」')
+  assert.doesNotMatch(stdout, /FAIL dsh-plugins-all/, '切片下不得对聚合包报 FAIL')
+})
+
+test('增量切片（切片内含聚合包）：聚合段仍执行，不因门控被误跳过', () => {
+  const { stdout } = runPackCheck(['--packages', 'dsh-plugins-all'])
+  assert.doesNotMatch(stdout, /聚合包专项跳过/, '聚合包在切片内时不得跳过')
+  assert.match(stdout, /(PASS|FAIL) @wingsky-1\/dsh-plugins-all/, '聚合包在切片内时必须进入聚合段')
+})
+
+test('全仓口径：聚合段必须执行，且产物缺失时 fail-loud 可诊断', () => {
+  // 全仓口径只跑一次（真实 pack 各包，约 12-15s）：三条断言共享同一份输出。
+  const { stdout } = runPackCheck([])
+  assert.doesNotMatch(stdout, /聚合包专项跳过/, '全仓口径不得跳过聚合段——这是夜间/发版覆盖的唯一入口')
+  assert.match(stdout, /(PASS|FAIL) @wingsky-1\/dsh-plugins-all/, '全仓口径必须进入聚合段')
+  if (/PASS @wingsky-1\/dsh-plugins-all/.test(stdout)) return
+  // 产物缺失分支（test:scripts 不保证聚合包已构建）：须给出可诊断原因而非 pnpm 裸错误
+  assert.match(stdout, /缺 packages\/dsh-plugins-all\/lib\/index\.js/, '缺产物须给出可诊断原因，而非 pnpm 裸错误')
+  assert.match(stdout, /本段是产物级断言/, '须显式声明本段的产物前提')
+})


### PR DESCRIPTION
## 说明

修复两处「**产物级断言与产物口径不一致**」导致的 **CI/本地假红**。两处都与 PR 改动内容无关——也就是说，它们会让正常的 PR 被误判为坏，属比「漏检」更难发现的失败模式。

载体：`Part of #744`（架构重构的判据地基需要在健康门禁上推进；本 PR 不涉及产品代码）。

## 改动

### 1. `scripts/gate/pack-check.ts` — 聚合包专项不受 `--packages` 切片控制

**症状**（CI `Build / Contract / Smoke / Pack`，PR #747 首次触发）：

```
FAIL @wingsky-1/dsh-plugins-all | 缺 lib/index.js
pack-check：1 个失败
```

**根因**：聚合段是**产物级**断言（需要 `packages/dsh-plugins-all/lib/index.js`），而聚合包由 `pnpm build` 产出、不由本脚本产出。但切片只作用于上方逐包循环：

```js
const scoped  = resolvePackageScopeOrExit(process.argv.slice(2), [...plugins, AGGREGATE_NAME])
const targets = scoped === null ? plugins : plugins.filter((p) => scoped.includes(p))   // ← 只作用于逐包循环
...
{ const AGG = 'dsh-plugins-all'   // ← 无条件执行，未共用 scoped
  execFileSync('pnpm', ['--filter', aggName, 'pack', ...]) }
```

该 job 只构建 `HIT_PACKAGES` 命中包（`prepare-package-outputs` 同步按命中包切片），故命中包不含聚合包时其产物必然不存在。

**为何此前未暴露**：本仓大多数 PR 会改到 global 面（`shared/**`、`scripts/**`、`.github/**`、根级 `package.json` / `pnpm-lock.yaml` / `pnpm-workspace.yaml` / `tsconfig.base.json`），`ci-matrix.mjs:72` 的 `shouldFallback = globalHit || ...` 随即**全量回退** ⇒ HIT 含全部包 ⇒ 聚合包被构建。只有「只改单个插件包」的 PR 才命中——而 `docs/**` 与单包路径**刻意不在** global 面（`ci.yml:97` 注释）。

**与脚本自身设计意图的冲突**：`pack-check.ts:61-64` 注释逐字写明「聚合包…**不在逐包 pack 循环内**…其一致性由 `checkAggregateConsistency` 覆盖」，但紧随其后的段又对它做了一次需要产物的 pack。

**修法**（选项 A：既修假红、又不放宽判据、且不丢全仓覆盖）：

1. 聚合段与逐包循环**共用同一 `scoped` 口径**；
2. 产物前提缺失时 **fail-loud 并给出可诊断原因**（覆盖「artifact 链路静默丢包」），而非让 `pnpm pack` 抛裸错误；
3. **全仓覆盖不丢**：未传 `--packages` 时本段照旧执行——夜间 `observe.yml` 的「Pack check（全仓）」与 `release.yml` 都是无切片口径，两处都会执行本段（`observe.yml:64` 注释即声明「全仓产物闸必须在这里落地」）。

### 2. `scripts/gate/local-gate.mjs` — 前置构建步骤的 `--filter` 与取值拼成单个字符串

**症状**：`pnpm gate:pr` 的「build 编译面前置包」**恒失败**，且因 fail-fast 连带 `test:scripts` 被跳过（`exit=skip`）：

```
[ERROR] Unknown options: 'filter @wingsky-1/dsh-notifier...', 'filter @wingsky-1/dsh-mcp-manager...'
```

**根因**：`:88` 用模板字符串把 `--filter` 与取值并成了**一个 argv 元素**：

```js
args: [...PREREQ_PACKAGES.map((p) => `--filter @wingsky-1/${p}...`), 'build'],   // ← 单元素
```

而本文件其余步骤都是两个独立元素（`:97` / `:99` 的 `['--filter', f]`）。同文件内写法不一致，属笔误。

**修法**：`flatMap` 产出 `['--filter', spec]` 两个独立元素。

## 验证

```
pnpm gate:pr                                          exit=0
  └── 27 步全绿，含此前恒失败的两步：
      exit=0  build 编译面前置包（test:scripts 依赖：dsh-notifier, dsh-mcp-manager）
      exit=0  test:scripts（门禁脚本自测）
[local-gate] 结果：PASS

node --test scripts/test/pack-check-scope.test.ts      exit=0（3/3）
  ✔ 增量切片：聚合段不执行，且不报 FAIL（修的是假红，不是放宽判据）
  ✔ 增量切片（切片内含聚合包）：聚合段仍执行，不因门控被误跳过
  ✔ 全仓口径：聚合段必须执行，且产物缺失时 fail-loud 可诊断
```

**四种路径实测**（`pack-check.ts` 直接驱动）：

| 口径 | 聚合包产物 | 聚合段行为 | exit |
|---|---|---|---|
| 全仓（无 `--packages`） | 就位 | 执行 → `PASS @wingsky-1/dsh-plugins-all` | 0 |
| 切片（`--packages dsh-mcp-manager`） | 就位 | 跳过（打印口径说明） | 0 |
| 切片（`--packages dsh-mcp-manager`） | **缺失** | 跳过 | 0 ← **原缺陷即此条假红** |
| 全仓（无 `--packages`） | **缺失** | `FAIL … 缺 packages/dsh-plugins-all/lib/index.js —— 本段是产物级断言…` | 1 |

### 回归测试设计取舍

`test:scripts` 只保证 `script-test-prereqs.mjs` 登记的包（`dsh-notifier` / `dsh-mcp-manager`）被构建，**不含聚合包**，故全仓口径的用例对「产物在 / 不在」两种情形分别断言，不假定聚合包已构建——与 `pack-check` 自身的 fail-loud 语义一致。全仓口径真实 `pnpm pack` 各包（约 12-20s），故该口径在模块内只跑一次、共享输出。

## 边界

- 不改产品代码（`packages/**` 零改动）；不改 `.github/**`（本仓红线）。
- **不放宽任何判据**：全仓口径下聚合段的断言强度不变，只是不再在「聚合包本就未构建」的切片场景下假红。

### 客户端改动截图证据（勾选式）

- [x] **不涉及客户端改动**（未改动 `src/client/**`、`src/client/style.css`、客户端产物 `lib/client.js`）
- [ ] 涉及客户端改动，已在隔离环境实测并归档截图
