### PR TITLE
ci(observe): #718 S1.1+S1.4+S1.5 夜间变异班三段式矩阵化（plan / quality‖shards / collect 收口）

### DIFF
--- a/.github/workflows/observe.yml
+++ b/.github/workflows/observe.yml
@@ -3,7 +3,7 @@ name: Observe (nightly)
 # #85 v3 F1/F6 定案：观察期采集与变异门禁的夜间调度。
 # - cov（含阈值硬校验：vitest 的 coverage.thresholds 未达标即非零退出）；
 #   CRAP 明细自 #722 阶段三起停用（数据源口径不可比），见下方 Coverage 步骤旁注释
-# - 全量变异（串行）
+# - 全量变异（#718 S1.1 起改为**逐段矩阵**，并行度由 max-parallel 控制）
 # - 报告落 issue（幂等：同日不重开）；回落 >1pp 自动追评（隔夜必有工单）
 # 变异硬门禁在本 workflow 生效：任一包 covered < threshold 且 strict 开启 → 运行失败。
 # #276 方案 A + #433 调度重设计 + #572 孤立分支基线：本 workflow 为每日全量班（北京次日 04:00 = UTC 20:00，
@@ -14,6 +14,20 @@ name: Observe (nightly)
 #   请勿"好心"补 restore 步骤（会破坏全量基线语义）。
 # - 全量运行末尾将 incremental 基线提交至孤立分支 baseline/mutation（单 commit 纯文本树，
 #   #572），PR 侧 ci.yml mutation-gate 直接浅拉取该分支走增量变异，彻底剥离 main 分支代码树巨型 JSON 与自动 PR 噪音。
+#
+# #718 S1.1 / S1.4 / S1.5（本 job 拓扑的成因，务必连着读）：
+# - **S1.5 job 边界**：`quality`（install + build + contract/pack:check/verify:npmlayout +
+#   stryker:check + cov + crap）与 `mutation-shards` **无相互依赖、并行跑**；两者产出由
+#   `mutation-collect`（判分 + 单点 push 基线 + 报告 + 工单，if: always()）收口。
+#   为什么必须拆：原单 job 串行 90 分钟，任一长段擦边即整班被杀，且被杀点在报告步骤之前
+#   ⇒ 当夜无工单、无留痕、基线不更新（#718 两次事故 34536263640 / 34652766708 的形态）。
+# - **S1.1 矩阵化**：段清单由 `stryker.conf.d/*.json` 派生（`mutation-plan` job 秒级产出），
+#   每段一个矩阵实例；`max-parallel: 5`（S0.3 实测账户并发额度上界 20，留足余量给
+#   build-test 与其它 workflow）。
+# - **S1.4 逐段超时**：`timeout-minutes` 取 `matrix.shard.timeoutMinutes`，由
+#   `scripts/gate/mutation-plan.mjs` 按 `mutation-segment-ledger.json` 里该段 `scope=full`
+#   的实测墙钟 × 1.5 + 构建开销派生，下限 10 分钟（#718 整合版规定）；无实测的段取保守
+#   默认值。`fail-fast: false`：单段失败不连坐其余段，配合 `gh run rerun --failed` 定向重跑。
 
 on:
   schedule:
@@ -33,15 +47,44 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  nightly:
-    name: Cov / Crap / Mutation nightly
+  # ── 段清单与逐段超时 ──────────────────────────────────────────────
+  # 为什么需要这个 job：GHA 的动态 matrix 只能引用 `needs` 的 output，**不能读工作区文件**，
+  # 而「哪些段要跑」的唯一事实源是 stryker.conf.d/*.json（随拆段/加包自动演进，
+  # #720 拆段即 31→33）。故由本 job 把文件系统事实翻译成 matrix 可消费的 JSON。
+  # 秒级完成，不构成并行度瓶颈。
+  mutation-plan:
+    name: Plan mutation shards
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 5
+    outputs:
+      shards: ${{ steps.plan.outputs.shards }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 24
+          # 本 job 只跑 Node 内置模块，不 pnpm install；显式关掉 setup-node 的
+          # package-manager-cache（它会调 PATH 里的 pnpm，而本 job 无 pnpm/action-setup）
+          package-manager-cache: false
+
+      - name: Derive shard matrix（段清单 + 逐段超时）
+        id: plan
+        run: node scripts/gate/mutation-plan.mjs
+
+  # ── 质量侧（无 needs：与 mutation-shards 并行跑，S1.5）──────────────
+  quality:
+    name: Quality (cov / crap / artifact gates)
+    runs-on: ubuntu-latest
+    # cov + crap + 三个全仓产物闸 + 全量 build 的实测墙钟远低于此值；
+    # 设 30 分钟是给 runner 抖动与主干增长留余量，不与变异段的预算互相挤占。
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-        # #220 按需基线：push 事件需 before 对象可达以 diff 变动包（fail-closed 全量兜底）
         with:
           fetch-depth: 0
 
@@ -86,60 +129,137 @@ jobs:
       - name: CRAP（热点报告；strict 见 gauntlet.config.json 的 crap.strict）
         run: pnpm crap
 
-      - name: Resolve mutation suites（#276 方案 A + #433 全量班：每日一次全量）
-        id: suite-plan
+      - name: Upload coverage summary（供 mutation-collect 的报告展示；#718 S1.5）
+        # 报告正文同时含覆盖率与变异率，故覆盖率产物必须跨 job 传递。
+        # 失败时不阻断收口：collect 侧的 observe-check 对该文件本就是可选的。
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: coverage-summary
+          path: coverage/coverage-summary.json
+          retention-days: 14
+          if-no-files-found: warn
+
+  # ── 变异矩阵：每段一个实例（S1.1）────────────────────────────────
+  mutation-shards:
+    name: Mutation shard (${{ matrix.shard.seg }})
+    needs: mutation-plan
+    strategy:
+      # S1.4：单段失败不连坐——原串行实现的「单配置失败记账继续跑完」语义由矩阵天然承担，
+      # 且失败段可用 `gh run rerun --failed` 定向重跑，无需整班重来。
+      fail-fast: false
+      # S1.1：S0.3 实测账户并发额度上界 20（20 个 gate:full run 中 15 个精确触达且从未超过）。
+      # 取 5 留足余量给 build-test 矩阵与其它 workflow 的并发需求。
+      max-parallel: 5
+      matrix:
+        # 段清单与逐段超时均来自 mutation-plan（见该 job 与文件头注释）
+        shard: ${{ fromJSON(needs.mutation-plan.outputs.shards) }}
+    runs-on: ubuntu-latest
+    # S1.4：逐段超时（下限 10 分钟），由台账里该段 scope=full 的实测墙钟派生；
+    # 无实测的段取保守默认值。原实现取整班 90 分钟，长段擦边即整班被杀。
+    timeout-minutes: ${{ matrix.shard.timeoutMinutes }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+        # 版本以根 package.json 的 packageManager 字段为单一事实源（勿同时指定 version）
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # 必须全量构建（run #32790425132 教训）：变异面按 src 级文件 glob 声明，
+      # 但测试面与 workspace 内联链（shared/ 与依赖包副本）需要全集一致的构建产物。
+      - name: Build all packages
+        run: pnpm build
+
+      - name: Mutation shard（全量冷跑：本班无基线 restore，见文件头）
+        run: npx stryker run "stryker.conf.d/${{ matrix.shard.seg }}.json"
+
+      # if: always()：实例非零退出（崩溃 / 内建阈值不足）时已产出的报告照常下发聚合判分；
+      # 未产出报告时 if-no-files-found: error 让实例自身红（fail-closed）。
+      - name: Upload shard reports（交 mutation-collect 统一判分与归档）
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: mutation-shard-${{ matrix.shard.seg }}
+          path: |
+            coverage/mutation/${{ matrix.shard.seg }}.json
+            coverage/mutation/incremental-*.json
+          retention-days: 1
+          if-no-files-found: error
+
+  # ── 收口：判分 + 单点 push 基线 + 报告 + 工单（S1.5）──────────────
+  # - 各段报告（mutation-shards 矩阵）与覆盖率（quality）在此汇合后判分：
+  #   报告齐备性由 observe-check.mjs 按 stryker.conf.d/ 派生的段集合校验（缺段 fail-closed）。
+  # - `if: always()`：矩阵实例失败、quality 失败（cov 阈值不达标）时本 job 仍运行——
+  #   它同时承担「已产出数据的收集」与「异常留痕」，这正是 #718 两次事故中缺失的环节
+  #   （取消点在报告步骤之前 ⇒ 当夜无工单、基线不更新且无人察觉）。
+  # - 判分链与基线推送均为纯 Node 内置模块 + git，无需 pnpm install。
+  mutation-collect:
+    name: Mutation collect (score + baseline + report)
+    needs: [mutation-plan, quality, mutation-shards]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          # 基线推送要操作孤立分支，需要完整 ref 视图
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 24
+          # 本 job 不 pnpm install（判分链为纯 Node 内置模块），必须显式关闭
+          # setup-node v5 默认的 package-manager-cache：它探测到 pnpm-lock.yaml 会调
+          # PATH 中的 pnpm，而本 job 无 pnpm/action-setup（实证 run 32879414842）。
+          package-manager-cache: false
+
+      - name: Download shard reports
+        # 全段失败时也可能零产物：不因下载为空而阻断收口——「零报告」本身要由
+        # 后续的报告齐备性校验判红并留痕，而不是让本步骤先崩掉。
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: mutation-shard-*
+          path: coverage/mutation
+
+      - name: Download coverage summary
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: coverage-summary
+          path: coverage
+
+      - name: Restore report layout（多 artifact 下载各建子目录，平铺回 coverage/mutation/）
+        id: reports
         run: |
           set -e
-          # 全量清单（glob conf 目录为单一事实源）——全量班即全量变异，无 push
-          # 裁剪分支（#220 按需基线的 push 触发已随 #276 方案 A 调度重设计移除，
-          # #433 起本 workflow 收敛为每日全量班，见本文件 on: 节）
-          ls stryker.conf.d/dsh-*.json > /tmp/suites.txt
-          echo "mode=full" >> "$GITHUB_OUTPUT"
-          echo "has_suites=true" >> "$GITHUB_OUTPUT"
-
-      - name: Mutation suites（串行执行计划内变异配置；单配置失败记账继续跑完，结尾统一判红）
-        # id 供 collect 步骤区分「整套 skip（无产物无从收集）」与「部分失败
-        # （记账夜已产出的基线照常收集）」（#217）
-        id: mutation-suites
-        if: steps.suite-plan.outputs.has_suites == 'true'
-        # #178 逐包容错：strict 判红路径下 incremental 基线已先落盘（StrykerJS 源码核实），
-        # 记账继续可让后续包照常产出报告与基线，避免单包连锁丢弃整夜数据。
-        # #220 B 方案：循环清单由 suite-plan 步骤产出（全量 glob 或按需裁剪），
-        # 本步骤不再关心名单来源
-        run: |
-          FAILED=0
-          FAILED_CONFS=''
-          while read -r conf; do
-            name="$(basename "$conf" .json)"
-            echo "::group::stryker $name"
-            if npx stryker run "$conf"; then
-              echo "::endgroup::"
-            else
-              echo "::endgroup::"
-              echo "::error::变异套件失败：$name（记账后继续执行其余配置）"
-              FAILED=1
-              FAILED_CONFS="$FAILED_CONFS $name"
-            fi
-          done < /tmp/suites.txt
-          if [ "$FAILED" -ne 0 ]; then
-            echo "::error::以下变异套件失败，统一判红:$FAILED_CONFS"
-            exit 1
+          mkdir -p coverage/mutation
+          DIRS="$(ls -d coverage/mutation/mutation-shard-* 2>/dev/null || true)"
+          for dir in $DIRS; do cp "$dir"/*.json coverage/mutation/ 2>/dev/null || true; done
+          COUNT=$(ls coverage/mutation/dsh-*.json 2>/dev/null | wc -l | tr -d ' ')
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "报告 artifact 还原完成：${COUNT} 份段报告"
+          if [ "$COUNT" -eq 0 ]; then
+            echo '::warning::本班次未产出任何段报告（全部实例失败或被杀）—— 基线不更新，由收尾工单留痕'
           fi
-
-      - name: Push baseline to orphan branch（#572：提交纯文本树到孤立分支）
-        # #572：替代旧方案（#204 方案 A：向 main 自动建 PR 提交数十万行 JSON 导致 git 膨胀）。
-        # 将最新增量基线以单 commit 纯文本树推送到孤立分支 refs/heads/baseline/mutation，
-        # 享受 Git Blob 原生内容去重红利，彻底净化 main 分支代码树与提交历史。
-        # if: always() && 非 skipped 且有计划 —— 部分失败夜已产出的基线文件照常收集；
-        # 但整套变异被 skip 或按需计划为空时无任何产物，不运行。
-        if: always() && steps.mutation-suites.outcome != 'skipped' && steps.suite-plan.outputs.has_suites == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OBSERVE_PAT: ${{ secrets.OBSERVE_PAT }}
-        run: node scripts/gate/orphan-baseline.mjs push
 
       - name: Threshold check & report body（阈值校验 + 回落检测 + 报告产出）
         id: report
+        if: steps.reports.outputs.count != '0'
         run: |
           set -e
           node scripts/gate/observe-check.mjs --body-file observe-body.md --marker-file observe-marker.txt
@@ -147,6 +267,18 @@ jobs:
           # 触发 "Matching delimiter not found" 解析失败；GitHub 官方文档明示值不可控时
           # 应写文件而非用 delimiter 格式）。下游步骤直接读 observe-body.md /
           # observe-marker.txt（[ -s file ] 判断非空）。
+
+      - name: Push baseline to orphan branch（#572：提交纯文本树到孤立分支）
+        # #572：替代旧方案（#204 方案 A：向 main 自动建 PR 提交数十万行 JSON 导致 git 膨胀）。
+        # 将最新增量基线以单 commit 纯文本树推送到孤立分支 refs/heads/baseline/mutation，
+        # 享受 Git Blob 原生内容去重红利，彻底净化 main 分支代码树与提交历史。
+        # #718 S1.5：本步骤**单点**落在收口 job——矩阵各实例不再各自推送，消除并发覆盖踩踏；
+        # 部分失败夜已产出的基线文件照常收集（if: always() + 有报告才推）。
+        if: always() && steps.reports.outputs.count != '0'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OBSERVE_PAT: ${{ secrets.OBSERVE_PAT }}
+        run: node scripts/gate/orphan-baseline.mjs push
 
       - name: Create/update observe issue（幂等：同日重跑不重复建；回落即追评）
         if: always() && steps.report.outcome == 'success'
@@ -176,4 +308,6 @@ jobs:
             coverage/coverage-summary.json
             coverage/mutation/
           retention-days: 14
-          if-no-files-found: error   # 报告缺失本身即异常（fail-closed，评审 F4 旁证）
+          # 报告缺失本身即异常，但此处不判红：判红由 observe-check 的段齐备性校验承担，
+          # 本步骤只负责留档（若在此 error，被杀夜次会连「零产物」这一事实都留不下）。
+          if-no-files-found: warn

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,7 @@
 - `gate/test-surface.mjs` / `gate/mutation-topology.mjs` — 测试分层与变异面登记校验（唯一事实源 `data/mutation-topology.json`）。
 - `gate/threshold-monotonic.mjs` — 阈值单调性校验（对比 `origin/main`，只许升不许降）：守护 `vitest.config.ts` 的 `coverage.thresholds`（#722 阶段三起的覆盖率唯一事实源）与 `gauntlet.config.json` 的变异阈值。
 - `gate/mutation-ledger.mjs` — 变异段实测台账（#718 S0.2）：从 Actions run 日志解析逐段 `wallSeconds`（真实执行时间，区别于会被增量班刷新的文件 mtime）与复用率/杀灭分布；`--check` 离线校验覆盖不变量（测量值 ∪ `unmeasured` == 当前 `stryker.conf.d` 段集合，消失的历史段须在 `superseded` 登记取代关系），由 `test:scripts` 调用。生成模式需 gh 与网络，故定位为维护者工具、不进 CI（进 CI 需改 `.github/`，属红线段）。
+- `gate/mutation-plan.mjs` — 夜间变异矩阵的段清单与逐段超时派生（#718 S1.1/S1.4）：段清单 glob `stryker.conf.d/dsh-*.json`（与 ci-matrix / mutation-gate 同源），超时按 `mutation-segment-ledger.json` 里该段 `scope=full` 的实测墙钟 × 1.5 + 构建开销派生、下限 10 分钟，无实测的段取保守默认；输出 matrix JSON 供 `observe.yml` 的动态矩阵消费（GHA 矩阵只能引用 needs output、不能读工作区文件，故单列一个秒级 plan job）。
 
 ## maintenance/（一次性维护脚本，按需手工执行）
 
@@ -50,6 +51,7 @@
 - `test/crap-check.test.ts` — crap-check 脚本自测（config.strict 单一开关；#722 阶段五起含「非 src 口径数据必须 fail-closed」用例）。
 - `test/threshold-monotonic.test.ts` — 阈值单调性自测（#722：vitest.config.ts 的 coverage.thresholds 提取、降线判红、缺块 fail-closed）。
 - `test/mutation-ledger.test.ts` — 变异段台账自测（#718 S0.2：GHA 日志解析口径含单空格前缀与 ANSI 剥离、未闭合段宁缺勿造、`wallSeconds` 正数不变量、覆盖全部段对账、历史段 `superseded` 登记）。
+- `test/mutation-plan.test.ts` — 变异矩阵段清单与超时派生自测（#718 S1.1/S1.4：段清单口径同源、超时只用 `scope=full` 实测、公式与下限不被放宽、无实测落保守默认）。
 - `test/pack-check-scope.test.ts` — pack-check 聚合段切片口径自测（#722/#751：增量切片下不得对未构建的聚合包假红；全仓口径必须仍执行该段，缺产物 fail-loud 且 exit 与判定自洽；切片用例取 `script-test-prereqs.mjs` 的 PREREQ 包——取清单外的包会把假红从 pack:check 搬进 test:scripts）。
 
 ## data/（配置数据）

--- a/scripts/data/mutation-segment-ledger.json
+++ b/scripts/data/mutation-segment-ledger.json
@@ -3,6 +3,213 @@
   "measurements": [
     {
       "run": {
+        "id": 34536263640,
+        "workflow": "observe.yml",
+        "event": "schedule",
+        "conclusion": "cancelled",
+        "createdAt": "2026-09-10T22:12:31Z",
+        "headSha": "98f003f0aa9c24b725da29068c31460eeab1dd5f"
+      },
+      "scope": "full",
+      "measuredAt": "2026-09-12T06:37:33.483Z",
+      "logSource": "gh run view 34536263640 --log",
+      "segments": [
+        {
+          "seg": "dsh-lan-proxy-1",
+          "startedAt": "2026-09-10T22:13:46.2135240",
+          "endedAt": "2026-09-10T22:17:04.5870062",
+          "wallSeconds": 198.4,
+          "mutants": 693,
+          "dryTests": 2,
+          "dryRunSeconds": 6,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": "3 minutes and 17 seconds"
+        },
+        {
+          "seg": "dsh-lan-proxy-2",
+          "startedAt": "2026-09-10T22:17:04.5886151",
+          "endedAt": "2026-09-10T22:18:50.5549645",
+          "wallSeconds": 106,
+          "mutants": 691,
+          "dryTests": 2,
+          "dryRunSeconds": 6,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": "1 minute and 44 seconds"
+        },
+        {
+          "seg": "dsh-lan-proxy-3",
+          "startedAt": "2026-09-10T22:18:50.5565501",
+          "endedAt": "2026-09-10T22:19:34.2101211",
+          "wallSeconds": 43.7,
+          "mutants": 313,
+          "dryTests": 2,
+          "dryRunSeconds": 6,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": "42 seconds"
+        },
+        {
+          "seg": "dsh-lan-proxy-4",
+          "startedAt": "2026-09-10T22:19:34.2116904",
+          "endedAt": "2026-09-10T22:19:54.6670322",
+          "wallSeconds": 20.5,
+          "mutants": 82,
+          "dryTests": 2,
+          "dryRunSeconds": 6,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": "19 seconds"
+        },
+        {
+          "seg": "dsh-mcp-manager-entry",
+          "startedAt": "2026-09-10T22:19:54.6685404",
+          "endedAt": "2026-09-10T22:23:32.7331516",
+          "wallSeconds": 218.1,
+          "mutants": 477,
+          "dryTests": 13,
+          "dryRunSeconds": 53,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": "3 minutes and 36 seconds"
+        },
+        {
+          "seg": "dsh-mcp-manager-manager",
+          "startedAt": "2026-09-10T22:23:32.7346429",
+          "endedAt": "2026-09-10T22:32:37.3775172",
+          "wallSeconds": 544.6,
+          "mutants": 991,
+          "dryTests": 13,
+          "dryRunSeconds": 52,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": "9 minutes and 3 seconds"
+        },
+        {
+          "seg": "dsh-mcp-manager-middleware",
+          "startedAt": "2026-09-10T22:32:37.3791300",
+          "endedAt": "2026-09-10T22:50:41.1521842",
+          "wallSeconds": 1083.8,
+          "mutants": 1646,
+          "dryTests": 13,
+          "dryRunSeconds": 52,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": "18 minutes and 2 seconds"
+        },
+        {
+          "seg": "dsh-mcp-manager-routes",
+          "startedAt": "2026-09-10T22:50:41.1536692",
+          "endedAt": "2026-09-10T22:52:33.6807288",
+          "wallSeconds": 112.5,
+          "mutants": 536,
+          "dryTests": 13,
+          "dryRunSeconds": 52,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": "1 minute and 51 seconds"
+        },
+        {
+          "seg": "dsh-mcp-manager-runtime",
+          "startedAt": "2026-09-10T22:52:33.6822192",
+          "endedAt": "2026-09-10T23:13:45.9376886",
+          "wallSeconds": 1272.3,
+          "mutants": 1822,
+          "dryTests": 13,
+          "dryRunSeconds": 52,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": "21 minutes and 11 seconds"
+        },
+        {
+          "seg": "dsh-mcp-manager-supervisor",
+          "startedAt": "2026-09-10T23:13:45.9392486",
+          "endedAt": "2026-09-10T23:23:57.6214399",
+          "wallSeconds": 611.7,
+          "mutants": 1150,
+          "dryTests": 13,
+          "dryRunSeconds": 52,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": "10 minutes and 10 seconds"
+        },
+        {
+          "seg": "dsh-notifier-channels",
+          "startedAt": "2026-09-10T23:23:57.6233023",
+          "endedAt": "2026-09-10T23:24:48.3032546",
+          "wallSeconds": 50.7,
+          "mutants": 285,
+          "dryTests": 24,
+          "dryRunSeconds": 14,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": "49 seconds"
+        },
+        {
+          "seg": "dsh-notifier-config",
+          "startedAt": "2026-09-10T23:24:48.3047358",
+          "endedAt": "2026-09-10T23:35:03.9063685",
+          "wallSeconds": 615.6,
+          "mutants": 2365,
+          "dryTests": 24,
+          "dryRunSeconds": 14,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": "10 minutes and 14 seconds"
+        },
+        {
+          "seg": "dsh-notifier-events",
+          "startedAt": "2026-09-10T23:35:03.9078396",
+          "endedAt": "2026-09-10T23:36:47.8923396",
+          "wallSeconds": 104,
+          "mutants": 553,
+          "dryTests": 24,
+          "dryRunSeconds": 14,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": "1 minute and 42 seconds"
+        },
+        {
+          "seg": "dsh-notifier-pipeline",
+          "startedAt": "2026-09-10T23:36:47.8938637",
+          "endedAt": "2026-09-10T23:37:53.2749202",
+          "wallSeconds": 65.4,
+          "mutants": 227,
+          "dryTests": 24,
+          "dryRunSeconds": 14,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": "1 minute and 4 seconds"
+        },
+        {
+          "seg": "dsh-notifier-sdk",
+          "startedAt": "2026-09-10T23:37:53.2763428",
+          "endedAt": "2026-09-10T23:40:03.0736961",
+          "wallSeconds": 129.8,
+          "mutants": 393,
+          "dryTests": 24,
+          "dryRunSeconds": 14,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": "2 minutes and 8 seconds"
+        },
+        {
+          "seg": "dsh-notifier-server",
+          "startedAt": "2026-09-10T23:40:03.0751763",
+          "endedAt": "2026-09-10T23:42:51.7697965",
+          "wallSeconds": 168.7,
+          "mutants": 722,
+          "dryTests": 24,
+          "dryRunSeconds": 14,
+          "reused": null,
+          "reuseTotal": null,
+          "strykerReported": null
+        }
+      ]
+    },
+    {
+      "run": {
         "id": 34579060425,
         "workflow": "observe-incremental.yml",
         "event": "schedule",

--- a/scripts/gate/mutation-plan.mjs
+++ b/scripts/gate/mutation-plan.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * scripts/gate/mutation-plan.mjs —— 夜间变异矩阵的段清单与逐段超时派生（#718 S1.1 / S1.4）。
+ *
+ * 为什么单独成脚本：GHA 的动态 matrix 只能引用 needs 的 output（不能读工作区文件），
+ * 而「哪些段要跑」的唯一事实源是 `stryker.conf.d/*.json`（段集合随拆段/加包自动演进）。
+ * 故由一个秒级 plan job 把「文件系统事实」翻译成 matrix 可消费的 JSON。
+ *
+ * 为什么超时按段派生而不是取一个全局值：#718 的两次事故都是**单段擦边超时**
+ * （run 34536263640 的 mcp-manager-runtime 21.2 min 对 90 min 的整班预算）。矩阵化后
+ * 每段独立 job，超时若仍取全局值，长段会把短段的风险预算一并吃掉；按段取实测 P95
+ * 才能让「单段异常」只影响单段。
+ *
+ * 超时取值（口径必须随数字一起引用）：
+ *   - 有 `scope=full` 实测的段：`ceil(实测最长 wallSeconds / 60 × 1.5) + 构建开销`（1.5 为安全系数）；
+ *   - 无实测的段：`DEFAULT_TIMEOUT_MINUTES`（保守值，与 ci.yml 的 mutation-gate 同源）；
+ *   - 一律不低于 `TIMEOUT_FLOOR_MINUTES`（#718 整合版规定的下限）。
+ * 之所以只用 `scope=full` 的实测：全量冷跑的段耗时可达同段增量耗时（有基线复用）的数倍
+ * （实测 mcp-manager-supervisor：全量 10.19 min 对增量 104 s，约 5.9 倍），拿增量值定超时会
+ * 造成系统性擦边。
+ *
+ * 用法：node scripts/gate/mutation-plan.mjs        # 打印 matrix JSON（供 GITHUB_OUTPUT）
+ * 退出码：0 = 成功；2 = 环境错误（conf 目录为空 / 台账不可解析）。
+ */
+import { appendFileSync, existsSync, readFileSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const CONF_DIR = join(ROOT, 'stryker.conf.d')
+const LEDGER_PATH = join(ROOT, 'scripts', 'data', 'mutation-segment-ledger.json')
+
+/** 无全量实测时的保守超时（与 ci.yml 的 mutation-gate 一致，该 job 已覆盖过最坏冷跑）。 */
+export const DEFAULT_TIMEOUT_MINUTES = 30
+/** #718 整合版规定的下限：低于它会让短段在正常的 runner 抖动下擦边。 */
+export const TIMEOUT_FLOOR_MINUTES = 10
+/** checkout + pnpm install + 全量 build 的墙钟开销（矩阵实例每段都要付一次）。 */
+export const SETUP_OVERHEAD_MINUTES = 4
+/** 实测值的放大系数：runner 抖动 + 主干代码增长。 */
+export const SAFETY_FACTOR = 1.5
+
+/** 段清单：`stryker.conf.d/dsh-*.json` 的文件名去 `.json`（与 ci-matrix / mutation-gate 同源口径）。 */
+export function listSegments(confDir = CONF_DIR) {
+  return readdirSync(confDir)
+    .filter((f) => f.startsWith('dsh-') && f.endsWith('.json'))
+    .map((f) => f.slice(0, -'.json'.length))
+    .sort()
+}
+
+/** 从台账抽取每段在 `scope=full` 下的最长实测墙钟（秒）；无实测的段不出现在结果里。 */
+export function fullScopePeaks(ledger) {
+  const peaks = new Map()
+  for (const m of ledger?.measurements ?? []) {
+    if (m.scope !== 'full') continue
+    for (const s of m.segments ?? []) {
+      if (typeof s.wallSeconds !== 'number' || !(s.wallSeconds > 0)) continue
+      const prev = peaks.get(s.seg) ?? 0
+      if (s.wallSeconds > prev) peaks.set(s.seg, s.wallSeconds)
+    }
+  }
+  return peaks
+}
+
+/** 单段超时（分钟）：有全量实测则按其放大 + 构建开销，否则取保守默认；一律不低于下限。 */
+export function timeoutForSegment(seg, peaks) {
+  const measured = peaks.get(seg)
+  if (measured === undefined) return DEFAULT_TIMEOUT_MINUTES
+  const minutes = Math.ceil((measured / 60) * SAFETY_FACTOR + SETUP_OVERHEAD_MINUTES)
+  return Math.max(TIMEOUT_FLOOR_MINUTES, minutes)
+}
+
+/** 生成 matrix：`[{ seg, timeoutMinutes }]`，按段名字典序（与 conf 目录顺序一致，便于比对）。 */
+export function buildShardMatrix(segs, peaks) {
+  return segs.map((seg) => ({ seg, timeoutMinutes: timeoutForSegment(seg, peaks) }))
+}
+
+function main() {
+  const segs = listSegments()
+  if (segs.length === 0) {
+    console.error(`[mutation-plan] ${CONF_DIR} 下无 dsh-*.json —— 段集合为空（fail-closed）`)
+    return 2
+  }
+  let ledger = null
+  if (existsSync(LEDGER_PATH)) {
+    try {
+      ledger = JSON.parse(readFileSync(LEDGER_PATH, 'utf8'))
+    } catch (e) {
+      console.error(`[mutation-plan] 台账不可解析：${LEDGER_PATH} —— ${String(e.message).split('\n')[0]}`)
+      return 2
+    }
+  }
+  const peaks = fullScopePeaks(ledger)
+  const matrix = buildShardMatrix(segs, peaks)
+  const measured = matrix.filter((m) => peaks.has(m.seg)).length
+  const json = JSON.stringify(matrix)
+  // 诊断走 stderr：stdout 只放 matrix JSON，避免污染 GITHUB_OUTPUT
+  console.error(`[mutation-plan] ${matrix.length} 段；其中 ${measured} 段有全量实测超时，`
+    + `${matrix.length - measured} 段用保守默认 ${DEFAULT_TIMEOUT_MINUTES} min；`
+    + `超时区间 ${Math.min(...matrix.map((m) => m.timeoutMinutes))}~${Math.max(...matrix.map((m) => m.timeoutMinutes))} min`)
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `shards=${json}\n`, 'utf8')
+    console.log(`shards 已写入 GITHUB_OUTPUT（${matrix.length} 项）`)
+  } else {
+    console.log(`shards=${json}`)
+  }
+  return 0
+}
+
+// CLI 守卫：被测试 import 时不执行 main（纯函数可离线复用）。
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.exit(main())
+}

--- a/scripts/test/mutation-plan.test.ts
+++ b/scripts/test/mutation-plan.test.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// @ts-nocheck
+'use strict'
+
+/**
+ * 夜间变异矩阵的段清单与逐段超时派生回归（#718 S1.1 / S1.4）。
+ *
+ * 为什么需要它：矩阵的段清单与每段超时都直接决定「哪些变异会跑」「跑多久算擦边」——
+ * 前者漏段 = 包级变异率静默偏低（mutation-gate 按 mutant id 去重聚合，遗漏偏低），
+ * 后者取错口径 = 长段在正常抖动下被误杀（用增量实测定全量超时就属此类，实测同段
+ * 全量可达增量的数倍）。故这里锁死四条：
+ *   1. 段清单口径与 ci-matrix / mutation-gate 同源（dsh- 前缀 + .json，去后缀）；
+ *   2. 超时只认 `scope=full` 的实测（增量值不得参与定标）；
+ *   3. 超时公式与下限（#718 整合版规定 10 分钟）不被静默放宽；
+ *   4. 无实测的段必须落到保守默认值，而不是 0 或继承别的段的值。
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  DEFAULT_TIMEOUT_MINUTES,
+  SETUP_OVERHEAD_MINUTES,
+  SAFETY_FACTOR,
+  TIMEOUT_FLOOR_MINUTES,
+  buildShardMatrix,
+  fullScopePeaks,
+  listSegments,
+  timeoutForSegment,
+} from '../gate/mutation-plan.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+test('段清单：只认 dsh-*.json 且去后缀，与 ci-matrix / mutation-gate 同源口径', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'mutation-plan-'))
+  try {
+    for (const f of ['dsh-b-z.json', 'dsh-a.json', 'README.md', 'not-dsh-c.json']) {
+      writeFileSync(join(dir, f), '{}')
+    }
+    assert.deepEqual(listSegments(dir), ['dsh-a', 'dsh-b-z'])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('段清单：目录为空时返回空数组（由调用方 fail-closed，不在此吞掉）', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'mutation-plan-'))
+  try {
+    assert.deepEqual(listSegments(dir), [])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('超时定标只用 scope=full 的实测：增量值不得参与（同段全量可达增量的数倍）', () => {
+  const peaks = fullScopePeaks({
+    measurements: [
+      { scope: 'incremental', segments: [{ seg: 's1', wallSeconds: 3600 }] },
+      { scope: 'full', segments: [{ seg: 's1', wallSeconds: 600 }] },
+    ],
+  })
+  assert.equal(peaks.get('s1'), 600, '必须取 full 口径的值，忽略更大的 incremental 值')
+})
+
+test('超时定标：同一段多次 full 测量取最大值（不得取平均或首次）', () => {
+  const peaks = fullScopePeaks({
+    measurements: [
+      { scope: 'full', segments: [{ seg: 's1', wallSeconds: 600 }] },
+      { scope: 'full', segments: [{ seg: 's1', wallSeconds: 900 }] },
+    ],
+  })
+  assert.equal(peaks.get('s1'), 900)
+})
+
+test('超时公式：实测 × 安全系数 + 构建开销，且不低于下限', () => {
+  const peaks = new Map([['big', 21.2 * 60], ['tiny', 20]])
+  // 21.2 min × 1.5 + 4 = 35.8 → 36
+  assert.equal(timeoutForSegment('big', peaks), Math.ceil(21.2 * SAFETY_FACTOR + SETUP_OVERHEAD_MINUTES))
+  // 20 s × 1.5 + 4 = 4.5 → 5，但下限 10 生效
+  assert.equal(timeoutForSegment('tiny', peaks), TIMEOUT_FLOOR_MINUTES)
+  assert.ok(SAFETY_FACTOR > 1, '安全系数必须 > 1（大于 1 才是余量）')
+})
+
+test('超时：无实测的段取保守默认，不得取 0 或继承他段值', () => {
+  const peaks = new Map([['known', 600]])
+  assert.equal(timeoutForSegment('unknown', peaks), DEFAULT_TIMEOUT_MINUTES)
+  assert.ok(DEFAULT_TIMEOUT_MINUTES >= TIMEOUT_FLOOR_MINUTES, '保守默认不得低于下限')
+})
+
+test('矩阵结构：每项含 seg 与 timeoutMinutes，顺序与传入段序一致', () => {
+  const m = buildShardMatrix(['a', 'b'], new Map([['a', 600]]))
+  assert.deepEqual(m.map((x) => x.seg), ['a', 'b'])
+  for (const x of m) assert.ok(Number.isInteger(x.timeoutMinutes) && x.timeoutMinutes >= TIMEOUT_FLOOR_MINUTES)
+})
+
+test('真实仓库：段清单与 stryker.conf.d 文件集精确一致（漏段即判红）', () => {
+  const confFiles = readdirSync(join(ROOT, 'stryker.conf.d')).filter((f) => f.endsWith('.json')).sort()
+  const expected = confFiles.map((f) => f.slice(0, -'.json'.length))
+  assert.deepEqual(listSegments(join(ROOT, 'stryker.conf.d')), expected,
+    'mutation-plan 的段清单必须与 stryker.conf.d 文件集一一对应')
+})
+
+test('真实仓库：入库台账的 full 测量值确实被超时派生消费', () => {
+  const ledger = JSON.parse(readFileSync(join(ROOT, 'scripts', 'data', 'mutation-segment-ledger.json'), 'utf8'))
+  const peaks = fullScopePeaks(ledger)
+  const matrix = buildShardMatrix(listSegments(join(ROOT, 'stryker.conf.d')), peaks)
+  const measured = matrix.filter((m) => m.timeoutMinutes !== DEFAULT_TIMEOUT_MINUTES)
+  // 不硬编码具体段数：只断言「有全量实测的段确实派生出非默认超时」这一因果关系
+  for (const m of matrix) {
+    if (peaks.has(m.seg)) {
+      assert.notEqual(m.timeoutMinutes, DEFAULT_TIMEOUT_MINUTES,
+        `${m.seg} 有 full 实测却落到默认超时——派生链断了`)
+    }
+  }
+  assert.ok(measured.length > 0 || peaks.size === 0,
+    '台账里存在 full 测量时，矩阵必须至少消费一条')
+})

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -247,12 +247,13 @@ test('#433+#572 调度重设计与孤立分支基线: observe 全量班（北京
   // ── 全量班（observe.yml）：每日一次，北京次日 04:00 = UTC 20:00 ──
   assert.ok(OBSERVE.includes("'0 20 * * *'"),
     '全量班 cron 必须为每日一次 UTC 20:00（北京次日 04:00）')
-  assert.ok(OBSERVE.includes('Resolve mutation suites'), '全量班 suite-plan 步骤在位')
-  assert.ok(OBSERVE.includes('ls stryker.conf.d/dsh-*.json > /tmp/suites.txt'),
-    '全量班 suite-plan 必须纯全量（glob conf 目录为单一事实源，无 push 裁剪分支）')
+  // #718 S1.1：全量班由「单 job 串行循环」改为「逐段矩阵」，段清单的单一事实源
+  // 从 workflow 内联 glob 迁到 mutation-plan.mjs（仍 glob conf 目录，无 push 裁剪分支）
+  assert.ok(OBSERVE.includes('node scripts/gate/mutation-plan.mjs'),
+    '全量班段清单必须由 mutation-plan.mjs 派生（glob conf 目录为单一事实源，无 push 裁剪分支）')
   assert.ok(!OBSERVE.includes('EVENT_NAME'), 'observe 不得再依赖 push/事件类型（#276 方案 A 已移除 push 触发）')
-  assert.ok(OBSERVE.includes('steps.suite-plan.outputs.has_suites == \'true\''),
-    '全量班变异执行与 push 必须以 has_suites 为前提——空计划不跑 push')
+  assert.ok(OBSERVE.includes("steps.reports.outputs.count != '0'"),
+    '全量班变异执行与 push 必须以「有段报告产出」为前提——空产物不跑 push（原 has_suites 语义的矩阵化等价物）')
   assert.ok(!OBSERVE.includes('skip_pr=true'), '#572：全量班已迁移至孤立分支，日期闸与 PR 步骤已退役')
   assert.ok(OBSERVE.includes('orphan-baseline.mjs push'), '全量班调用 orphan-baseline.mjs push 提交孤立分支')
 
@@ -269,16 +270,25 @@ test('#433+#572 调度重设计与孤立分支基线: observe 全量班（北京
 })
 
 test('#220 段式三方一致：observe 计划 ↔ stryker.conf.d 文件集 ↔ gauntlet 包集', () => {
-  // observe 两班（全量班 observe.yml + 增量班 observe-incremental.yml）循环清单
-  // 均由各自 suite-plan 步骤产出（#433：全量班即全量、增量班基于基线跑增量但
-  // 清单同样 glob 全量——新增配置自动纳入，Stryker 增量模式跳过未变 mutant）；
-  // 循环本身从计划文件读取
-  for (const [name, wf] of [['observe.yml', OBSERVE], ['observe-incremental.yml', OBSERVE_INC]]) {
-    assert.ok(wf.includes('ls stryker.conf.d/dsh-*.json'),
-      `${name} suite-plan 的全量清单必须以 glob stryker.conf.d/dsh-*.json 为单一事实源（新增配置自动纳入）`)
-    assert.ok(wf.includes('while read -r conf; do'),
-      `${name} 变异循环必须从 suite-plan 清单文件逐行消费`)
-  }
+  // observe 两班的段清单都必须以 `stryker.conf.d/` 为单一事实源（新增配置自动纳入），
+  // 但 #718 S1.1 后载体不同：
+  //   - 全量班改为逐段矩阵，段清单必须在 **workflow 之前** 派生（动态 matrix 只能引用
+  //     needs output，不能读工作区文件），故 glob 迁进 `scripts/gate/mutation-plan.mjs`；
+  //   - 增量班未矩阵化（#718 S2.2 单独处置），仍是 workflow 内联 glob + 逐行循环。
+  // 判据随之拆成「workflow 调用脚本 + 脚本内 glob」两段合取——强度不降（多锁一条脚本侧口径）。
+  assert.ok(OBSERVE.includes('node scripts/gate/mutation-plan.mjs'),
+    'observe.yml 段清单必须由 mutation-plan.mjs 派生')
+  assert.ok(OBSERVE.includes('shard: ${{ fromJSON(needs.mutation-plan.outputs.shards) }}'),
+    'observe.yml 矩阵必须消费 mutation-plan 的段清单（不得硬编码段列表）')
+  const planSrc = readFileSync(join(ROOT, 'scripts', 'gate', 'mutation-plan.mjs'), 'utf8')
+  assert.ok(planSrc.includes('stryker.conf.d') && planSrc.includes('readdirSync'),
+    'mutation-plan.mjs 必须以 stryker.conf.d/ 目录为段清单的单一事实源（新增配置自动纳入）')
+  assert.ok(planSrc.includes("startsWith('dsh-')"),
+    'mutation-plan.mjs 的段清单口径必须与 ci-matrix / mutation-gate 同源（dsh- 前缀 + .json 后缀）')
+  assert.ok(OBSERVE_INC.includes('ls stryker.conf.d/dsh-*.json'),
+    'observe-incremental.yml suite-plan 的全量清单必须以 glob stryker.conf.d/dsh-*.json 为单一事实源（新增配置自动纳入）')
+  assert.ok(OBSERVE_INC.includes('while read -r conf; do'),
+    'observe-incremental.yml 变异循环必须从 suite-plan 清单文件逐行消费')
 
   // stryker.conf.d 实际文件集 → 基础包名集合（段配置 <pkg>-<后缀>.json 与包级
   // <pkg>.json 统一归并到 <pkg>——功能段名/数字段名兼容，basePkgOfConf 共享函数）
@@ -1019,8 +1029,11 @@ test('#722: 全仓产物闸在夜间班次落地（PR 改增量后全仓口径�
   }
 })
 
-test('#217+#572: observe 两班 Mutation suites id + push 区分整套 skip 与部分失败', () => {
-  for (const [name, wf] of [['observe.yml', OBSERVE], ['observe-incremental.yml', OBSERVE_INC]]) {
+test('#217+#572: observe 两班变异记账与 push 区分整套 skip 与部分失败', () => {
+  // 增量班未矩阵化（#718 S2.2 单独处置）：仍是「Mutation suites 步骤 + outcome != skipped」
+  {
+    const name = 'observe-incremental.yml'
+    const wf = OBSERVE_INC
     const sIdx = wf.indexOf('- name: Mutation suites')
     assert.ok(sIdx > 0, `${name} Mutation suites 步骤在位`)
     const sBlock = wf.slice(sIdx, wf.indexOf('- name:', sIdx + 10))
@@ -1031,4 +1044,60 @@ test('#217+#572: observe 两班 Mutation suites id + push 区分整套 skip 与�
     assert.ok(pBlock.includes("if: always() && steps.mutation-suites.outcome != 'skipped'"),
       `${name} push 条件必须区分整套 skip（无产物不推送）与部分失败（记账班次照常提交）`)
   }
+  // #718 S1.1/S1.5：全量班矩阵化后，「整套 skip vs 部分失败」由收口 job 的
+  // 「有段报告才推送」承担——零报告 = 无产物 = 不推送；部分失败 = 有报告 = 照常提交，
+  // 与原语义词一一对应。另锁「齐备性判定必须早于 push」这一时序（push 消费其 output）。
+  {
+    const sIdx = OBSERVE.indexOf('\n  mutation-shards:')
+    assert.ok(sIdx > 0, 'observe.yml mutation-shards job 在位（原 Mutation suites 步骤的矩阵化替身）')
+    const cIdx = OBSERVE.indexOf('\n  mutation-collect:')
+    assert.ok(cIdx > 0, 'observe.yml mutation-collect job 在位（收口：判分 + 单点 push + 报告 + 工单）')
+    const pIdx = OBSERVE.indexOf('- name: Push baseline to orphan branch', cIdx)
+    assert.ok(pIdx > cIdx, 'observe.yml push 必须落在收口 job 内（单点推送，消除矩阵并发踩踏）')
+    const pBlock = OBSERVE.slice(pIdx, OBSERVE.indexOf('- name:', pIdx + 10))
+    assert.ok(pBlock.includes("if: always() && steps.reports.outputs.count != '0'"),
+      'observe.yml push 条件必须区分零产物（不推送）与部分失败（有报告即照常提交）')
+    const rIdx = OBSERVE.indexOf('- name: Restore report layout', cIdx)
+    assert.ok(rIdx > cIdx && rIdx < pIdx, '报告齐备性判定必须排在 push 之前（push 依赖其 output）')
+  }
+})
+
+test('#718 S1.1/S1.4/S1.5: observe 全量班三段式矩阵（plan / quality+shards 并行 / collect 收口）', () => {
+  // S1.1 矩阵化：段清单跨 job 传递，矩阵消费它（不得硬编码段列表）
+  assert.ok(OBSERVE.includes('shards: ${{ steps.plan.outputs.shards }}'),
+    'mutation-plan 必须把段清单作为 job output 暴露给矩阵')
+  assert.ok(OBSERVE.includes('shard: ${{ fromJSON(needs.mutation-plan.outputs.shards) }}'),
+    '矩阵必须以 fromJSON 消费段清单')
+  // S1.1 并行度 + S1.4 fail-fast：都在 strategy 块内断言（块内含解释性注释，
+  // 用行锚定的局部切片而不是跨行正则，避免注释一变断言就假红）
+  const shardsStart = OBSERVE.indexOf('\n  mutation-shards:')
+  const stratIdx = OBSERVE.indexOf('    strategy:', shardsStart)
+  assert.ok(stratIdx > shardsStart, 'observe.yml mutation-shards 必须声明 strategy')
+  const stratBlock = OBSERVE.slice(stratIdx, OBSERVE.indexOf('\n    runs-on:', stratIdx))
+  assert.ok(/max-parallel:\s*5\s*$/m.test(stratBlock),
+    'observe.yml 矩阵必须声明 max-parallel: 5（#718 S1.1；S0.3 实测额度上界 20，取 5 留余量）')
+  assert.ok(/fail-fast:\s*false\s*$/m.test(stratBlock),
+    'observe.yml 矩阵必须 fail-fast: false（#718 S1.4：单段失败不连坐，可定向重跑）')
+  // S1.4 逐段超时：必须引用矩阵携带的值，而不是全局常量
+  assert.ok(OBSERVE.includes('timeout-minutes: ${{ matrix.shard.timeoutMinutes }}'),
+    'observe.yml 矩阵超时必须逐段取自 matrix.shard.timeoutMinutes（#718 S1.4）')
+  assert.ok(!/timeout-minutes:\s*90\s*$/m.test(OBSERVE),
+    '整班 90 分钟超时必须退役（长段擦边即整班被杀的成因）')
+  // S1.5 job 边界：quality 与 mutation-shards 无相互依赖（并行），collect 收口两者
+  const qIdx = OBSERVE.indexOf('\n  quality:')
+  const shardsIdx = OBSERVE.indexOf('\n  mutation-shards:')
+  const collectIdx = OBSERVE.indexOf('\n  mutation-collect:')
+  assert.ok(qIdx > 0 && shardsIdx > qIdx && collectIdx > shardsIdx, 'job 顺序须为 quality → mutation-shards → mutation-collect')
+  const qBlock = OBSERVE.slice(qIdx, shardsIdx)
+  assert.ok(!/^\s{4}needs:/m.test(qBlock),
+    'quality 不得声明 needs——它必须与 mutation-shards 并行（#718 S1.5）')
+  const cBlock = OBSERVE.slice(collectIdx)
+  assert.ok(/needs:\s*\[mutation-plan, quality, mutation-shards\]/.test(cBlock),
+    'mutation-collect 必须 needs 三者（收口全部上游）')
+  assert.ok(/^\s{4}if:\s*always\(\)/m.test(cBlock),
+    'mutation-collect 必须 if: always()（上游失败/被杀时仍收口并留痕，#718 S1.3 的基础）')
+  // 单点 push：矩阵实例内不得出现 push（否则回到并发踩踏）
+  const shardsBlock = OBSERVE.slice(shardsIdx, collectIdx)
+  assert.ok(!shardsBlock.includes('orphan-baseline.mjs push'),
+    '矩阵实例内不得推送基线——推送必须单点落在收口 job')
 })


### PR DESCRIPTION
Refs #718（S1 主改第一批：S1.1 + S1.4 + S1.5）

`#718` 的 `approved` 在位（裁决 1「有条件批准：骨架不动，实施按下列已定项执行」；裁决 4 要求「先拆段、后台账」——拆段 #746 与 S0 #753 均已合并）。本 PR **只动 `observe.yml` 的 job 拓扑**，不改判分口径、不改 `ci.yml`、不改产品代码。

## 改动清单

| 文件 | 说明 |
|---|---|
| `.github/workflows/observe.yml` | 单 job 串行 90 分钟 → 三段式：`mutation-plan` → `quality` ‖ `mutation-shards` → `mutation-collect` |
| `scripts/gate/mutation-plan.mjs` | 新增：派生段清单 + 逐段超时（矩阵的 `needs` 输入） |
| `scripts/test/mutation-plan.test.ts` | 新增：9 例（段清单口径、超时只用 full 实测、公式与下限、无实测落默认） |
| `scripts/test/workflow-assert.test.ts` | 3 个既有用例随结构等价更新 + 1 个新用例锁死矩阵结构 |
| `scripts/data/mutation-segment-ledger.json` | 追加 run `34536263640` 的 `scope=full` 记录（16 段），作为超时定标依据 |
| `scripts/README.md` | 上述文件登记 |

## S1.1 矩阵化

- 段清单唯一事实源仍是 `stryker.conf.d/dsh-*.json`（与 `ci-matrix` / `mutation-gate` 同源口径），但**载体从 workflow 内联 glob 迁到 `mutation-plan.mjs`**——GHA 的动态矩阵只能引用 `needs` 的 output，不能读工作区文件。故单列一个秒级 plan job，实测产出 **33 段**。
- `mutation-shards` 以 `fromJSON(needs.mutation-plan.outputs.shards)` 展开；`max-parallel: 5`（S0.3 实测账户并发额度上界 **20**，留余量给 build-test 与其它 workflow）。
- artifact 拓扑复用 `ci.yml` 既有形态：每实例上传 `mutation-shard-<seg>`（报告 + 该段 incremental 基线），collect 以 `pattern:` 下载后平铺回 `coverage/mutation/`。

## S1.4 超时与定向重跑

`timeout-minutes: ${{ matrix.shard.timeoutMinutes }}`，由 `mutation-plan.mjs` 按 `mutation-segment-ledger.json` 里该段 **`scope=full`** 的实测墙钟派生：

```
timeout = max(10, ceil(实测最长 wallSeconds / 60 × 1.5) + 4)
```

实测派生区间 **10 ~ 36 min**（15 段有全量实测；18 段无实测取保守默认 30 min）。

**为什么只用 `scope=full`**：同段全量冷跑可达增量耗时（有基线复用）的数倍——实测 `dsh-mcp-manager-supervisor` 全量 10.19 min 对增量 104 s，约 5.9 倍。拿增量值定超时会造成系统性擦边，这正是 #718 两次事故的成因之一。

同时：整班 90 分钟 timeout 退役；`fail-fast: false`（单段失败不连坐，`gh run rerun --failed` 可定向重跑）。

## S1.5 job 边界

| job | 内容 | 依赖 |
|---|---|---|
| `mutation-plan` | 段清单 + 逐段超时 | 无（秒级） |
| `quality` | install + build + contract/pack:check/verify:npmlayout + stryker:check + cov + crap | **无**（与 shards 并行） |
| `mutation-shards` | 每段一个实例（全量冷跑，本班不 restore） | `mutation-plan` |
| `mutation-collect` | 报告齐备性判定 + 判分 + **单点** push 基线 + 报告 + 工单 | 三者，`if: always()` |

拆分的直接动因：原单 job 串行 90 分钟，任一长段擦边即**整班被杀**，且被杀点在报告步骤之前 ⇒ 当夜无工单、无留痕、基线不更新（`34536263640` / `34652766708` 的形态）。

「整套 skip vs 部分失败」的原语义（`steps.mutation-suites.outcome != 'skipped'`）由 collect 的 **「有段报告才推送」**（`steps.reports.outputs.count != '0'`）等价承担：零报告 = 无产物 = 不推送；部分失败 = 有报告 = 照常提交。

## 门禁

| 命令 | exit code |
|---|---|
| `pnpm build` / `pnpm test` / `pnpm typecheck` | 0 / 0 / 0 |
| `pnpm contract` / `pnpm pack:check` / `pnpm verify:npmlayout` | 0 / 0 / 0 |
| `pnpm test:scripts` | 0（390/390） |
| `pnpm stryker:check` / `pnpm aggregate:check` | 0 / 0 |
| `pnpm docs:check` / `pnpm lint` | 0 / 0 |

另有针对 workflow 的结构校验（本 PR 实跑）：

| 校验 | 结果 |
|---|---|
| YAML 解析（`yaml.safe_load`） | 通过；jobs = `mutation-plan` / `quality` / `mutation-shards` / `mutation-collect` |
| 全部 `uses:` 的 action SHA 与仓库其它 workflow 逐一对齐 | 5/5 一致（含 `pnpm/action-setup`） |
| `node scripts/gate/mutation-plan.mjs` | 33 段，超时区间 10~36 min |

## 验收判据对照（#718 整合版）

| # | 判据 | 本 PR | 证据 |
|---|---|---|---|
| 1 | 归档集 == 从 `stryker.conf.d/` 动态推导的段集合（不硬编码 31/33） | 满足 | 段清单由 `mutation-plan.mjs` glob 派生；`workflow-assert` 断言矩阵必须 `fromJSON` 消费它 |
| 2 | 夜班连续 N 次 0 取消、0 触顶超时；P95 墙钟 ≤ max(关键路径×1.2, 15 min) | **待观察** | 需下一次夜班（20:00 UTC）实测，见下方风险 |
| 4 | 留痕可复跑 | 部分（S1.3 在后续 PR） | 本 PR 已让 collect 具备 `if: always()` 收口点；工单留痕本身属 S1.3 |
| 5 | `pnpm stryker:check` 通过 | 满足 | exit 0 |

## 风险与验证限制（务必连着读）

1. **workflow 结构改动无法本地端到端验证**。本地能做的都做了（YAML 解析、action SHA 对齐、矩阵派生实跑、静态断言 390/390），但「矩阵是否真的按 5 并发展开」「artifact 是否正确汇合」「collect 是否在任何上游失败下都收口」只有真实 run 能证。
2. **首次夜班的观察点**：`gh run list --workflow observe.yml` 的 job 数与并发峰值、collect 是否在 quality 失败时仍运行、基线是否更新（`git ls-remote origin refs/heads/mutation-baseline-sync` 之外的 `baseline/mutation` 最新 commit 时间）。
3. **回滚**：单 PR revert 即可回到串行实现（本 PR 不引入数据迁移，基线格式未变）。
4. **未做的部分**：S1.2（归档并集记账 + 可回滚）与 S1.3（异常留痕工单）不在本 PR；`observe-incremental.yml` 未矩阵化（#718 S2.2 单独处置）。故本 PR 合并后，**被杀夜的留痕仍不完整**——这一点不应被本 PR 的合入误读为 S1 已完成。

### 客户端改动截图证据（勾选式）

- [x] **不涉及客户端改动**（未改动 `src/client/**`、`src/client/style.css`、客户端产物 `lib/client.js`）
- [ ] 涉及客户端改动，已在隔离环境实测并归档截图
