### PR TITLE
chore(gate): #718 S0 测量——concurrency A/B 实测 + 逐段耗时复用率台账 + 并发额度扫描 (#718)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,6 +24,7 @@
 - `gate/gen-stryker-conf.mjs` — 变异配置生成/校验：派生 `vitest.stryker.d/<pkg>.config.ts` 并同步各包 `--min`（`--check` 供门禁，`--sync-test-min` 改 `--min`）。
 - `gate/test-surface.mjs` / `gate/mutation-topology.mjs` — 测试分层与变异面登记校验（唯一事实源 `data/mutation-topology.json`）。
 - `gate/threshold-monotonic.mjs` — 阈值单调性校验（对比 `origin/main`，只许升不许降）：守护 `vitest.config.ts` 的 `coverage.thresholds`（#722 阶段三起的覆盖率唯一事实源）与 `gauntlet.config.json` 的变异阈值。
+- `gate/mutation-ledger.mjs` — 变异段实测台账（#718 S0.2）：从 Actions run 日志解析逐段 `wallSeconds`（真实执行时间，区别于会被增量班刷新的文件 mtime）与复用率/杀灭分布；`--check` 离线校验覆盖不变量（测量值 ∪ `unmeasured` == 当前 `stryker.conf.d` 段集合，消失的历史段须在 `superseded` 登记取代关系），由 `test:scripts` 调用。生成模式需 gh 与网络，故定位为维护者工具、不进 CI（进 CI 需改 `.github/`，属红线段）。
 
 ## maintenance/（一次性维护脚本，按需手工执行）
 
@@ -33,6 +34,7 @@
 
 - `lib/client-contract-lib.ts` — 客户端契约断言（stub/执行实现同源唯一事实源）。
 - `lib/plugins-manifest-lib.ts` — 插件清单单一事实源（issue #36）纯函数库。
+- `lib/mutation-ledger-lib.mjs` — 变异段台账的解析与覆盖对账纯函数（#718 S0.2，与 `gate/mutation-ledger.mjs` 同源实现，测试离线 import）。
 
 ## release/（发布/周期 CI 专用）
 
@@ -47,11 +49,13 @@
 - `test/collect-licenses.test.ts` — collect-licenses 脚本自测。
 - `test/crap-check.test.ts` — crap-check 脚本自测（config.strict 单一开关；#722 阶段五起含「非 src 口径数据必须 fail-closed」用例）。
 - `test/threshold-monotonic.test.ts` — 阈值单调性自测（#722：vitest.config.ts 的 coverage.thresholds 提取、降线判红、缺块 fail-closed）。
+- `test/mutation-ledger.test.ts` — 变异段台账自测（#718 S0.2：GHA 日志解析口径含单空格前缀与 ANSI 剥离、未闭合段宁缺勿造、`wallSeconds` 正数不变量、覆盖全部段对账、历史段 `superseded` 登记）。
 - `test/pack-check-scope.test.ts` — pack-check 聚合段切片口径自测（#722/#751：增量切片下不得对未构建的聚合包假红；全仓口径必须仍执行该段，缺产物 fail-loud 且 exit 与判定自洽；切片用例取 `script-test-prereqs.mjs` 的 PREREQ 包——取清单外的包会把假红从 pack:check 搬进 test:scripts）。
 
 ## data/（配置数据）
 
 - `data/plugins-manifest.json` — 插件清单（某插件是否参与聚合/发布校验的唯一声明处）。
+- `data/mutation-segment-ledger.json` — 变异段实测台账（#718 S0.2）：逐段 `wallSeconds` + mutant 数 + 复用率，由 `gate/mutation-ledger.mjs` 从 run 日志生成；`unmeasured` 登记尚无测量值的段，`superseded` 登记被拆分/更名的历史段。
 - `data/gauntlet.config.json` — 变异 / CRAP / ESLint 复杂度阈值唯一事实源（覆盖率阈值自 #722 阶段三起改由 `vitest.config.ts` 的 `coverage.thresholds` 承载；`complexity` 段自 #722 阶段五起供 `tools/lint` 消费）。
 
 ## tools/lint/（lint 工具链隔离包，非发布包）

--- a/scripts/data/mutation-segment-ledger.json
+++ b/scripts/data/mutation-segment-ledger.json
@@ -1,0 +1,407 @@
+{
+  "$comment": "变异段实测台账（#718 S0.2）——由 scripts/gate/mutation-ledger.mjs 从 Actions run 日志解析生成，禁止手工编造数值。核心量 wallSeconds = 日志里 `##[group]stryker <seg>` 与配对 `##[endgroup]` 的墙钟（含 Stryker 启动、项目读取、instrument、dry run、变异执行、报告落盘；不含 install/build）。为什么不取段配置文件的 mtime：增量班次会周期性重写 stryker.conf.d/ 与 coverage/mutation/，文件时间戳永远是「刚刚」，无法区分「真的重测过」与「只是被重写」——台账的真实执行时间是唯一可信判据。scope 标口径：incremental = 有基线 restore 的增量班；full = 夜班全量冷跑（无 restore）。覆盖不变量由 scripts/gate/mutation-ledger.mjs --check 强制（test:scripts 内调用）：本次测量值 ∪ unmeasured 必须精确等于当前 stryker.conf.d 派生的段集合；已消失的历史段必须在 superseded 登记取代关系。",
+  "measurements": [
+    {
+      "run": {
+        "id": 34579060425,
+        "workflow": "observe-incremental.yml",
+        "event": "schedule",
+        "conclusion": "success",
+        "createdAt": "2026-09-11T08:24:55Z",
+        "headSha": "184ba08060ff5507c97c31b133d5e613ce29f892"
+      },
+      "scope": "incremental",
+      "measuredAt": "2026-09-12T04:35:31.489Z",
+      "logSource": "gh run view 34579060425 --log",
+      "segments": [
+        {
+          "seg": "dsh-lan-proxy-1",
+          "startedAt": "2026-09-11T08:25:17.5069391",
+          "endedAt": "2026-09-11T08:25:27.5328974",
+          "wallSeconds": 10,
+          "mutants": 693,
+          "dryTests": 2,
+          "dryRunSeconds": 5,
+          "reused": 533,
+          "reuseTotal": 693,
+          "strykerReported": "7 seconds"
+        },
+        {
+          "seg": "dsh-lan-proxy-2",
+          "startedAt": "2026-09-11T08:25:27.5340763",
+          "endedAt": "2026-09-11T08:25:36.1646441",
+          "wallSeconds": 8.6,
+          "mutants": 691,
+          "dryTests": 2,
+          "dryRunSeconds": 5,
+          "reused": 545,
+          "reuseTotal": 691,
+          "strykerReported": "7 seconds"
+        },
+        {
+          "seg": "dsh-lan-proxy-3",
+          "startedAt": "2026-09-11T08:25:36.1657798",
+          "endedAt": "2026-09-11T08:25:45.0025605",
+          "wallSeconds": 8.8,
+          "mutants": 313,
+          "dryTests": 2,
+          "dryRunSeconds": 5,
+          "reused": 237,
+          "reuseTotal": 313,
+          "strykerReported": "8 seconds"
+        },
+        {
+          "seg": "dsh-lan-proxy-4",
+          "startedAt": "2026-09-11T08:25:45.0036771",
+          "endedAt": "2026-09-11T08:25:53.7535627",
+          "wallSeconds": 8.8,
+          "mutants": 82,
+          "dryTests": 2,
+          "dryRunSeconds": 5,
+          "reused": 50,
+          "reuseTotal": 82,
+          "strykerReported": "8 seconds"
+        },
+        {
+          "seg": "dsh-mcp-manager-entry",
+          "startedAt": "2026-09-11T08:25:53.7547029",
+          "endedAt": "2026-09-11T08:26:45.9452802",
+          "wallSeconds": 52.2,
+          "mutants": 477,
+          "dryTests": 13,
+          "dryRunSeconds": 49,
+          "reused": 359,
+          "reuseTotal": 477,
+          "strykerReported": "51 seconds"
+        },
+        {
+          "seg": "dsh-mcp-manager-manager",
+          "startedAt": "2026-09-11T08:26:45.9464511",
+          "endedAt": "2026-09-11T08:27:55.0360859",
+          "wallSeconds": 69.1,
+          "mutants": 991,
+          "dryTests": 13,
+          "dryRunSeconds": 49,
+          "reused": 899,
+          "reuseTotal": 991,
+          "strykerReported": "1 minute and 8 seconds"
+        },
+        {
+          "seg": "dsh-mcp-manager-middleware",
+          "startedAt": "2026-09-11T08:27:55.0372581",
+          "endedAt": "2026-09-11T08:28:47.3872442",
+          "wallSeconds": 52.4,
+          "mutants": 1646,
+          "dryTests": 13,
+          "dryRunSeconds": 49,
+          "reused": 1255,
+          "reuseTotal": 1646,
+          "strykerReported": "51 seconds"
+        },
+        {
+          "seg": "dsh-mcp-manager-routes",
+          "startedAt": "2026-09-11T08:28:47.3884714",
+          "endedAt": "2026-09-11T08:29:39.2635438",
+          "wallSeconds": 51.9,
+          "mutants": 536,
+          "dryTests": 13,
+          "dryRunSeconds": 49,
+          "reused": 375,
+          "reuseTotal": 536,
+          "strykerReported": "51 seconds"
+        },
+        {
+          "seg": "dsh-mcp-manager-runtime",
+          "startedAt": "2026-09-11T08:29:39.2646725",
+          "endedAt": "2026-09-11T08:30:49.1467984",
+          "wallSeconds": 69.9,
+          "mutants": 1822,
+          "dryTests": 13,
+          "dryRunSeconds": 49,
+          "reused": 1521,
+          "reuseTotal": 1822,
+          "strykerReported": "1 minute and 9 seconds"
+        },
+        {
+          "seg": "dsh-mcp-manager-supervisor",
+          "startedAt": "2026-09-11T08:30:49.1479648",
+          "endedAt": "2026-09-11T08:32:33.4655492",
+          "wallSeconds": 104.3,
+          "mutants": 1150,
+          "dryTests": 13,
+          "dryRunSeconds": 49,
+          "reused": 916,
+          "reuseTotal": 1150,
+          "strykerReported": "1 minute and 43 seconds"
+        },
+        {
+          "seg": "dsh-notifier-channels",
+          "startedAt": "2026-09-11T08:32:33.4667339",
+          "endedAt": "2026-09-11T08:32:48.1042428",
+          "wallSeconds": 14.6,
+          "mutants": 285,
+          "dryTests": 23,
+          "dryRunSeconds": 11,
+          "reused": 188,
+          "reuseTotal": 285,
+          "strykerReported": "13 seconds"
+        },
+        {
+          "seg": "dsh-notifier-config",
+          "startedAt": "2026-09-11T08:32:48.1054450",
+          "endedAt": "2026-09-11T08:33:03.3149728",
+          "wallSeconds": 15.2,
+          "mutants": 2365,
+          "dryTests": 23,
+          "dryRunSeconds": 12,
+          "reused": 1986,
+          "reuseTotal": 2365,
+          "strykerReported": "14 seconds"
+        },
+        {
+          "seg": "dsh-notifier-events",
+          "startedAt": "2026-09-11T08:33:03.3161011",
+          "endedAt": "2026-09-11T08:33:18.8220475",
+          "wallSeconds": 15.5,
+          "mutants": 553,
+          "dryTests": 23,
+          "dryRunSeconds": 12,
+          "reused": 475,
+          "reuseTotal": 553,
+          "strykerReported": "14 seconds"
+        },
+        {
+          "seg": "dsh-notifier-pipeline",
+          "startedAt": "2026-09-11T08:33:18.8232428",
+          "endedAt": "2026-09-11T08:33:33.5325446",
+          "wallSeconds": 14.7,
+          "mutants": 227,
+          "dryTests": 23,
+          "dryRunSeconds": 12,
+          "reused": 186,
+          "reuseTotal": 227,
+          "strykerReported": "14 seconds"
+        },
+        {
+          "seg": "dsh-notifier-sdk",
+          "startedAt": "2026-09-11T08:33:33.5337144",
+          "endedAt": "2026-09-11T08:33:48.2885567",
+          "wallSeconds": 14.8,
+          "mutants": 393,
+          "dryTests": 23,
+          "dryRunSeconds": 11,
+          "reused": 278,
+          "reuseTotal": 393,
+          "strykerReported": "14 seconds"
+        },
+        {
+          "seg": "dsh-notifier-server",
+          "startedAt": "2026-09-11T08:33:48.2897043",
+          "endedAt": "2026-09-11T08:34:03.0065657",
+          "wallSeconds": 14.7,
+          "mutants": 722,
+          "dryTests": 23,
+          "dryRunSeconds": 11,
+          "reused": 504,
+          "reuseTotal": 722,
+          "strykerReported": "14 seconds"
+        },
+        {
+          "seg": "dsh-notifier-stores",
+          "startedAt": "2026-09-11T08:34:03.0078302",
+          "endedAt": "2026-09-11T08:34:17.5233758",
+          "wallSeconds": 14.5,
+          "mutants": 161,
+          "dryTests": 23,
+          "dryRunSeconds": 11,
+          "reused": 132,
+          "reuseTotal": 161,
+          "strykerReported": "13 seconds"
+        },
+        {
+          "seg": "dsh-notifier-text",
+          "startedAt": "2026-09-11T08:34:17.5245920",
+          "endedAt": "2026-09-11T08:34:32.2388578",
+          "wallSeconds": 14.7,
+          "mutants": 506,
+          "dryTests": 23,
+          "dryRunSeconds": 11,
+          "reused": 314,
+          "reuseTotal": 506,
+          "strykerReported": "14 seconds"
+        },
+        {
+          "seg": "dsh-provider-usage-apply",
+          "startedAt": "2026-09-11T08:34:32.2399992",
+          "endedAt": "2026-09-11T08:34:41.9868468",
+          "wallSeconds": 9.7,
+          "mutants": 310,
+          "dryTests": 15,
+          "dryRunSeconds": 6,
+          "reused": 219,
+          "reuseTotal": 310,
+          "strykerReported": "9 seconds"
+        },
+        {
+          "seg": "dsh-provider-usage-contracts",
+          "startedAt": "2026-09-11T08:34:41.9880450",
+          "endedAt": "2026-09-11T08:34:51.7628646",
+          "wallSeconds": 9.8,
+          "mutants": 524,
+          "dryTests": 15,
+          "dryRunSeconds": 6,
+          "reused": 426,
+          "reuseTotal": 524,
+          "strykerReported": "9 seconds"
+        },
+        {
+          "seg": "dsh-provider-usage-entry",
+          "startedAt": "2026-09-11T08:34:51.7640045",
+          "endedAt": "2026-09-11T08:35:01.5603650",
+          "wallSeconds": 9.8,
+          "mutants": 536,
+          "dryTests": 15,
+          "dryRunSeconds": 6,
+          "reused": 403,
+          "reuseTotal": 536,
+          "strykerReported": "9 seconds"
+        },
+        {
+          "seg": "dsh-provider-usage-errsurf",
+          "startedAt": "2026-09-11T08:35:01.5616352",
+          "endedAt": "2026-09-11T08:35:11.2734976",
+          "wallSeconds": 9.7,
+          "mutants": 38,
+          "dryTests": 15,
+          "dryRunSeconds": 6,
+          "reused": 25,
+          "reuseTotal": 38,
+          "strykerReported": "9 seconds"
+        },
+        {
+          "seg": "dsh-provider-usage-pipeline",
+          "startedAt": "2026-09-11T08:35:11.2746951",
+          "endedAt": "2026-09-11T08:35:21.4226349",
+          "wallSeconds": 10.1,
+          "mutants": 1593,
+          "dryTests": 15,
+          "dryRunSeconds": 6,
+          "reused": 1365,
+          "reuseTotal": 1593,
+          "strykerReported": "9 seconds"
+        },
+        {
+          "seg": "dsh-provider-usage-registry",
+          "startedAt": "2026-09-11T08:35:21.4238071",
+          "endedAt": "2026-09-11T08:35:31.1457228",
+          "wallSeconds": 9.7,
+          "mutants": 234,
+          "dryTests": 15,
+          "dryRunSeconds": 6,
+          "reused": 189,
+          "reuseTotal": 234,
+          "strykerReported": "9 seconds"
+        },
+        {
+          "seg": "dsh-provider-usage-report-execute",
+          "startedAt": "2026-09-11T08:35:31.1469359",
+          "endedAt": "2026-09-11T08:35:41.1044263",
+          "wallSeconds": 10,
+          "mutants": 629,
+          "dryTests": 15,
+          "dryRunSeconds": 6,
+          "reused": 506,
+          "reuseTotal": 629,
+          "strykerReported": "9 seconds"
+        },
+        {
+          "seg": "dsh-provider-usage-report-schedule",
+          "startedAt": "2026-09-11T08:35:41.1058494",
+          "endedAt": "2026-09-11T08:35:51.1548823",
+          "wallSeconds": 10,
+          "mutants": 894,
+          "dryTests": 15,
+          "dryRunSeconds": 6,
+          "reused": 546,
+          "reuseTotal": 894,
+          "strykerReported": "9 seconds"
+        },
+        {
+          "seg": "dsh-provider-usage-routes",
+          "startedAt": "2026-09-11T08:35:51.1561777",
+          "endedAt": "2026-09-11T08:36:01.1267598",
+          "wallSeconds": 10,
+          "mutants": 858,
+          "dryTests": 15,
+          "dryRunSeconds": 6,
+          "reused": 608,
+          "reuseTotal": 858,
+          "strykerReported": "9 seconds"
+        },
+        {
+          "seg": "dsh-provider-usage-sanitize",
+          "startedAt": "2026-09-11T08:36:01.1280731",
+          "endedAt": "2026-09-11T08:36:11.3439504",
+          "wallSeconds": 10.2,
+          "mutants": 415,
+          "dryTests": 15,
+          "dryRunSeconds": 7,
+          "reused": 331,
+          "reuseTotal": 415,
+          "strykerReported": "9 seconds"
+        },
+        {
+          "seg": "dsh-provider-usage-trend-aggregate",
+          "startedAt": "2026-09-11T08:36:11.3451358",
+          "endedAt": "2026-09-11T08:36:21.4610043",
+          "wallSeconds": 10.1,
+          "mutants": 1280,
+          "dryTests": 15,
+          "dryRunSeconds": 6,
+          "reused": 1133,
+          "reuseTotal": 1280,
+          "strykerReported": "9 seconds"
+        },
+        {
+          "seg": "dsh-provider-usage-trend-collect",
+          "startedAt": "2026-09-11T08:36:21.4621893",
+          "endedAt": "2026-09-11T08:36:31.3268582",
+          "wallSeconds": 9.9,
+          "mutants": 670,
+          "dryTests": 15,
+          "dryRunSeconds": 6,
+          "reused": 585,
+          "reuseTotal": 670,
+          "strykerReported": "9 seconds"
+        },
+        {
+          "seg": "dsh-web-file-preview",
+          "startedAt": "2026-09-11T08:36:31.3280660",
+          "endedAt": "2026-09-11T08:36:34.1562589",
+          "wallSeconds": 2.8,
+          "mutants": 204,
+          "dryTests": 1,
+          "dryRunSeconds": 0,
+          "reused": 164,
+          "reuseTotal": 204,
+          "strykerReported": "2 seconds"
+        }
+      ]
+    }
+  ],
+  "unmeasured": {
+    "dsh-notifier-config-normalize": "#720 静态拆段（PR #746，main dbd92fd）新增段，尚无成功 run 覆盖——首个 observe 班次后由 mutation-ledger 补齐",
+    "dsh-notifier-config-validate": "#720 静态拆段（PR #746，main dbd92fd）新增段，尚无成功 run 覆盖——首个 observe 班次后由 mutation-ledger 补齐",
+    "dsh-notifier-config-rest": "#720 静态拆段（PR #746，main dbd92fd）新增段，尚无成功 run 覆盖——首个 observe 班次后由 mutation-ledger 补齐"
+  },
+  "superseded": {
+    "dsh-notifier-config": {
+      "replacedBy": [
+        "dsh-notifier-config-normalize",
+        "dsh-notifier-config-validate",
+        "dsh-notifier-config-rest"
+      ],
+      "reason": "#720 静态拆段（PR #746）：原 config 段 9 实现 2366 mutant 按文件密度拆三段（877/862/627），本段不再存在于 stryker.conf.d"
+    }
+  }
+}

--- a/scripts/gate/mutation-ledger.mjs
+++ b/scripts/gate/mutation-ledger.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * scripts/gate/mutation-ledger.mjs —— 变异段实测台账的生成与校验（#718 S0.2）。
+ *
+ * 定位：**维护者/本地工具，不进 CI**。生成模式要拉 Actions run 日志（需要 gh 与网络），
+ * 而入库台账的校验（--check）是离线的、由 test:scripts 调用。之所以不做成 CI 采集步骤：
+ * 那会改动 `.github/workflows/`（红线段），而本项是零红线的测量任务。
+ *
+ * 台账的唯一可信量是 `wallSeconds`（run 日志里 `##[group]stryker <seg>` 与配对
+ * `##[endgroup]` 的墙钟）。为什么不取段配置文件的 mtime：增量班次会周期性重写这些
+ * 文件，mtime 永远是「刚刚」，无法区分「真的重测过」与「只是被重写」。
+ *
+ * 用法：
+ *   node scripts/gate/mutation-ledger.mjs --run <run-id> [--workflow <name>] --scope incremental --write
+ *   node scripts/gate/mutation-ledger.mjs --from-log <path> --run <id> [--workflow <n>] --scope <s> --write
+ *   node scripts/gate/mutation-ledger.mjs --check      # 离线校验入库台账（覆盖全部段 + 字段完整）
+ *
+ * 退出码：0 = 通过；1 = 校验失败；2 = 环境/用法错误。
+ */
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  checkLedgerEntry,
+  expectedSegsFromConfFiles,
+  parseSegmentLedger,
+  reconcileLedgerSegments,
+} from '../lib/mutation-ledger-lib.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const CONF_DIR = join(ROOT, 'stryker.conf.d')
+const LEDGER_PATH = join(ROOT, 'scripts', 'data', 'mutation-segment-ledger.json')
+const argv = process.argv.slice(2)
+const opt = (name) => {
+  const i = argv.indexOf(name)
+  return i === -1 ? undefined : argv[i + 1]
+}
+
+function currentSegs() {
+  return expectedSegsFromConfFiles(readdirSync(CONF_DIR))
+}
+
+/** 台账的段索引：测量值 ∪ 显式登记为「尚未测到」的段（两者共同构成「覆盖全部段」）。 */
+export function ledgerCoverage(ledger) {
+  const measured = new Set()
+  for (const m of ledger.measurements ?? []) for (const s of m.segments ?? []) measured.add(s.seg)
+  const unmeasured = new Set(Object.keys(ledger.unmeasured ?? {}))
+  return { measured, unmeasured, all: new Set([...measured, ...unmeasured]) }
+}
+
+/** 离线校验：覆盖全部段（不漏不重）+ 每条记录字段完整 + unmeasured 必有理由 + 游离段必有 superseded 登记。 */
+export function checkLedger(ledger, expected) {
+  const problems = []
+  const { measured, unmeasured, all } = ledgerCoverage(ledger)
+  const expectedSet = new Set(expected)
+  const superseded = ledger.superseded ?? {}
+  for (const s of expectedSet) if (!all.has(s)) problems.push(`台账未覆盖段：${s}（既无测量值，也未登记进 unmeasured）`)
+  for (const s of all) {
+    if (expectedSet.has(s)) continue
+    // 段被拆分/更名后，历史测量值仍有对照价值，故不要求删除；但必须显式登记取代关系，
+    // 否则「段集合与 stryker.conf.d 脱节」这件事会静默存在（漏段的反面同样危险）。
+    const sup = superseded[s]
+    if (sup === undefined) {
+      problems.push(`台账存在游离段：${s}（当前 stryker.conf.d 已无该段；若已被拆分/更名，请在 superseded 登记取代关系）`)
+      continue
+    }
+    if (!Array.isArray(sup.replacedBy) || sup.replacedBy.length === 0) problems.push(`superseded.${s} 缺少 replacedBy`)
+    for (const r of sup.replacedBy ?? []) {
+      if (!expectedSet.has(r)) problems.push(`superseded.${s}.replacedBy 指向当前不存在的段：${r}`)
+    }
+    if (typeof sup.reason !== 'string' || sup.reason.trim() === '') problems.push(`superseded.${s} 缺少 reason`)
+  }
+  for (const s of measured) if (unmeasured.has(s)) problems.push(`段 ${s} 同时出现在测量值与 unmeasured 中（语义冲突）`)
+  for (const [s, reason] of Object.entries(ledger.unmeasured ?? {})) {
+    if (typeof reason !== 'string' || reason.trim() === '') problems.push(`unmeasured.${s} 缺少理由（必须写明为何尚无测量值）`)
+  }
+  for (const m of ledger.measurements ?? []) {
+    if (typeof m.run?.id !== 'number') problems.push('measurements 条目缺少 run.id')
+    if (typeof m.scope !== 'string' || m.scope.trim() === '') problems.push(`run ${m.run?.id}: scope 缺失`)
+    const segs = m.segments ?? []
+    if (segs.length === 0) problems.push(`run ${m.run?.id}: segments 为空`)
+    const seen = new Set()
+    for (const s of segs) {
+      if (seen.has(s.seg)) problems.push(`run ${m.run?.id}: 段 ${s.seg} 重复登记`)
+      seen.add(s.seg)
+      problems.push(...checkLedgerEntry(s).map((p) => `run ${m.run?.id}: ${p}`))
+    }
+  }
+  return problems
+}
+
+function ghRunMeta(runId) {
+  try {
+    return JSON.parse(execFileSync('gh', ['run', 'view', String(runId), '--repo', 'wingsky-1/dsh-plugin-hub',
+      '--json', 'databaseId,name,event,conclusion,createdAt,headSha'], { encoding: 'utf8' }))
+  } catch (e) {
+    console.error(`[ledger] 读取 run ${runId} 元数据失败：${String(e.message).split('\n')[0]}`)
+    process.exit(2)
+  }
+}
+
+function main() {
+  const isCheck = argv.includes('--check')
+  if (isCheck) {
+    if (!existsSync(LEDGER_PATH)) {
+      console.error(`[ledger] 台账不存在：${LEDGER_PATH}`)
+      return 2
+    }
+    const problems = checkLedger(JSON.parse(readFileSync(LEDGER_PATH, 'utf8')), currentSegs())
+    for (const p of problems) console.error(`[ledger] ${p}`)
+    if (problems.length > 0) {
+      console.error(`[ledger] --check 失败：${problems.length} 项（拆段/加包后必须重测并更新台账）`)
+      return 1
+    }
+    const ledger = JSON.parse(readFileSync(LEDGER_PATH, 'utf8'))
+    const { measured, unmeasured } = ledgerCoverage(ledger)
+    const cur = new Set(currentSegs())
+    const historical = [...measured].filter((s) => !cur.has(s))
+    console.log(`[ledger] --check 通过：覆盖全部 ${cur.size} 段`
+      + `（已测 ${[...measured].filter((s) => cur.has(s)).length} + 待测 ${unmeasured.size}）`
+      + (historical.length > 0 ? `；历史段 ${historical.length} 条已在 superseded 登记取代关系` : ''))
+    return 0
+  }
+
+  const runId = opt('--run')
+  const fromLog = opt('--from-log')
+  if (runId === undefined || fromLog === undefined) {
+    console.error('用法：--run <id> --from-log <path> [--workflow <name>] --scope <full|incremental> --write')
+    return 2
+  }
+  const scope = opt('--scope')
+  if (scope !== 'full' && scope !== 'incremental') {
+    console.error('[ledger] --scope 必须是 full 或 incremental（口径必须显式，否则耗时不可比）')
+    return 2
+  }
+  const logText = readFileSync(fromLog, 'utf8')
+  const segments = parseSegmentLedger(logText)
+  if (segments.length === 0) {
+    console.error(`[ledger] 日志中未解析到任何 stryker 段：${fromLog}（run 未跑变异，或日志格式已变）`)
+    return 2
+  }
+  const meta = ghRunMeta(runId)
+  const entry = {
+    run: {
+      id: meta.databaseId,
+      workflow: opt('--workflow') ?? meta.name,
+      event: meta.event,
+      conclusion: meta.conclusion,
+      createdAt: meta.createdAt,
+      headSha: meta.headSha,
+    },
+    scope,
+    measuredAt: new Date().toISOString(),
+    logSource: `gh run view ${runId} --log`,
+    segments,
+  }
+  const ledger = existsSync(LEDGER_PATH)
+    ? JSON.parse(readFileSync(LEDGER_PATH, 'utf8'))
+    : { $comment: '', measurements: [], unmeasured: {} }
+  ledger.measurements = (ledger.measurements ?? []).filter((m) => m.run?.id !== entry.run.id)
+  ledger.measurements.push(entry)
+  const covered = new Set(segments.map((s) => s.seg))
+  for (const s of covered) delete ledger.unmeasured[s]
+  ledger.measurements.sort((a, b) => (a.run?.id ?? 0) - (b.run?.id ?? 0))
+  if (argv.includes('--write')) {
+    writeFileSync(LEDGER_PATH, JSON.stringify(ledger, null, 2) + '\n', 'utf8')
+    console.log(`[ledger] 已写入 ${LEDGER_PATH}：run ${entry.run.id} ${segments.length} 段（scope=${scope}）`)
+  } else {
+    console.log(JSON.stringify(entry, null, 2))
+  }
+  const problems = checkLedger(ledger, currentSegs())
+  for (const p of problems) console.error(`[ledger] ${p}`)
+  return problems.length === 0 ? 0 : 1
+}
+
+// CLI 守卫：被测试 import 时（argv[1] 不是本文件）不得执行 main，避免测试进程被 exit 带走。
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.exit(main())
+}

--- a/scripts/lib/mutation-ledger-lib.mjs
+++ b/scripts/lib/mutation-ledger-lib.mjs
@@ -1,0 +1,140 @@
+/**
+ * scripts/lib/mutation-ledger-lib.mjs —— 变异段实测台账的解析与对账纯函数（#718 S0.2）。
+ *
+ * 为什么需要它：`observe*.yml` 的变异段逐段耗时只存在于 Actions run 日志里，仓库内没有
+ * 任何持久记录；而「最近一次测量」的判据如果取文件 mtime，会被增量班次反复刷新成永远新鲜
+ * （段文件被重写但内容并未重测），从而让陈旧基线看起来是新的。故台账的唯一可信来源是
+ * **run 日志解析出的真实执行时间**，字段为 `wallSeconds`（段 group 边界的墙钟），
+ * 与文件时间戳无任何关系。
+ *
+ * 为什么是纯函数：CLI 侧（`scripts/gate/mutation-ledger.mjs`）需要网络（拉 run 日志），
+ * 不能进 CI；而入库台账的**对账断言**必须在 `test:scripts` 内离线可跑。故这里只放
+ * 无副作用的解析与对账函数，两侧共用同一份实现——避免「生成侧一套口径、断言侧一套口径」。
+ */
+
+/** Stryker 段在 GHA 日志里的 group 名（`stryker <conf-base-name>`，见 observe*.yml 的循环）。 */
+const GROUP_PREFIX = 'stryker '
+
+/** 日志行时间戳（GHA 前缀 `2026-09-11T08:32:48.1054450Z`，小数位不定长）。 */
+const TIMESTAMP = /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+)Z/
+
+/** ANSI 颜色转义（Stryker 的 reporter 输出带色）。 */
+const ANSI = /\u001b\[[0-9;]*m/g
+
+/** `gh run view --log` 的行前缀：`<job>\t<step>\t<timestamp>Z <content>`（时间戳与正文间有一个空格）。 */
+export function parseLogLine(line) {
+  const parts = line.split('\t')
+  if (parts.length < 3) return null
+  const rest = parts.slice(2).join('\t')
+  const m = TIMESTAMP.exec(rest)
+  if (m === null) return null
+  // trimStart：时间戳与正文之间的分隔空格必须剥掉，否则 `##[group]` 前缀判定永不成立
+  // （实测 gh 日志恒为 `<ts>Z <content>` 单空格形态）。
+  const body = rest.slice(m.index + m[0].length).replace(ANSI, '').trimStart()
+  return { job: parts[0], step: parts[1], at: m[1], body }
+}
+
+/**
+ * 解析一段（group 内）的文本，抽取 Stryker 自报的量化字段。
+ * 字段全部可选：`Done in` 在段被取消/失败时不会出现，缺失即 null（不得用 0 冒充）。
+ */
+export function parseSegmentBody(lines) {
+  const text = lines.join('\n')
+  const mutants = /with (\d+) mutant/.exec(text)
+  const dry = /Ran (\d+) tests in (\d+) seconds/.exec(text)
+  const reuse = /(\d+) of (\d+) mutant result\(s\) are reused/.exec(text)
+  const done = /Done in ([^.]+)\./.exec(text)
+  return {
+    mutants: mutants === null ? null : Number(mutants[1]),
+    dryTests: dry === null ? null : Number(dry[1]),
+    dryRunSeconds: dry === null ? null : Number(dry[2]),
+    reused: reuse === null ? null : Number(reuse[1]),
+    reuseTotal: reuse === null ? null : Number(reuse[2]),
+    strykerReported: done === null ? null : done[1].trim(),
+  }
+}
+
+/**
+ * 从 GHA 原始日志解析逐段实测（栈式配对 `##[group]stryker <seg>` 与 `##[endgroup]`）。
+ *
+ * 为什么用栈而不是「下一个 group 起点」：Stryker 自身的输出里也可能出现 `##[group]`，
+ * 用后者会把段边界切错。返回按出现顺序排列的记录，段墙钟 = 配对 endgroup 与 group 的时间差；
+ * 段被杀导致 group 未闭合时该段不出现在结果里（宁缺勿造）。
+ */
+export function parseSegmentLedger(logText) {
+  const raw = logText.split('\n')
+  const events = []
+  for (let i = 0; i < raw.length; i++) {
+    const parsed = parseLogLine(raw[i])
+    if (parsed === null) continue
+    if (parsed.body.startsWith('##[group]' + GROUP_PREFIX)) {
+      events.push({ kind: 'open', line: i, at: parsed.at, seg: parsed.body.slice(('##[group]' + GROUP_PREFIX).length).trim() })
+    } else if (parsed.body.startsWith('##[endgroup]')) {
+      events.push({ kind: 'close', line: i, at: parsed.at })
+    }
+  }
+  const stack = []
+  const out = []
+  for (const ev of events) {
+    if (ev.kind === 'open') {
+      stack.push(ev)
+      continue
+    }
+    const open = stack.pop()
+    if (open === undefined) continue
+    const body = []
+    for (let i = open.line; i <= ev.line; i++) {
+      const parsed = parseLogLine(raw[i])
+      if (parsed !== null) body.push(parsed.body)
+    }
+    out.push({
+      seg: open.seg,
+      startedAt: open.at,
+      endedAt: ev.at,
+      wallSeconds: Math.round(((Date.parse(ev.at + 'Z') - Date.parse(open.at + 'Z')) / 1000) * 10) / 10,
+      ...parseSegmentBody(body),
+    })
+  }
+  return out
+}
+
+/**
+ * 台账「覆盖全部段」对账：实测段集合必须与期望段集合**精确相等**。
+ *
+ * 为什么必须相等而不是包含：漏段（测量没覆盖某个段）会让 S1.4 的超时分位数与 #742 的
+ * wall-clock 上界基于不完整数据；多段（段已改名/删除而台账未更新）说明台账与
+ * `stryker.conf.d/` 已脱节。两种都必须判红——拆段/加包后必须重测并更新台账。
+ */
+export function reconcileLedgerSegments(measuredSegs, expectedSegs) {
+  const measured = new Set(measuredSegs)
+  const expected = new Set(expectedSegs)
+  return {
+    missing: [...expected].filter((s) => !measured.has(s)).sort(),
+    extra: [...measured].filter((s) => !expected.has(s)).sort(),
+    ok: measured.size === expected.size && [...expected].every((s) => measured.has(s)),
+  }
+}
+
+/**
+ * 台账条目字段完整性校验（结构不变量，与具体数值无关）。
+ * 返回问题清单（空数组 = 通过）。`wallSeconds` 必须是正数——它是台账的核心量，
+ * 取 0 或负数说明解析失败却被当成有效测量写入。
+ */
+export function checkLedgerEntry(entry) {
+  const problems = []
+  if (typeof entry?.seg !== 'string' || entry.seg.trim() === '') problems.push('seg 缺失')
+  if (typeof entry?.wallSeconds !== 'number' || !(entry.wallSeconds > 0)) problems.push(`${entry?.seg}: wallSeconds 必须是正数`)
+  if (entry?.mutants !== null && !(Number.isInteger(entry?.mutants) && entry.mutants > 0)) problems.push(`${entry?.seg}: mutants 缺失或非正整数`)
+  if (entry?.reused !== null && entry?.reuseTotal !== null && !(entry.reused >= 0 && entry.reused <= entry.reuseTotal)) {
+    problems.push(`${entry?.seg}: reused 必须在 [0, reuseTotal] 内`)
+  }
+  return problems
+}
+
+/** 由 `stryker.conf.d/` 的文件名派生期望段集合（与 ci-matrix / mutation-gate 同源口径）。 */
+export function expectedSegsFromConfFiles(confFileNames) {
+  return confFileNames
+    .filter((f) => f.startsWith('dsh-') && f.endsWith('.json'))
+    .map((f) => f.slice(0, -'.json'.length))
+    .sort()
+}

--- a/scripts/maintenance/scan-actions-concurrency.mjs
+++ b/scripts/maintenance/scan-actions-concurrency.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * scripts/maintenance/scan-actions-concurrency.mjs —— Actions 并发峰值扫描（#718 S0.3）。
+ *
+ * 为什么需要它：`observe.yml` 把全部变异段串行放在**单个 job** 内，所以夜班日志里看不到
+ * 任何并发信息；账户的并发额度只能从**多 job 矩阵**的 run（`ci.yml` 的 build-test 与
+ * mutation-gate）反推。S1.1 的「变异矩阵化 + `max-parallel: N`」需要一个实测上界，
+ * 而不是推断值——本脚本给出该上界及其饱和特征（额度用满后 job 会呈「一个结束→一个开始」
+ * 的严格配对）。
+ *
+ * 判据（为什么是「峰值 + 配对形态」而不是只看峰值）：单看峰值无法区分「额度上限是 20」
+ * 与「恰好同时有 20 个 job 就绪」。额度饱和的特征是峰值处**长时间维持**且新增只会发生在
+ * 有 job 结束之后——脚本按事件序列打印该形态，供人工判读。
+ *
+ * 定位：维护者/本地工具，需 gh 与网络，**不进 CI**（进 CI 属 `.github/` 红线段）。
+ *
+ * 用法：
+ *   node scripts/maintenance/scan-actions-concurrency.mjs [样本数] [--top N] [--run <id>]
+ *   例：node scripts/maintenance/scan-actions-concurrency.mjs 100 --top 5
+ *       node scripts/maintenance/scan-actions-concurrency.mjs --run 34628767342
+ *
+ * 退出码：0 = 扫描完成；2 = 环境错误（gh 不可用 / 无样本）。
+ */
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const argv = process.argv.slice(2)
+const flag = (name) => {
+  const i = argv.indexOf(name)
+  return i === -1 ? undefined : argv[i + 1]
+}
+const REPO = 'wingsky-1/dsh-plugin-hub'
+
+function ghJson(args) {
+  try {
+    return JSON.parse(execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }))
+  } catch (e) {
+    console.error(`[scan] gh 调用失败：${String(e.message).split('\n')[0]}`)
+    return null
+  }
+}
+
+/**
+ * 半开区间扫描：返回同时运行的 job 数峰值、峰值维持区间，以及峰值后的运行数上界。
+ *
+ * 饱和判据（三者同时成立才说明「峰值＝额度上限」而非「恰好凑巧」）：
+ *   1. 峰值在多个相互独立的 run 上完全一致；
+ *   2. 峰值维持一段时间（不是瞬时尖峰）；
+ *   3. 峰值之后运行数**从未超过**峰值——新 job 只能等旧 job 让位。
+ */
+export function peakConcurrency(jobs) {
+  const events = []
+  for (const j of jobs) {
+    if (!j.started_at || !j.completed_at) continue
+    const s = Date.parse(j.started_at)
+    const e = Date.parse(j.completed_at)
+    if (!(e > s)) continue // skipped / 零宽度 job 不占并发
+    events.push({ at: s, delta: 1, name: j.name })
+    events.push({ at: e, delta: -1, name: j.name })
+  }
+  events.sort((a, b) => a.at - b.at || a.delta - b.delta)
+  let cur = 0
+  let peak = 0
+  let peakAt = null
+  let peakUntil = null
+  let maxAfterPeak = 0
+  for (const ev of events) {
+    cur += ev.delta
+    if (cur > peak) {
+      peak = cur
+      peakAt = ev.at
+      peakUntil = null
+    } else if (peakAt !== null && cur < peak && peakUntil === null) {
+      peakUntil = ev.at
+    }
+    if (peakUntil !== null) maxAfterPeak = Math.max(maxAfterPeak, cur)
+  }
+  return {
+    peak,
+    peakAt,
+    peakUntil,
+    countedJobs: events.filter((e) => e.delta === 1).length,
+    maxAfterPeak,
+    heldSeconds: peakUntil === null ? 0 : Math.round((peakUntil - peakAt) / 1000),
+  }
+}
+
+function scanRun(runId) {
+  const d = ghJson(['api', `repos/${REPO}/actions/runs/${runId}/jobs?per_page=100`])
+  if (d === null) return null
+  const jobs = d.jobs ?? []
+  const r = peakConcurrency(jobs)
+  console.log(`\n== run ${runId} ==`)
+  console.log(`job 总数 ${jobs.length}，计入并发 ${r.countedJobs}`
+    + `，峰值 ${r.peak}（首达 ${new Date(r.peakAt).toISOString()}，维持 ${r.heldSeconds}s）`)
+  console.log(`峰值后运行数上界 ${r.maxAfterPeak}`
+    + `（${r.maxAfterPeak <= r.peak ? '未超过峰值 → 新 job 只能等旧 job 让位，符合额度饱和' : '超过峰值 → 峰值是瞬时尖峰，不能据此定标'}）`)
+  return { runId, ...r, totalJobs: jobs.length }
+}
+
+function main() {
+  const runId = flag('--run')
+  if (runId !== undefined) {
+    const r = scanRun(runId)
+    return r === null ? 2 : 0
+  }
+  const limit = Number(argv.find((a) => /^\d+$/.test(a)) ?? 40)
+  const top = Number(flag('--top') ?? 8)
+  const runs = ghJson(['run', 'list', '--repo', REPO, '--limit', String(limit),
+    '--json', 'databaseId,name,event,createdAt,conclusion'])
+  if (runs === null || runs.length === 0) {
+    console.error('[scan] 未取到 run 列表')
+    return 2
+  }
+  console.log(`扫描 ${runs.length} 个 run 的 job 时间线…`)
+  const rows = []
+  for (const r of runs) {
+    const d = ghJson(['api', `repos/${REPO}/actions/runs/${r.databaseId}/jobs?per_page=100`])
+    if (d === null) continue
+    const { peak, countedJobs, heldSeconds } = peakConcurrency(d.jobs ?? [])
+    rows.push({ peak, heldSeconds, runId: r.databaseId, workflow: r.name, event: r.event, createdAt: r.createdAt, countedJobs })
+  }
+  rows.sort((a, b) => b.peak - a.peak || b.countedJobs - a.countedJobs)
+  console.log(`\n${'peak'.padStart(5)} ${'held_s'.padStart(6)} ${'jobs'.padStart(5)}  ${'run_id'.padStart(12)}  event           createdAt`)
+  for (const r of rows.slice(0, top)) {
+    console.log(`${String(r.peak).padStart(5)} ${String(r.heldSeconds).padStart(6)} ${String(r.countedJobs).padStart(5)}  ${String(r.runId).padStart(12)}  ${r.event.padEnd(15)} ${r.createdAt}`)
+  }
+  const max = rows.length > 0 ? rows[0].peak : 0
+  console.log(`\n实测并发峰值 max=${max}（样本 ${rows.length}）`)
+  if (max > 0) {
+    const winner = rows[0]
+    console.log(`最高样本 run ${winner.runId} —— 用 --run ${winner.runId} 查看饱和形态`)
+  }
+  return 0
+}
+
+// CLI 守卫：被 import 时（argv[1] 不是本文件）不执行 main，便于复用 peakConcurrency。
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.exit(main())
+}

--- a/scripts/test/mutation-ledger.test.ts
+++ b/scripts/test/mutation-ledger.test.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * 变异段台账的解析与覆盖不变量回归（#718 S0.2）。
+ *
+ * 为什么存在：台账是 S1.4（超时按分段 P95 定标）与 #742（PR wall-clock 上界）的输入，
+ * 它的两个失效形态都很隐蔽——漏段（测量没覆盖某段）会让分位数基于不完整样本，
+ * 取文件 mtime 当「新鲜度」会把增量班次的文件重写误判成重测。故这里锁死：
+ *   1. 解析器只认「日志里真实出现的段」，未闭合的 group 宁缺勿造；
+ *   2. wallSeconds 必须是正数（解析失败不得以 0 冒充有效测量）；
+ *   3. 入库台账的覆盖不变量：测量值 ∪ unmeasured == 当前 stryker.conf.d 段集合，
+ *      消失的历史段必须在 superseded 登记取代关系。
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  checkLedgerEntry,
+  expectedSegsFromConfFiles,
+  parseLogLine,
+  parseSegmentBody,
+  parseSegmentLedger,
+  reconcileLedgerSegments,
+} from '../lib/mutation-ledger-lib.mjs'
+import { checkLedger, ledgerCoverage } from '../gate/mutation-ledger.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const LEDGER_PATH = join(ROOT, 'scripts', 'data', 'mutation-segment-ledger.json')
+
+/** 构造一行 GHA 原始日志（口径：`<job>\t<step>\t<timestamp>Z <content>`，时间戳与正文间单空格）。 */
+const line = (ts, body) => `job\tSTEP\t${ts}Z ${body}`
+
+const FIXTURE = [
+  line('2026-09-11T08:00:00.0000000', '##[group]stryker dsh-x-a'),
+  line('2026-09-11T08:00:01.0000000', '\u001b[32mINFO Instrumenter\u001b[39m Instrumented 1 source file(s) with 100 mutant'),
+  line('2026-09-11T08:00:02.0000000', '\u001b[32mINFO DryRunExecutor\u001b[39m Initial test run succeeded. Ran 7 tests in 3 seconds'),
+  line('2026-09-11T08:00:03.0000000', '\u001b[32mINFO IncrementalDiffer\u001b[39m Incremental report:'),
+  line('2026-09-11T08:00:04.0000000', '40 of 100 mutant result(s) are reused.'),
+  line('2026-09-11T08:00:05.0000000', '\u001b[32mINFO MutationTestExecutor\u001b[39m Done in 13 seconds.'),
+  line('2026-09-11T08:00:06.0000000', '##[endgroup]'),
+  // 未闭合的段（被杀）：不得出现在结果里
+  line('2026-09-11T08:00:07.0000000', '##[group]stryker dsh-x-b'),
+  line('2026-09-11T08:00:08.0000000', '\u001b[32mINFO Instrumenter\u001b[39m Instrumented 1 source file(s) with 50 mutant'),
+].join('\n')
+
+test('解析器：单空格前缀 + ANSI 剥离 + 栈式配对 + 未闭合段宁缺勿造', () => {
+  const segs = parseSegmentLedger(FIXTURE)
+  assert.equal(segs.length, 1, '只应解析出已闭合的那一段')
+  const a = segs[0]
+  assert.equal(a.seg, 'dsh-x-a')
+  assert.equal(a.mutants, 100)
+  assert.equal(a.reused, 40)
+  assert.equal(a.reuseTotal, 100)
+  assert.equal(a.dryRunSeconds, 3)
+  assert.equal(a.strykerReported, '13 seconds')
+  assert.equal(a.wallSeconds, 6, 'wallSeconds = endgroup 与 group 的时间差')
+  assert.ok(!segs.some((s) => s.seg === 'dsh-x-b'), '未闭合段不得出现（宁缺勿造，不得用 0 冒充）')
+})
+
+test('解析器：时间戳与正文间的空格必须剥离（否则 group 前缀判定永不成立）', () => {
+  const parsed = parseLogLine(line('2026-09-11T08:00:00.0000000', '##[group]stryker dsh-x-a'))
+  assert.equal(parsed.body, '##[group]stryker dsh-x-a')
+})
+
+test('段字段抽取：字段缺失一律为 null，不得用 0 冒充', () => {
+  const body = parseSegmentBody(['nothing here'])
+  assert.deepEqual(body, {
+    mutants: null, dryTests: null, dryRunSeconds: null, reused: null, reuseTotal: null, strykerReported: null,
+  })
+})
+
+test('wallSeconds 必须是正数（解析失败不得当作有效测量写入台账）', () => {
+  assert.deepEqual(checkLedgerEntry({ seg: 'x', wallSeconds: 1.5, mutants: 10, reused: null, reuseTotal: null }), [])
+  assert.ok(checkLedgerEntry({ seg: 'x', wallSeconds: 0, mutants: 10 }).some((p) => p.includes('wallSeconds')))
+  assert.ok(checkLedgerEntry({ seg: 'x', wallSeconds: -1, mutants: 10 }).some((p) => p.includes('wallSeconds')))
+  assert.ok(checkLedgerEntry({ seg: 'x', wallSeconds: 1, mutants: 10, reused: 5, reuseTotal: 3 })
+    .some((p) => p.includes('reused')))
+})
+
+test('覆盖对账：漏段与游离段都必须暴露', () => {
+  assert.deepEqual(reconcileLedgerSegments(['a', 'b'], ['a', 'b']).ok, true)
+  const miss = reconcileLedgerSegments(['a'], ['a', 'b'])
+  assert.deepEqual(miss.missing, ['b'])
+  assert.equal(miss.ok, false)
+  const extra = reconcileLedgerSegments(['a', 'b', 'c'], ['a', 'b'])
+  assert.deepEqual(extra.extra, ['c'])
+  assert.equal(extra.ok, false)
+})
+
+test('覆盖对账：段名派生自 conf 文件名（与 ci-matrix / mutation-gate 同源口径）', () => {
+  assert.deepEqual(
+    expectedSegsFromConfFiles(['dsh-notifier-config-rest.json', 'README.md', 'dsh-web-file-preview.json']),
+    ['dsh-notifier-config-rest', 'dsh-web-file-preview'],
+  )
+})
+
+test('入库台账：覆盖全部段不变量成立（测量值 ∪ unmeasured == 当前 conf 段集合）', () => {
+  const ledger = JSON.parse(readFileSync(LEDGER_PATH, 'utf8'))
+  const expected = expectedSegsFromConfFiles(readdirSync(join(ROOT, 'stryker.conf.d')))
+  assert.ok(expected.length > 0, 'stryker.conf.d 非空')
+  const problems = checkLedger(ledger, expected)
+  assert.deepEqual(problems, [], `台账覆盖不变量被破坏：\n${problems.join('\n')}`)
+  const { all } = ledgerCoverage(ledger)
+  const expectedSet = new Set(expected)
+  // 「覆盖全部段」的正面断言：当前每一段都必须被测量值或 unmeasured 解释
+  for (const s of expectedSet) assert.ok(all.has(s), `段 ${s} 既无测量值也未登记 unmeasured`)
+})
+
+test('入库台账：每条测量记录的 wallSeconds 为正且字段完整（口径是日志墙钟，不是文件 mtime）', () => {
+  const ledger = JSON.parse(readFileSync(LEDGER_PATH, 'utf8'))
+  assert.ok(ledger.measurements.length > 0, '至少一条测量记录')
+  for (const m of ledger.measurements) {
+    assert.ok(['full', 'incremental'].includes(m.scope), `run ${m.run.id}: scope 必须标明口径`)
+    assert.equal(typeof m.run.headSha, 'string', `run ${m.run.id}: 缺少 headSha（口径溯源）`)
+    for (const s of m.segments) {
+      assert.ok(s.wallSeconds > 0, `${s.seg}: wallSeconds 必须为正`)
+      assert.match(s.startedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, `${s.seg}: 缺少日志时间戳`)
+    }
+  }
+})
+
+test('入库台账：历史段必须在 superseded 登记取代关系且指向现存段', () => {
+  const ledger = JSON.parse(readFileSync(LEDGER_PATH, 'utf8'))
+  const expected = new Set(expectedSegsFromConfFiles(readdirSync(join(ROOT, 'stryker.conf.d'))))
+  const { measured } = ledgerCoverage(ledger)
+  for (const s of measured) {
+    if (expected.has(s)) continue
+    const sup = ledger.superseded?.[s]
+    assert.ok(sup, `历史段 ${s} 未在 superseded 登记`)
+    for (const r of sup.replacedBy) assert.ok(expected.has(r), `superseded.${s}.replacedBy 指向不存在的段 ${r}`)
+  }
+})


### PR DESCRIPTION
Refs #718（S0 阶段，零红线；不关闭本 issue）

按 #718 维护者裁决 4「#720 拆段与 S0 并行，且在 S0.1 / S0.2 之前完成」执行：拆段已先落地
（#746 → main `dbd92fd`），本 PR 交付 S0 测量。**未改动 `.github/`**，全部为 `scripts/` 下的
测量工具 + 台账 + 断言。

## 改动清单

| 文件 | 说明 |
|---|---|
| `scripts/data/mutation-segment-ledger.json` | 台账：逐段 `wallSeconds`（真实执行时间）+ mutant 数 + dry run + 复用率 |
| `scripts/lib/mutation-ledger-lib.mjs` | GHA 日志 → 台账的解析与覆盖对账纯函数 |
| `scripts/gate/mutation-ledger.mjs` | 生成/校验 CLI（生成需 gh + 网络，故不进 CI；`--check` 离线，由 `test:scripts` 调用） |
| `scripts/test/mutation-ledger.test.ts` | 断言 9 例（解析口径 / `wallSeconds` 正数不变量 / 覆盖全部段 / 历史段登记） |
| `scripts/maintenance/scan-actions-concurrency.mjs` | Actions 并发峰值扫描（只读 API，供结论复现） |
| `scripts/README.md` | 上述文件的登记条目 |

## S0.1 concurrency A/B（三档实测，两轮）

**口径**：`taskset -c 0-3` 限定到 **4 个不同物理核**（本机 i7-8550U：`cpu0-3` = core 0..3 各 1 线程，
`cpu4-7` 是其超线程），以对齐 CI runner 的 4 vCPU；每档前删除该段 incremental 文件 ⇒ **全量冷跑**；
段墙钟 = 命令起止（与 CI 日志 `##[group]stryker` 边界同口径）。选段 `dsh-notifier-config-rest`
（627 mutant，拆段后新增段）。

| concurrency | 超订（4 核） | 第一轮墙钟 | 第二轮墙钟 | 相对 c4 |
|---|---|---|---|---|
| 4 | 1x | 1113.4 s | 1092.8 s | 1.00x |
| 8 | 2x | 679.9 s | — | **快 1.64x** |
| 16 | 4x | 620.2 s | 597.4 s | **快 1.81x** |

（Stryker 自报与段墙钟相差 < 2 s，两者同口径；两轮偏差：c4 1.9%、c16 3.8%）

**结论：4 倍超订没有变慢，反而快约 1.8 倍。** 这与「4 vCPU 上 16 线程是 4 倍超订、是长尾的合理嫌疑」
（#720 手段 5 的前提）方向相反——单 mutant 的测试执行里固定延迟（vitest worker 启动、模块加载、IO）
占比高，多 worker 重叠这些延迟的收益超过 CPU 争抢的代价。

**对 #720 手段 5（「该段 concurrency 从 16 降到 4~8」）的含义：本实测不支持该手段**——按此调整
会让该段耗时增加到约 1.8 倍。该手段若要采纳，需要 CI runner 上的反证。

**口径限制（必须随数字一起引用）**：

1. 本机是低压移动 CPU（i7-8550U @1.8GHz），与 GitHub runner 的服务器级 CPU 架构不同；
   `taskset` 限制的是调度亲和性，本机 `cpu4-7`（同物理核的超线程）仍可能被系统进程占用。
2. 单段测量（`dsh-notifier-config-rest`，627 mutant），未覆盖全部 33 段。
3. 第一轮 c16 档与门禁 `build`/`test` 重叠（宿主有其它 CPU 负载），第二轮为安静环境；两轮结论一致
   （c16 分别比 c4 快 1.80x / 1.83x），故方向与幅度都可重复。

## S0.2 逐段耗时 + 复用率台账

**来源 run**：`34579060425`（`observe-incremental.yml`，2026-09-11T08:24Z，success）——**未新增任何 CI 采集器**，
全部由 `gh run view --log` 的既有日志解析。

**为什么台账记「真实执行时间」而不是文件 mtime**：增量班次会周期性重写 `stryker.conf.d/` 与
`coverage/mutation/`，文件时间戳永远是「刚刚」，无法区分「真的重测过」与「只是被重写」。台账的
`wallSeconds` 取自日志里 group 边界的墙钟，与文件系统无关。

**覆盖全部段断言**（`test:scripts` 内）：`测量值 ∪ unmeasured` 必须精确等于当前 `stryker.conf.d`
派生的段集合，且消失的历史段必须在 `superseded` 登记取代关系。拆段后的当前状态：

- 已测 30 段（沿用拆段前 run；这 30 段的定义逐字未变）
- 待测 3 段（`config-normalize` / `config-validate` / `config-rest`）显式登记进 `unmeasured`，理由写明
  「#720 拆段新增，尚无成功 run 覆盖」——首个 observe 班次后由 `mutation-ledger` 补齐
- 历史段 `dsh-notifier-config` 在 `superseded` 登记 `replacedBy` 三个新段 + 理由

**断言有效性已实证**：台账在登记 `unmeasured` / `superseded` **之前**，`--check` 精确报出 4 项
（`dsh-notifier-config-normalize|validate|rest` 未覆盖 + `dsh-notifier-config` 游离）；补齐后 exit 0。

## S0.3 并发额度扫描

**方法**：`scripts/maintenance/scan-actions-concurrency.mjs` 对 run 的 job 时间线做半开区间扫描，
判据是三者同时成立——峰值跨 run 一致、峰值非瞬时尖峰、峰值后运行数从未超过峰值。

**结果**（100 个 run 样本）：

| 样本类别 | 数量 | job 数 | 峰值分布 |
|---|---|---|---|
| 矩阵全展开 run（`gate:full`） | 20 | 42 | 20 × 15、19 × 4、18 × 1 |
| 其余 run（默认 PR/push，无变异矩阵） | 80 | 9-12 | 7 × 47、6 × 4、1 × 28、0 × 1 |

**实测并发额度上界 = 20**（推断值 16~20 的上界得到确认）。饱和证据：42 个 job 的 run 中 15 个精确
触达 20 且**从未超过**；`run 34628767342` 触达峰值后运行数上界仍为 20（新 job 只能等旧 job 让位）。

**对 S1.1 的含义**：`max-parallel: 5` 远低于实测上界 20，不会触碰额度；但 build-test 矩阵
（7-8 实例）与 mutation 矩阵（33 段）并行时共享同一额度——全展开仍被额度和到 20 并发，
`max-parallel` 正是在这个上限内做显式排队。

## 门禁

| 命令 | exit code |
|---|---|
| `pnpm build` | 0 |
| `pnpm test` | 0 |
| `pnpm contract` | 0 |
| `pnpm pack:check` | 0 |
| `pnpm typecheck` | 0 |
| `pnpm test:scripts` | 0（389/389 pass，含本 PR 新增 9 例） |
| `pnpm stryker:check` | 0 |
| `pnpm docs:check` | 0 |
| `pnpm lint` | 0 |
| `node scripts/gate/mutation-ledger.mjs --check` | 0（覆盖全部 33 段：已测 30 + 待测 3；1 条历史段已登记取代关系） |

## 边界

- 不改 `.github/**`（本仓红线）：S0 的三项都不需要新增 CI 采集器，台账由既有日志解析。
- 不改产品代码（`packages/**` 零改动）。
- 产物零污染：`git status --porcelain | grep -E 'undefined/|\.jsonl$'` 为空。

### 客户端改动截图证据（勾选式）

- [x] **不涉及客户端改动**（未改动 `src/client/**`、`src/client/style.css`、客户端产物 `lib/client.js`）
- [ ] 涉及客户端改动，已在隔离环境实测并归档截图
