### PR TITLE
fix(ci): #718 S2.1 overlay 加固——产物过期与无产物分流 + 写路径统一

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,13 +376,17 @@ jobs:
           if-no-files-found: error
 
       - name: Upload incremental baseline artifact（供合并后秒级 overlay 复用 #572）
-        # 变异测试通过时上传产出的增量基线文件，供 PR 合入 main 后由 baseline-overlay.yml 秒级复用
+        # 变异测试通过时上传产出的增量基线文件，供 PR 合入 main 后由 baseline-overlay.yml 秒级复用。
+        # 保留期从 1 天放宽到 7 天（#718 S2.1）：overlay 只在**合入那一刻**去取这份产物，
+        # 1 天的窗口意味着「PR 隔天再合」或「CI 跑完隔夜才合」时产物已过期，该 PR 命中段的新基线
+        # 就静默进不了归档（overlay 侧的静默 no-op 已同步改为 fail-loud，但放宽窗口才是治本）。
+        # 公开仓库的 Actions 存储不计费；单次 CI 的变异产物合计约 10~20 MB。
         if: success()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mutation-incremental-${{ matrix.combo.package }}-${{ matrix.combo.seg }}
           path: coverage/mutation/${{ env.BASENAME }}.json
-          retention-days: 1
+          retention-days: 7
           if-no-files-found: ignore
 
   # ── 第 3 段之三：聚合判分收尾（artifact 汇合 + 逐包变异率判分，#217）──

--- a/scripts/gate/baseline-archive.mjs
+++ b/scripts/gate/baseline-archive.mjs
@@ -51,6 +51,39 @@ export function mutationArtifacts(artifacts) {
   return (artifacts ?? []).filter((a) => typeof a?.name === 'string' && a.name.startsWith(MUTATION_ARTIFACT_PREFIX))
 }
 
+/** ci.yml 变异矩阵实例的 job 名形态：`Mutation gate (<pkg> · <seg>)`。 */
+export const MUTATION_GATE_JOB_RE = /^Mutation gate \(/
+
+/**
+ * 「看不到变异产物」的两态分流（#718 S2.1）。
+ *
+ * 旧实现只有一句「未产生任何增量变异产物，安全跳过」，把两件相反的事压成同一个静默 no-op：
+ *   · 真·无产物：PR 没触及变异切片，overlay 本就无事可做——正确的 no-op；
+ *   · 产物丢了：CI 确实跑过变异实例，但产物已过期/被删——该 PR 命中段的新基线**永远**进不了
+ *     归档，而日志只说了一句「没有产物」，与前者完全同形，事后无法区分。
+ *
+ * 判据取「该 CI run 里有没有变异矩阵实例」：实例存在 ⇒ 产物必定产出过（上传步骤是实例内
+ * `if: success()` 门控），所以「看不到产物」只能解释为丢失。`expiredArtifactCount` 只作原因里的
+ * 旁证，不单独当判据——过期记录本身也可能已被清理，届时它同样是 0。
+ */
+export function classifyMissingMutationProducts({ jobNames, expiredArtifactCount = 0 } = {}) {
+  const instances = (jobNames ?? []).filter((n) => typeof n === 'string' && MUTATION_GATE_JOB_RE.test(n))
+  if (instances.length > 0) {
+    return {
+      kind: 'lost',
+      instanceCount: instances.length,
+      reason:
+        `CI 曾运行 ${instances.length} 个变异矩阵实例，但产物已不可见`
+        + `（过期或被删除；本次 run 中 ${expiredArtifactCount} 个 artifact 标记 expired）`,
+    }
+  }
+  return {
+    kind: 'none',
+    instanceCount: 0,
+    reason: 'CI 未运行任何变异矩阵实例（纯文档 / 未触及变异切片）',
+  }
+}
+
 /**
  * 期望被归档的段文件名集合（由 stryker.conf.d/*.json 派生，与 stryker 配置同源）。
  * `dsh-web-file-preview.json`（未拆分包的 seg="0"）→ `incremental-web-file-preview.json`；

--- a/scripts/gate/baseline-push.mjs
+++ b/scripts/gate/baseline-push.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * scripts/gate/baseline-push.mjs — 归档分支写路径的共用管线（#718 S2.1）
+ *
+ * 为什么单独成文件：`baseline/mutation` 有两个写入方（夜间全量班的并集入档、PR 合并后的 overlay），
+ * 两者都要「组纯文本树 → 建孤立 commit → 打回滚快照 → 带租约推送」。同一操作两份实现正是 #718
+ * 的成因之一（探针判定、分页取全、对账都各写过一遍，随后各自漏修），故写路径只留这一份。
+ *
+ * 约定（与 #572 的存储形态绑定）：
+ *   · 孤立分支深度恒为 1（`commit-tree` 不带父节点）——可回滚性由快照 tag 承担，不由父链承担；
+ *   · 推送用带**显式期望值**的 `--force-with-lease`：本路径不做 fetch，无参形式会退化成裸 `--force`；
+ *   · 沿用文件由调用方给 `blobSha`（直接复用远端已有 blob），字节级一致因而零新对象。
+ */
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  ARCHIVE_SNAPSHOT_KEEP,
+  BASELINE_MANIFEST_FILE,
+  pruneSnapshotPlan,
+  snapshotTagFor,
+} from './baseline-archive.mjs';
+
+const MAX_BUFFER = 64 * 1024 * 1024; // 64MB，防止巨型基线 JSON 突破 Node 默认 1MB maxBuffer
+const BOT_IDENTITY = {
+  GIT_AUTHOR_NAME: 'github-actions[bot]',
+  GIT_AUTHOR_EMAIL: 'github-actions[bot]@users.noreply.github.com',
+  GIT_COMMITTER_NAME: 'github-actions[bot]',
+  GIT_COMMITTER_EMAIL: 'github-actions[bot]@users.noreply.github.com',
+};
+
+function runGit(args, options = {}) {
+  const { input, env, ignoreError = false } = options;
+  try {
+    return execFileSync('git', args, {
+      encoding: 'utf8',
+      stdio: [input ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+      input,
+      maxBuffer: MAX_BUFFER,
+      env: { ...process.env, ...env },
+    }).trim();
+  } catch (err) {
+    if (ignoreError) return null;
+    const stderr = err.stderr ? String(err.stderr).trim() : '';
+    throw new Error(`git ${args.join(' ')} failed: ${stderr || err.message}`);
+  }
+}
+
+export function hashFile(path) {
+  return runGit(['hash-object', '-w', path]);
+}
+
+export function hashBlob(content) {
+  return runGit(['hash-object', '-w', '--stdin'], { input: content });
+}
+
+/** manifest 的序列化形态（写入远端树与写入本地报告目录必须是同一份字节）。 */
+export function serializeManifest(manifest) {
+  return JSON.stringify(manifest, null, 2) + '\n';
+}
+
+/**
+ * manifest 条目。`preserved` 里的文件沿用其远端条目——那里的 mtime 是**上次真实测量时间**，
+ * 重新盖章会让「基线是否陈旧」无从判断（#718 S3.1 要修的那个坑）。
+ */
+export function buildManifest(dir, names, preserved = {}) {
+  const manifest = {};
+  for (const f of names) {
+    if (preserved[f]) {
+      manifest[f] = preserved[f];
+      continue;
+    }
+    const fullPath = join(dir, f);
+    const buf = readFileSync(fullPath);
+    manifest[f] = {
+      size: buf.length,
+      mtime: statSync(fullPath).mtime.toISOString(),
+      sha256: createHash('sha256').update(buf).digest('hex'),
+    };
+  }
+  return manifest;
+}
+
+/** 归档分支当前 tip。空字符串 = 广告里没有这条 ref（首推）；取不到则抛错，不在未知状态下推送。 */
+function remoteBranchTip(target, branch) {
+  let stdout;
+  try {
+    stdout = execFileSync('git', ['ls-remote', '--heads', target, `refs/heads/${branch}`], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: MAX_BUFFER,
+      // 无 TTY 时凭据缺失会让 git 挂起等待输入，显式关掉交互提示。
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    }).trim();
+  } catch {
+    throw new Error('无法读取归档分支 tip（远端不可达或凭据缺失），拒绝在未知状态下推送');
+  }
+  return stdout ? stdout.split(/\s+/)[0] : '';
+}
+
+/** 给旧 tip 打回滚快照 tag。必须先于新树推送——tag 指向的对象在推之前得是可达的。 */
+function pushSnapshotTag(target, oldSha, keep, log) {
+  const tag = snapshotTagFor(oldSha);
+  runGit(['push', target, `${oldSha}:refs/tags/${tag}`]);
+  log(`回滚快照：refs/tags/${tag}（保留最近 ${keep} 个）`);
+}
+
+function pruneSnapshotTags(target, keep, log) {
+  const listed = runGit(['ls-remote', '--tags', target, 'refs/tags/baseline-snap-*'], { ignoreError: true });
+  const refs = (listed ?? '')
+    .split('\n')
+    .map((l) => l.trim().split(/\s+/)[1])
+    .filter(Boolean);
+  const stale = pruneSnapshotPlan(refs, keep);
+  if (stale.length === 0) return;
+  // 逐个删除且不连坐：过期快照留着只是多占一个 ref，不影响本次写入的正确性。
+  for (const ref of stale) runGit(['push', target, '--delete', ref], { ignoreError: true });
+  log(`清理过期回滚快照 ${stale.length} 个`);
+}
+
+/**
+ * 组树 → 建孤立 commit → 打快照 → 带租约推送。
+ *
+ * `entries` 为 `[{ name, blobSha }]`（沿用文件复用远端 blob sha）；`manifest` 由本函数序列化并
+ * 作为树里的 manifest.json。给了 `manifestPath` 就同时落一份到本地（增量班的报告目录要用）。
+ */
+export function pushBaselineTree({
+  target,
+  branch,
+  entries,
+  manifest,
+  subject,
+  keep = ARCHIVE_SNAPSHOT_KEEP,
+  manifestPath,
+  label = 'baseline-push',
+  log = () => {},
+}) {
+  const say = (msg) => log(`[${label}] ${msg}`);
+  const ordered = [...entries].sort((a, b) => (a.name < b.name ? -1 : 1));
+  const manifestBlobSha = hashBlob(serializeManifest(manifest));
+  if (manifestPath) writeFileSync(manifestPath, serializeManifest(manifest));
+
+  const allFiles = [...ordered.map((e) => e.name), BASELINE_MANIFEST_FILE];
+  say(`准备提交 ${allFiles.length} 个基线文件到孤立分支 ${branch}...`);
+
+  const mktreeLines = [
+    ...ordered.map((e) => `100644 blob ${e.blobSha}\t${e.name}`),
+    `100644 blob ${manifestBlobSha}\t${BASELINE_MANIFEST_FILE}`,
+  ];
+  const treeSha = runGit(['mktree'], { input: mktreeLines.join('\n') + '\n' });
+  const commitSha = runGit(['commit-tree', treeSha, '-m', subject], { env: BOT_IDENTITY });
+
+  const oldSha = remoteBranchTip(target, branch);
+  if (oldSha) {
+    pushSnapshotTag(target, oldSha, keep, say);
+    pruneSnapshotTags(target, keep, say);
+    say(`推送 commit ${commitSha.slice(0, 8)} 到 refs/heads/${branch}（租约 expect ${oldSha.slice(0, 8)}）...`);
+    runGit([
+      'push',
+      `--force-with-lease=refs/heads/${branch}:${oldSha}`,
+      target,
+      `${commitSha}:refs/heads/${branch}`,
+    ]);
+  } else {
+    say(`推送 commit ${commitSha.slice(0, 8)} 到 refs/heads/${branch}（首推）...`);
+    runGit(['push', target, `${commitSha}:refs/heads/${branch}`]);
+  }
+  say(`成功同步基线至孤立分支 ${branch}（包含 ${allFiles.length} 份文件）`);
+}

--- a/scripts/gate/baseline/README.md
+++ b/scripts/gate/baseline/README.md
@@ -59,6 +59,34 @@
     `node scripts/gate/orphan-baseline.mjs restore`
   - 注意：本地若没有可用的 `origin`（或远端不可达），该命令会**非零退出**，不再静默降级（见下节）。
 
+### 「产物过期」与「无产物」分流（#718 S2.1）
+
+overlay 原来只有一句「未产生任何增量变异产物，安全跳过」，把两件相反的事压成同一个静默 no-op：
+
+| 形态 | 事实 | 正确处置 |
+|---|---|---|
+| 真·无产物 | PR 没触及变异切片，overlay 无事可做 | no-op（`exit 0`） |
+| 产物丢失 | CI 确实跑过变异矩阵实例，但产物已过期/被删 | 该 PR 命中段的新基线**永远**进不了归档 → **fail-loud** |
+
+两者在旧日志里完全同形，事后无法区分。判据取「该 CI run 里有没有变异矩阵实例」
+（`classifyMissingMutationProducts`）：实例存在 ⇒ 产物必定产出过（上传步骤是实例内 `if: success()`
+门控），所以「看不到产物」只能解释为丢失。汇总判分 job `Mutation gate verdict (...)` 不计入实例数。
+*jobs 查询本身失败时降级为 no-op*——这个分流用于**提高**报警灵敏度，不该因为多一次查询失败把纯文档 PR 判红。
+
+同一类静默降级还有一处：**有产物却一个都没覆盖成功**（下载/解析全线失败，或产物全部过期）原本也是
+`exit 0`。现在同样 fail-loud 并点名是「已过期 N 个」还是「下载或解析全部失败」。
+
+配套放宽产物保留期：`ci.yml` 里 `mutation-incremental-*` 的 `retention-days` 由 **1 → 7 天**。
+overlay 只在合入那一刻取产物，1 天窗口意味着「CI 跑完隔夜才合」时产物已过期——告警只是兜底，
+放宽窗口才是治本（公开仓库的 Actions 存储不计费）。
+
+### 写路径单一实现（#718 S2.1）
+
+`baseline/mutation` 的两个写入方（夜间全量班的并集入档、PR 合并后的 overlay）此前各写一套
+「组树 → 建 commit → 强推」plumbing，包括各自的裸 `--force`。现统一走 `scripts/gate/baseline-push.mjs`：
+两者共用回滚快照 tag、保留窗口与带显式期望值的 `--force-with-lease`，overlay 侧不再有裸 `--force`。
+沿用段在 manifest 里保留远端条目（其 `mtime` 是上次真实测量时间）——两个写入方口径一致。
+
 ### 恢复与查询失败的三态语义（#718）
 
 `orphan-baseline.mjs restore` 与 `overlay-baseline.mjs` 的远端探针**共用同一判据**

--- a/scripts/gate/orphan-baseline.mjs
+++ b/scripts/gate/orphan-baseline.mjs
@@ -27,23 +27,19 @@
  *       （拒绝以空基线继续——写路径上这意味着删段，见 #718）
  *     - 取到后浅拉取（fetch --depth=1）并把 incremental-*.json 与 manifest.json 恢复到 coverage/mutation/
  */
-import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import {
-  ARCHIVE_SNAPSHOT_KEEP,
-  ARCHIVE_SNAPSHOT_TAG_PREFIX,
   BASELINE_FILE_RE,
   BASELINE_MANIFEST_FILE,
   classifyRemoteProbe,
   decideRestoreOutcome,
   expectedBaselineFiles,
   planArchive,
-  pruneSnapshotPlan,
-  snapshotTagFor,
 } from './baseline-archive.mjs';
+import { buildManifest, hashFile, pushBaselineTree } from './baseline-push.mjs';
 
 const action = process.argv[2];
 const BRANCH = 'baseline/mutation';
@@ -53,12 +49,6 @@ const MAX_BUFFER = 64 * 1024 * 1024; // 64MB，防止巨型基线 JSON 突破 No
 const PROBE_ATTEMPTS = 3;
 // 环境故障（远端不可达）可能瞬时，按与 fetch 同规格的退避重试；测试用 0 秒避免拖慢套件。
 const RETRY_DELAY_MS = Number(process.env.ORPHAN_BASELINE_RETRY_DELAY_MS ?? 2000);
-const BOT_IDENTITY = {
-  GIT_AUTHOR_NAME: 'github-actions[bot]',
-  GIT_AUTHOR_EMAIL: 'github-actions[bot]@users.noreply.github.com',
-  GIT_COMMITTER_NAME: 'github-actions[bot]',
-  GIT_COMMITTER_EMAIL: 'github-actions[bot]@users.noreply.github.com',
-};
 
 function runGit(args, options = {}) {
   const { input, env, ignoreError = false } = options;
@@ -109,16 +99,6 @@ function remoteTarget() {
   const token = process.env.OBSERVE_PAT || process.env.GITHUB_TOKEN;
   const repo = process.env.GITHUB_REPOSITORY;
   return token && repo ? `https://x-access-token:${token}@github.com/${repo}.git` : 'origin';
-}
-
-/**
- * 归档分支当前 tip。空字符串 = 广告里没有这条 ref（首推）；取不到则抛错——
- * 首推与「读不到」都会走到非快进推送，但两者要给出不同的话，否则排障时无从区分。
- */
-function remoteTipSha() {
-  const res = runGitProbe(['ls-remote', '--heads', remoteTarget(), `refs/heads/${BRANCH}`]);
-  if (!res.ok) throw new Error('无法读取归档分支 tip（远端不可达或凭据缺失），拒绝在未知状态下推送');
-  return res.stdout ? res.stdout.split(/\s+/)[0] : '';
 }
 
 /**
@@ -233,93 +213,6 @@ function readRemoteTree() {
   return { files, blobs, manifest, entries };
 }
 
-/**
- * manifest 条目。沿用文件保留远端条目（其 mtime 是**上次真实测量时间**；重新盖章会让陈旧
- * 判据失效——重写时间戳正是 #718 S3.1 要修的那个坑），新算文件现算。
- */
-function buildManifest(dir, names, preserved = {}) {
-  const manifest = {};
-  for (const f of names) {
-    if (preserved[f]) {
-      manifest[f] = preserved[f];
-      continue;
-    }
-    const fullPath = join(dir, f);
-    const buf = readFileSync(fullPath);
-    manifest[f] = {
-      size: buf.length,
-      mtime: statSync(fullPath).mtime.toISOString(),
-      sha256: createHash('sha256').update(buf).digest('hex'),
-    };
-  }
-  return manifest;
-}
-
-function hashFile(path) {
-  return runGit(['hash-object', '-w', path]);
-}
-
-function hashBlob(content) {
-  return runGit(['hash-object', '-w', '--stdin'], { input: content });
-}
-
-/** 给旧 tip 打回滚快照 tag。必须先于新树推送——tag 指向的对象在推之前得是可达的。 */
-function pushSnapshotTag(oldSha) {
-  const tag = snapshotTagFor(oldSha);
-  runGit(['push', remoteTarget(), `${oldSha}:refs/tags/${tag}`]);
-  console.log(`[orphan-baseline] 回滚快照：refs/tags/${tag}（保留最近 ${ARCHIVE_SNAPSHOT_KEEP} 个）`);
-}
-
-function pruneSnapshotTags() {
-  const listed = runGit(
-    ['ls-remote', '--tags', remoteTarget(), `refs/tags/${ARCHIVE_SNAPSHOT_TAG_PREFIX}*`],
-    { ignoreError: true },
-  );
-  const refs = (listed ?? '')
-    .split('\n')
-    .map((l) => l.trim().split(/\s+/)[1])
-    .filter(Boolean);
-  const stale = pruneSnapshotPlan(refs);
-  if (stale.length === 0) return;
-  // 逐个删除：一条失败不连坐，过期快照留着只是多占一个 ref，不影响本次入档的正确性。
-  for (const ref of stale) runGit(['push', remoteTarget(), '--delete', ref], { ignoreError: true });
-  console.log(`[orphan-baseline] 清理过期回滚快照 ${stale.length} 个`);
-}
-
-/**
- * 归档分支深度恒为 1（无父 commit）：可回滚性靠快照 tag 承担，而不是靠父链——
- * 后者会让每次入档都把历史带上远端，与 #572「剥离 main 分支代码树巨型 JSON」的初衷分叉。
- * 推送用带显式 expect 的 `--force-with-lease`：本路径不做 fetch，无参形式会退化成裸 force（#718 裁决）。
- */
-function pushBaselineCommit(entries, subject) {
-  const allFiles = [...entries.map((e) => e.name), BASELINE_MANIFEST_FILE];
-  console.log(`[orphan-baseline] 准备提交 ${allFiles.length} 个基线文件到孤立分支 ${BRANCH}...`);
-
-  const mktreeLines = entries.map((e) => `100644 blob ${e.blobSha}\t${e.name}`);
-  const treeSha = runGit(['mktree'], { input: mktreeLines.join('\n') + '\n' });
-  const commitSha = runGit(['commit-tree', treeSha, '-m', subject], { env: BOT_IDENTITY });
-
-  const target = remoteTarget();
-  const oldSha = remoteTipSha();
-  if (oldSha) {
-    pushSnapshotTag(oldSha);
-    pruneSnapshotTags();
-    console.log(
-      `[orphan-baseline] 推送 commit ${commitSha.slice(0, 8)} 到 refs/heads/${BRANCH}（租约 expect ${oldSha.slice(0, 8)}）...`,
-    );
-    runGit([
-      'push',
-      `--force-with-lease=refs/heads/${BRANCH}:${oldSha}`,
-      target,
-      `${commitSha}:refs/heads/${BRANCH}`,
-    ]);
-  } else {
-    console.log(`[orphan-baseline] 推送 commit ${commitSha.slice(0, 8)} 到 refs/heads/${BRANCH}（首推）...`);
-    runGit(['push', target, `${commitSha}:refs/heads/${BRANCH}`]);
-  }
-  console.log(`[orphan-baseline] 成功同步基线至孤立分支 ${BRANCH}（包含 ${allFiles.length} 份文件）`);
-}
-
 if (action === 'push') {
   if (!existsSync(TARGET_DIR)) {
     console.error(`[orphan-baseline] 源目录不存在: ${TARGET_DIR}`);
@@ -332,16 +225,16 @@ if (action === 'push') {
     process.exit(1);
   }
 
-  const manifestPath = join(TARGET_DIR, BASELINE_MANIFEST_FILE);
-  writeFileSync(manifestPath, JSON.stringify(buildManifest(TARGET_DIR, baselineFiles), null, 2) + '\n');
-
-  pushBaselineCommit(
-    [
-      ...baselineFiles.map((f) => ({ name: f, blobSha: hashFile(join(TARGET_DIR, f)) })),
-      { name: BASELINE_MANIFEST_FILE, blobSha: hashFile(manifestPath) },
-    ].sort((a, b) => (a.name < b.name ? -1 : 1)),
-    'chore(ci): update mutation baseline snapshot [skip ci]',
-  );
+  pushBaselineTree({
+    target: remoteTarget(),
+    branch: BRANCH,
+    entries: baselineFiles.map((f) => ({ name: f, blobSha: hashFile(join(TARGET_DIR, f)) })),
+    manifest: buildManifest(TARGET_DIR, baselineFiles),
+    subject: 'chore(ci): update mutation baseline snapshot [skip ci]',
+    manifestPath: join(TARGET_DIR, BASELINE_MANIFEST_FILE),
+    label: 'orphan-baseline',
+    log: console.log,
+  });
 } else if (action === 'archive') {
   if (!existsSync(TARGET_DIR)) {
     console.error(`[orphan-baseline] 源目录不存在: ${TARGET_DIR}`);
@@ -392,18 +285,18 @@ if (action === 'push') {
     preserved[f] = remote.manifest[f];
   }
 
-  const manifest = buildManifest(TARGET_DIR, plan.newlyMeasured, preserved);
-  const entries = [
-    // 沿用文件直接复用远端 blob sha：不做内容往返，字节级一致因而零新对象。
-    ...plan.carriedOver.map((f) => ({ name: f, blobSha: remote.blobs.get(f) })),
-    ...plan.newlyMeasured.map((f) => ({ name: f, blobSha: hashFile(join(TARGET_DIR, f)) })),
-    { name: BASELINE_MANIFEST_FILE, blobSha: hashBlob(JSON.stringify(manifest, null, 2) + '\n') },
-  ].sort((a, b) => (a.name < b.name ? -1 : 1));
-
-  pushBaselineCommit(
-    entries,
-    `chore(ci): archive mutation baseline（并集入档 新算${plan.newlyMeasured.length}/沿用${plan.carriedOver.length}/缺${plan.missing.length}）[skip ci]`,
-  );
+  pushBaselineTree({
+    target: remoteTarget(),
+    branch: BRANCH,
+    entries: kept.map((f) =>
+      // 沿用文件直接复用远端 blob sha：不做内容往返，字节级一致因而零新对象。
+      plan.carriedOver.includes(f) ? { name: f, blobSha: remote.blobs.get(f) } : { name: f, blobSha: hashFile(join(TARGET_DIR, f)) },
+    ),
+    manifest: buildManifest(TARGET_DIR, plan.newlyMeasured, preserved),
+    subject: `chore(ci): archive mutation baseline（并集入档 新算${plan.newlyMeasured.length}/沿用${plan.carriedOver.length}/缺${plan.missing.length}）[skip ci]`,
+    label: 'orphan-baseline',
+    log: console.log,
+  });
 } else if (action === 'restore') {
   mkdirSync(TARGET_DIR, { recursive: true });
 

--- a/scripts/gate/overlay-baseline.mjs
+++ b/scripts/gate/overlay-baseline.mjs
@@ -8,29 +8,21 @@
  * 差量覆盖（Overlay）到当前孤立分支 refs/heads/baseline/mutation 上，15 秒内完成同步。
  */
 import { execFileSync, execSync } from 'node:child_process';
-import { createHash } from 'node:crypto';
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import {
   BASELINE_FILE_RE,
   GH_API_PER_PAGE,
+  classifyMissingMutationProducts,
   classifyRemoteProbe,
   expectedBaselineFiles,
   mergeArtifactPage,
   mutationArtifacts,
   reconcileArchive,
 } from './baseline-archive.mjs';
+import { buildManifest, hashFile, pushBaselineTree } from './baseline-push.mjs';
 
 const repo = process.env.GITHUB_REPOSITORY;
 const commitSha = process.env.COMMIT_SHA || execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
@@ -84,6 +76,29 @@ function probeArchiveRef() {
     }
   }
   return 'unreachable';
+}
+
+/**
+ * 该 CI run 的 job 名清单（#718 S2.1）。只在「看不到变异产物」这一支调用——正常路径不为它多付
+ * 一次 API 往返。取不到就返回空数组（= 判为「真·无产物」）：这个分流是为了**提高**报警灵敏度，
+ * 不该因为多一次查询失败而把正常的纯文档 PR 判红。
+ */
+function fetchRunJobNames(runId) {
+  try {
+    return runGh([
+      'api',
+      '--paginate',
+      `repos/${repo}/actions/runs/${runId}/jobs?per_page=${GH_API_PER_PAGE}`,
+      '--jq',
+      '.jobs[].name',
+    ])
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+  } catch (err) {
+    console.warn(`[overlay-baseline] 查询 run jobs 失败，无法分流「产物过期」与「无产物」: ${err.message}`);
+    return [];
+  }
 }
 
 async function main() {
@@ -179,9 +194,32 @@ async function main() {
   }
 
   const mutArtifacts = mutationArtifacts(artifacts);
+  const expiredArtifacts = artifacts.filter((a) => a?.expired === true);
   if (mutArtifacts.length === 0) {
-    console.log(`[overlay-baseline] PR #${pr.number} 未产生任何增量变异产物（纯文档/未触及变异切片），安全跳过 (No-op)`);
+    // #718 S2.1：分流「真·无产物」与「产物已过期/被删」。后者若也走静默 no-op，该 PR 命中段的
+    // 新基线就永远进不了归档，而日志与前者完全同形（这是本缺陷此前无法从日志发现的原因）。
+    const verdict = classifyMissingMutationProducts({
+      jobNames: fetchRunJobNames(successfulCiRun.id),
+      expiredArtifactCount: expiredArtifacts.length,
+    });
+    if (verdict.kind === 'lost') {
+      console.error(`[overlay-baseline] ${verdict.reason} —— 该 PR 命中段的新基线未进归档（fail-loud）`);
+      console.error(
+        '[overlay-baseline] 处置：重跑该 PR 的 CI 后重新触发合并，或等下一次全量班次并集入档重建；'
+        + '若为保留期过短所致，调 ci.yml 里变异产物的 retention-days。',
+      );
+      process.exit(1);
+    }
+    console.log(`[overlay-baseline] PR #${pr.number} ${verdict.reason}，安全跳过 (No-op)`);
     process.exit(0);
+  }
+  if (expiredArtifacts.length > 0) {
+    // 部分过期：产物还在，能覆盖的先覆盖；但必须点名，否则「哪些段没被覆盖」只能靠人的记忆。
+    console.warn(
+      `[overlay-baseline] ::warning::本次 CI 有 ${expiredArtifacts.length} 个 artifact 已过期`
+      + `（${expiredArtifacts.slice(0, 5).map((a) => a.name).join(', ')}${expiredArtifacts.length > 5 ? ' …' : ''}）`
+      + '—— 其对应的段不会被本次覆盖',
+    );
   }
 
   console.log(`[overlay-baseline] 发现 ${mutArtifacts.length} / ${artifacts.length} 个增量产物，准备执行差量覆盖 (Overlay)...`);
@@ -192,6 +230,8 @@ async function main() {
   const artifactsDir = join(tmpWork, 'artifacts');
   const carriedForward = []; // 旧基线里带过来的段文件（对账用：区分「本次覆盖」与「沿用旧版」）
   const overlaid = []; // 本次真正写入的段文件
+  // 远端 manifest：本次未覆盖的沿用段要保留它的条目（那里的 mtime 是上次真实测量时间）。
+  let remoteManifest = {};
   mkdirSync(baselineDir, { recursive: true });
   mkdirSync(artifactsDir, { recursive: true });
 
@@ -225,6 +265,14 @@ async function main() {
         process.exit(1);
       }
       console.log(`[overlay-baseline] 孤立分支 ${BRANCH} 尚不存在（首夜），基于当前产物构建全新快照`);
+    }
+    try {
+      remoteManifest = JSON.parse(readFileSync(join(baselineDir, 'manifest.json'), 'utf8'));
+    } catch {
+      // 缺 manifest / 内容损坏：沿用段的陈旧判据取不到，但覆盖本身仍是对的，
+      // 故降级为「现存条目一律重算」并点名，而不是让整次合并丢基线。
+      console.warn('[overlay-baseline] 远端 manifest 不可用，沿用段的时间戳将按本次时间重算（陈旧判据降级）');
+      remoteManifest = {};
     }
 
     // 6. 逐个下载增量产物并覆盖同名基线
@@ -272,8 +320,18 @@ async function main() {
     }
 
     if (overlayCount === 0) {
-      console.log('[overlay-baseline] 没有成功覆盖任何有效基线文件，跳过推送');
-      process.exit(0);
+      // #718 S2.1：有产物却一个都没覆盖成功 = 下载/解析全线失败或产物全部过期。旧实现只打印一句
+      // 「跳过推送」就 exit 0，与「真·无产物」同形——整次合并的基线就这么静默丢掉了。
+      const expiredNames = mutArtifacts.filter((a) => a?.expired === true).map((a) => a.name);
+      console.error(
+        `[overlay-baseline] 发现 ${mutArtifacts.length} 个变异产物但无一覆盖成功（`
+        + (expiredNames.length > 0
+          ? `其中 ${expiredNames.length} 个已过期: ${expiredNames.slice(0, 5).join(', ')}`
+          : '下载或解析全部失败')
+        + '）—— 本次合并的基线未更新（fail-loud）',
+      );
+      process.exitCode = 1;
+      return;
     }
 
     // 6.5 对账（#714 后续修复）：期望集合 = stryker.conf.d 派生的段文件；缺口 = 既没被本次覆盖
@@ -295,60 +353,29 @@ async function main() {
       console.error('[overlay-baseline] 这些段将每次全量重跑。检查上游：产物是否上传成功 / 分页是否取全 / 段配置是否漂移。');
     }
 
-    // 7. 重新校准并生成 manifest.json
+    // 7. 重建 manifest 并入档。写路径与夜间班的并集入档共用 baseline-push.mjs——同一操作两份实现
+    //    正是 #718 的成因之一（两份各自漏修），回滚快照与带租约推送也由该模块统一承担。
     const allFiles = readdirSync(baselineDir)
-      .filter((f) => /^incremental-.+\.json$/.test(f))
+      .filter((f) => BASELINE_FILE_RE.test(f))
       .sort();
 
-    const manifest = {};
+    // 本次未覆盖的沿用段保留远端 manifest 条目：那里的 mtime 是上次真实测量时间，
+    // 重新盖章会让「基线是否陈旧」无从判断（#718 S3.1 要修的那个坑）。
+    const preserved = {};
     for (const f of allFiles) {
-      const fullPath = join(baselineDir, f);
-      const buf = readFileSync(fullPath);
-      const st = statSync(fullPath);
-      manifest[f] = {
-        size: buf.length,
-        mtime: st.mtime.toISOString(),
-        sha256: createHash('sha256').update(buf).digest('hex'),
-      };
-    }
-    writeFileSync(join(baselineDir, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
-    allFiles.push('manifest.json');
-
-    // 8. 用 Git plumbing 构建孤立 commit 并推送
-    console.log(`[overlay-baseline] 准备提交 ${allFiles.length} 个基线文件到孤立分支...`);
-    const mktreeLines = [];
-    for (const f of allFiles) {
-      const fullPath = join(baselineDir, f);
-      const blobSha = runCmd('git', ['hash-object', '-w', fullPath]);
-      mktreeLines.push(`100644 blob ${blobSha}\t${f}`);
+      if (!overlaid.includes(f) && remoteManifest[f]) preserved[f] = remoteManifest[f];
     }
 
-    const treeSha = execFileSync('git', ['mktree'], {
-      input: mktreeLines.join('\n') + '\n',
-      encoding: 'utf8',
-      maxBuffer: MAX_BUFFER,
-    }).trim();
-
-    const commitMsg = `chore(baseline): overlay incremental from PR #${pr.number} [skip ci]`;
-    const commitShaNew = runCmd(
-      'git',
-      ['commit-tree', treeSha, '-m', commitMsg],
-      {
-        env: {
-          GIT_AUTHOR_NAME: 'github-actions[bot]',
-          GIT_AUTHOR_EMAIL: 'github-actions[bot]@users.noreply.github.com',
-          GIT_COMMITTER_NAME: 'github-actions[bot]',
-          GIT_COMMITTER_EMAIL: 'github-actions[bot]@users.noreply.github.com',
-        },
-      },
-    );
-
-    const remoteTarget = token
-      ? `https://x-access-token:${token}@github.com/${repo}.git`
-      : 'origin';
-
-    runCmd('git', ['push', '--force', remoteTarget, `${commitShaNew}:refs/heads/${BRANCH}`]);
-    console.log(`[overlay-baseline] 成功完成 PR #${pr.number} 产物差量覆盖并强推至 ${BRANCH}！`);
+    pushBaselineTree({
+      target: token ? `https://x-access-token:${token}@github.com/${repo}.git` : 'origin',
+      branch: BRANCH,
+      entries: allFiles.map((f) => ({ name: f, blobSha: hashFile(join(baselineDir, f)) })),
+      manifest: buildManifest(baselineDir, allFiles, preserved),
+      subject: `chore(baseline): overlay incremental from PR #${pr.number} [skip ci]`,
+      label: 'overlay-baseline',
+      log: console.log,
+    });
+    console.log(`[overlay-baseline] 成功完成 PR #${pr.number} 产物差量覆盖并推至 ${BRANCH}！`);
     if (archiveGap) {
       console.error('[overlay-baseline] 归档已更新，但存在缺口（见上）—— 本次以非零退出暴露问题');
       process.exitCode = 1;

--- a/scripts/test/baseline-archive.test.ts
+++ b/scripts/test/baseline-archive.test.ts
@@ -22,6 +22,8 @@ import {
   ARCHIVE_SNAPSHOT_KEEP,
   BASELINE_FILE_RE,
   GH_API_PER_PAGE,
+  MUTATION_GATE_JOB_RE,
+  classifyMissingMutationProducts,
   classifyRemoteProbe,
   decideRestoreOutcome,
   expectedBaselineFiles,
@@ -284,4 +286,39 @@ test('#718 S1.2: 回滚快照 tag —— 名字含旧 tip 短 sha，保留窗口
   assert.deepEqual(pruneSnapshotPlan(refs.slice(0, 2)), [], '未超窗口不得删任何快照')
   // 非本前缀的 tag（例如发布 tag）绝不能被这条清理逻辑碰到。
   assert.deepEqual(pruneSnapshotPlan(['refs/tags/v1.2.3', 'refs/tags/baseline-snap-other']), [], '只清理自己的前缀')
+})
+
+// ── #718 S2.1：overlay 的「产物过期」与「无产物」分流 ────────────────────────
+
+test('#718 S2.1: 「看不到变异产物」两态分流 —— 汇总判分 job 不得被误计为矩阵实例', () => {
+  const lost = classifyMissingMutationProducts({
+    jobNames: [
+      'Detect changed packages',
+      'Mutation gate (dsh-notifier · text)',
+      'Mutation gate (dsh-notifier · events)',
+      'Mutation gate verdict (aggregate)',
+    ],
+    expiredArtifactCount: 3,
+  })
+  assert.equal(lost.kind, 'lost', '有实例却看不到产物 ⇒ 只能是丢失')
+  assert.equal(lost.instanceCount, 2, '汇总判分 job「Mutation gate verdict (...)」不是矩阵实例，不得计入')
+  assert.ok(lost.reason.includes('产物已不可见'), '原因须点名「不可见」，与「没有产物」区分开')
+  assert.ok(lost.reason.includes('3'), '过期 artifact 计数作为旁证写进原因')
+
+  const none = classifyMissingMutationProducts({
+    jobNames: ['Detect changed packages', 'Build / Test / Typecheck (dsh-notifier)'],
+    expiredArtifactCount: 0,
+  })
+  assert.equal(none.kind, 'none', '没跑过变异实例 ⇒ 正确的 no-op')
+  assert.equal(none.instanceCount, 0)
+  assert.ok(none.reason.includes('未运行任何变异矩阵实例'))
+
+  // 空 / 脏输入不得抛，且一律落到 no-op：这个分流用于**提高**报警灵敏度，
+  // 宁可漏报一次，也不能因为上游返回形态异常把纯文档 PR 判红。
+  for (const input of [undefined, {}, { jobNames: null }, { jobNames: [1, null, ''] }]) {
+    assert.equal(classifyMissingMutationProducts(input).kind, 'none', `脏输入 ${JSON.stringify(input)} 应落 no-op`)
+  }
+
+  assert.equal(MUTATION_GATE_JOB_RE.test('Mutation gate verdict (aggregate)'), false, '汇总 job 名不匹配实例形态')
+  assert.equal(MUTATION_GATE_JOB_RE.test('Mutation gate (dsh-notifier · text)'), true)
 })

--- a/scripts/test/orphan-baseline.test.ts
+++ b/scripts/test/orphan-baseline.test.ts
@@ -202,7 +202,7 @@ test('#718: overlay-baseline 恢复段——探针说 present 但拉取失败时
   }
 });
 
-test('#718: overlay-baseline 恢复段——探针明确 absent 时走首夜且不得崩（exit 0）', () => {
+test('#718: overlay-baseline 恢复段——探针明确 absent 时走首夜且不得崩', () => {
   const tmp = mkdtempSync(join(tmpdir(), 'overlay-test-firstnight-'));
   const bin = mkdtempSync(join(tmpdir(), 'overlay-test-bin2-'));
   try {
@@ -227,8 +227,11 @@ exec "${real}" "$@"
     });
     assert.doesNotMatch(r.out, /ReferenceError/, '不得因变量作用域抛 ReferenceError');
     assert.match(r.out, /尚不存在（首夜）/, 'absent 应走首夜分支');
-    // 之后产物下载失败 → overlayCount 0 → 无有效覆盖，跳过推送并正常退出。
-    assert.equal(r.status, 0, `首夜应继续并最终 no-op exit 0，实际 ${r.status}: ${r.out}`);
+    // 之后产物下载失败 → overlayCount 0。**有产物却一个都没覆盖成功**不是「无事可做」：
+    // #718 S2.1 起按 fail-loud 处理（旧行为是打印一句「跳过推送」就 exit 0，整次合并的基线静默丢失）。
+    assert.equal(r.status, 1, `有产物但无一覆盖成功必须 exit 1，实际 ${r.status}: ${r.out}`);
+    assert.match(r.out, /无一覆盖成功/, '须点名「有产物但无一覆盖成功」');
+    assert.match(r.out, /基线未更新/, '须说明后果');
   } finally {
     rmSync(tmp, { recursive: true, force: true });
     rmSync(bin, { recursive: true, force: true });
@@ -469,6 +472,204 @@ test('#718 S1.2: archive 期望集合为空必须 fail-loud（防把整棵基线
     const r = runScript(scriptPath, ['archive'], { cwd: tmp });
     assert.equal(r.status, 1, `空期望集合必须 exit 1，实际 ${r.status}: ${r.out}`);
     assert.match(r.out, /无法从 .*stryker\.conf\.d 派生期望段集合/, '须点名期望集合派生失败');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ── #718 S2.1：overlay 的「产物过期」与「无产物」分流 ────────────────────────
+// 旧实现把两件相反的事压成同一句「未产生任何增量变异产物，安全跳过」：真·无产物（正确的 no-op）
+// 与产物已过期/被删（该 PR 命中段的新基线永远进不了归档）。日志里两者完全同形，事后无法区分。
+
+/**
+ * S2.1 用的假 gh：在既有 pulls/runs/artifacts 分流之上支持 jobs 查询。
+ * jobs 走 `gh api --paginate <url> --jq ...` 形态，故 `$2` 是 `--paginate`、URL 落在 `$3`——
+ * 与 `$2` 是 URL 的既有三条分流天然不冲突（假 gh 不做 jq，直接输出脚本已烘焙好的结果）。
+ */
+function writeFakeGhForOverlay(dir, { jobNames = [], artifacts = '[]' } = {}) {
+  const head = `[{"number":7,"merged_at":"2026-01-01T00:00:00Z","head":{"sha":"${'b'.repeat(40)}"}}]`;
+  const runs = '[{"name":"CI","conclusion":"success","id":12345}]';
+  const script = `#!/bin/sh
+case "$2" in
+  *commits/*/pulls) printf '%s' '${head}'; exit 0 ;;
+  *artifacts*) printf '%s' '${artifacts}'; exit 0 ;;
+  *actions/runs*) printf '%s' '${runs}'; exit 0 ;;
+  --paginate) printf '%s\\n' ${jobNames.map((n) => `'${n}'`).join(' ')}; exit 0 ;;
+esac
+echo "unexpected gh args: $*" >&2; exit 1
+`;
+  const p = join(dir, 'gh');
+  writeFileSync(p, script, { mode: 0o755 });
+  return p;
+}
+
+function runOverlayWithFakeGh(tmp, options) {
+  writeFakeGhForOverlay(tmp, options);
+  return runScript(overlayScriptPath, [], {
+    cwd: tmp,
+    env: {
+      PATH: `${tmp}:${process.env.PATH}`,
+      GITHUB_REPOSITORY: 'owner/repo',
+      COMMIT_SHA: 'a'.repeat(40),
+      GH_TOKEN: 'dummy',
+    },
+  });
+}
+
+test('#718 S2.1: 变异产物已丢失必须 fail-loud（CI 跑过变异实例却看不到产物）', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'overlay-s21-lost-'));
+  try {
+    const r = runOverlayWithFakeGh(tmp, {
+      // run 里确实有变异矩阵实例（且汇总判分 job 不得被误计），但产物列表里一份变异产物都没有：
+      // 上传步骤是实例内 if: success() 门控，实例存在 ⇒ 产物产出过 ⇒ 只能解释为过期/被删。
+      jobNames: [
+        'Detect changed packages',
+        'Mutation gate (dsh-notifier · text)',
+        'Mutation gate verdict (aggregate)',
+      ],
+      artifacts: '{"total_count":1,"artifacts":[{"name":"observe-reports","expired":true}]}',
+    });
+    assert.equal(r.status, 1, `产物丢失必须 exit 1，实际 ${r.status}: ${r.out}`);
+    assert.match(r.out, /产物已不可见/, '须点名「曾运行变异实例但看不到产物」');
+    assert.match(r.out, /未进归档/, '须说明后果（该 PR 命中段的新基线未进归档）');
+    assert.match(r.out, /retention-days/, '须给出可执行的处置方向');
+    assert.doesNotMatch(r.out, /安全跳过 \(No-op\)/, '不得与「真·无产物」同形');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('#718 S2.1: 真·无产物仍是合法 no-op（CI 未运行任何变异实例）', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'overlay-s21-none-'));
+  try {
+    // 与上一条同形（都看不到变异产物），区别只在 run 里没有变异矩阵实例 = 纯文档 PR。
+    // 分流必须把这一支保留为 no-op，否则每个纯文档 PR 合并都会把 main 判红。
+    const r = runOverlayWithFakeGh(tmp, {
+      jobNames: ['Detect changed packages', 'Build / Test / Typecheck (dsh-notifier)'],
+      artifacts: '{"total_count":0,"artifacts":[]}',
+    });
+    assert.equal(r.status, 0, `真·无产物必须 exit 0，实际 ${r.status}: ${r.out}`);
+    assert.match(r.out, /未运行任何变异矩阵实例/, '须明说判据是「没跑过变异实例」');
+    assert.match(r.out, /安全跳过 \(No-op\)/, '保持既有 no-op 文案');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('#718 S2.1: jobs 查询失败不得把纯文档 PR 误判为产物丢失', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'overlay-s21-jobsfail-'));
+  const bin = mkdtempSync(join(tmpdir(), 'overlay-s21-bin-'));
+  try {
+    // 用 git shim 之外的手段不奏效（这里要坏的是 gh 的 jobs 分支），故写一个只让 --paginate 失败的假 gh。
+    writeFakeGh(tmp, { pullsOk: true, runsOk: true, artifactsOk: true, artifacts: '{"total_count":0,"artifacts":[]}' });
+    const r = runScript(overlayScriptPath, [], {
+      cwd: tmp,
+      env: {
+        PATH: `${tmp}:${process.env.PATH}`,
+        GITHUB_REPOSITORY: 'owner/repo',
+        COMMIT_SHA: 'a'.repeat(40),
+        GH_TOKEN: 'dummy',
+      },
+    });
+    assert.equal(r.status, 0, `jobs 查询失败应降级为 no-op 而非判红，实际 ${r.status}: ${r.out}`);
+    assert.match(r.out, /查询 run jobs 失败/, '须点名 jobs 查询失败（分流灵敏度降级，但不误伤）');
+    assert.match(r.out, /安全跳过 \(No-op\)/, '降级为 no-op');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+    rmSync(bin, { recursive: true, force: true });
+  }
+});
+
+/**
+ * 端到端假 gh：pulls / runs / artifacts 之外还支持 `gh run download`（真在目标目录落一份段文件）。
+ * 只有这条用例会走到 overlay 的写路径，故下载必须真产出文件，否则测不到 push。
+ */
+function writeFakeGhForOverlayPush(dir, { fileName, content }) {
+  const head = `[{"number":7,"merged_at":"2026-01-01T00:00:00Z","head":{"sha":"${'b'.repeat(40)}"}}]`;
+  const runs = '[{"name":"CI","conclusion":"success","id":12345}]';
+  const artifacts = '{"total_count":1,"artifacts":[{"name":"mutation-incremental-dsh-alpha"}]}';
+  const script = `#!/bin/sh
+case "$2" in
+  *commits/*/pulls) printf '%s' '${head}'; exit 0 ;;
+  *artifacts*) printf '%s' '${artifacts}'; exit 0 ;;
+  *actions/runs*) printf '%s' '${runs}'; exit 0 ;;
+esac
+case "$1" in
+  run)
+    DIR=""
+    prev=""
+    for a in "$@"; do
+      [ "$prev" = "-D" ] && DIR="$a"
+      prev="$a"
+    done
+    [ -n "$DIR" ] || exit 1
+    mkdir -p "$DIR"
+    printf '%s' '${content}' > "$DIR/${fileName}"
+    exit 0 ;;
+esac
+echo "unexpected gh args: $*" >&2; exit 1
+`;
+  const p = join(dir, 'gh');
+  writeFileSync(p, script, { mode: 0o755 });
+  return p;
+}
+
+test('#718 S2.1: overlay 端到端——差量覆盖生效 + 沿用段保留旧 manifest 条目 + 回滚快照', () => {
+  const tmp = initBaselineRepo(['alpha', 'beta']);
+  try {
+    // 远端先有一份完整基线（alpha/beta 各一段）
+    writeBaselines(tmp, {
+      'incremental-alpha.json': '{"seg":"alpha","gen":1}',
+      'incremental-beta.json': '{"seg":"beta","gen":1}',
+    });
+    assert.equal(runScript(scriptPath, ['push'], { cwd: tmp }).status, 0, '播种基线');
+    const tipBefore = execFileSync('git', ['rev-parse', 'refs/heads/baseline/mutation'], {
+      cwd: tmp,
+      encoding: 'utf8',
+    }).trim();
+    const manifestBefore = JSON.parse(readArchived(tmp, 'manifest.json'));
+    // push 会往报告目录写 manifest，清掉以免干扰后续断言
+    rmSync(join(tmp, 'coverage', 'mutation', 'manifest.json'));
+
+    // 该 PR 的 CI 只产出了 alpha 段的新基线（内容换代）
+    writeFakeGhForOverlayPush(tmp, { fileName: 'incremental-alpha.json', content: '{"seg":"alpha","gen":2}' });
+    const r = runScript(overlayScriptPath, [], {
+      cwd: tmp,
+      env: {
+        PATH: `${tmp}:${process.env.PATH}`,
+        GITHUB_REPOSITORY: 'owner/repo',
+        COMMIT_SHA: 'a'.repeat(40),
+      },
+    });
+    assert.equal(r.status, 0, `overlay 应成功，实际 ${r.status}: ${r.out}`);
+    assert.match(r.out, /差量覆盖: incremental-alpha\.json/, '覆盖段须逐条点名');
+    assert.match(r.out, /对账：期望 2 段，本次覆盖 1 段，沿用旧基线 2 段/, '对账口径保持既有文案');
+
+    assert.equal(readArchived(tmp, 'incremental-alpha.json'), '{"seg":"alpha","gen":2}', '覆盖段换成新内容');
+    assert.equal(readArchived(tmp, 'incremental-beta.json'), '{"seg":"beta","gen":1}', '未覆盖段原样保留');
+
+    // 沿用段的 manifest 条目必须逐字段保留：其 mtime 是上次真实测量时间，重新盖章会让
+    // 「基线是否陈旧」无从判断（旧实现给所有文件重算，这条锁住回归）。
+    const manifestAfter = JSON.parse(readArchived(tmp, 'manifest.json'));
+    assert.deepEqual(
+      manifestAfter['incremental-beta.json'],
+      manifestBefore['incremental-beta.json'],
+      '沿用段的 manifest 条目不得被本次刷新',
+    );
+    assert.notDeepEqual(
+      manifestAfter['incremental-alpha.json'],
+      manifestBefore['incremental-alpha.json'],
+      '覆盖段的 manifest 条目必须重算',
+    );
+
+    // 写路径与夜间班共用：回滚快照 tag 指向本次入档前的 tip
+    const tag = execFileSync('git', ['tag', '-l', 'baseline-snap-*'], { cwd: tmp, encoding: 'utf8' }).trim();
+    assert.ok(tag.length > 0, 'overlay 也必须留下回滚快照（深度恒为 1，可回滚性由 tag 承担）');
+    assert.equal(
+      execFileSync('git', ['rev-parse', `refs/tags/${tag}`], { cwd: tmp, encoding: 'utf8' }).trim(),
+      tipBefore,
+      '快照 tag 必须指向 overlay 入档前的 tip',
+    );
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 关联 issue

#718（S2.1）。**不自动关闭**——S2.2 / S2.3 / S2.4 / S3 仍在计划内。本 PR 是 S2.2（增量班退役）
的前置：退役后 PR 合入的 overlay 成为基线新鲜度的**主路径**，它必须先能区分「没事可做」与「产物丢了」。

## 问题（两处静默降级，同一形态）

`overlay-baseline.mjs` 在「看不到变异产物」时只有一句日志、然后 `exit 0`：

```
[overlay-baseline] PR #N 未产生任何增量变异产物（纯文档/未触及变异切片），安全跳过 (No-op)
```

这句话把两件**相反**的事压成同一个静默 no-op：

| 形态 | 事实 | 应有处置 |
|---|---|---|
| 真·无产物 | PR 没触及变异切片 | no-op（正确） |
| 产物丢失 | CI 跑过变异实例，产物已过期/被删 | 该 PR 命中段的新基线**永远**进不了归档 → 必须留痕 |

两者在日志里完全同形，事后无法区分。**成因已知且就在仓库里**：`ci.yml` 的
`mutation-incremental-*` 产物 `retention-days: 1` —— overlay 只在**合入那一刻**取产物，
1 天窗口意味着「CI 跑完隔夜才合」就必然过期。

同一类静默降级还有第二处：**有产物却一个都没覆盖成功**（下载/解析全线失败，或产物全部过期）
原本也是 `exit 0` + 一句「跳过推送」。

## 改动清单

| 文件 | 改动 |
|---|---|
| `scripts/gate/baseline-archive.mjs` | 新增纯函数 `classifyMissingMutationProducts` + `MUTATION_GATE_JOB_RE`（两态分流判据） |
| `scripts/gate/baseline-push.mjs` | **新增**：归档分支写路径的共用管线（组树 / 建孤立 commit / 回滚快照 tag / 带显式租约推送 / manifest 构建） |
| `scripts/gate/overlay-baseline.mjs` | 两态分流（`lost` → fail-loud、`none` → no-op）；`overlayCount === 0` 改 fail-loud；部分过期发 `::warning::` 点名；沿用段保留远端 manifest 条目；写路径切到 `baseline-push.mjs`（**去掉裸 `--force`**） |
| `scripts/gate/orphan-baseline.mjs` | 写路径切到 `baseline-push.mjs`（删掉本文件里的重复 plumbing，行为不变） |
| `.github/workflows/ci.yml` | `mutation-incremental-*` 的 `retention-days` 由 **1 → 7 天**（治本） |
| `scripts/test/baseline-archive.test.ts` | +1 纯函数用例（两态分流 + 汇总判分 job 不得误计 + 脏输入落 no-op） |
| `scripts/test/orphan-baseline.test.ts` | +4 用例（产物丢失 fail-loud / 真·无产物 no-op / jobs 查询失败不误伤 / **overlay 端到端跑到 push**）+ 1 个既有用例语义更新（有产物但无一覆盖成功：`exit 0` → `exit 1`）|
| `scripts/gate/baseline/README.md` | 新增「产物过期与无产物分流」「写路径单一实现」两节 |

三件事放在同一个 PR 的理由（可拆）：它们是**同一失效类**的三层——告警（可见）＋ 保留期（治本）
＋ 写路径统一（overlay 是 S2.2 之后的主写入方，不该留着第二份裸 `--force`）。

## 判据与边界

判据：**该 CI run 里有没有变异矩阵实例**。

- 实例存在 ⇒ 产物必定产出过（上传步骤是实例内 `if: success()` 门控）⇒「看不到产物」只能解释为丢失 → fail-loud；
- 没有实例 ⇒ 纯文档 / 未触及切片 ⇒ no-op（保持既有文案与退出码）。

边界（有意选择）：

- **汇总判分 job 不算实例**：`Mutation gate verdict (aggregate)` 与矩阵实例
  `Mutation gate (<pkg> · <seg>)` 只差一个括号，`MUTATION_GATE_JOB_RE` 用 `^Mutation gate \(` 把它排除。
- **jobs 查询本身失败 → 降级为 no-op**：这个分流用于**提高**报警灵敏度，不该因为多一次 API 查询失败
  把纯文档 PR 判红（有专门的用例锁这条）。
- **部分过期只告警不判红**：产物还在，能覆盖的先覆盖；点名是为了让「哪些段没被覆盖」不必靠人的记忆。
- **本 PR 不动** `overlay` 里「该 PR 找不到成功状态的 CI Run」那一支（仍是 no-op）。它只在
  「CI 未绿就合入」时触发（分支保护的治理问题），风险低于本次修的两处；如需收紧应单独评估，
  避免把治理问题的噪声混进基线链。

## 逐条命令与 exit code

本 worktree 实跑（`pnpm install --frozen-lockfile` → exit 0）：

| 命令 | exit code | 关键输出 |
|---|---|---|
| `pnpm build` | 0 | 全部包 `lib/index.js` 生成完成 |
| `pnpm test` | 0 | 7 个包套件全通过（合计 6690 用例） |
| `pnpm contract` | 0 | 全通过 |
| `pnpm pack:check` | 0 | 6 子包 tarball 完整 + 聚合包「完整且与子包一致」 |
| `pnpm test:scripts` | 0 | `tests 416 / pass 416 / fail 0`（含本次新增 5 例与 1 例语义更新） |
| `pnpm typecheck` | 0 | — |
| `pnpm docs:check` | 0 | `verify-docs：7 个包 + 根 README + 26 个 agent 规则文档` → 「文档一致性：通过」 |
| `git status --porcelain \| grep -E 'undefined/\|\.jsonl$'` | 1（无匹配） | 产物零污染（#218） |

门禁选择依据：改 `scripts/` → `pnpm test:scripts`；改 `.github/` 与 `scripts/test`（后者是纯测试改动，故在首轮门禁后追加重跑）→ 复跑 `test:scripts`；改 README → `pnpm docs:check`。

## 实测数据

### 分流两态的实证（真实假 gh/假 git 驱动，离线可复现）

| 场景 | 判据输入 | 结果 |
|---|---|---|
| CI 跑过 2 个变异实例（含汇总 job 一个），artifact 列表无变异产物、另有 1 个 `expired` 报告 | `kind=lost, instanceCount=2` | `exit 1` + `产物已不可见` + `未进归档` + 指向 `retention-days` |
| CI 只跑了 detect/build 两个 job，无变异实例 | `kind=none, instanceCount=0` | `exit 0` + `未运行任何变异矩阵实例` + `安全跳过 (No-op)` |
| jobs 查询失败（假 gh 不认 `--paginate`） | 降级 | `exit 0` + `查询 run jobs 失败` + no-op |
| 有 1 个变异产物但无一覆盖成功（首夜 + 下载失败） | 计数 | `exit 1`（**旧行为是 `exit 0`**）+ `无一覆盖成功` + `基线未更新` |

### 保留期

| 位置 | 改动前 | 改动后 |
|---|---|---|
| `ci.yml` 的 `mutation-incremental-*` | `retention-days: 1` | `retention-days: 7` |

口径说明：单次 PR CI 的变异产物合计约 10~20 MB（33 段 × 350~600 KB）；公开仓库的 Actions 存储不计费。
7 天对应「PR 的 CI 跑完到实际合入」的常见跨度（含周末）。

### 端到端（overlay 一路跑到 push）

新用例把 overlay 从「反查已合并 PR」一直驱动到「推送归档」：fake gh 真在下载目录落一份
`incremental-alpha.json`（内容换代），远端先有 alpha / beta 两段。断言：

- `差量覆盖: incremental-alpha.json` 生效，alpha 换成新内容、未覆盖的 beta 段原样保留；
- **beta 段的 manifest 条目逐字段不变**（沿用段保留上次真实测量时间），alpha 段条目重算；
- 回滚快照 tag 指向 overlay 入档前的 tip。

这是重构后**唯一**覆盖 overlay 写路径的用例——此前 overlay 的所有用例都在 push 之前就返回了
（新增写路径统一后若不补这条，裸 `--force` 改成带租约推送将处于无测试覆盖状态）。

## 验收判据对照表（#718 S2.1）

| 判据 | 落地 | 证据 |
|---|---|---|
| 「artifact 过期」与「无产物」分流告警 | `classifyMissingMutationProducts` → `lost` fail-loud / `none` no-op | 上表前两行 |
| 过期场景的告警实证 | 假 gh 构造「有实例、无产物、有 expired」并实测 | 上表第一行 + 用例 `产物已丢失必须 fail-loud` |
| 不误伤真·无产物 | 同形输入、无实例 → no-op | 上表第二行 |
| overlay 不再裸 `--force` | 写路径统一到 `baseline-push.mjs` | 两写入方共用快照 tag + 显式租约 |
| 沿用段时间戳不再被刷新 | 沿用段保留远端 manifest 条目 | 端到端用例断言 beta 段 manifest 条目逐字节不变 |
