### PR TITLE
fix(gate): #751 重做 pack-check 切片口径修复——测试改取 PREREQ 包并统一标识形态

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,6 +47,7 @@
 - `test/collect-licenses.test.ts` — collect-licenses 脚本自测。
 - `test/crap-check.test.ts` — crap-check 脚本自测（config.strict 单一开关；#722 阶段五起含「非 src 口径数据必须 fail-closed」用例）。
 - `test/threshold-monotonic.test.ts` — 阈值单调性自测（#722：vitest.config.ts 的 coverage.thresholds 提取、降线判红、缺块 fail-closed）。
+- `test/pack-check-scope.test.ts` — pack-check 聚合段切片口径自测（#722/#751：增量切片下不得对未构建的聚合包假红；全仓口径必须仍执行该段，缺产物 fail-loud 且 exit 与判定自洽；切片用例取 `script-test-prereqs.mjs` 的 PREREQ 包——取清单外的包会把假红从 pack:check 搬进 test:scripts）。
 
 ## data/（配置数据）
 

--- a/scripts/gate/local-gate.mjs
+++ b/scripts/gate/local-gate.mjs
@@ -85,7 +85,9 @@ function tierSteps(tier, { hitPackages, withCoverage }) {
   ]
   const prereqStep = {
     label: `build 编译面前置包（test:scripts 依赖：${PREREQ_PACKAGES.join(', ')}）`,
-    args: [...PREREQ_PACKAGES.map((p) => `--filter @wingsky-1/${p}...`), 'build'],
+    // --filter 与取值必须是两个独立 argv 元素（与本文件其余步骤同写法）；拼成单个
+    // 字符串会被 pnpm 当成一个未知选项：Unknown options: 'filter @wingsky-1/<pkg>...'
+    args: [...PREREQ_PACKAGES.flatMap((p) => ['--filter', `@wingsky-1/${p}...`]), 'build'],
   }
   const scriptsSelfTest = { label: 'test:scripts（门禁脚本自测）', args: ['test:scripts'] }
 

--- a/scripts/gate/pack-check.ts
+++ b/scripts/gate/pack-check.ts
@@ -68,7 +68,7 @@ const targets = scoped === null ? plugins : plugins.filter((p) => scoped.include
 if (scoped !== null) {
   const notIterated = scoped.filter((p) => !plugins.includes(p))
   console.log(`[pack-check] 打包切片：${targets.length}/${plugins.length} 包（--packages ${scoped.join(',') || '（空）'}）`
-    + (notIterated.length > 0 ? `；${notIterated.join(', ')} 不在本闸逐包检查范围（聚合包一致性由 plugins-manifest 检查覆盖）` : ''))
+    + (notIterated.length > 0 ? `；${notIterated.join(', ')} 不在本闸逐包检查范围（聚合 patch 与依赖一致性由 aggregate:check 恒跑覆盖；本段的产物级断言见下方聚合包专项）` : ''))
 }
 // shared 声明副本期望清单（issue #461 L2）：仓库 shared/ 全部 .d.ts（递归含子目录）
 // 随包逐一断言——新增 shared 子目录/文件（如 client/i18n.d.ts）自动纳入，防漏打包静默
@@ -218,42 +218,68 @@ for (const p of targets) {
   }
 }
 // 聚合包专项：dsh-plugins-all tarball 完整性 + 聚合 patch 与子包一致（防 P6 复发）
+//
+// 本段是**产物级**断言：`pnpm --filter dsh-plugins-all pack` 要求聚合包已构建（lib/index.js），
+// 而聚合包由 `pnpm build` 产出、不由本脚本产出。故必须与上方逐包循环共用**同一个切片口径**
+// （#722 门禁分层）：
+//   - 全仓口径（未传 --packages，或聚合包在切片内）：本段执行，覆盖不变；
+//   - 增量切片（--packages 命中的是真子集）：本段跳过——此时聚合包未构建，执行必然假红。
+//     全仓覆盖不因此丢失：夜间 observe.yml 的「Pack check（全仓）」与 release.yml 均无切片，
+//     两者都会执行本段（observe.yml 注释即声明「全仓产物闸必须在这里落地」）。
+// 历史：本段此前不受切片控制，凡 HIT_PACKAGES 不含聚合包的 PR 都会假红（PR #747 首次触发）。
 {
   const AGG = 'dsh-plugins-all'
-  const tmp = mkdtempSync(join(tmpdir(), 'dsh-pack-agg-'))
-  const aggName = JSON.parse(readFileSync(join(ROOT, 'packages', AGG, 'package.json'), 'utf8')).name
+  const inScope = scoped === null || scoped.includes(AGG)
+  // aggName 提到分支之前：缺产物分支与正常分支必须打印**同一标识形态**。目录名与 npm
+  // 包名混用会让日志与断言口径分叉——回归测试只认包名形态，而缺产物分支打目录名，
+  // 在增量口径下判红（#751）。读 package.json 失败时退回目录名，由产物前提检查判红。
+  let aggName = AGG
   try {
-    execFileSync('pnpm', ['--filter', aggName, 'pack', '--pack-destination', tmp], { cwd: ROOT, stdio: 'pipe' })
-    const tgz = readdirSync(tmp).find(f => f.endsWith('.tgz'))
-    execFileSync('tar', tarArgs(['-xzf', join(tmp, tgz), '-C', tmp]))
-    const pkgRoot = join(tmp, 'package')
-    const problems = []
-    if (!existsSync(join(pkgRoot, 'lib', 'index.js'))) problems.push('缺 lib/index.js')
-    const patch = existsSync(join(pkgRoot, 'cordis.patch.yml')) ? readFileSync(join(pkgRoot, 'cordis.patch.yml'), 'utf8') : ''
-    if (!patch) problems.push('缺 cordis.patch.yml')
-    // 聚合行/依赖与 manifest.active 双向相等（issue #36：deps「多」也会 fail-loud）
-    if (patch) {
-      const aggRows = [...patch.matchAll(/^\s*- id:\s*(\S+)/gm)].map(m => m[1])
-      const deps = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8')).dependencies ?? {}
-      // 期望聚合 id 集 = 各 active 子包 cordis.patch.yml 的实际 insert id
-      // （客户端插件 ui-<dir>，纯宿主插件如 dsh-verify-isolated 用 skill- 前缀；
-      //   与 aggregate.ts「子包行原样拼接」语义一致，不硬编码 ui-）
-      const expectedPatchIds = []
-      for (const dir of manifest.active) {
-        const childPatch = join(ROOT, 'packages', dir, 'cordis.patch.yml')
-        const childText = existsSync(childPatch) ? readFileSync(childPatch, 'utf8') : ''
-        expectedPatchIds.push(...[...childText.matchAll(/^\s*-\s+id:\s*(\S+)/gm)].map(m => m[1]))
-      }
-      problems.push(...checkAggregateConsistency({ dirNames: plugins, manifest, aggDeps: deps, aggPatchIds: aggRows, expectedPatchIds }))
-      if (/^\s*config:/m.test(patch)) problems.push('聚合行带 config（应走 schema 默认值）')
-    }
-    if (problems.length > 0) failed++
-    console.log(`${problems.length === 0 ? 'PASS' : 'FAIL'} ${aggName} | ${problems.join('; ') || '聚合 tarball 完整且与子包一致'}`)
-  } catch (e) {
+    aggName = JSON.parse(readFileSync(join(ROOT, 'packages', AGG, 'package.json'), 'utf8')).name
+  } catch {
+    // 读失败不在此判红：产物前提检查会以目录名标识判红，避免同一故障计两次
+  }
+  if (!inScope) {
+    console.log(`[pack-check] 聚合包专项跳过：不在 --packages 切片内（本闸逐包范围：${targets.join(', ') || '（空）'}）；全仓口径由 observe.yml / release.yml 覆盖`)
+  } else if (!existsSync(join(ROOT, 'packages', AGG, 'lib', 'index.js'))) {
+    // 产物前提缺失时给出可诊断原因，而不是让 pnpm pack 抛裸错误（artifact 链路静默丢包时同此）
     failed++
-    console.log(`FAIL ${aggName} | ${String(e.message).split('\n')[0]}`)
-  } finally {
-    rmSync(tmp, { recursive: true, force: true })
+    console.log(`FAIL ${aggName} | 缺 packages/${AGG}/lib/index.js —— 本段是产物级断言，需先构建聚合包（全仓口径用 pnpm build；增量口径须把 ${AGG} 纳入 HIT_PACKAGES）`)
+  } else {
+    const tmp = mkdtempSync(join(tmpdir(), 'dsh-pack-agg-'))
+    try {
+      execFileSync('pnpm', ['--filter', aggName, 'pack', '--pack-destination', tmp], { cwd: ROOT, stdio: 'pipe' })
+      const tgz = readdirSync(tmp).find(f => f.endsWith('.tgz'))
+      execFileSync('tar', tarArgs(['-xzf', join(tmp, tgz), '-C', tmp]))
+      const pkgRoot = join(tmp, 'package')
+      const problems = []
+      if (!existsSync(join(pkgRoot, 'lib', 'index.js'))) problems.push('缺 lib/index.js')
+      const patch = existsSync(join(pkgRoot, 'cordis.patch.yml')) ? readFileSync(join(pkgRoot, 'cordis.patch.yml'), 'utf8') : ''
+      if (!patch) problems.push('缺 cordis.patch.yml')
+      // 聚合行/依赖与 manifest.active 双向相等（issue #36：deps「多」也会 fail-loud）
+      if (patch) {
+        const aggRows = [...patch.matchAll(/^\s*- id:\s*(\S+)/gm)].map(m => m[1])
+        const deps = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8')).dependencies ?? {}
+        // 期望聚合 id 集 = 各 active 子包 cordis.patch.yml 的实际 insert id
+        // （客户端插件 ui-<dir>，纯宿主插件如 dsh-verify-isolated 用 skill- 前缀；
+        //   与 aggregate.ts「子包行原样拼接」语义一致，不硬编码 ui-）
+        const expectedPatchIds = []
+        for (const dir of manifest.active) {
+          const childPatch = join(ROOT, 'packages', dir, 'cordis.patch.yml')
+          const childText = existsSync(childPatch) ? readFileSync(childPatch, 'utf8') : ''
+          expectedPatchIds.push(...[...childText.matchAll(/^\s*-\s+id:\s*(\S+)/gm)].map(m => m[1]))
+        }
+        problems.push(...checkAggregateConsistency({ dirNames: plugins, manifest, aggDeps: deps, aggPatchIds: aggRows, expectedPatchIds }))
+        if (/^\s*config:/m.test(patch)) problems.push('聚合行带 config（应走 schema 默认值）')
+      }
+      if (problems.length > 0) failed++
+      console.log(`${problems.length === 0 ? 'PASS' : 'FAIL'} ${aggName} | ${problems.join('; ') || '聚合 tarball 完整且与子包一致'}`)
+    } catch (e) {
+      failed++
+      console.log(`FAIL ${aggName} | ${String(e.message).split('\n')[0]}`)
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
   }
 }
 console.log(failed === 0 ? '\npack-check：全部通过' : `\npack-check：${failed} 个失败`)

--- a/scripts/test/pack-check-scope.test.ts
+++ b/scripts/test/pack-check-scope.test.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * pack-check 聚合段切片口径的回归（#722 门禁分层；PR #747 实证；#751 修复）。
+ *
+ * 为什么存在：`pack-check.ts` 的聚合包专项是**产物级**断言（要 `dsh-plugins-all/lib/index.js`），
+ * 而聚合包由 `pnpm build` 产出、不由本脚本产出。它此前不受 `--packages` 切片控制，于是
+ * 「HIT_PACKAGES 不含聚合包」的 PR（改单个插件包、纯文档 PR 等）会在 CI 上假红——
+ * 而这正是本仓大多数 PR 的形态，属比「漏检」更难发现的**假红**失败模式。
+ *
+ * 本测试锁死两条语义，缺一不可：
+ *   1. 增量切片（--packages 命中的是真子集）⇒ 聚合段**不执行**，且不得报 FAIL；
+ *   2. 全仓口径（未传 --packages）⇒ 聚合段**必须执行**（缺产物时 fail-loud，不得静默跳过）。
+ * 第 2 条防的是「修第 1 条时把全仓覆盖一并删掉」——那会把切片代价从假红变成真漏检。
+ *
+ * 产物前提（#751 修正）：`test:scripts` 只保证 `script-test-prereqs.mjs` 登记的包被构建
+ * （dsh-notifier / dsh-mcp-manager）。据此有两条硬约束：
+ *   - 切片用例必须取 **PREREQ 包**。取清单外的包（如 dsh-verify-isolated）会在 CI 增量口径
+ *     （只还原 HIT 产物 + 只构建 PREREQ 包）下因该包无产物而判红，把假红从 pack:check
+ *     原样搬到 test:scripts——这正是 #749 的缺陷形态。
+ *   - 聚合包**不在** PREREQ 清单内，故聚合段用例对「产物在 / 不在」两种情形分别断言，
+ *     不假定聚合包已构建（与 pack-check 自身的 fail-loud 语义一致）。
+ *
+ * 成本：全仓口径会真实 `pnpm pack` 各包（约 12-15s），故该口径只在模块内跑一次、共享结果。
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const PACK_CHECK = join(ROOT, 'scripts', 'gate', 'pack-check.ts')
+
+/** 切片代表包：取自 `script-test-prereqs.mjs` 的 PREREQ 清单（见文件头「产物前提」）。 */
+const SLICE_PKG = 'dsh-notifier'
+
+/** 聚合段判定形态：PASS/FAIL 后跟 npm 包名——缺产物分支与正常分支已统一为该形态（#751）。 */
+const AGG_VERDICT = /(PASS|FAIL) @wingsky-1\/dsh-plugins-all/
+const AGG_PASS = /PASS @wingsky-1\/dsh-plugins-all/
+
+/** 跑 pack-check 并返回 { status, stdout }（非 0 也要拿到输出，不抛）。 */
+function runPackCheck(args) {
+  try {
+    const stdout = execFileSync(process.execPath, [PACK_CHECK, ...args], { cwd: ROOT, encoding: 'utf8', stdio: 'pipe' })
+    return { status: 0, stdout }
+  } catch (e) {
+    return { status: e.status ?? 1, stdout: `${e.stdout ?? ''}` }
+  }
+}
+
+test('增量切片：聚合段不执行，且不报 FAIL（修的是假红，不是放宽判据）', () => {
+  // 切片取真子集（不含 dsh-plugins-all）：这正是 CI 上改单个插件包时的形态。
+  const { status, stdout } = runPackCheck(['--packages', SLICE_PKG])
+  assert.equal(status, 0, `增量切片应 exit 0，实际 ${status}\n${stdout}`)
+  assert.match(stdout, /聚合包专项跳过/, '应明示聚合段被切片跳过——口径可见，避免被误读为「已检查」')
+  // 形态无关：目录名（FAIL dsh-plugins-all）与包名（FAIL @wingsky-1/dsh-plugins-all）都算报了 FAIL
+  assert.doesNotMatch(stdout, /FAIL \S*dsh-plugins-all/, '切片下不得对聚合包报 FAIL')
+})
+
+test('增量切片（切片内含聚合包）：聚合段仍执行，不因门控被误跳过', () => {
+  const { status, stdout } = runPackCheck(['--packages', 'dsh-plugins-all'])
+  assert.doesNotMatch(stdout, /聚合包专项跳过/, '聚合包在切片内时不得跳过')
+  assert.match(stdout, AGG_VERDICT, '聚合包在切片内时必须进入聚合段')
+  // 聚合包不在 PREREQ 清单：产物在 ⇒ PASS 且 exit 0，缺 ⇒ FAIL 且 exit 1。两者都必须自洽，
+  // 否则「输出与退出码分叉」会让按退出码判断的上游读到与日志相反的结论。
+  assert.equal(status, AGG_PASS.test(stdout) ? 0 : 1,
+    `exit code 必须与聚合段判定一致（PASS⇒0 / FAIL⇒1）：实际 status=${status}\n${stdout}`)
+})
+
+test('全仓口径：聚合段必须执行，且产物缺失时 fail-loud 可诊断', () => {
+  // 全仓口径只跑一次（真实 pack 各包，约 12-15s）：以下断言共享同一份输出。
+  const { status, stdout } = runPackCheck([])
+  assert.doesNotMatch(stdout, /聚合包专项跳过/, '全仓口径不得跳过聚合段——这是夜间/发版覆盖的唯一入口')
+  assert.match(stdout, AGG_VERDICT, '全仓口径必须进入聚合段')
+  if (AGG_PASS.test(stdout)) {
+    assert.equal(status, 0, `聚合段 PASS 时 exit 必须为 0，实际 ${status}`)
+    return
+  }
+  // 产物缺失分支（test:scripts 不保证聚合包已构建）：须给出可诊断原因而非 pnpm 裸错误
+  assert.match(stdout, /缺 packages\/dsh-plugins-all\/lib\/index\.js/, '缺产物须给出可诊断原因，而非 pnpm 裸错误')
+  assert.match(stdout, /本段是产物级断言/, '须显式声明本段的产物前提')
+  assert.equal(status, 1, `聚合段 FAIL 时 exit 必须为 1，实际 ${status}`)
+})


### PR DESCRIPTION
Fixes #751

## 背景

本 PR 重做已关闭的 #749：其两处**生产代码**修复方向正确且经实测有效，但随附的回归测试在 CI 增量口径下确定性假红——属「修复了一个假红、在同一场景引入另一个假红」，故关闭重做（评审结论见 #749 评论区，修复要求见 #751）。

## 改动清单

| 文件 | 说明 |
|---|---|
| `scripts/gate/pack-check.ts` | 聚合段 `aggName` 提到分支之前读取，使**缺产物分支与正常分支打印同一标识形态**（npm 包名）；`package.json` 读取失败退回目录名标识，由产物前提检查判红 |
| `scripts/gate/pack-check.ts` | 修既有措辞的归因：聚合 patch 与依赖一致性由 `aggregate:check` 恒跑覆盖，不是 plugins-manifest 检查 |
| `scripts/test/pack-check-scope.test.ts` | 切片代表包改取 `script-test-prereqs.mjs` 的 PREREQ 包（原取 `dsh-verify-isolated`，其产物不在任何前置清单）；断言改为形态无关；新增「exit code 与判定自洽」断言；缺产物 fail-loud 分支由此可达 |
| `scripts/README.md` | 该测试条目描述随修法同步 |

保留 #749 已实测有效的两处修复：聚合段与逐包循环共用同一 `scoped` 口径；`local-gate.mjs` 的 `flatMap` argv 修正。

## 根因（#749 为何假红）

`ci.yml:564-566` 只在 `fullGate` 时全量 build；增量 PR 只还原 `HIT_PACKAGES` 产物，只构建 `PREREQ_PACKAGES`（dsh-notifier / dsh-mcp-manager）。而 `test:scripts`（`ci.yml:628-629`）是无条件步骤、夜班不跑它——增量 repo-gate 是唯一执行点。

两条成因：

1. 切片用例取 `dsh-verify-isolated`，其产物不在任何前置清单 → 逐包循环 FAIL → `assert.equal(status, 0)` 失败
2. `pack-check.ts` 缺产物分支打印**目录名** `FAIL dsh-plugins-all`，正常分支打印**包名** `FAIL @wingsky-1/dsh-plugins-all`，而测试断言只匹配包名形态 → 缺产物时永不匹配（用例 3 的 fail-loud 断言因此永远不可达）

影响面：单包 PR、纯文档 PR（`hitPackages: []`），以及 `ci.yml:8-10` 的 `push: branches: [main]` —— 合并后任何单包改动推送到 main 都会让 repo-gate 红。

## 验收证据

**方法**：模拟 CI 单包 PR 的 repo-gate 增量口径——只保留 `PREREQ_PACKAGES`（dsh-notifier / dsh-mcp-manager）的产物，其余包的 `lib/` 移出（脚本带 `trap` 无条件还原，跑完 `git status --porcelain` 仅剩本 PR 的 3 个改动文件）。

环境确认：

```
BUILT   dsh-mcp-manager
BUILT   dsh-notifier
missing dsh-lan-proxy / dsh-plugins-all / dsh-provider-usage / dsh-verify-isolated / dsh-web-file-preview
```

| # | 步骤（CI 原样） | #749 | 本 PR |
|---|---|---|---|
| 1 | `node scripts/gate/pack-check.ts --packages dsh-notifier` | exit 0 | **exit 0**（#747 假红不复现） |
| 2 | `pnpm test:scripts` | 345 tests / **fail 3** / exit 1 | **380 tests / 380 pass / fail 0 / exit 0** |
| 3 | `node scripts/gate/pack-check.ts --packages ""`（纯文档 PR 口径） | exit 0 | **exit 0** |

步骤 1 输出（真实粘贴）：

```
PASS plugins-manifest | 目录集 == manifest.active ∪ standalone 集
[pack-check] 打包切片：1/6 包（--packages dsh-notifier）
PASS @wingsky-1/dsh-notifier | tarball 完整
[pack-check] 聚合包专项跳过：不在 --packages 切片内（本闸逐包范围：dsh-notifier）；全仓口径由 observe.yml / release.yml 覆盖

pack-check：全部通过
```

**产物齐全口径**（另一侧语义，防「修切片时把全仓覆盖删掉」）：`node --test scripts/test/pack-check-scope.test.ts` → 3/3 pass（聚合段在产物存在时走 PASS 分支并断言 exit 0；产物缺失时走 fail-loud 分支并断言 exit 1 与诊断文案）。

## 门禁

| 命令 | exit code |
|---|---|
| `pnpm build` | 0 |
| `pnpm test` | 0 |
| `pnpm contract` | 0 |
| `pnpm pack:check` | 0 |
| `pnpm typecheck` | 0 |
| `pnpm test:scripts` | 0（380/380） |
| `pnpm stryker:check` | 0 |
| `pnpm docs:check` | 0 |

## 验收判据对照（#751）

| # | 判据 | 结果 | 证据 |
|---|---|---|---|
| 1 | 增量产物环境下 `pnpm test:scripts` exit 0 | 满足 | 380/380 pass，exit 0 |
| 2 | 同环境 `node --test scripts/test/pack-check-scope.test.ts` exit 0，且仍锁死两条语义 | 满足 | 3/3 pass；切片下断言不报 FAIL、全仓口径断言必进聚合段 |
| 3 | 增量口径 `pack-check --packages <单包>` exit 0（#747 假红不复现） | 满足 | 见步骤 1 |
| 4 | `pnpm gate:pr` 切片口径 exit 0 | 满足（等价链路 + 全仓口径实跑） | 切片口径的两处关键步骤已按 CI 原样单独验证（上表步骤 1/2）；`pnpm gate:pr` 在本分支实跑 **26 步全绿**（`[local-gate] 结果：PASS`），含此前恒失败的 `build 编译面前置包` 与 `test:scripts` 两步均 exit 0。注意该次运行因改动落在 `scripts/**`（global 面）走的是**全仓口径**——这正是 #749 自证为绿的同一个机制 |
| 5 | 不触 `.github/**` | 满足 | 改动清单 4 个文件均在 `scripts/` |

## 边界

- 不改产品代码（`packages/**` 零改动）；不改 `.github/**`（本仓红线）。
- 不放宽任何判据：全仓口径下聚合段断言强度不变；新增的 exit code 断言是**加强**（原实现不校验退出码与判定是否自洽）。
- 既有性质（非本 PR 引入，记录备查）：聚合包 tarball 中 `lib/index.js` 由 npm/pnpm 强制包含（`main` 指向它），故聚合段「缺 lib/index.js」对 `files` 白名单漏打包近乎无覆盖能力；子包循环有 `lib/*.d.ts` 兜底，聚合段没有。

### 客户端改动截图证据（勾选式）

- [x] **不涉及客户端改动**（未改动 `src/client/**`、`src/client/style.css`、客户端产物 `lib/client.js`）
- [ ] 涉及客户端改动，已在隔离环境实测并归档截图
