### PR TITLE
fix(ci): #718 S1.2 归档改并集入档——先取回远端再叠加，段不再被失败实例吃掉

### DIFF
--- a/.github/workflows/observe.yml
+++ b/.github/workflows/observe.yml
@@ -268,17 +268,19 @@ jobs:
           # 应写文件而非用 delimiter 格式）。下游步骤直接读 observe-body.md /
           # observe-marker.txt（[ -s file ] 判断非空）。
 
-      - name: Push baseline to orphan branch（#572：提交纯文本树到孤立分支）
+      - name: Archive baseline to orphan branch（#718 S1.2：并集入档 + 对账）
         # #572：替代旧方案（#204 方案 A：向 main 自动建 PR 提交数十万行 JSON 导致 git 膨胀）。
         # 将最新增量基线以单 commit 纯文本树推送到孤立分支 refs/heads/baseline/mutation，
         # 享受 Git Blob 原生内容去重红利，彻底净化 main 分支代码树与提交历史。
-        # #718 S1.5：本步骤**单点**落在收口 job——矩阵各实例不再各自推送，消除并发覆盖踩踏；
-        # 部分失败夜已产出的基线文件照常收集（if: always() + 有报告才推）。
+        # #718 S1.5：本步骤**单点**落在收口 job——矩阵各实例不再各自推送，消除并发覆盖踩踏。
+        # #718 S1.2：由整树替换改为**并集入档**——先取回远端基线，本次未产出的段沿用远端文件
+        # 并在日志里记账（新算/沿用/缺/退役），段被失败实例吃掉因而在物理上不可能再发生；
+        # 拉取失败一律 fail-loud（取不到远端 = 沿用集合未知，以空集合推送就是删段）。
         if: always() && steps.reports.outputs.count != '0'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OBSERVE_PAT: ${{ secrets.OBSERVE_PAT }}
-        run: node scripts/gate/orphan-baseline.mjs push
+        run: node scripts/gate/orphan-baseline.mjs archive
 
       - name: Create/update observe issue（幂等：同日重跑不重复建；回落即追评）
         if: always() && steps.report.outcome == 'success'

--- a/scripts/gate/baseline-archive.mjs
+++ b/scripts/gate/baseline-archive.mjs
@@ -63,6 +63,62 @@ export function expectedBaselineFiles(confFileNames) {
     .sort()
 }
 
+/** 归档分支上参与对账的 manifest 文件名（记录每份基线文件的 size/mtime/sha256）。 */
+export const BASELINE_MANIFEST_FILE = 'manifest.json'
+
+/** 回滚快照 tag 前缀。刻意不以 `v` 开头——release.yml 由 `push: tags: v*` 触发。 */
+export const ARCHIVE_SNAPSHOT_TAG_PREFIX = 'baseline-snap-'
+
+/** 保留的回滚快照个数（每次入档产生一个，超出即删最旧）。 */
+export const ARCHIVE_SNAPSHOT_KEEP = 10
+
+/**
+ * 入档对账（#718 S1.2 的核心判定，纯函数）。
+ *
+ * 为什么需要它：旧实现把「本班次目录里有什么」当成「归档的全部内容」整树替换。段一旦没
+ * 产出（实例超时/被杀），该段文件就不在新树里 → 归档**静默缩水**；实测发生过 33 → 31，
+ * 且没有任何日志说出来。并集语义下缩水在物理上不可能，于是「本次没产出什么」必须变成
+ * 一条显式记账，而不是一个消失的文件。
+ *
+ * 四类互斥且完备（expected 为 `stryker.conf.d/` 派生的期望集合，是唯一事实源）：
+ *   · 新算   = 本次产出（本地有文件）——内容以本次为准；
+ *   · 沿用   = 本次未产出但远端有——保留旧内容继续用（Stryker 增量模式会自行识别内容已变）；
+ *   · 缺     = 两边都没有——该段在归档上没有可用基线，必须点名告警；
+ *   · 退役   = 不在期望集合里却存在于任一侧（段被拆并/改名后的遗留）——从归档移除，
+ *              否则并集语义会让它永远留在基线里（整树替换时代是被顺带清掉的）。
+ */
+export function planArchive({ expected, produced, carried } = {}) {
+  const expectedSet = new Set(expected ?? [])
+  const producedSet = new Set(produced ?? [])
+  const carriedSet = new Set(carried ?? [])
+  const expectedList = expected ?? []
+  const newlyMeasured = expectedList.filter((f) => producedSet.has(f))
+  const carriedOver = expectedList.filter((f) => !producedSet.has(f) && carriedSet.has(f))
+  const missing = expectedList.filter((f) => !producedSet.has(f) && !carriedSet.has(f))
+  const retired = [...new Set([...(carried ?? []), ...(produced ?? [])])]
+    .filter((f) => !expectedSet.has(f))
+    .sort()
+  return { newlyMeasured, carriedOver, missing, retired }
+}
+
+/**
+ * 回滚快照 tag 名：`baseline-snap-<UTC 紧凑时间戳>-<旧 tip 短 sha>`。
+ * 定长时间戳（ISO basic）保证字典序 = 时间序，保留策略不必解析时间。
+ * 附短 sha 是为了同一秒内两次入档也不撞名（撞名会让 `git push <sha>:refs/tags/<t>` 直接失败）。
+ */
+export function snapshotTagFor(tipSha, now = new Date()) {
+  const stamp = now.toISOString().replace(/[-:]/g, '').replace(/\.\d+Z$/, 'Z')
+  return `${ARCHIVE_SNAPSHOT_TAG_PREFIX}${stamp}-${String(tipSha).slice(0, 7)}`
+}
+
+/** 保留最近 keep 个快照 tag，返回应删除的 ref 全名（字典序即时间序）。 */
+export function pruneSnapshotPlan(refNames, keep = ARCHIVE_SNAPSHOT_KEEP) {
+  const ours = (refNames ?? [])
+    .filter((r) => typeof r === 'string' && r.startsWith(`refs/tags/${ARCHIVE_SNAPSHOT_TAG_PREFIX}`))
+    .sort()
+  return ours.slice(0, Math.max(0, ours.length - keep))
+}
+
 /**
  * 对账：把「本次真正覆盖的文件」与「旧基线已有的文件」并起来，找出期望集合里的缺口。
  * 调用方据此决定是否判红——缺口意味着该段在归档分支上没有可用基线：
@@ -105,8 +161,9 @@ export function classifyRemoteProbe({ ok, code }) {
  * 已知边界（必须诚实记录）：`absent` 只能证明「本次广告里没有这条 ref」，**不能**证明
  * 「服务端上不存在」——服务端可用 `uploadpack.hideRefs` 隐藏某条 ref，此时与真·首夜完全同形，
  * 本函数无从区分。这一支上唯一实际生效的防护是 workflow 层 `mutation-suites` 的 outcome 门控
- * （依赖 restore 非零退出，见 observe-incremental.yml）；**代码里并不存在「推送侧拒绝空/缺段
- * 快照」的保护**，补该保护已登记在 #718 的方案中（并集入档），尚未实施。
+ * （依赖 restore 非零退出，见 observe-incremental.yml）。
+ * 「推送侧拒绝空/缺段快照」的保护已由 #718 S1.2 落地：写路径改走并集入档（`planArchive`），
+ * 且拉取失败一律 fail-loud，不再存在「取不到就当空归档推回去」的分支。
  */
 export function decideRestoreOutcome({ probeStatus, fetchOk }) {
   if (fetchOk) return { action: 'restore' }

--- a/scripts/gate/baseline/README.md
+++ b/scripts/gate/baseline/README.md
@@ -11,11 +11,36 @@
 - **存储位置**：孤立分支 `baseline/mutation`（历史深度恒为 1，无父提交，不影响 main 分支代码树）；
 - **存储格式**：解开的纯文本 JSON 目录树（`incremental-*.json` + `manifest.json`），充分利用 Git Blob 原生内容寻址与去重红利（未变动文件 0 开销）；
 - **工作流同步**：
-  - 全量班（`observe.yml`）与增量班（`observe-incremental.yml`）跑完后，通过 `node scripts/gate/orphan-baseline.mjs push` 强推至孤立分支；
+  - 全量班（`observe.yml`）跑完后，通过 `node scripts/gate/orphan-baseline.mjs archive` **并集入档**（见下节）；
+  - 增量班（`observe-incremental.yml`）退役前仍走 `node scripts/gate/orphan-baseline.mjs push`（整树推送，
+    但它先 `restore` 再跑，所以推回去的本身就是全集）；
   - PR 门禁（`ci.yml` 的 `mutation-gate`）通过 `node scripts/gate/orphan-baseline.mjs restore` 浅拉取恢复到 `coverage/mutation/`；
-  - 增量班通过 `node scripts/gate/orphan-baseline.mjs restore` 恢复基线并执行增量；
   - PR 合并到 main 后由 `baseline-overlay.yml` → `node scripts/gate/overlay-baseline.mjs` 秒级差量覆盖（复用该 PR CI 产出的 `mutation-incremental-*` artifact）；
   - 任务统一收敛至互斥并发组 `concurrency: group: mutation-baseline-sync`。
+
+### 并集入档与可回滚（#718 S1.2）
+
+`archive` 之前，写入口是**整树替换**——把「本班次目录里有什么」当成「归档的全部内容」。段一旦没产出
+（矩阵实例超时/被杀），该段文件就不在新树里，归档**静默缩水**：实测 2026-09-12 全量班 33 段只成功
+31 段，归档随之从 33 段掉到 31 段，且没有任何日志说明。现在：
+
+- **并集语义**：先取回远端现存基线，再叠加本次产物。本次有的以本次为准（**新算**），本次没有但远端
+  有的沿用旧文件（**沿用**），两边都没有的显式点名（**缺**）。段被失败实例吃掉因而在物理上不可能再发生。
+- **逐项记账**：每次入档打印「期望 N 段：新算 x / 沿用 y / 缺 z / 退役 w」。缺段打 `::warning::` 并点名
+  （不判红——拆段当夜新段本就无基线可沿用）；真·数据丢失由段报告齐备性校验与台账 `--check` 兜底判红。
+- **退役清理**：期望集合由 `stryker.conf.d/dsh-*.json` 派生，不在集合里的遗留文件（段被拆并/改名后的旧文件）
+  从归档移除并点名。并集语义本身不会删文件，所以这一支必须显式做，否则遗留段会永远留在归档里。
+- **零新对象**：沿用文件直接复用远端 blob sha，不做内容往返，字节级一致因而保住「未变动文件 0 开销」。
+  沿用段在 `manifest.json` 里保留远端条目（其 `mtime` 是上次**真实测量**时间；重新盖章会让陈旧判据失效）。
+- **可回滚**：分支深度恒为 1（无父提交），可回滚性由**快照 tag** `baseline-snap-<UTC 时间戳>-<旧 tip 短 sha>`
+  承担，保留最近 10 个（`ARCHIVE_SNAPSHOT_KEEP`）。回滚即
+  `git push origin refs/tags/<快照 tag>:refs/heads/baseline/mutation --force`。
+  tag 刻意不以 `v` 开头——`release.yml` 由 `push: tags: v*` 触发。
+- **推送用显式租约**：`--force-with-lease=refs/heads/baseline/mutation:<读到的旧 sha>`。本路径不做 fetch，
+  无参的 `--force-with-lease` 会退化成裸 `--force`（#718 裁决），故必须带上读到的期望值。
+- **两条 fail-loud**：远端取不到（`present`/`unreachable` 且 fetch 失败）时拒绝入档——并集语义下
+  「取不到远端」等于「沿用集合未知」，以空集合推送就是删段；`stryker.conf.d/` 派生不出期望集合时同样拒绝
+  （空期望集合会把每个现存文件判成退役，反手删掉整棵归档）。
 
 ### 归档缺口与对账（#714 后续修复）
 `overlay-baseline.mjs` 曾按 GitHub API 的**默认分页（30 条/页）**读取 artifact 列表，而一次 PR CI 会产生
@@ -56,9 +81,10 @@
 
 **已知边界（不要误读为强保证）**：`absent` 只能证明「本次广告里没有这条 ref」，**不能**证明
 服务端上不存在——服务端可用 `uploadpack.hideRefs` 隐藏某条 ref，此时与真·首夜完全同形，
-客户端无从区分。这一支上**唯一实际生效**的防护是 workflow 层 `mutation-suites` 的 outcome
-门控（`observe-incremental.yml` 的 push 步骤要求它非 `skipped`，而它依赖 restore 非零退出）；
-**代码里没有「推送侧拒绝空/缺段快照」的保护**，补该保护已登记在 #718 的方案中（并集入档），尚未实施。
+客户端无从区分。这一支上 workflow 层 `mutation-suites` 的 outcome 门控（`observe-incremental.yml`
+的 push 步骤要求它非 `skipped`，而它依赖 restore 非零退出）仍在起作用；**写路径侧的防护**已由
+#718 S1.2 落地：全量班改走并集入档（`planArchive`，见上节），且拉取失败一律 fail-loud，
+「取不到就当空归档推回去」这条分支已不存在。
 
 **两条路径的有意差异**：orphan 侧在「远端树里有 blob 却无基线文件」时**拒绝继续**（fail-loud）；
 overlay 侧没有这个检查，而是由 `reconcileArchive` 以 `archiveGap` 判红、**仍照常推送**——

--- a/scripts/gate/orphan-baseline.mjs
+++ b/scripts/gate/orphan-baseline.mjs
@@ -6,12 +6,19 @@
  * 替代旧方案（#204 方案 A：把 20 份巨型 JSON 提交到 main 分支 scripts/gate/baseline/ 并自动建 PR），
  * 改为将增量基线纯文本树直接提交至独立的孤立分支 refs/heads/baseline/mutation（深度恒为 1）。
  *
- * 动作：
- *   node scripts/gate/orphan-baseline.mjs push
- *     - 从 coverage/mutation/ 收集 incremental-*.json 产物
+ * 写入有两条动作，语义不同、不可混用：
+ *   node scripts/gate/orphan-baseline.mjs archive（#718 S1.2，夜间全量班收口用）
+ *     - 先取回远端现存基线，再与本次产物做**并集**：本次有的以本次为准（新算），
+ *       本次没有但远端有的沿用旧文件（沿用），两边都没有的显式点名（缺）
+ *     - 期望集合由 stryker.conf.d/ 派生；不在集合里的遗留文件从归档移除（退役）
+ *     - 并集入档后「段被失败实例吃掉」在物理上不可能再发生（旧实现是整树替换，实测丢过 33 → 31）
+ *     - 沿用文件直接复用远端 blob sha，字节级一致因而零新对象（保住内容去重红利）
+ *
+ *   node scripts/gate/orphan-baseline.mjs push（增量班用，退役前保留）
+ *     - 从 coverage/mutation/ 收集 incremental-*.json 产物，整树推送（调用方已先 restore）
  *     - 生成 coverage/mutation/manifest.json（文件级 size/mtime/sha256）
- *     - 用 git plumbing（hash-object -> mktree -> commit-tree）生成单 Commit 纯文本树
- *     - 强制推送到 refs/heads/baseline/mutation
+ *
+ *   两条动作共用：先给旧 tip 打回滚快照 tag（保留最近 N 个），再以显式租约强推新树。
  *
  *   node scripts/gate/orphan-baseline.mjs restore
  *     - 探针 `ls-remote --exit-code` 判三态：广告里有该 ref / 广告里没有 / 环境故障（每态均带退避重试）
@@ -22,25 +29,36 @@
  */
 import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  statSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { classifyRemoteProbe, decideRestoreOutcome } from './baseline-archive.mjs';
+import {
+  ARCHIVE_SNAPSHOT_KEEP,
+  ARCHIVE_SNAPSHOT_TAG_PREFIX,
+  BASELINE_FILE_RE,
+  BASELINE_MANIFEST_FILE,
+  classifyRemoteProbe,
+  decideRestoreOutcome,
+  expectedBaselineFiles,
+  planArchive,
+  pruneSnapshotPlan,
+  snapshotTagFor,
+} from './baseline-archive.mjs';
 
 const action = process.argv[2];
 const BRANCH = 'baseline/mutation';
+const CONF_DIR = join(process.cwd(), 'stryker.conf.d');
 const TARGET_DIR = join(process.cwd(), 'coverage', 'mutation');
 const MAX_BUFFER = 64 * 1024 * 1024; // 64MB，防止巨型基线 JSON 突破 Node 默认 1MB maxBuffer
 const PROBE_ATTEMPTS = 3;
 // 环境故障（远端不可达）可能瞬时，按与 fetch 同规格的退避重试；测试用 0 秒避免拖慢套件。
 const RETRY_DELAY_MS = Number(process.env.ORPHAN_BASELINE_RETRY_DELAY_MS ?? 2000);
+const BOT_IDENTITY = {
+  GIT_AUTHOR_NAME: 'github-actions[bot]',
+  GIT_AUTHOR_EMAIL: 'github-actions[bot]@users.noreply.github.com',
+  GIT_COMMITTER_NAME: 'github-actions[bot]',
+  GIT_COMMITTER_EMAIL: 'github-actions[bot]@users.noreply.github.com',
+};
 
 function runGit(args, options = {}) {
   const { input, env, ignoreError = false } = options;
@@ -86,78 +104,33 @@ function sleep(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
-if (action === 'push') {
-  if (!existsSync(TARGET_DIR)) {
-    console.error(`[orphan-baseline] 源目录不存在: ${TARGET_DIR}`);
-    process.exit(1);
-  }
-
-  const baselineFiles = readdirSync(TARGET_DIR)
-    .filter((f) => /^incremental-.+\.json$/.test(f))
-    .sort();
-
-  if (baselineFiles.length === 0) {
-    console.error('[orphan-baseline] 未找到任何 incremental-*.json 基线文件，变异测试未产生可用基线');
-    process.exit(1);
-  }
-
-  // 1. 生成 manifest.json
-  const manifest = {};
-  for (const f of baselineFiles) {
-    const fullPath = join(TARGET_DIR, f);
-    const buf = readFileSync(fullPath);
-    const st = statSync(fullPath);
-    manifest[f] = {
-      size: buf.length,
-      mtime: st.mtime.toISOString(),
-      sha256: createHash('sha256').update(buf).digest('hex'),
-    };
-  }
-  const manifestPath = join(TARGET_DIR, 'manifest.json');
-  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
-  const allFiles = [...baselineFiles, 'manifest.json'];
-
-  console.log(`[orphan-baseline] 准备提交 ${allFiles.length} 个基线文件到孤立分支 ${BRANCH}...`);
-
-  // 2. 用 Git plumbing 构建纯文本 Tree（享受 Git Blob 原生内容寻址与去重红利）
-  const mktreeLines = [];
-  for (const f of allFiles) {
-    const fullPath = join(TARGET_DIR, f);
-    const blobSha = runGit(['hash-object', '-w', fullPath]);
-    mktreeLines.push(`100644 blob ${blobSha}\t${f}`);
-  }
-  const treeSha = runGit(['mktree'], { input: mktreeLines.join('\n') + '\n' });
-
-  // 3. 构建无父节点的孤立 Commit（单 commit 纯快照）
-  const commitSha = runGit(
-    ['commit-tree', treeSha, '-m', 'chore(ci): update mutation baseline snapshot [skip ci]'],
-    {
-      env: {
-        GIT_AUTHOR_NAME: 'github-actions[bot]',
-        GIT_AUTHOR_EMAIL: 'github-actions[bot]@users.noreply.github.com',
-        GIT_COMMITTER_NAME: 'github-actions[bot]',
-        GIT_COMMITTER_EMAIL: 'github-actions[bot]@users.noreply.github.com',
-      },
-    },
-  );
-
-  // 4. 组装远程推送目标
+/** 推送目标：CI 用带 token 的 URL（actions/checkout 的凭据不覆盖自定义 remote），本地退回 origin。 */
+function remoteTarget() {
   const token = process.env.OBSERVE_PAT || process.env.GITHUB_TOKEN;
   const repo = process.env.GITHUB_REPOSITORY;
-  const remoteTarget = token && repo
-    ? `https://x-access-token:${token}@github.com/${repo}.git`
-    : 'origin';
+  return token && repo ? `https://x-access-token:${token}@github.com/${repo}.git` : 'origin';
+}
 
-  console.log(`[orphan-baseline] 强推 commit ${commitSha.slice(0, 8)} 到 refs/heads/${BRANCH}...`);
-  runGit(['push', '--force', remoteTarget, `${commitSha}:refs/heads/${BRANCH}`]);
-  console.log(`[orphan-baseline] 成功同步基线至孤立分支 ${BRANCH}（包含 ${allFiles.length} 份文件）`);
+/**
+ * 归档分支当前 tip。空字符串 = 广告里没有这条 ref（首推）；取不到则抛错——
+ * 首推与「读不到」都会走到非快进推送，但两者要给出不同的话，否则排障时无从区分。
+ */
+function remoteTipSha() {
+  const res = runGitProbe(['ls-remote', '--heads', remoteTarget(), `refs/heads/${BRANCH}`]);
+  if (!res.ok) throw new Error('无法读取归档分支 tip（远端不可达或凭据缺失），拒绝在未知状态下推送');
+  return res.stdout ? res.stdout.split(/\s+/)[0] : '';
+}
 
-} else if (action === 'restore') {
-  mkdirSync(TARGET_DIR, { recursive: true });
-
-  // 探针：`--exit-code` 让 git 自己给出三态（0=广告里有这条 ref / 2=广告里没有 / 其它=环境故障）。
-  // 不能用「stdout 是否为空」反推「ref 不存在」——服务端隐藏 ref 时两者同形，见 decideRestoreOutcome。
-  // 环境故障可能瞬时，探针必须和 fetch 一样带退避重试：探针比它保护的操作更脆就本末倒置了。
+/**
+ * 探针 + 浅拉取远端基线树（restore 与 archive 共用同一判定，避免同一操作两份实现长期分叉）。
+ *
+ * 不能用「stdout 是否为空」反推「ref 不存在」——服务端隐藏 ref 时两者同形，见 decideRestoreOutcome。
+ * 环境故障可能瞬时，探针必须和 fetch 一样带退避重试：探针比它保护的操作更脆就本末倒置了。
+ * 只有「探针明确说广告里没有这条 ref」才跳过 fetch（为首夜白跑一轮注定失败的重试没有意义）。
+ * 探针结果不确定（unreachable）时仍要尝试 fetch：拉取成功说明基线确实在、能正常恢复，
+ * 不该因探针的假阴性把「可恢复」判成「判红」——decideRestoreOutcome 把 fetchOk 放在第一位。
+ */
+function probeAndFetchBaseline() {
   let probeStatus = 'unreachable';
   for (let attempt = 1; attempt <= PROBE_ATTEMPTS; attempt++) {
     const res = runGitProbe(['ls-remote', '--exit-code', '--heads', 'origin', `refs/heads/${BRANCH}`]);
@@ -169,9 +142,6 @@ if (action === 'push') {
     }
   }
 
-  // 只有「探针明确说广告里没有这条 ref」才跳过 fetch（为首夜白跑一轮注定失败的重试没有意义）。
-  // 探针结果不确定（unreachable）时仍要尝试 fetch：拉取成功说明基线确实在、能正常恢复，
-  // 不该因探针的假阴性把「可恢复」判成「判红」——decideRestoreOutcome 把 fetchOk 放在第一位。
   let fetched = false;
   if (probeStatus !== 'absent') {
     for (let attempt = 1; attempt <= PROBE_ATTEMPTS; attempt++) {
@@ -191,7 +161,253 @@ if (action === 'push') {
     }
   }
 
-  const outcome = decideRestoreOutcome({ probeStatus, fetchOk: fetched });
+  return { outcome: decideRestoreOutcome({ probeStatus, fetchOk: fetched }), fetched };
+}
+
+/** 目标目录里的段级基线文件（不含 manifest），排序后返回。 */
+function baselineFilesIn(dir) {
+  return readdirSync(dir)
+    .filter((f) => BASELINE_FILE_RE.test(f))
+    .sort();
+}
+
+/**
+ * 期望段集合 = stryker.conf.d/dsh-*.json 派生（与 ci-matrix / mutation-ledger 同源口径）。
+ * 空集合必须 fail-loud：期望集合为空会让每个现存文件都落进「退役」，并集语义反手把整棵归档删掉。
+ */
+function expectedFromConfDir() {
+  const confNames = existsSync(CONF_DIR)
+    ? readdirSync(CONF_DIR).filter((f) => f.startsWith('dsh-') && f.endsWith('.json'))
+    : [];
+  const expected = expectedBaselineFiles(confNames);
+  if (expected.length === 0) {
+    console.error(
+      `[orphan-baseline] 无法从 ${CONF_DIR} 派生期望段集合（拒绝入档：空期望集合会把整棵基线判成退役段）`,
+    );
+    process.exit(1);
+  }
+  return expected;
+}
+
+/**
+ * 读取 FETCH_HEAD 上的归档树：`ls-tree -l` 给出每份文件的 blob sha 与大小（不做内容往返）。
+ * blob sha 直接复用于并集树里的沿用文件——字节级一致，因而不产生新对象，保住内容去重红利。
+ */
+function readRemoteTree() {
+  const treeOutput = runGit(['ls-tree', '-r', '-l', 'FETCH_HEAD'], { ignoreError: true });
+  if (!treeOutput) return { files: [], blobs: new Map(), manifest: {}, entries: 0 };
+
+  const files = [];
+  const blobs = new Map();
+  let entries = 0;
+  for (const line of treeOutput.split('\n').filter(Boolean)) {
+    entries++;
+    const match = line.match(/^100644\s+blob\s+([0-9a-f]{40})\s+\d+\t(.+)$/);
+    if (!match) continue;
+    const [, blobSha, fileName] = match;
+    if (!BASELINE_FILE_RE.test(fileName)) continue;
+    files.push(fileName);
+    blobs.set(fileName, blobSha);
+  }
+  files.sort();
+
+  // 树里有条目却一份基线文件都没有 = 归档形状漂移（命名改了？）。此时「沿用集合为空」是假的，
+  // 继续并集会把用户可见的旧归档换成一份只剩本次产物的树——按 fail-loud 处理（与 restore 同判据）。
+  if (entries > 0 && files.length === 0) {
+    console.error(
+      `[orphan-baseline] 远端树含 ${entries} 个条目但无任何基线文件（命名漂移？），拒绝以空期望继续（fail-loud）`,
+    );
+    process.exit(1);
+  }
+
+  let manifest = {};
+  const rawManifest = runGit(['show', `FETCH_HEAD:${BASELINE_MANIFEST_FILE}`], { ignoreError: true });
+  if (rawManifest) {
+    try {
+      manifest = JSON.parse(rawManifest);
+    } catch {
+      console.error('[orphan-baseline] 远端 manifest.json 非法 JSON（拒绝沿用不可信的陈旧判据，fail-loud）');
+      process.exit(1);
+    }
+  }
+  return { files, blobs, manifest, entries };
+}
+
+/**
+ * manifest 条目。沿用文件保留远端条目（其 mtime 是**上次真实测量时间**；重新盖章会让陈旧
+ * 判据失效——重写时间戳正是 #718 S3.1 要修的那个坑），新算文件现算。
+ */
+function buildManifest(dir, names, preserved = {}) {
+  const manifest = {};
+  for (const f of names) {
+    if (preserved[f]) {
+      manifest[f] = preserved[f];
+      continue;
+    }
+    const fullPath = join(dir, f);
+    const buf = readFileSync(fullPath);
+    manifest[f] = {
+      size: buf.length,
+      mtime: statSync(fullPath).mtime.toISOString(),
+      sha256: createHash('sha256').update(buf).digest('hex'),
+    };
+  }
+  return manifest;
+}
+
+function hashFile(path) {
+  return runGit(['hash-object', '-w', path]);
+}
+
+function hashBlob(content) {
+  return runGit(['hash-object', '-w', '--stdin'], { input: content });
+}
+
+/** 给旧 tip 打回滚快照 tag。必须先于新树推送——tag 指向的对象在推之前得是可达的。 */
+function pushSnapshotTag(oldSha) {
+  const tag = snapshotTagFor(oldSha);
+  runGit(['push', remoteTarget(), `${oldSha}:refs/tags/${tag}`]);
+  console.log(`[orphan-baseline] 回滚快照：refs/tags/${tag}（保留最近 ${ARCHIVE_SNAPSHOT_KEEP} 个）`);
+}
+
+function pruneSnapshotTags() {
+  const listed = runGit(
+    ['ls-remote', '--tags', remoteTarget(), `refs/tags/${ARCHIVE_SNAPSHOT_TAG_PREFIX}*`],
+    { ignoreError: true },
+  );
+  const refs = (listed ?? '')
+    .split('\n')
+    .map((l) => l.trim().split(/\s+/)[1])
+    .filter(Boolean);
+  const stale = pruneSnapshotPlan(refs);
+  if (stale.length === 0) return;
+  // 逐个删除：一条失败不连坐，过期快照留着只是多占一个 ref，不影响本次入档的正确性。
+  for (const ref of stale) runGit(['push', remoteTarget(), '--delete', ref], { ignoreError: true });
+  console.log(`[orphan-baseline] 清理过期回滚快照 ${stale.length} 个`);
+}
+
+/**
+ * 归档分支深度恒为 1（无父 commit）：可回滚性靠快照 tag 承担，而不是靠父链——
+ * 后者会让每次入档都把历史带上远端，与 #572「剥离 main 分支代码树巨型 JSON」的初衷分叉。
+ * 推送用带显式 expect 的 `--force-with-lease`：本路径不做 fetch，无参形式会退化成裸 force（#718 裁决）。
+ */
+function pushBaselineCommit(entries, subject) {
+  const allFiles = [...entries.map((e) => e.name), BASELINE_MANIFEST_FILE];
+  console.log(`[orphan-baseline] 准备提交 ${allFiles.length} 个基线文件到孤立分支 ${BRANCH}...`);
+
+  const mktreeLines = entries.map((e) => `100644 blob ${e.blobSha}\t${e.name}`);
+  const treeSha = runGit(['mktree'], { input: mktreeLines.join('\n') + '\n' });
+  const commitSha = runGit(['commit-tree', treeSha, '-m', subject], { env: BOT_IDENTITY });
+
+  const target = remoteTarget();
+  const oldSha = remoteTipSha();
+  if (oldSha) {
+    pushSnapshotTag(oldSha);
+    pruneSnapshotTags();
+    console.log(
+      `[orphan-baseline] 推送 commit ${commitSha.slice(0, 8)} 到 refs/heads/${BRANCH}（租约 expect ${oldSha.slice(0, 8)}）...`,
+    );
+    runGit([
+      'push',
+      `--force-with-lease=refs/heads/${BRANCH}:${oldSha}`,
+      target,
+      `${commitSha}:refs/heads/${BRANCH}`,
+    ]);
+  } else {
+    console.log(`[orphan-baseline] 推送 commit ${commitSha.slice(0, 8)} 到 refs/heads/${BRANCH}（首推）...`);
+    runGit(['push', target, `${commitSha}:refs/heads/${BRANCH}`]);
+  }
+  console.log(`[orphan-baseline] 成功同步基线至孤立分支 ${BRANCH}（包含 ${allFiles.length} 份文件）`);
+}
+
+if (action === 'push') {
+  if (!existsSync(TARGET_DIR)) {
+    console.error(`[orphan-baseline] 源目录不存在: ${TARGET_DIR}`);
+    process.exit(1);
+  }
+
+  const baselineFiles = baselineFilesIn(TARGET_DIR);
+  if (baselineFiles.length === 0) {
+    console.error('[orphan-baseline] 未找到任何 incremental-*.json 基线文件，变异测试未产生可用基线');
+    process.exit(1);
+  }
+
+  const manifestPath = join(TARGET_DIR, BASELINE_MANIFEST_FILE);
+  writeFileSync(manifestPath, JSON.stringify(buildManifest(TARGET_DIR, baselineFiles), null, 2) + '\n');
+
+  pushBaselineCommit(
+    [
+      ...baselineFiles.map((f) => ({ name: f, blobSha: hashFile(join(TARGET_DIR, f)) })),
+      { name: BASELINE_MANIFEST_FILE, blobSha: hashFile(manifestPath) },
+    ].sort((a, b) => (a.name < b.name ? -1 : 1)),
+    'chore(ci): update mutation baseline snapshot [skip ci]',
+  );
+} else if (action === 'archive') {
+  if (!existsSync(TARGET_DIR)) {
+    console.error(`[orphan-baseline] 源目录不存在: ${TARGET_DIR}`);
+    process.exit(1);
+  }
+
+  const produced = baselineFilesIn(TARGET_DIR);
+  if (produced.length === 0) {
+    console.error('[orphan-baseline] 未找到任何 incremental-*.json 基线文件，变异测试未产生可用基线');
+    process.exit(1);
+  }
+  const expected = expectedFromConfDir();
+
+  const { outcome, fetched } = probeAndFetchBaseline();
+  if (outcome.action === 'fail') {
+    // 并集语义下「取不到远端」等于「沿用集合未知」：以空沿用集合推送 = 删段。故一律 fail-loud。
+    console.error(`[orphan-baseline] ${outcome.reason}（fail-loud，拒绝以空沿用集合入档）`);
+    process.exit(1);
+  }
+
+  const remote = fetched ? readRemoteTree() : { files: [], blobs: new Map(), manifest: {} };
+  if (outcome.action === 'bootstrap') console.log(`::notice::${outcome.reason}`);
+
+  const plan = planArchive({ expected, produced, carried: remote.files });
+  const total = expected.length;
+  console.log(
+    `[orphan-baseline] 归档对账（期望 ${total} 段）：新算 ${plan.newlyMeasured.length} / 沿用 ${plan.carriedOver.length} / 缺 ${plan.missing.length} / 退役 ${plan.retired.length}`,
+  );
+  if (plan.retired.length > 0) {
+    console.log(`[orphan-baseline] 退役段（配置已不在期望集合，从归档移除）：${plan.retired.join(' ')}`);
+  }
+  if (plan.missing.length > 0) {
+    // 告警而非判红：段首次入档（拆段当夜）本就无基线可沿用，判红会让每次拆段必然红一夜。
+    // 真·数据丢失由 workflow 的段报告齐备性校验与台账 --check 兜底判红。
+    console.warn(
+      `::warning::归档缺段 ${plan.missing.length} 个（本次未产出且远端无沿用——查实例是否超时/被杀）：${plan.missing.join(' ')}`,
+    );
+  }
+
+  const kept = [...plan.newlyMeasured, ...plan.carriedOver].sort();
+  const preserved = {};
+  for (const f of plan.carriedOver) {
+    if (!remote.manifest[f]) {
+      // 归档写入方从不漏条目，缺条目意味着这份树不是本脚本写的（人工推送/截断）。
+      console.error(`[orphan-baseline] 远端 manifest 缺 ${f} 条目（归档形状异常），拒绝沿用不可信条目（fail-loud）`);
+      process.exit(1);
+    }
+    preserved[f] = remote.manifest[f];
+  }
+
+  const manifest = buildManifest(TARGET_DIR, plan.newlyMeasured, preserved);
+  const entries = [
+    // 沿用文件直接复用远端 blob sha：不做内容往返，字节级一致因而零新对象。
+    ...plan.carriedOver.map((f) => ({ name: f, blobSha: remote.blobs.get(f) })),
+    ...plan.newlyMeasured.map((f) => ({ name: f, blobSha: hashFile(join(TARGET_DIR, f)) })),
+    { name: BASELINE_MANIFEST_FILE, blobSha: hashBlob(JSON.stringify(manifest, null, 2) + '\n') },
+  ].sort((a, b) => (a.name < b.name ? -1 : 1));
+
+  pushBaselineCommit(
+    entries,
+    `chore(ci): archive mutation baseline（并集入档 新算${plan.newlyMeasured.length}/沿用${plan.carriedOver.length}/缺${plan.missing.length}）[skip ci]`,
+  );
+} else if (action === 'restore') {
+  mkdirSync(TARGET_DIR, { recursive: true });
+
+  const { outcome, fetched } = probeAndFetchBaseline();
 
   if (outcome.action === 'fail') {
     console.error(`[orphan-baseline] ${outcome.reason}（fail-loud，本次未执行变异测试）`);
@@ -200,6 +416,10 @@ if (action === 'push') {
   if (outcome.action === 'bootstrap') {
     console.log(`::notice::${outcome.reason}`);
     process.exit(0);
+  }
+  if (!fetched) {
+    console.error('[orphan-baseline] 恢复结果与探针不一致（fail-loud）');
+    process.exit(1);
   }
 
   // 遍历远端 commit 中的文件并写回目标目录
@@ -215,7 +435,7 @@ if (action === 'push') {
     const match = line.match(/^100644\s+blob\s+[0-9a-f]{40}\t(.+)$/);
     if (!match) continue;
     const fileName = match[1];
-    if (/^incremental-.+\.json$/.test(fileName) || fileName === 'manifest.json') {
+    if (BASELINE_FILE_RE.test(fileName) || fileName === BASELINE_MANIFEST_FILE) {
       const content = runGit(['show', `FETCH_HEAD:${fileName}`]);
       writeFileSync(join(TARGET_DIR, fileName), content);
       restored++;
@@ -232,8 +452,9 @@ if (action === 'push') {
     );
     process.exit(1);
   }
-
 } else {
-  console.error(`[orphan-baseline] 未知动作: ${action}，用法: node scripts/gate/orphan-baseline.mjs [push|restore]`);
+  console.error(
+    `[orphan-baseline] 未知动作: ${action}，用法: node scripts/gate/orphan-baseline.mjs [archive|push|restore]`,
+  );
   process.exit(1);
 }

--- a/scripts/test/baseline-archive.test.ts
+++ b/scripts/test/baseline-archive.test.ts
@@ -19,6 +19,7 @@ import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import {
+  ARCHIVE_SNAPSHOT_KEEP,
   BASELINE_FILE_RE,
   GH_API_PER_PAGE,
   classifyRemoteProbe,
@@ -26,7 +27,10 @@ import {
   expectedBaselineFiles,
   mergeArtifactPage,
   mutationArtifacts,
+  planArchive,
+  pruneSnapshotPlan,
   reconcileArchive,
+  snapshotTagFor,
 } from '../gate/baseline-archive.mjs'
 
 const ROOT = join(import.meta.dirname, '..', '..')
@@ -214,4 +218,70 @@ test('#718: restore 三态判定 —— 「取不到」与「不存在」必须�
 
   // 未知状态属于编程错误：宁可判红，也不能默默降级。
   assert.equal(decideRestoreOutcome({ probeStatus: 'bogus', fetchOk: false }).action, 'fail')
+})
+
+// ── #718 S1.2：并集入档对账 ──────────────────────────────────────────────────
+// 旧写入口是整树替换：本班次没产出的段直接在新树里消失，且没有任何日志说出来（实测 33 → 31）。
+// planArchive 把「本次没产出什么」变成一条显式记账，并把归档里不该留的遗留段点名退役。
+
+test('#718 S1.2: 并集对账 —— 未产出但远端有的段沿用，两边都没有的才算缺', () => {
+  const expected = ['incremental-a.json', 'incremental-b.json', 'incremental-c.json']
+  const plan = planArchive({
+    expected,
+    produced: ['incremental-a.json'],
+    carried: ['incremental-a.json', 'incremental-b.json'],
+  })
+  assert.deepEqual(plan.newlyMeasured, ['incremental-a.json'], '本次产出 = 新算')
+  assert.deepEqual(plan.carriedOver, ['incremental-b.json'], '未产出但远端有 = 沿用（不丢段）')
+  assert.deepEqual(plan.missing, ['incremental-c.json'], '两边都没有 = 缺（必须告警）')
+  // 三类互斥且完备：并起来恰好等于期望集合，不多不少。
+  assert.deepEqual(
+    [...plan.newlyMeasured, ...plan.carriedOver, ...plan.missing].sort(),
+    [...expected].sort(),
+    '三类必须互斥且完备，否则计数会掩盖丢段',
+  )
+  assert.deepEqual(plan.retired, [])
+})
+
+test('#718 S1.2: 并集对账 —— 段被拆并/改名后的遗留文件必须退役，否则永远留在归档里', () => {
+  // 真实形态：dsh-notifier-config 拆成 -normalize/-validate/-rest 三段后，旧文件仍在归档上。
+  const plan = planArchive({
+    expected: ['incremental-notifier-config-normalize.json', 'incremental-notifier-config-rest.json'],
+    produced: ['incremental-notifier-config-rest.json'],
+    carried: ['incremental-notifier-config.json', 'incremental-notifier-config-normalize.json'],
+  })
+  assert.deepEqual(plan.retired, ['incremental-notifier-config.json'], '不在期望集合的遗留段要退役')
+  assert.deepEqual(plan.carriedOver, ['incremental-notifier-config-normalize.json'])
+  assert.deepEqual(plan.missing, [])
+})
+
+test('#718 S1.2: 并集对账 —— 首次入档（无远端）时除本次产出外全为缺，且不得报退役', () => {
+  const plan = planArchive({ expected: ['incremental-a.json', 'incremental-b.json'], produced: ['incremental-a.json'] })
+  assert.deepEqual(plan.missing, ['incremental-b.json'], '首夜缺段是预期形态，靠告警而非判红')
+  assert.deepEqual(plan.retired, [], '本地产出都在期望集合内时不得报退役')
+  // 期望集合为空是编程/配置错误：此时每个文件都会被判退役，故调用方必须在此之前 fail-loud。
+  const degenerate = planArchive({ expected: [], produced: ['incremental-a.json'], carried: ['incremental-b.json'] })
+  assert.deepEqual(degenerate.retired, ['incremental-a.json', 'incremental-b.json'])
+})
+
+test('#718 S1.2: 回滚快照 tag —— 名字含旧 tip 短 sha，保留窗口按时间序裁剪', () => {
+  const tip = 'a'.repeat(40)
+  const tag = snapshotTagFor(tip, new Date('2026-09-12T09:40:00.000Z'))
+  assert.equal(tag, `baseline-snap-20260912T094000Z-${'a'.repeat(7)}`)
+  // release.yml 由 `push: tags: v*` 触发：快照 tag 一旦以 v 开头就会误触发发布管线。
+  assert.ok(!tag.startsWith('v'), '快照 tag 不得以 v 开头（会命中 release.yml 的 v* 触发器）')
+  // 同一秒内两次入档（旧 tip 不同）也必须区分得开，否则 tag 推送直接失败。
+  assert.notEqual(tag, snapshotTagFor('b'.repeat(40), new Date('2026-09-12T09:40:00.000Z')))
+
+  const refs = Array.from({ length: ARCHIVE_SNAPSHOT_KEEP + 3 }, (_, i) =>
+    `refs/tags/baseline-snap-202609${String(i + 1).padStart(2, '0')}T000000Z-${'c'.repeat(7)}`,
+  )
+  assert.deepEqual(
+    pruneSnapshotPlan(refs),
+    refs.slice(0, 3),
+    `超出保留窗口的 ${3} 个（最旧）应被清理`,
+  )
+  assert.deepEqual(pruneSnapshotPlan(refs.slice(0, 2)), [], '未超窗口不得删任何快照')
+  // 非本前缀的 tag（例如发布 tag）绝不能被这条清理逻辑碰到。
+  assert.deepEqual(pruneSnapshotPlan(['refs/tags/v1.2.3', 'refs/tags/baseline-snap-other']), [], '只清理自己的前缀')
 })

--- a/scripts/test/orphan-baseline.test.ts
+++ b/scripts/test/orphan-baseline.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -310,6 +310,165 @@ test('#572: orphan-baseline 本地 push 与 restore 往返完整性', () => {
     assert.ok(file1.includes('Killed'), '内容恢复一致');
     assert.ok(file2.includes('Survived'), '内容恢复一致');
     assert.ok(manifest['incremental-test-pkg.json'].size > 0, 'manifest 存在且包含文件统计');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ── #718 S1.2：并集入档（archive）────────────────────────────────────────────
+// 旧写入口把「本班次目录里有什么」当成「归档的全部内容」整树替换：段一旦没产出（实例超时/
+// 被杀），该段文件就不在新树里，归档**静默缩水**（实测 33 → 31 且无任何日志）。以下用例锁住
+// 并集语义、三类记账、退役清理与两条 fail-loud 分支。
+
+/** 造一个「origin 指向自身」的模拟仓库（archive/push/restore 都能在上面真跑）。 */
+function initBaselineRepo(confNames: string[]): string {
+  const tmp = mkdtempSync(join(tmpdir(), 'orphan-archive-'));
+  execFileSync('git', ['init'], { cwd: tmp, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'test'], { cwd: tmp, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: tmp, stdio: 'ignore' });
+  writeFileSync(join(tmp, 'dummy.txt'), 'dummy');
+  execFileSync('git', ['add', '.'], { cwd: tmp, stdio: 'ignore' });
+  execFileSync('git', ['commit', '-m', 'initial'], { cwd: tmp, stdio: 'ignore' });
+  execFileSync('git', ['remote', 'add', 'origin', tmp], { cwd: tmp, stdio: 'ignore' });
+
+  const confDir = join(tmp, 'stryker.conf.d');
+  mkdirSync(confDir, { recursive: true });
+  for (const name of confNames) {
+    writeFileSync(join(confDir, `dsh-${name}.json`), JSON.stringify({ mutate: ['src/**/*.ts'] }));
+  }
+  mkdirSync(join(tmp, 'coverage', 'mutation'), { recursive: true });
+  return tmp;
+}
+
+function writeBaselines(repo: string, files: Record<string, string>): void {
+  const dir = join(repo, 'coverage', 'mutation');
+  for (const [name, content] of Object.entries(files)) writeFileSync(join(dir, name), content);
+}
+
+function archivedFiles(repo: string): string[] {
+  return execFileSync('git', ['ls-tree', '-r', '--name-only', 'refs/heads/baseline/mutation'], {
+    cwd: repo,
+    encoding: 'utf8',
+  })
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .sort();
+}
+
+function readArchived(repo: string, name: string): string {
+  return execFileSync('git', ['show', `refs/heads/baseline/mutation:${name}`], { cwd: repo, encoding: 'utf8' });
+}
+
+test('#718 S1.2: archive 并集入档——本次未产出的段沿用远端，段数不缩水', () => {
+  const tmp = initBaselineRepo(['alpha', 'beta', 'gamma']);
+  try {
+    writeBaselines(tmp, {
+      'incremental-alpha.json': '{"seg":"alpha"}',
+      'incremental-beta.json': '{"seg":"beta"}',
+      'incremental-gamma.json': '{"seg":"gamma"}',
+    });
+    const seeded = runScript(scriptPath, ['push'], { cwd: tmp });
+    assert.equal(seeded.status, 0, `首次 push 应成功，实际 ${seeded.status}: ${seeded.out}`);
+    const tipBefore = execFileSync('git', ['rev-parse', 'refs/heads/baseline/mutation'], {
+      cwd: tmp,
+      encoding: 'utf8',
+    }).trim();
+    // push 会往本班次报告目录写 manifest；清掉它以便断言 archive 不污染该目录
+    rmSync(join(tmp, 'coverage', 'mutation', 'manifest.json'));
+
+    // 模拟「beta/gamma 两个实例被杀」：本次只产出 alpha
+    rmSync(join(tmp, 'coverage', 'mutation', 'incremental-beta.json'));
+    rmSync(join(tmp, 'coverage', 'mutation', 'incremental-gamma.json'));
+
+    const archived = runScript(scriptPath, ['archive'], { cwd: tmp });
+    assert.equal(archived.status, 0, `archive 应成功，实际 ${archived.status}: ${archived.out}`);
+    assert.match(
+      archived.out,
+      /归档对账（期望 3 段）：新算 1 \/ 沿用 2 \/ 缺 0 \/ 退役 0/,
+      '三类计数 + 退役必须逐项记账',
+    );
+
+    assert.deepEqual(
+      archivedFiles(tmp),
+      ['incremental-alpha.json', 'incremental-beta.json', 'incremental-gamma.json', 'manifest.json'],
+      '并集入档后段的集合不得缩水（旧实现会在这里抹掉 beta/gamma）',
+    );
+    assert.equal(readArchived(tmp, 'incremental-beta.json'), '{"seg":"beta"}', '沿用段保留远端内容');
+    assert.ok(
+      !existsSync(join(tmp, 'coverage', 'mutation', 'manifest.json')),
+      'archive 不得把 manifest 写进本班次报告目录（会污染 observe-reports 留档）',
+    );
+
+    const tag = execFileSync('git', ['tag', '-l', 'baseline-snap-*'], { cwd: tmp, encoding: 'utf8' }).trim();
+    assert.ok(tag.length > 0, '入档必须留下回滚快照 tag（分支深度恒为 1，可回滚性由 tag 承担）');
+    assert.equal(
+      execFileSync('git', ['rev-parse', `refs/tags/${tag}`], { cwd: tmp, encoding: 'utf8' }).trim(),
+      tipBefore,
+      '快照 tag 必须指向入档前的 tip（真回滚点）',
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('#718 S1.2: archive 退役清理 + 缺段点名告警', () => {
+  const tmp = initBaselineRepo(['alpha', 'beta']);
+  try {
+    // 远端先有一份「段已拆并/改名」的遗留文件，且 beta 从未有过基线
+    writeBaselines(tmp, {
+      'incremental-alpha.json': '{"seg":"alpha"}',
+      'incremental-removed.json': '{"seg":"removed"}',
+    });
+    const seeded = runScript(scriptPath, ['push'], { cwd: tmp });
+    assert.equal(seeded.status, 0, `首次 push 应成功，实际 ${seeded.status}: ${seeded.out}`);
+
+    const archived = runScript(scriptPath, ['archive'], { cwd: tmp });
+    assert.equal(archived.status, 0, `archive 应成功，实际 ${archived.status}: ${archived.out}`);
+    assert.match(archived.out, /新算 1 \/ 沿用 0 \/ 缺 1 \/ 退役 1/, '缺与退役必须分别计数');
+    assert.match(
+      archived.out,
+      /::warning::归档缺段 1 个.*incremental-beta\.json/,
+      '缺段必须点名告警（告警而非判红：段首次入档本就无基线可沿用）',
+    );
+    assert.match(archived.out, /退役段.*incremental-removed\.json/, '退役段必须显式点名');
+    assert.deepEqual(
+      archivedFiles(tmp),
+      ['incremental-alpha.json', 'manifest.json'],
+      '退役段从归档移除；缺段不得落盘为空文件',
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('#718 S1.2: archive 拉取失败必须 fail-loud（拒绝以空沿用集合入档）', () => {
+  const tmp = initBaselineRepo(['alpha']);
+  const bin = mkdtempSync(join(tmpdir(), 'orphan-archive-bin-'));
+  try {
+    writeBaselines(tmp, { 'incremental-alpha.json': '{"seg":"alpha"}' });
+    // ls-remote 放行（present）、fetch 强制失败 → 「基线可能存在但取不到」这一支
+    writeGitShim(bin, { fetchFails: true });
+    const r = runScript(scriptPath, ['archive'], {
+      cwd: tmp,
+      env: { PATH: `${bin}:${process.env.PATH}` },
+    });
+    assert.equal(r.status, 1, `拉取失败必须 exit 1，实际 ${r.status}: ${r.out}`);
+    assert.match(r.out, /拒绝以空沿用集合入档/, '须点名拒绝原因（取不到远端 ≠ 远端为空）');
+    assert.match(r.out, /存在但拉取失败/, '须走「存在但恢复失败」站点，而不是笼统的无法确认');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+    rmSync(bin, { recursive: true, force: true });
+  }
+});
+
+test('#718 S1.2: archive 期望集合为空必须 fail-loud（防把整棵基线判成退役）', () => {
+  const tmp = initBaselineRepo([]);
+  try {
+    writeBaselines(tmp, { 'incremental-alpha.json': '{"seg":"alpha"}' });
+    const r = runScript(scriptPath, ['archive'], { cwd: tmp });
+    assert.equal(r.status, 1, `空期望集合必须 exit 1，实际 ${r.status}: ${r.out}`);
+    assert.match(r.out, /无法从 .*stryker\.conf\.d 派生期望段集合/, '须点名期望集合派生失败');
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/scripts/test/workflow-assert.test.ts
+++ b/scripts/test/workflow-assert.test.ts
@@ -255,7 +255,12 @@ test('#433+#572 调度重设计与孤立分支基线: observe 全量班（北京
   assert.ok(OBSERVE.includes("steps.reports.outputs.count != '0'"),
     '全量班变异执行与 push 必须以「有段报告产出」为前提——空产物不跑 push（原 has_suites 语义的矩阵化等价物）')
   assert.ok(!OBSERVE.includes('skip_pr=true'), '#572：全量班已迁移至孤立分支，日期闸与 PR 步骤已退役')
-  assert.ok(OBSERVE.includes('orphan-baseline.mjs push'), '全量班调用 orphan-baseline.mjs push 提交孤立分支')
+  // #718 S1.2：全量班写入口由整树替换改为并集入档。整树替换下「段被失败实例吃掉」是静默
+  // 丢段（实测 33 → 31），故这里同时锁正向（archive 在位）与反向（push 不得回流）。
+  assert.ok(OBSERVE.includes('orphan-baseline.mjs archive'),
+    '全量班必须走并集入档（#718 S1.2：先取回远端再叠加，缺段显式记账）')
+  assert.ok(!OBSERVE.includes('orphan-baseline.mjs push'),
+    '全量班不得回退为整树替换的 push（#718 S1.2：会静默丢段）')
 
   // ── 增量班（observe-incremental.yml）：每日四班次，北京 12/16/20/24 = UTC 04/08/12/16 ──
   assert.ok(OBSERVE_INC.includes("'0 4,8,12,16 * * *'"),
@@ -401,7 +406,11 @@ test('gauntlet: mutation.packages 全部带 threshold 字段且 ≥60（阶段�
 // PR 侧通过 orphan-baseline.mjs restore 浅拉取恢复。
 
 test('#178+#204+#572: observe 两班均使用孤立分支基线——全量班不 restore、增量班 restore 孤立分支', () => {
-  for (const [name, wf] of [['observe.yml', OBSERVE], ['observe-incremental.yml', OBSERVE_INC]]) {
+  // #718 S1.2：写入口按班次分工——全量班走并集入档（archive），增量班退役前仍是整树 push
+  for (const [name, wf, writeStep, writeCmd] of [
+    ['observe.yml', OBSERVE, 'Archive baseline to orphan branch', 'orphan-baseline.mjs archive'],
+    ['observe-incremental.yml', OBSERVE_INC, 'Push baseline to orphan branch', 'orphan-baseline.mjs push'],
+  ]) {
     assert.ok(
       !wf.includes('actions/cache/restore'),
       `${name} 严禁出现 restore 缓存步骤——基线走孤立分支（勿"好心"补 actions/cache restore）`,
@@ -414,12 +423,12 @@ test('#178+#204+#572: observe 两班均使用孤立分支基线——全量班�
       !wf.includes('create-pull-request@'),
       `${name} #572 已废除基线自动开 PR 合入 main（杜绝 git 树与提交历史膨胀）`,
     )
-    const pushIdx = wf.indexOf('Push baseline to orphan branch')
-    assert.ok(pushIdx > 0, `${name} push 步骤在位（增量基线 → 孤立分支 baseline/mutation）`)
+    const pushIdx = wf.indexOf(writeStep)
+    assert.ok(pushIdx > 0, `${name} 基线写入步骤「${writeStep}」在位（增量基线 → 孤立分支 baseline/mutation）`)
     const pushBlock = wf.slice(pushIdx, wf.indexOf('- name:', pushIdx + 10))
     assert.ok(pushBlock.includes('if: always()'),
-      `${name} push 步骤必须 if: always()（部分失败班次已产出的基线照常收集并强推）`)
-    assert.ok(pushBlock.includes('orphan-baseline.mjs push'), `${name} orphan-baseline.mjs push 脚本执行点在位`)
+      `${name} 基线写入步骤必须 if: always()（部分失败班次已产出的基线照常收集并强推）`)
+    assert.ok(pushBlock.includes(writeCmd), `${name} 基线写入必须调用 ${writeCmd}`)
     assert.ok(wf.includes('contents: write'), `${name} permissions 需 contents: write（孤立分支推送需要）`)
     assert.ok(wf.includes('mutation-baseline-sync'), `${name} concurrency 统一为 mutation-baseline-sync（防止覆盖踩踏）`)
   }
@@ -1052,11 +1061,11 @@ test('#217+#572: observe 两班变异记账与 push 区分整套 skip 与部分�
     assert.ok(sIdx > 0, 'observe.yml mutation-shards job 在位（原 Mutation suites 步骤的矩阵化替身）')
     const cIdx = OBSERVE.indexOf('\n  mutation-collect:')
     assert.ok(cIdx > 0, 'observe.yml mutation-collect job 在位（收口：判分 + 单点 push + 报告 + 工单）')
-    const pIdx = OBSERVE.indexOf('- name: Push baseline to orphan branch', cIdx)
-    assert.ok(pIdx > cIdx, 'observe.yml push 必须落在收口 job 内（单点推送，消除矩阵并发踩踏）')
+    const pIdx = OBSERVE.indexOf('- name: Archive baseline to orphan branch', cIdx)
+    assert.ok(pIdx > cIdx, 'observe.yml 入档必须落在收口 job 内（单点写入，消除矩阵并发踩踏）')
     const pBlock = OBSERVE.slice(pIdx, OBSERVE.indexOf('- name:', pIdx + 10))
     assert.ok(pBlock.includes("if: always() && steps.reports.outputs.count != '0'"),
-      'observe.yml push 条件必须区分零产物（不推送）与部分失败（有报告即照常提交）')
+      'observe.yml 入档条件必须区分零产物（不推送）与部分失败（有报告即照常提交）')
     const rIdx = OBSERVE.indexOf('- name: Restore report layout', cIdx)
     assert.ok(rIdx > cIdx && rIdx < pIdx, '报告齐备性判定必须排在 push 之前（push 依赖其 output）')
   }


### PR DESCRIPTION
## 关联 issue

#718（S1.2）。**不自动关闭**——S1.3 / S2 / S3 仍在计划内（本 PR 只做 S1.2）。

## 问题（实测缺陷，非推测）

归档分支 `baseline/mutation` 的写入口此前是**整树替换**：把「本班次 `coverage/mutation/` 里有什么」当成
「归档的全部内容」推上去。段一旦没产出（矩阵实例超时/被杀），该段文件就不在新树里，归档**静默缩水**，
且没有任何日志说明。

生产实证（2026-09-12）：

| 时刻 | 事件 | 归档段数 |
|---|---|---|
| 07:45–08:56 | 全量班 [34681565987](https://github.com/wingsky-1/dsh-plugin-hub/actions/runs/34681565987)：33 段只成功 31 段（`dsh-notifier-events` 10.33 min 被 timeout 杀） | 33 → **31** |
| 08:56–09:40 | 增量班 [34682727870](https://github.com/wingsky-1/dsh-plugin-hub/actions/runs/34682727870)：`restore` 只拿到 32 份（31 段 + manifest） | 31 |
| ↳ 日志 | `No incremental result file found at coverage/mutation/incremental-notifier-events.json, a full mutation testing run will be performed.`（server 同） | |
| ↳ 代价 | 该班被迫重算被吃掉的两段（events 12.29 min、server 15.73 min，其余段缓存命中 0.25–1.7 min），**全程 43.0 min，险过 45 min 超时** | 31 → 33 |
| 09:40–10:49 | 全量班 [34685879342](https://github.com/wingsky-1/dsh-plugin-hub/actions/runs/34685879342)：33/33 全绿 | 33 |

即：**当前唯一能补回丢段的路径是那个每日四班次、正被计划退役的增量班**（#718 S2.2）。S1.2 让丢段
在物理上不再可能，S2.2 才有成立的前提。

## 改动清单

| 文件 | 改动 |
|---|---|
| `scripts/gate/orphan-baseline.mjs` | 新增 `archive` 动作（并集入档）；抽出共用推送管线（manifest / mktree / 快照 tag / 显式租约）；`restore` 的探针+拉取抽成 `probeAndFetchBaseline()` 与 `archive` 共用同一判据 |
| `scripts/gate/baseline-archive.mjs` | 新增纯函数 `planArchive` / `snapshotTagFor` / `pruneSnapshotPlan` 与常量 `ARCHIVE_SNAPSHOT_TAG_PREFIX` / `ARCHIVE_SNAPSHOT_KEEP` / `BASELINE_MANIFEST_FILE`；订正「推送侧保护尚未实施」的过时注释 |
| `.github/workflows/observe.yml` | 收口 job 的写入口 `push` → `archive`（步骤更名 `Archive baseline to orphan branch`） |
| `scripts/test/baseline-archive.test.ts` | +4 纯函数用例（并集四类互斥完备 / 拆段遗留退役 / 首夜全缺 / 快照 tag 命名与保留窗口） |
| `scripts/test/orphan-baseline.test.ts` | +4 e2e 用例（并集不缩水 / 退役+缺段点名 / 拉取失败 fail-loud / 空期望集合 fail-loud） |
| `scripts/test/workflow-assert.test.ts` | 静态锁同步：全量班必须 `archive` 且**不得**回退为 `push`；写入口按班次分表断言 |
| `scripts/gate/baseline/README.md` | 新增「并集入档与可回滚」一节；订正三态语义一节里「尚无推送侧保护」的说明 |

## 语义（新写入口）

```
node scripts/gate/orphan-baseline.mjs archive
```

1. **取回远端**（探针三态 + 退避重试，与 `restore` 同一判据）；取不到一律 **fail-loud**——
   并集语义下「取不到远端」等于「沿用集合未知」，以空集合推送就是删段。
2. **并集 + 分类**（期望集合由 `stryker.conf.d/dsh-*.json` 派生，唯一事实源）：
   - **新算** = 本次产出，内容以本次为准；
   - **沿用** = 本次未产出但远端有，保留旧文件（Stryker 增量模式会自行识别内容已变）；
   - **缺** = 两边都没有 → `::warning::` + 点名（**告警而非判红**：拆段当夜新段本就无基线可沿用，
     判红会让每次拆段必然红一夜；真·数据丢失由段报告齐备性校验与台账 `--check` 兜底判红）；
   - **退役** = 不在期望集合却存在于任一侧（段被拆并/改名后的遗留）→ 从归档移除并点名。
     并集本身不删文件，所以这一支必须显式做，否则遗留段会永远留在归档里。
3. **可回滚**：分支深度仍恒为 1，可回滚性由快照 tag `baseline-snap-<UTC 时间戳>-<旧 tip 短 sha>`
   承担，保留最近 10 个；tag 刻意不以 `v` 开头（`release.yml` 由 `push: tags: v*` 触发）。
4. **显式租约**：`--force-with-lease=refs/heads/baseline/mutation:<读到的旧 sha>`。本路径不做 fetch，
   无参的 `--force-with-lease` 会退化成裸 `--force`（#718 裁决第 9 条），故必须带上读到的期望值。
5. **零新对象**：沿用文件直接复用远端 blob sha（不做内容往返，字节级一致），保住「未变动文件 0 开销」；
   沿用段在 `manifest.json` 里**保留远端条目**——其 `mtime` 是上次真实测量时间，重新盖章会让陈旧判据失效
   （#718 S3.1 要修的那个坑）。

副作用与边界（诚实记录）：

- 全量班写入口新增一条 fail-loud：远端取不到时入档失败。这是有意的——原来那一路会静默丢段。
- `push`（整树推送）保留给增量班，S2.2 退役它之后即无调用方；两处语义差异是有意的，不当作不一致。
- 本 PR **不修**已丢失的历史：`archive` 防的是未来丢段，不能凭空造出从未测过的段（这类段会落在「缺」并告警）。
- `overlay-baseline.mjs` 未动（S2.1 处置）；它仍是差量覆盖，其 force push 与自有的分页/对账逻辑留给 S2.1。

## 逐条命令与 exit code

本 worktree 实跑（`pnpm install --frozen-lockfile` → exit 0）：

| 命令 | exit code | 关键输出 |
|---|---|---|
| `pnpm build` | 0 | 全部包 `lib/index.js` 生成完成 |
| `pnpm test` | 0 | 7 个包套件全通过（合计 6690 用例，`dsh-mcp-manager` 1137 / `dsh-verify-isolated` 313 …） |
| `pnpm contract` | 0 | `forbid-module-state-src: OK（扫描 40 文件）` 等全通过 |
| `pnpm pack:check` | 0 | 6 子包 tarball 完整 + 聚合包「完整且与子包一致」 |
| `pnpm test:scripts` | 0 | `tests 411 / pass 411 / fail 0`（含本次新增 8 例） |
| `pnpm typecheck` | 0 | — |
| `pnpm docs:check` | 0 | `verify-docs：7 个包 + 根 README + 26 个 agent 规则文档` → 「文档一致性：通过」 |
| `git status --porcelain \| grep -E 'undefined/\|\.jsonl$'` | 1（无匹配） | 产物零污染（#218） |

门禁选择依据：改 `scripts/` → 追加 `pnpm test:scripts`；改 `.github/` → `workflow-assert` 静态锁在 `test:scripts` 内；改 README → `pnpm docs:check`。

新增用例 8 个：4 个纯函数（`planArchive` 四类互斥完备 / 拆段遗留退役 / 首夜全缺 / 快照 tag 命名与保留窗口）、
4 个 e2e（并集不缩水且不污染报告目录 / 退役+缺段点名 / 拉取失败 fail-loud / 空期望集合 fail-loud）。

## 实测数据

### 口径

- 全部为**本地隔离仓库实跑**（`mkdtemp` + `git init` + `origin` 指向自身），不触真实归档分支。
- 场景用**仓库真实的 33 份 `stryker.conf.d/dsh-*.json`**，起点是拆段前的真实 31 段基线形态
  （30 段沿用 + 旧的 `incremental-notifier-config.json` 单段）。
- 「本次产出」= 33 段里 events / server 两个实例被杀，其余 31 段产出（与生产 34681565987 同形）。

### A/B（同一输入，仅换写入口）

| 写入口 | 归档段数（conf=33） | 被杀两段 | 遗留旧段 |
|---|---|---|---|
| 旧 `push`（整树替换） | **31**（丢 2 段，无任何日志） | 0/2 | 已清 |
| 新 `archive`（并集入档） | **33**（完整） | **2/2** | 已退役并点名 |

新写入口的记账输出：

```
[orphan-baseline] 归档对账（期望 33 段）：新算 31 / 沿用 2 / 缺 0 / 退役 1
[orphan-baseline] 退役段（配置已不在期望集合，从归档移除）：incremental-notifier-config.json
[orphan-baseline] 回滚快照：refs/tags/baseline-snap-20260912T112325Z-02cdb6e（保留最近 10 个）
[orphan-baseline] 推送 commit ... 到 refs/heads/baseline/mutation（租约 expect ...）
[orphan-baseline] 成功同步基线至孤立分支 baseline/mutation（包含 34 份文件）
```

旧实现下同一输入的归档结果 = **31 段**，与生产 `restore` 拿到的「32 份 = 31 段 + manifest」逐字吻合，
即本次改动的 A/B 复现了真实缺陷。

租约语义单独验证（路径目标，与 CI 的 https URL 同属非命名远端）：

```
正确租约 → OK: 租约匹配 → 推送成功
过期租约 → ! [rejected] ... (stale info) / error: failed to push some refs
```

## 验收判据对照表（#718 S1.2）

| 判据 | 落地 | 证据 |
|---|---|---|
| 归档写入改「restore 远端 → 叠加本次产物 → 对账 → push」 | `archive` 动作（observe.yml 收口 job） | A/B：33 段完整，`新算 31 / 沿用 2 / 缺 0 / 退役 1` |
| 「新算 / 沿用 / 缺」三类计数 | 每次入档打印一行对账 | 同上 |
| 缺段告警 | `::warning::` + 逐个点名 | e2e 用例 `archive 退役清理 + 缺段点名告警` |
| 修不可回滚（保留 N commit 或快照 tag；不用裸 `--force`） | 快照 tag 保留 10 个 + 显式租约 | tag 指向入档前 tip；过期租约被 `stale info` 拒绝 |
| 不引入退化为裸 force 的 `--force-with-lease` | 显式 `<ref>:<expect>` 形式 | 见上 |
| 段被失败实例吃掉不再发生 | 并集语义 | A/B：旧 31 段 → 新 33 段 |

## 门禁
