### PR TITLE
docs(ci): #718 措辞扫描——退役班次遗留的「observe 四班次」改为「observe 夜间全量班」

### DIFF
--- a/packages/dsh-mcp-manager/docs/architecture-contract.md
+++ b/packages/dsh-mcp-manager/docs/architecture-contract.md
@@ -143,7 +143,7 @@
 | test/integration/service-contract.test.ts | `readFileSync("src/bootstrap/apply-services.ts")` + marker 扫描 | 同步扫描路径到新位置（bootstrap/apply-services.ts）；**阶段 1–5 该文件禁止薄转发/移动** |
 | stryker.conf.d/dsh-mcp-manager-{manager,entry,supervisor,middleware,routes,runtime}.json | mutate=显式 src 文件清单 | 按新域一次性重画六段；gen-stryker-conf --check 保持 topology 三方一致 |
 | scripts/data/mutation-topology.json | 段模板数据源 + workflow-assert 锚定 | 同步段定义 |
-| observe 基线 | src 口径四班次重建；incremental 缓存覆盖 | 迁移后重建基线（covered 回落豁免，见 2.5） |
+| observe 基线 | src 口径夜间全量班重建；incremental 缓存覆盖 | 迁移后重建基线（covered 回落豁免，见 2.5） |
 | bundle-host client 入口 | 探测链 src/client.tsx→…→src/client/index.ts | src/client/index.ts 保留即无感 |
 | smoke/unit | 全部 import ../lib/index.js | 不受影响（验证项） |
 | ~~mutate-scope-guard~~ | **已退役（#276）** | 不列入（workflow-assert 锁定不得再调用） |

--- a/packages/dsh-mcp-manager/docs/architecture-redesign-review.md
+++ b/packages/dsh-mcp-manager/docs/architecture-redesign-review.md
@@ -13,7 +13,7 @@
    bootstrap/ 该测试必红（pnpm test 必跑路径）。
 2. stryker/基线影响严重低估：六段 stryker.conf.d mutate 是显式 src 文件清单，
    mutation-topology.json 由 workflow-assert 锚定三方一致，PR 有 mutate-scope-guard，
-   observe 基线为 src 口径四班次重建；物理迁移 = 清单全失效 + incremental 缓存全废 +
+   observe 基线为 src 口径夜间全量班重建；物理迁移 = 清单全失效 + incremental 缓存全废 +
    58.74%（<60%）基线的重建窗口。方案一笔带过。
 3. 拆分归属多处错位：B10 是 ws_mcp_search 检索面缺陷（middleware-register.ts:181）非执行管道；
    目录检索函数族（searchCatalogMulti/listCatalog/findToolDetail/boundCatalogTools/scoreTool/

--- a/packages/dsh-mcp-manager/docs/architecture-redesign.md
+++ b/packages/dsh-mcp-manager/docs/architecture-redesign.md
@@ -160,7 +160,7 @@ src/client/
 
 ### 集中式纯搬移 PR（阶段 6）
 - 前置：B 系列行为修复**全部完成**（B12/B19 已提前，见阶段表），迁移 PR 零行为变更；
-- 静态面清单（必须同步，否则必红）：service-contract.test.ts:145 扫描路径；stryker 六段 mutate 清单 + mutation-topology.json + workflow-assert；observe 基线（src 口径四班次重建）策略；incremental 缓存作废处理；bundle-host client 入口（src/client/index.ts 保留即无感）。
+- 静态面清单（必须同步，否则必红）：service-contract.test.ts:145 扫描路径；stryker 六段 mutate 清单 + mutation-topology.json + workflow-assert；observe 基线（src 口径夜间全量班重建）策略；incremental 缓存作废处理；bundle-host client 入口（src/client/index.ts 保留即无感）。
 - **迁移专用验证三件套（二轮 B 补机制）**：① 迁移前基线快照（全绿门禁 + smoke 断言清单逐条记录）；② 迁移 PR 的 `git diff --stat` 校验（只含 rename/移动，无内容变更）；③ 迁移后全绿 + observe 基线重建触发。
 - 门禁策略（D7 闭环后）：covered 口径已达标（74.66≥60），迁移 PR 不卡总得分；incremental 缓存作废后走 observe 夜间重建豁免或手动重建基线。
 

--- a/packages/dsh-mcp-manager/docs/refactor-phase0-spec.md
+++ b/packages/dsh-mcp-manager/docs/refactor-phase0-spec.md
@@ -139,7 +139,7 @@
 | test/integration/service-contract.test.ts | `readFileSync("src/bootstrap/apply-services.ts")` + marker 扫描 | 同步扫描路径到新位置（bootstrap/apply-services.ts）；阶段 1–5 该文件禁止薄转发/移动 |
 | stryker.conf.d/dsh-mcp-manager-{manager,entry,supervisor,middleware,routes,runtime}.json | mutate=显式 src 文件清单 | 按新域一次性重画六段；gen-stryker-conf --check 保持 topology 三方一致 |
 | scripts/data/mutation-topology.json | 段模板数据源 + workflow-assert 锚定 | 同步段定义 |
-| observe 基线 | src 口径四班次重建；incremental 缓存覆盖 | 迁移后重建基线（covered 回落豁免，D7） |
+| observe 基线 | src 口径夜间全量班重建；incremental 缓存覆盖 | 迁移后重建基线（covered 回落豁免，D7） |
 | bundle-host client 入口 | 探测链 src/client.tsx→…→src/client/index.ts | src/client/index.ts 保留即无感 |
 | smoke/unit | 全部 import ../lib/index.js | 不受影响（验证项） |
 | ~~mutate-scope-guard~~ | **已退役（#276）** | 不列入（workflow-assert 锁定不得再调用） |

--- a/scripts/data/gauntlet.config.json
+++ b/scripts/data/gauntlet.config.json
@@ -28,7 +28,7 @@
         "fixedDate": "2026-08-24",
         "fixedDuration": "6m56s",
         "config": "stryker.conf.d/dsh-notifier-{server,message,config,history}.json（#342 二期：功能命名——事件/连接域 server / 消息构造 message / 配置迁移 config / 历史静默 history；message.ts 单文件 145s 物理极限维持）",
-        "scope": "src 级四段（#342 二期）：server index+server / message message.ts / config config+migrate+settings / history history+quiet-hours；基线为 src 口径，由四班次 observe 重建",
+        "scope": "src 级四段（#342 二期）：server index+server / message message.ts / config config+migrate+settings / history history+quiet-hours；基线为 src 口径，由 observe 夜间全量班重建",
         "threshold": 60
       },
       "dsh-web-file-preview": {
@@ -40,10 +40,10 @@
         "baselineErrors": 0,
         "baselineDate": "2026-08-24",
         "baselineDuration": "15s",
-        "baselineScope": "#698 重定位后 mutate 面 = src/{index,present-open}.ts（客户端 src/client/** 排除在 mutate 面外）；旧基线（自研预览实现的 lib/index.js:1255-1924）随代码删除作废，待 observe 四班次重建",
+        "baselineScope": "#698 重定位后 mutate 面 = src/{index,present-open}.ts（客户端 src/client/** 排除在 mutate 面外）；旧基线（自研预览实现的 lib/index.js:1255-1924）随代码删除作废，待 observe 夜间全量班重建",
         "config": "stryker.conf.d/dsh-web-file-preview.json",
         "threshold": 60,
-        "scope": "src 级全量（#276 方案 A）；基线为 src 口径，由四班次 observe 重建"
+        "scope": "src 级全量（#276 方案 A）；基线为 src 口径，由 observe 夜间全量班重建"
       },
       "dsh-mcp-manager": {
         "baselineScore": 58.74,
@@ -60,7 +60,7 @@
         "config": "stryker.conf.d/dsh-mcp-manager-{manager,entry,supervisor,middleware,routes,runtime}.json（#342 二期：功能命名——核心 manager / 入口 entry / 监督 supervisor / 中间件 middleware / 路由 routes / 运行时 runtime；manager.ts 单文件 134s 物理极限维持）",
         "hardeningNote": "#148 变异加固轮：6 个单测 commit 将 covered 由 29.37% 提升至 74.66%；耗时优化（#173）零杀伤 testFiles 移除 + conc8，3m52s→3m0s",
         "threshold": 60,
-        "scope": "src 级六段（#342 二期）：manager manager.ts / entry index+normalize+import / supervisor supervisor+middleware-state+store+scope / middleware middleware+middleware-utils+middleware-const / routes middleware-register+routes / runtime catalog+apply+transport+placement-math+config-schema+protocol+middleware-types；基线为 src 口径，由四班次 observe 重建"
+        "scope": "src 级六段（#342 二期）：manager manager.ts / entry index+normalize+import / supervisor supervisor+middleware-state+store+scope / middleware middleware+middleware-utils+middleware-const / routes middleware-register+routes / runtime catalog+apply+transport+placement-math+config-schema+protocol+middleware-types；基线为 src 口径，由 observe 夜间全量班重建"
       },
       "dsh-provider-usage": {
         "baselineScore": 71.41,
@@ -77,7 +77,7 @@
         "config": "stryker.conf.d/dsh-provider-usage-{entry,apply,contracts,sanitize,registry,pipeline,trend-aggregate,trend-collect,report-schedule,report-execute,routes,errsurf}.json（#342 二期六段 + 阶段零四段 + 阶段一 routes 段 + 阶段二 D8 归位 + 阶段三 errsurf 新段）",
         "hardeningNote": "#150 两阶段达标开启 strict；阶段零（#670）：补盲区四段 + testFiles；阶段一（#670）：routes 段开段；阶段二（#670）：D8 last-run/report-index/executor/list-dirs/report-config-service 新文件并入 report 段；阶段三（#670）：aggregator 拆分为 aggregate-rows/aggregate-query 两纯函数模块并入 trend-aggregate 段 + R8 台账守恒断言（unit-trend-ledger）与 errsurf（unit-errsurf）入 testFiles + errsurf 新段；基线已全包 12 段实测重建 71.41%",
         "threshold": 60,
-        "scope": "src 级十二段（#342 二期六段 + 阶段零四段 + 阶段一 routes 段 + 阶段三 errsurf 段）：entry / apply / contracts / sanitize / registry registry+user-adapter-loader / pipeline history+v2+hotreload+placement-math+path-resolve+client-logic+provider-config+charts+stats-service / trend-aggregate aggregator+aggregate-rows+aggregate-query+store+index（阶段三 D2 拆分并入 mutate 面） / trend-collect collector+types / report-schedule config+schedule+scheduler+tasks+last-run+report-config-service（D8 归位）/ report-execute runner+generate+format+report-index+executor+list-dirs（D8 归位）/ routes stats+adapters+ui+reports / errsurf errsurf.ts（阶段三 B）；基线为 src 口径，由四班次 observe 重建"
+        "scope": "src 级十二段（#342 二期六段 + 阶段零四段 + 阶段一 routes 段 + 阶段三 errsurf 段）：entry / apply / contracts / sanitize / registry registry+user-adapter-loader / pipeline history+v2+hotreload+placement-math+path-resolve+client-logic+provider-config+charts+stats-service / trend-aggregate aggregator+aggregate-rows+aggregate-query+store+index（阶段三 D2 拆分并入 mutate 面） / trend-collect collector+types / report-schedule config+schedule+scheduler+tasks+last-run+report-config-service（D8 归位）/ report-execute runner+generate+format+report-index+executor+list-dirs（D8 归位）/ routes stats+adapters+ui+reports / errsurf errsurf.ts（阶段三 B）；基线为 src 口径，由 observe 夜间全量班重建"
       },
       "dsh-lan-proxy": {
         "baselineScore": 52.43,
@@ -94,7 +94,7 @@
         "config": "stryker.conf.d/dsh-lan-proxy-{1..4}.json（#220 B 段拆分，区间原样四段；s1 proxy 单文件不可细分维持现状）",
         "hardeningNote": "#147 变异加固轮：covered 由 49.75% 提升至 62.52%，60% 第一阶达标",
         "threshold": 60,
-        "scope": "src 级四段（#276 方案 A）：seg1 proxy / seg2 apply+config / seg3 config-routes+migrate / seg4 settings+cert+index；基线为 src 口径，由四班次 observe 重建"
+        "scope": "src 级四段（#276 方案 A）：seg1 proxy / seg2 apply+config / seg3 config-routes+migrate / seg4 settings+cert+index；基线为 src 口径，由 observe 夜间全量班重建"
       }
     }
   }

--- a/scripts/data/mutation-topology.json
+++ b/scripts/data/mutation-topology.json
@@ -56,7 +56,7 @@
                         "!packages/dsh-lan-proxy/src/client/**",
                         "!packages/dsh-lan-proxy/src/types.ts"
                     ],
-                    "comment": "#276 方案 A：src 级文件组分段（1）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#276 方案 A：src 级文件组分段（1）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "2": {
                     "mutate": [
@@ -67,7 +67,7 @@
                         "!packages/dsh-lan-proxy/src/client/**",
                         "!packages/dsh-lan-proxy/src/types.ts"
                     ],
-                    "comment": "#276 方案 A：src 级文件组分段（2）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#276 方案 A：src 级文件组分段（2）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "3": {
                     "mutate": [
@@ -78,7 +78,7 @@
                         "!packages/dsh-lan-proxy/src/client/**",
                         "!packages/dsh-lan-proxy/src/types.ts"
                     ],
-                    "comment": "#276 方案 A：src 级文件组分段（3）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#276 方案 A：src 级文件组分段（3）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "4": {
                     "mutate": [
@@ -90,7 +90,7 @@
                         "!packages/dsh-lan-proxy/src/client/**",
                         "!packages/dsh-lan-proxy/src/types.ts"
                     ],
-                    "comment": "#276 方案 A：src 级文件组分段（4）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#276 方案 A：src 级文件组分段（4）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 }
             },
             "testLayers": {}
@@ -111,7 +111,7 @@
                         "!packages/dsh-mcp-manager/src/integration/**",
                         "!packages/dsh-mcp-manager/src/placement-math.ts"
                     ],
-                    "comment": "#664 阶段6重画：entry——index+workspace（工作空间路由域）+config/model（归一化/导入/schema）；阶段1–5变异盲区（workspace/新文件）在本阶段随集中搬移一并纳入重画（v3 C4/C-DIR）；types/integration（type-only）与 placement-math.ts（shared 薄转发）显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建（D7 迁移豁免）。"
+                    "comment": "#664 阶段6重画：entry——index+workspace（工作空间路由域）+config/model（归一化/导入/schema）；阶段1–5变异盲区（workspace/新文件）在本阶段随集中搬移一并纳入重画（v3 C4/C-DIR）；types/integration（type-only）与 placement-math.ts（shared 薄转发）显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建（D7 迁移豁免）。"
                 },
                 "manager": {
                     "mutate": [
@@ -123,7 +123,7 @@
                         "!packages/dsh-mcp-manager/src/integration/**",
                         "!packages/dsh-mcp-manager/src/placement-math.ts"
                     ],
-                    "comment": "#664 阶段6重画：manager——connection/orchestrator（McpManager 类主体+展示投影 tool-names，原 manager.ts 迁入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建（D7 迁移豁免）。"
+                    "comment": "#664 阶段6重画：manager——connection/orchestrator（McpManager 类主体+展示投影 tool-names，原 manager.ts 迁入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建（D7 迁移豁免）。"
                 },
                 "middleware": {
                     "mutate": [
@@ -138,7 +138,7 @@
                         "!packages/dsh-mcp-manager/src/integration/**",
                         "!packages/dsh-mcp-manager/src/placement-math.ts"
                     ],
-                    "comment": "#664 阶段6重画：middleware——中间层池（runtime/middleware）+limits（原 middleware-const）+工具注册面（inject/）+策略裁决族（pipeline/authorize，原 middleware-utils 并入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建（D7 迁移豁免）。"
+                    "comment": "#664 阶段6重画：middleware——中间层池（runtime/middleware）+limits（原 middleware-const）+工具注册面（inject/）+策略裁决族（pipeline/authorize，原 middleware-utils 并入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建（D7 迁移豁免）。"
                 },
                 "routes": {
                     "mutate": [
@@ -150,7 +150,7 @@
                         "!packages/dsh-mcp-manager/src/integration/**",
                         "!packages/dsh-mcp-manager/src/placement-math.ts"
                     ],
-                    "comment": "#664 阶段6重画：routes——api 层（routes 装配/端点控制器/查询辅助，原 routes*.ts 迁入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建（D7 迁移豁免）。"
+                    "comment": "#664 阶段6重画：routes——api 层（routes 装配/端点控制器/查询辅助，原 routes*.ts 迁入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建（D7 迁移豁免）。"
                 },
                 "supervisor": {
                     "mutate": [
@@ -165,7 +165,7 @@
                         "!packages/dsh-mcp-manager/src/integration/**",
                         "!packages/dsh-mcp-manager/src/placement-math.ts"
                     ],
-                    "comment": "#664 阶段6重画：supervisor——连接监督器（runtime/supervisor+reconnect）+状态持久化（config/store，原 middleware-state/store 迁入）+统计（stats）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建（D7 迁移豁免）。"
+                    "comment": "#664 阶段6重画：supervisor——连接监督器（runtime/supervisor+reconnect）+状态持久化（config/store，原 middleware-state/store 迁入）+统计（stats）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建（D7 迁移豁免）。"
                 },
                 "runtime": {
                     "mutate": [
@@ -182,7 +182,7 @@
                         "!packages/dsh-mcp-manager/src/integration/**",
                         "!packages/dsh-mcp-manager/src/placement-math.ts"
                     ],
-                    "comment": "#664 阶段6重画：runtime——组合根（bootstrap/，原 apply*.ts 迁入）+transport/protocol+shared/placement-math（#378：placement 纯核心上移 shared，mutate 跟随；lib→src hook 对 shared 段返回 null 默认解析）+pipeline（执行管道域，阶段1–5变异盲区随迁纳入）+catalog（目录域，原 catalog.ts 迁入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建（D7 迁移豁免）。"
+                    "comment": "#664 阶段6重画：runtime——组合根（bootstrap/，原 apply*.ts 迁入）+transport/protocol+shared/placement-math（#378：placement 纯核心上移 shared，mutate 跟随；lib→src hook 对 shared 段返回 null 默认解析）+pipeline（执行管道域，阶段1–5变异盲区随迁纳入）+catalog（目录域，原 catalog.ts 迁入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建（D7 迁移豁免）。"
                 }
             },
             "testLayers": {
@@ -214,7 +214,7 @@
                         "!packages/dsh-notifier/src/**/interface.ts",
                         "!packages/dsh-notifier/src/client/**"
                     ],
-                    "comment": "#720 静态拆段（1/3）：原 #669 PR2 T2-7 的 config 段按文件 mutant 密度拆三。本段 = normalize.ts 单文件 877 mutant（占原段 2366 的 37.1%），是段内 mutant 的最大来源。拆段动因是密度失衡而非文件数：normalize.ts 284 行 877 mutant 对 config.ts 307 行 95 mutant（密度差约 8 倍），按行数或按文件数均分都会拆错。按文件拆而非按行区间（--mutate file:1-142）：行号是脆弱依赖，且会把分段 SSOT 从本文件迁进 CI matrix，扩大自研面。interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#720 静态拆段（1/3）：原 #669 PR2 T2-7 的 config 段按文件 mutant 密度拆三。本段 = normalize.ts 单文件 877 mutant（占原段 2366 的 37.1%），是段内 mutant 的最大来源。拆段动因是密度失衡而非文件数：normalize.ts 284 行 877 mutant 对 config.ts 307 行 95 mutant（密度差约 8 倍），按行数或按文件数均分都会拆错。按文件拆而非按行区间（--mutate file:1-142）：行号是脆弱依赖，且会把分段 SSOT 从本文件迁进 CI matrix，扩大自研面。interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "config-validate": {
                     "mutate": [
@@ -224,7 +224,7 @@
                         "!packages/dsh-notifier/src/**/interface.ts",
                         "!packages/dsh-notifier/src/client/**"
                     ],
-                    "comment": "#720 静态拆段（2/3）：本段 = validators.ts 单文件 862 mutant（占原段 2366 的 36.4%），与 normalize.ts 合计 73.5%。二者单独成段而不与其余文件混装，是因为 mutant 密度与行数严重不成比例（validators.ts 324 行 / 862 mutant 对 config.ts 307 行 / 95 mutant，密度差约 8 倍）——按行数或按文件数均分都会拆错。interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#720 静态拆段（2/3）：本段 = validators.ts 单文件 862 mutant（占原段 2366 的 36.4%），与 normalize.ts 合计 73.5%。二者单独成段而不与其余文件混装，是因为 mutant 密度与行数严重不成比例（validators.ts 324 行 / 862 mutant 对 config.ts 307 行 / 95 mutant，密度差约 8 倍）——按行数或按文件数均分都会拆错。interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "config-rest": {
                     "mutate": [
@@ -240,7 +240,7 @@
                         "!packages/dsh-notifier/src/**/interface.ts",
                         "!packages/dsh-notifier/src/client/**"
                     ],
-                    "comment": "#720 静态拆段（3/3）：原 config 段余下 7 实现（config/migrate/paths/redact/settings/quiet-hours/settings-bridge）合计 627 mutant（占原段 26.5%），远低于两个密度异常文件，故合并为一段。配置域划分沿用 #669 PR2 T2-7（settings-bridge/quiet-hours 自 PR1 盲区并入，S3-30 修复）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#720 静态拆段（3/3）：原 config 段余下 7 实现（config/migrate/paths/redact/settings/quiet-hours/settings-bridge）合计 627 mutant（占原段 26.5%），远低于两个密度异常文件，故合并为一段。配置域划分沿用 #669 PR2 T2-7（settings-bridge/quiet-hours 自 PR1 盲区并入，S3-30 修复）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "text": {
                     "mutate": [
@@ -252,7 +252,7 @@
                         "!packages/dsh-notifier/src/**/interface.ts",
                         "!packages/dsh-notifier/src/client/**"
                     ],
-                    "comment": "#669 PR2 T2-7 按域重划：text——文案域（message/sanitize/system-commands，PR1 message 段按域更名）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#669 PR2 T2-7 按域重划：text——文案域（message/sanitize/system-commands，PR1 message 段按域更名）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "pipeline": {
                     "mutate": [
@@ -264,7 +264,7 @@
                         "!packages/dsh-notifier/src/**/interface.ts",
                         "!packages/dsh-notifier/src/client/**"
                     ],
-                    "comment": "#669 PR2 T2-7 按域重划：pipeline——核心状态机裁决/投递/编排（adjudicate/deliver + orchestrate；orchestrate 为 #733 M1-F1 自 sdk/service.ts 迁入的编排三函数，T2-1 工厂化后入面，N-24 落地）；testFiles 含 unit-pipeline-contract/unit-pipeline-orchestrate（N-14/N-15 注入面契约杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#669 PR2 T2-7 按域重划：pipeline——核心状态机裁决/投递/编排（adjudicate/deliver + orchestrate；orchestrate 为 #733 M1-F1 自 sdk/service.ts 迁入的编排三函数，T2-1 工厂化后入面，N-24 落地）；testFiles 含 unit-pipeline-contract/unit-pipeline-orchestrate（N-14/N-15 注入面契约杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "events": {
                     "mutate": [
@@ -276,7 +276,7 @@
                         "!packages/dsh-notifier/src/**/interface.ts",
                         "!packages/dsh-notifier/src/client/**"
                     ],
-                    "comment": "#669 PR2 T2-7 按域重划：events——核心状态机事件面（event-handlers/aggregate/agent-session，S3-30 修复入面）；testFiles 含 unit-event-handlers/unit-aggregate（N-6/N-7 直测杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#669 PR2 T2-7 按域重划：events——核心状态机事件面（event-handlers/aggregate/agent-session，S3-30 修复入面）；testFiles 含 unit-event-handlers/unit-aggregate（N-6/N-7 直测杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "channels": {
                     "mutate": [
@@ -290,7 +290,7 @@
                         "!packages/dsh-notifier/src/**/interface.ts",
                         "!packages/dsh-notifier/src/client/**"
                     ],
-                    "comment": "#669 PR2 T2-7 按域重划：channels——频道域（bark/browser/system/webhook/outbound，S3-30 盲区修复）；testFiles 含 unit-webhook/e2e-outbound（N-10/N-13/B-3 杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#669 PR2 T2-7 按域重划：channels——频道域（bark/browser/system/webhook/outbound，S3-30 盲区修复）；testFiles 含 unit-webhook/e2e-outbound（N-10/N-13/B-3 杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "stores": {
                     "mutate": [
@@ -301,7 +301,7 @@
                         "!packages/dsh-notifier/src/**/interface.ts",
                         "!packages/dsh-notifier/src/client/**"
                     ],
-                    "comment": "#669 PR2 T2-7 按域重划：stores——存储域（history/status，PR1 history 段收窄，quiet-hours 归 config）；testFiles 含 unit-stores（N-4 直测杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#669 PR2 T2-7 按域重划：stores——存储域（history/status，PR1 history 段收窄，quiet-hours 归 config）；testFiles 含 unit-stores（N-4 直测杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "server": {
                     "mutate": [
@@ -313,7 +313,7 @@
                         "!packages/dsh-notifier/src/**/interface.ts",
                         "!packages/dsh-notifier/src/client/**"
                     ],
-                    "comment": "#669 PR2 T2-7 按域重划：server——服务域（routes/sse-bus/system-notifier；index.ts 装配层移出归 sdk 段）；testFiles 含 unit-server-sse-bus/unit-system-notifier（N-11/N-12 注入面直测杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#669 PR2 T2-7 按域重划：server——服务域（routes/sse-bus/system-notifier；index.ts 装配层移出归 sdk 段）；testFiles 含 unit-server-sse-bus/unit-system-notifier（N-11/N-12 注入面直测杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "sdk": {
                     "mutate": [
@@ -324,7 +324,7 @@
                         "!packages/dsh-notifier/src/**/interface.ts",
                         "!packages/dsh-notifier/src/client/**"
                     ],
-                    "comment": "#669 PR2 T2-7 按域重划：sdk——服务装配面（sdk/service.ts + 根 index.ts 并入：装配层归服务面，独立 assembly 段单文件且 re-export 过半可杀性低，并入 sdk 均衡段规模；原注释至此的『service.d.ts 非 src TS 不入面』已失效——该文件由 #733 M2a 删除，声明合并迁入 index.ts）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#669 PR2 T2-7 按域重划：sdk——服务装配面（sdk/service.ts + 根 index.ts 并入：装配层归服务面，独立 assembly 段单文件且 re-export 过半可杀性低，并入 sdk 均衡段规模；原注释至此的『service.d.ts 非 src TS 不入面』已失效——该文件由 #733 M2a 删除，声明合并迁入 index.ts）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 }
             },
             "testLayers": {
@@ -352,7 +352,7 @@
                         "!packages/dsh-provider-usage/src/client/**",
                         "!packages/dsh-provider-usage/src/types.ts"
                     ],
-                    "comment": "#342 v4：src 级文件组分段（2）——apply 单列（#316 拆分后最重文件独立成段）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#342 v4：src 级文件组分段（2）——apply 单列（#316 拆分后最重文件独立成段）；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "errsurf": {
                     "mutate": [
@@ -373,7 +373,7 @@
                         "!packages/dsh-provider-usage/src/client/**",
                         "!packages/dsh-provider-usage/src/types.ts"
                     ],
-                    "comment": "#342 v4：src 级文件组分段（3）——contracts+domain1/pipeline/guards（契约面）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#342 v4：src 级文件组分段（3）——contracts+domain1/pipeline/guards（契约面）；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "entry": {
                     "mutate": [
@@ -386,7 +386,7 @@
                         "!packages/dsh-provider-usage/src/client/**",
                         "!packages/dsh-provider-usage/src/types.ts"
                     ],
-                    "comment": "#342 v4：src 级文件组分段（1）——index+user-adapters+ui-config+config（配置/入口面）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#342 v4：src 级文件组分段（1）——index+user-adapters+ui-config+config（配置/入口面）；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "pipeline": {
                     "mutate": [
@@ -404,7 +404,7 @@
                         "!packages/dsh-provider-usage/src/client/**",
                         "!packages/dsh-provider-usage/src/types.ts"
                     ],
-                    "comment": "#342 v4：src 级文件组分段（5）——history/v2/hotreload/placement-math/path-resolve/client-logic/provider-config/charts/stats-service（历史/管线/热更/图表/C3 服务面；charts 纳入修复变异盲区；阶段零补 stats-service 盲区）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#342 v4：src 级文件组分段（5）——history/v2/hotreload/placement-math/path-resolve/client-logic/provider-config/charts/stats-service（历史/管线/热更/图表/C3 服务面；charts 纳入修复变异盲区；阶段零补 stats-service 盲区）；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "registry": {
                     "mutate": [
@@ -415,7 +415,7 @@
                         "!packages/dsh-provider-usage/src/client/**",
                         "!packages/dsh-provider-usage/src/types.ts"
                     ],
-                    "comment": "#342 二期：功能命名段（registry）——registry+user-adapter-loader（注册表域，25s；阶段零补 loader 盲区）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#342 二期：功能命名段（registry）——registry+user-adapter-loader（注册表域，25s；阶段零补 loader 盲区）；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "sanitize": {
                     "mutate": [
@@ -425,7 +425,7 @@
                         "!packages/dsh-provider-usage/src/client/**",
                         "!packages/dsh-provider-usage/src/types.ts"
                     ],
-                    "comment": "#342 二期：功能命名段（sanitize）——sanitize（数据净化域，115s）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+                    "comment": "#342 二期：功能命名段（sanitize）——sanitize（数据净化域，115s）；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
                 },
                 "trend-aggregate": {
                     "mutate": [
@@ -519,7 +519,7 @@
                         "!packages/dsh-web-file-preview/src/client/**",
                         "!packages/dsh-web-file-preview/src/types.ts"
                     ],
-                    "comment": "#276 方案 A：src 级单段（mutate 直指 src，文件 glob 声明，无行号无漂移）；测试经 src 入口加载插桩代码；incremental 基线随 observe 四班次重建。"
+                    "comment": "#276 方案 A：src 级单段（mutate 直指 src，文件 glob 声明，无行号无漂移）；测试经 src 入口加载插桩代码；incremental 基线随 observe 夜间全量班重建。"
                 }
             },
             "testLayers": {}

--- a/stryker.conf.d/dsh-lan-proxy-1.json
+++ b/stryker.conf.d/dsh-lan-proxy-1.json
@@ -37,5 +37,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-lan-proxy-1.json",
-  "_comment": "#276 方案 A：src 级文件组分段（1）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#276 方案 A：src 级文件组分段（1）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-lan-proxy-2.json
+++ b/stryker.conf.d/dsh-lan-proxy-2.json
@@ -38,5 +38,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-lan-proxy-2.json",
-  "_comment": "#276 方案 A：src 级文件组分段（2）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#276 方案 A：src 级文件组分段（2）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-lan-proxy-3.json
+++ b/stryker.conf.d/dsh-lan-proxy-3.json
@@ -38,5 +38,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-lan-proxy-3.json",
-  "_comment": "#276 方案 A：src 级文件组分段（3）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#276 方案 A：src 级文件组分段（3）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-lan-proxy-4.json
+++ b/stryker.conf.d/dsh-lan-proxy-4.json
@@ -39,5 +39,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-lan-proxy-4.json",
-  "_comment": "#276 方案 A：src 级文件组分段（4）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#276 方案 A：src 级文件组分段（4）——mutate 为源文件名清单，密度均衡声明，无行号无漂移；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-mcp-manager-entry.json
+++ b/stryker.conf.d/dsh-mcp-manager-entry.json
@@ -42,5 +42,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-mcp-manager-entry.json",
-  "_comment": "#664 阶段6重画：entry——index+workspace（工作空间路由域）+config/model（归一化/导入/schema）；阶段1–5变异盲区（workspace/新文件）在本阶段随集中搬移一并纳入重画（v3 C4/C-DIR）；types/integration（type-only）与 placement-math.ts（shared 薄转发）显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建（D7 迁移豁免）。"
+  "_comment": "#664 阶段6重画：entry——index+workspace（工作空间路由域）+config/model（归一化/导入/schema）；阶段1–5变异盲区（workspace/新文件）在本阶段随集中搬移一并纳入重画（v3 C4/C-DIR）；types/integration（type-only）与 placement-math.ts（shared 薄转发）显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建（D7 迁移豁免）。"
 }

--- a/stryker.conf.d/dsh-mcp-manager-manager.json
+++ b/stryker.conf.d/dsh-mcp-manager-manager.json
@@ -40,5 +40,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-mcp-manager-manager.json",
-  "_comment": "#664 阶段6重画：manager——connection/orchestrator（McpManager 类主体+展示投影 tool-names，原 manager.ts 迁入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建（D7 迁移豁免）。"
+  "_comment": "#664 阶段6重画：manager——connection/orchestrator（McpManager 类主体+展示投影 tool-names，原 manager.ts 迁入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建（D7 迁移豁免）。"
 }

--- a/stryker.conf.d/dsh-mcp-manager-middleware.json
+++ b/stryker.conf.d/dsh-mcp-manager-middleware.json
@@ -43,5 +43,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-mcp-manager-middleware.json",
-  "_comment": "#664 阶段6重画：middleware——中间层池（runtime/middleware）+limits（原 middleware-const）+工具注册面（inject/）+策略裁决族（pipeline/authorize，原 middleware-utils 并入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建（D7 迁移豁免）。"
+  "_comment": "#664 阶段6重画：middleware——中间层池（runtime/middleware）+limits（原 middleware-const）+工具注册面（inject/）+策略裁决族（pipeline/authorize，原 middleware-utils 并入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建（D7 迁移豁免）。"
 }

--- a/stryker.conf.d/dsh-mcp-manager-routes.json
+++ b/stryker.conf.d/dsh-mcp-manager-routes.json
@@ -40,5 +40,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-mcp-manager-routes.json",
-  "_comment": "#664 阶段6重画：routes——api 层（routes 装配/端点控制器/查询辅助，原 routes*.ts 迁入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建（D7 迁移豁免）。"
+  "_comment": "#664 阶段6重画：routes——api 层（routes 装配/端点控制器/查询辅助，原 routes*.ts 迁入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建（D7 迁移豁免）。"
 }

--- a/stryker.conf.d/dsh-mcp-manager-runtime.json
+++ b/stryker.conf.d/dsh-mcp-manager-runtime.json
@@ -45,5 +45,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-mcp-manager-runtime.json",
-  "_comment": "#664 阶段6重画：runtime——组合根（bootstrap/，原 apply*.ts 迁入）+transport/protocol+shared/placement-math（#378：placement 纯核心上移 shared，mutate 跟随；lib→src hook 对 shared 段返回 null 默认解析）+pipeline（执行管道域，阶段1–5变异盲区随迁纳入）+catalog（目录域，原 catalog.ts 迁入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建（D7 迁移豁免）。"
+  "_comment": "#664 阶段6重画：runtime——组合根（bootstrap/，原 apply*.ts 迁入）+transport/protocol+shared/placement-math（#378：placement 纯核心上移 shared，mutate 跟随；lib→src hook 对 shared 段返回 null 默认解析）+pipeline（执行管道域，阶段1–5变异盲区随迁纳入）+catalog（目录域，原 catalog.ts 迁入）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建（D7 迁移豁免）。"
 }

--- a/stryker.conf.d/dsh-mcp-manager-supervisor.json
+++ b/stryker.conf.d/dsh-mcp-manager-supervisor.json
@@ -43,5 +43,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-mcp-manager-supervisor.json",
-  "_comment": "#664 阶段6重画：supervisor——连接监督器（runtime/supervisor+reconnect）+状态持久化（config/store，原 middleware-state/store 迁入）+统计（stats）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建（D7 迁移豁免）。"
+  "_comment": "#664 阶段6重画：supervisor——连接监督器（runtime/supervisor+reconnect）+状态持久化（config/store，原 middleware-state/store 迁入）+统计（stats）；types/integration（type-only）与 placement-math.ts 显式排除；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建（D7 迁移豁免）。"
 }

--- a/stryker.conf.d/dsh-notifier-channels.json
+++ b/stryker.conf.d/dsh-notifier-channels.json
@@ -44,5 +44,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-notifier-channels.json",
-  "_comment": "#669 PR2 T2-7 按域重划：channels——频道域（bark/browser/system/webhook/outbound，S3-30 盲区修复）；testFiles 含 unit-webhook/e2e-outbound（N-10/N-13/B-3 杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#669 PR2 T2-7 按域重划：channels——频道域（bark/browser/system/webhook/outbound，S3-30 盲区修复）；testFiles 含 unit-webhook/e2e-outbound（N-10/N-13/B-3 杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-notifier-config-normalize.json
+++ b/stryker.conf.d/dsh-notifier-config-normalize.json
@@ -40,5 +40,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-notifier-config-normalize.json",
-  "_comment": "#720 静态拆段（1/3）：原 #669 PR2 T2-7 的 config 段按文件 mutant 密度拆三。本段 = normalize.ts 单文件 877 mutant（占原段 2366 的 37.1%），是段内 mutant 的最大来源。拆段动因是密度失衡而非文件数：normalize.ts 284 行 877 mutant 对 config.ts 307 行 95 mutant（密度差约 8 倍），按行数或按文件数均分都会拆错。按文件拆而非按行区间（--mutate file:1-142）：行号是脆弱依赖，且会把分段 SSOT 从本文件迁进 CI matrix，扩大自研面。interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#720 静态拆段（1/3）：原 #669 PR2 T2-7 的 config 段按文件 mutant 密度拆三。本段 = normalize.ts 单文件 877 mutant（占原段 2366 的 37.1%），是段内 mutant 的最大来源。拆段动因是密度失衡而非文件数：normalize.ts 284 行 877 mutant 对 config.ts 307 行 95 mutant（密度差约 8 倍），按行数或按文件数均分都会拆错。按文件拆而非按行区间（--mutate file:1-142）：行号是脆弱依赖，且会把分段 SSOT 从本文件迁进 CI matrix，扩大自研面。interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-notifier-config-rest.json
+++ b/stryker.conf.d/dsh-notifier-config-rest.json
@@ -46,5 +46,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-notifier-config-rest.json",
-  "_comment": "#720 静态拆段（3/3）：原 config 段余下 7 实现（config/migrate/paths/redact/settings/quiet-hours/settings-bridge）合计 627 mutant（占原段 26.5%），远低于两个密度异常文件，故合并为一段。配置域划分沿用 #669 PR2 T2-7（settings-bridge/quiet-hours 自 PR1 盲区并入，S3-30 修复）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#720 静态拆段（3/3）：原 config 段余下 7 实现（config/migrate/paths/redact/settings/quiet-hours/settings-bridge）合计 627 mutant（占原段 26.5%），远低于两个密度异常文件，故合并为一段。配置域划分沿用 #669 PR2 T2-7（settings-bridge/quiet-hours 自 PR1 盲区并入，S3-30 修复）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-notifier-config-validate.json
+++ b/stryker.conf.d/dsh-notifier-config-validate.json
@@ -40,5 +40,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-notifier-config-validate.json",
-  "_comment": "#720 静态拆段（2/3）：本段 = validators.ts 单文件 862 mutant（占原段 2366 的 36.4%），与 normalize.ts 合计 73.5%。二者单独成段而不与其余文件混装，是因为 mutant 密度与行数严重不成比例（validators.ts 324 行 / 862 mutant 对 config.ts 307 行 / 95 mutant，密度差约 8 倍）——按行数或按文件数均分都会拆错。interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#720 静态拆段（2/3）：本段 = validators.ts 单文件 862 mutant（占原段 2366 的 36.4%），与 normalize.ts 合计 73.5%。二者单独成段而不与其余文件混装，是因为 mutant 密度与行数严重不成比例（validators.ts 324 行 / 862 mutant 对 config.ts 307 行 / 95 mutant，密度差约 8 倍）——按行数或按文件数均分都会拆错。interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-notifier-events.json
+++ b/stryker.conf.d/dsh-notifier-events.json
@@ -42,5 +42,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-notifier-events.json",
-  "_comment": "#669 PR2 T2-7 按域重划：events——核心状态机事件面（event-handlers/aggregate/agent-session，S3-30 修复入面）；testFiles 含 unit-event-handlers/unit-aggregate（N-6/N-7 直测杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#669 PR2 T2-7 按域重划：events——核心状态机事件面（event-handlers/aggregate/agent-session，S3-30 修复入面）；testFiles 含 unit-event-handlers/unit-aggregate（N-6/N-7 直测杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-notifier-pipeline.json
+++ b/stryker.conf.d/dsh-notifier-pipeline.json
@@ -42,5 +42,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-notifier-pipeline.json",
-  "_comment": "#669 PR2 T2-7 按域重划：pipeline——核心状态机裁决/投递/编排（adjudicate/deliver + orchestrate；orchestrate 为 #733 M1-F1 自 sdk/service.ts 迁入的编排三函数，T2-1 工厂化后入面，N-24 落地）；testFiles 含 unit-pipeline-contract/unit-pipeline-orchestrate（N-14/N-15 注入面契约杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#669 PR2 T2-7 按域重划：pipeline——核心状态机裁决/投递/编排（adjudicate/deliver + orchestrate；orchestrate 为 #733 M1-F1 自 sdk/service.ts 迁入的编排三函数，T2-1 工厂化后入面，N-24 落地）；testFiles 含 unit-pipeline-contract/unit-pipeline-orchestrate（N-14/N-15 注入面契约杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-notifier-sdk.json
+++ b/stryker.conf.d/dsh-notifier-sdk.json
@@ -41,5 +41,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-notifier-sdk.json",
-  "_comment": "#669 PR2 T2-7 按域重划：sdk——服务装配面（sdk/service.ts + 根 index.ts 并入：装配层归服务面，独立 assembly 段单文件且 re-export 过半可杀性低，并入 sdk 均衡段规模；原注释至此的『service.d.ts 非 src TS 不入面』已失效——该文件由 #733 M2a 删除，声明合并迁入 index.ts）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#669 PR2 T2-7 按域重划：sdk——服务装配面（sdk/service.ts + 根 index.ts 并入：装配层归服务面，独立 assembly 段单文件且 re-export 过半可杀性低，并入 sdk 均衡段规模；原注释至此的『service.d.ts 非 src TS 不入面』已失效——该文件由 #733 M2a 删除，声明合并迁入 index.ts）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-notifier-server.json
+++ b/stryker.conf.d/dsh-notifier-server.json
@@ -42,5 +42,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-notifier-server.json",
-  "_comment": "#669 PR2 T2-7 按域重划：server——服务域（routes/sse-bus/system-notifier；index.ts 装配层移出归 sdk 段）；testFiles 含 unit-server-sse-bus/unit-system-notifier（N-11/N-12 注入面直测杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#669 PR2 T2-7 按域重划：server——服务域（routes/sse-bus/system-notifier；index.ts 装配层移出归 sdk 段）；testFiles 含 unit-server-sse-bus/unit-system-notifier（N-11/N-12 注入面直测杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-notifier-stores.json
+++ b/stryker.conf.d/dsh-notifier-stores.json
@@ -41,5 +41,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-notifier-stores.json",
-  "_comment": "#669 PR2 T2-7 按域重划：stores——存储域（history/status，PR1 history 段收窄，quiet-hours 归 config）；testFiles 含 unit-stores（N-4 直测杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#669 PR2 T2-7 按域重划：stores——存储域（history/status，PR1 history 段收窄，quiet-hours 归 config）；testFiles 含 unit-stores（N-4 直测杀灭面）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-notifier-text.json
+++ b/stryker.conf.d/dsh-notifier-text.json
@@ -42,5 +42,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-notifier-text.json",
-  "_comment": "#669 PR2 T2-7 按域重划：text——文案域（message/sanitize/system-commands，PR1 message 段按域更名）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#669 PR2 T2-7 按域重划：text——文案域（message/sanitize/system-commands，PR1 message 段按域更名）；interface.ts 纯 re-export 不入变异面；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-provider-usage-apply.json
+++ b/stryker.conf.d/dsh-provider-usage-apply.json
@@ -43,5 +43,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-provider-usage-apply.json",
-  "_comment": "#342 v4：src 级文件组分段（2）——apply 单列（#316 拆分后最重文件独立成段）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#342 v4：src 级文件组分段（2）——apply 单列（#316 拆分后最重文件独立成段）；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-provider-usage-contracts.json
+++ b/stryker.conf.d/dsh-provider-usage-contracts.json
@@ -44,5 +44,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-provider-usage-contracts.json",
-  "_comment": "#342 v4：src 级文件组分段（3）——contracts+domain1/pipeline/guards（契约面）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#342 v4：src 级文件组分段（3）——contracts+domain1/pipeline/guards（契约面）；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-provider-usage-entry.json
+++ b/stryker.conf.d/dsh-provider-usage-entry.json
@@ -46,5 +46,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-provider-usage-entry.json",
-  "_comment": "#342 v4：src 级文件组分段（1）——index+user-adapters+ui-config+config（配置/入口面）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#342 v4：src 级文件组分段（1）——index+user-adapters+ui-config+config（配置/入口面）；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-provider-usage-pipeline.json
+++ b/stryker.conf.d/dsh-provider-usage-pipeline.json
@@ -51,5 +51,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-provider-usage-pipeline.json",
-  "_comment": "#342 v4：src 级文件组分段（5）——history/v2/hotreload/placement-math/path-resolve/client-logic/provider-config/charts/stats-service（历史/管线/热更/图表/C3 服务面；charts 纳入修复变异盲区；阶段零补 stats-service 盲区）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#342 v4：src 级文件组分段（5）——history/v2/hotreload/placement-math/path-resolve/client-logic/provider-config/charts/stats-service（历史/管线/热更/图表/C3 服务面；charts 纳入修复变异盲区；阶段零补 stats-service 盲区）；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-provider-usage-registry.json
+++ b/stryker.conf.d/dsh-provider-usage-registry.json
@@ -44,5 +44,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-provider-usage-registry.json",
-  "_comment": "#342 二期：功能命名段（registry）——registry+user-adapter-loader（注册表域，25s；阶段零补 loader 盲区）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#342 二期：功能命名段（registry）——registry+user-adapter-loader（注册表域，25s；阶段零补 loader 盲区）；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-provider-usage-sanitize.json
+++ b/stryker.conf.d/dsh-provider-usage-sanitize.json
@@ -43,5 +43,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-provider-usage-sanitize.json",
-  "_comment": "#342 二期：功能命名段（sanitize）——sanitize（数据净化域，115s）；测试全套跑（perTest 关联）；incremental 基线随 observe 四班次重建。"
+  "_comment": "#342 二期：功能命名段（sanitize）——sanitize（数据净化域，115s）；测试全套跑（perTest 关联）；incremental 基线随 observe 夜间全量班重建。"
 }

--- a/stryker.conf.d/dsh-web-file-preview.json
+++ b/stryker.conf.d/dsh-web-file-preview.json
@@ -37,5 +37,5 @@
   },
   "incremental": true,
   "incrementalFile": "coverage/mutation/incremental-web-file-preview.json",
-  "_comment": "#276 方案 A：src 级单段（mutate 直指 src，文件 glob 声明，无行号无漂移）；测试经 src 入口加载插桩代码；incremental 基线随 observe 四班次重建。"
+  "_comment": "#276 方案 A：src 级单段（mutate 直指 src，文件 glob 声明，无行号无漂移）；测试经 src 入口加载插桩代码；incremental 基线随 observe 夜间全量班重建。"
 }


### PR DESCRIPTION
## 关联 issue

#718（S2.2 的收尾措辞扫描，**约定单独一个机械 PR**）。**不自动关闭**——S2.3 / S2.4 / S3 仍在计划内。

## 背景

#758（S2.2）退役了每日四班次增量班，但 SSOT 与文档里仍写着「incremental 基线随 observe **四班次**重建」——
与实际调度不符：现在基线新鲜度只有两条路径（PR 合入即 overlay + 每日一次的全量班并集入档）。

## 改动清单（纯措辞，零语义）

| 文件 | 处数 | 替换 |
|---|---|---|
| `scripts/data/mutation-topology.json` | 27 | `incremental 基线随 observe 四班次重建` → `…observe 夜间全量班重建` |
| `scripts/data/gauntlet.config.json` | 6 | `由四班次 observe 重建` → `由 observe 夜间全量班重建`；`待 observe 四班次重建` → `待 observe 夜间全量班重建` |
| `packages/dsh-mcp-manager/docs/*.md` | 4 | `src 口径四班次重建` → `src 口径夜间全量班重建` |
| `stryker.conf.d/*.json` | 27 | `pnpm stryker:gen` **重生成**（`_comment` 由 SSOT 派生） |

不改分段、阈值、包集、mutate 面——`stryker:gen` 的 diff 逐行核对只有 `_comment` 一行变化。

> 注：改 SSOT 注释后**必须**重生成，否则 `pnpm stryker:check` 判红（#746 实施期踩过这个坑，
> 当时的红是 `[gen-stryker-conf] 配置文件内容与拓扑派生不一致`）。

## 刻意不改（历史记录，改了就是伪造）

- `docs/release-notes/v0.1.14.md`、`v0.2.1.md`——记录当时发布的调度形态；
- `docs/mutation-speedup-methodology.md`——当时的速度优化分析与其状态表；
- `scripts/data/mutation-segment-ledger.json` 的 `workflow: observe-incremental.yml`——如实记录该 run 来自增量班；
- `scripts/gate/baseline/README.md` 与 `AGENTS.md` 里各 1 处「原每日四班次增量班已退役」——这是**正确的现状说明**，不是陈旧措辞。

## 逐条命令与 exit code

本 worktree 实跑（`pnpm install --frozen-lockfile` → exit 0）：

| 命令 | exit code | 关键输出 |
|---|---|---|
| `pnpm stryker:check` | 0 | 生成物与拓扑 SSOT 一致（重生成后无差异） |
| `pnpm build` | 0 | 全部包 `lib/index.js` 生成完成 |
| `pnpm test` | 0 | 7 个包套件全通过（合计 6690 用例） |
| `pnpm contract` | 0 | 全通过 |
| `pnpm pack:check` | 0 | 6 子包 tarball 完整 + 聚合包一致 |
| `pnpm test:scripts` | 0 | `tests 416 / pass 416 / fail 0`（含 gauntlet ↔ conf ↔ 段数 三方一致断言） |
| `pnpm typecheck` | 0 | — |
| `pnpm docs:check` | 0 | 「文档一致性：通过」 |

全仓 `grep -rn 四班次`（排除历史文档与 ledger）只剩上述 2 处**退役说明**。